### PR TITLE
perf(ai): reduce broker snapshot and tool-loop cloning (#2028)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ fern = "0.7"
 log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 schemars = { version = "1", features = ["derive"] }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 toml = "0.8"
 image = { version = "0.25", default-features = false, features = ["bmp", "gif", "jpeg", "png", "tiff", "webp"] }

--- a/src/plexi_ai/backend/mod.rs
+++ b/src/plexi_ai/backend/mod.rs
@@ -10,7 +10,7 @@
 pub mod ollama;
 pub mod openrouter;
 
-use std::sync::mpsc;
+use std::sync::{mpsc, Arc};
 
 use crate::app_protocol::ModelTier;
 
@@ -81,10 +81,12 @@ pub struct AiBackendRequest {
     /// Tool-call turns: `{"role": "assistant", "content": null, "tool_calls": […]}`.
     /// Tool-result turns: `{"role": "tool", "content": "…", "tool_call_id": "…"}`.
     pub messages: Vec<serde_json::Value>,
-    /// System prompt (injected on every call for the native API).
-    pub system: String,
-    /// Tools to inject into the request when non-empty.
-    pub tools: Vec<crate::app_protocol::AiTool>,
+    /// System prompt (injected on every call for the native API). Shared via
+    /// `Arc<str>` so repeated tool-loop iterations clone only the pointer.
+    pub system: Arc<str>,
+    /// Tools to inject into the request when non-empty. Shared via `Arc<[_]>`
+    /// so tool-loop iterations clone only the pointer.
+    pub tools: Arc<[crate::app_protocol::AiTool]>,
     /// Model tier from the broker request. Used by backends to apply
     /// tier-specific request parameters (e.g. disabling reasoning for Low).
     pub model_tier: Option<ModelTier>,

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -15,7 +15,7 @@
 //! thread with a blocking call. The broker's `dispatch` method is therefore
 //! expected to be invoked from a worker thread spawned by the routing layer.
 
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock, RwLock};
 
 use crate::app_protocol::{AiMessage, AiTool, ModelTier};
 use crate::config::{AiConfig, OllamaBackendConfig, OpenRouterBackendConfig};
@@ -41,25 +41,25 @@ pub struct PaneContext {
 /// dispatching `AiQuery` so the broker receives the full workspace context.
 ///
 /// The inner `Arc<Vec<PaneContext>>` is swapped atomically on each update.
-/// Readers clone only the `Arc` pointer (not the vector contents), so the
-/// lock is held for a single pointer-width store rather than for the duration
-/// of a full vector copy.
-static PANE_SNAPSHOT: OnceLock<Mutex<Arc<Vec<PaneContext>>>> = OnceLock::new();
+/// Readers hold only a read-lock long enough to clone the Arc pointer
+/// (not the vector contents); the RwLock allows concurrent snapshot reads
+/// while the single per-frame writer holds an exclusive write-lock briefly.
+static PANE_SNAPSHOT: OnceLock<RwLock<Arc<Vec<PaneContext>>>> = OnceLock::new();
 
-fn pane_snapshot() -> &'static Mutex<Arc<Vec<PaneContext>>> {
-    PANE_SNAPSHOT.get_or_init(|| Mutex::new(Arc::new(Vec::new())))
+fn pane_snapshot() -> &'static RwLock<Arc<Vec<PaneContext>>> {
+    PANE_SNAPSHOT.get_or_init(|| RwLock::new(Arc::new(Vec::new())))
 }
 
 /// Replace the global pane context snapshot. Called once per frame by the host.
 pub fn update_pane_snapshot(panes: Vec<PaneContext>) {
-    *pane_snapshot().lock().unwrap() = Arc::new(panes);
+    *pane_snapshot().write().unwrap() = Arc::new(panes);
 }
 
 /// Read the current pane context snapshot. Called by routing on `AiQuery`.
 /// Returns an `Arc` pointer — callers pay only for a reference-count increment,
-/// not a full vector copy.
+/// not a full vector copy. Concurrent reads do not block each other.
 pub fn get_pane_snapshot() -> Arc<Vec<PaneContext>> {
-    pane_snapshot().lock().unwrap().clone()
+    pane_snapshot().read().unwrap().clone()
 }
 
 /// One brokered request — what the routing layer hands to a broker. `app_id`
@@ -1021,18 +1021,13 @@ mod tests {
         use std::sync::{Arc, Mutex};
 
         /// Backend that returns a tool call on turn 1, final text on turn 2.
-        /// Records which Arc addresses it sees for system/tools so the test can
-        /// verify pointer-sharing (no per-iteration deep copies).
+        /// Clones the Arc itself (not raw pointers) from each invocation so the
+        /// test can compare allocations with `Arc::ptr_eq` after the call.
         struct ToolThenTextBackend {
             calls: Arc<Mutex<u32>>,
-            system_ptrs: Arc<Mutex<Vec<*const u8>>>,
-            tools_ptrs: Arc<Mutex<Vec<*const AiTool>>>,
+            seen_systems: Arc<Mutex<Vec<Arc<str>>>>,
+            seen_tools: Arc<Mutex<Vec<Arc<[AiTool]>>>>,
         }
-
-        // SAFETY: raw pointers are only read in the main thread assertions after
-        // the backend drops. No aliasing writes occur after the pointer is stored.
-        unsafe impl Send for ToolThenTextBackend {}
-        unsafe impl Sync for ToolThenTextBackend {}
 
         impl AiBackend for ToolThenTextBackend {
             fn name(&self) -> &str { "tool-then-text" }
@@ -1047,9 +1042,9 @@ mod tests {
                     *c += 1;
                     *c
                 };
-                // Record Arc data pointers to verify sharing across iterations.
-                self.system_ptrs.lock().unwrap().push(req.system.as_ptr());
-                self.tools_ptrs.lock().unwrap().push(req.tools.as_ptr());
+                // Clone the Arc itself so we can check pointer identity later.
+                self.seen_systems.lock().unwrap().push(Arc::clone(&req.system));
+                self.seen_tools.lock().unwrap().push(Arc::clone(&req.tools));
 
                 assert_eq!(&*req.system, "sys");
                 assert_eq!(req.tools.len(), 1);
@@ -1078,12 +1073,12 @@ mod tests {
             }
         }
 
-        let system_ptrs: Arc<Mutex<Vec<*const u8>>> = Arc::new(Mutex::new(Vec::new()));
-        let tools_ptrs: Arc<Mutex<Vec<*const AiTool>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_systems: Arc<Mutex<Vec<Arc<str>>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_tools: Arc<Mutex<Vec<Arc<[AiTool]>>>> = Arc::new(Mutex::new(Vec::new()));
         let backend = ToolThenTextBackend {
             calls: Arc::new(Mutex::new(0)),
-            system_ptrs: Arc::clone(&system_ptrs),
-            tools_ptrs: Arc::clone(&tools_ptrs),
+            seen_systems: Arc::clone(&seen_systems),
+            seen_tools: Arc::clone(&seen_tools),
         };
 
         let tool = AiTool {
@@ -1117,12 +1112,12 @@ mod tests {
         assert_eq!(resp.tokens_in, 30, "token counts must accumulate across iterations");
         assert_eq!(resp.tokens_out, 13);
 
-        // Both iterations must have seen the same Arc data pointer — no deep copy.
-        let sp = system_ptrs.lock().unwrap();
-        assert_eq!(sp.len(), 2, "backend must be called exactly twice");
-        assert_eq!(sp[0], sp[1], "system Arc must point to the same allocation on both iterations");
-        let tp = tools_ptrs.lock().unwrap();
-        assert_eq!(tp[0], tp[1], "tools Arc must point to the same allocation on both iterations");
+        // Both iterations must have received the same Arc allocation — no deep copy.
+        let ss = seen_systems.lock().unwrap();
+        assert_eq!(ss.len(), 2, "backend must be called exactly twice");
+        assert!(Arc::ptr_eq(&ss[0], &ss[1]), "system Arc must be the same allocation on both iterations");
+        let st = seen_tools.lock().unwrap();
+        assert!(Arc::ptr_eq(&st[0], &st[1]), "tools Arc must be the same allocation on both iterations");
     }
 
     /// Verify `fetch_generation_cost` parses total_cost as string or float.

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -39,19 +39,26 @@ pub struct PaneContext {
 /// Singleton holding a snapshot of all open panes across all windows.
 /// Written by `PlexiApp::update()` each frame; read by `route_command` when
 /// dispatching `AiQuery` so the broker receives the full workspace context.
-static PANE_SNAPSHOT: OnceLock<Arc<Mutex<Vec<PaneContext>>>> = OnceLock::new();
+///
+/// The inner `Arc<Vec<PaneContext>>` is swapped atomically on each update.
+/// Readers clone only the `Arc` pointer (not the vector contents), so the
+/// lock is held for a single pointer-width store rather than for the duration
+/// of a full vector copy.
+static PANE_SNAPSHOT: OnceLock<Mutex<Arc<Vec<PaneContext>>>> = OnceLock::new();
 
-fn pane_snapshot() -> &'static Arc<Mutex<Vec<PaneContext>>> {
-    PANE_SNAPSHOT.get_or_init(|| Arc::new(Mutex::new(Vec::new())))
+fn pane_snapshot() -> &'static Mutex<Arc<Vec<PaneContext>>> {
+    PANE_SNAPSHOT.get_or_init(|| Mutex::new(Arc::new(Vec::new())))
 }
 
 /// Replace the global pane context snapshot. Called once per frame by the host.
 pub fn update_pane_snapshot(panes: Vec<PaneContext>) {
-    *pane_snapshot().lock().unwrap() = panes;
+    *pane_snapshot().lock().unwrap() = Arc::new(panes);
 }
 
 /// Read the current pane context snapshot. Called by routing on `AiQuery`.
-pub fn get_pane_snapshot() -> Vec<PaneContext> {
+/// Returns an `Arc` pointer — callers pay only for a reference-count increment,
+/// not a full vector copy.
+pub fn get_pane_snapshot() -> Arc<Vec<PaneContext>> {
     pane_snapshot().lock().unwrap().clone()
 }
 
@@ -68,7 +75,9 @@ pub struct AiBrokerRequest {
     /// prepends a compact workspace context block to the system prompt.
     pub workspace_root: Option<std::path::PathBuf>,
     /// Currently open panes — listed in the host context block.
-    pub open_panes: Vec<PaneContext>,
+    /// `Arc`-wrapped so callers share the snapshot pointer rather than copying
+    /// the full vector on every dispatch.
+    pub open_panes: Arc<Vec<PaneContext>>,
     /// Tool dispatcher snapshot. When `Some`, the broker runs a tool loop
     /// and dispatches any tool calls the model makes.
     pub tool_dispatcher: Option<std::sync::Arc<ToolDispatcher>>,
@@ -383,33 +392,37 @@ fn run_turn_and_respond(
     on_delta: &mut dyn FnMut(turn_loop::TurnDelta<'_>),
 ) -> AiBrokerResponse {
     // Build effective system prompt (optionally prepend host context).
-    let system = if request.system.starts_with("# no-host-context") {
-        request.system.clone()
+    // Wrap in `Arc<str>` immediately so each tool-loop iteration clones only
+    // the pointer rather than the full string.
+    let system: Arc<str> = if request.system.starts_with("# no-host-context") {
+        Arc::from(request.system)
     } else if let Some(root) = &request.workspace_root {
         let prefix = build_context_prefix(root, &request.open_panes);
-        format!("{prefix}{}", request.system)
+        Arc::from(format!("{prefix}{}", request.system))
     } else {
-        request.system.clone()
+        Arc::from(request.system)
     };
 
     // Collect tools: from request AND from global registry via dispatcher.
+    // Move request.tools (no clone) then extend with registry tools, then
+    // freeze into an Arc<[_]> so each tool-loop iteration clones only the pointer.
     let registry_tools = request
         .tool_dispatcher
         .as_ref()
         .map(|d| d.all_tools())
         .unwrap_or_default();
-    let mut all_tools: Vec<AiTool> = request.tools.clone();
+    let mut all_tools_vec: Vec<AiTool> = request.tools;
     for t in registry_tools {
-        if !all_tools.iter().any(|existing| existing.name == t.name) {
-            all_tools.push(t);
+        if !all_tools_vec.iter().any(|existing| existing.name == t.name) {
+            all_tools_vec.push(t);
         }
     }
-
-    let tool_names: Vec<&str> = all_tools.iter().map(|t| t.name.as_str()).collect();
+    let tool_names: Vec<&str> = all_tools_vec.iter().map(|t| t.name.as_str()).collect();
     log::info!(
         "ai_broker[{}]: model={model_id}, tools={tool_names:?}",
         request.app_id,
     );
+    let all_tools: Arc<[AiTool]> = all_tools_vec.into();
 
     // Convert messages to JSON values for the backend.
     let mut conv: Vec<serde_json::Value> = messages_to_json(&request.messages);
@@ -431,8 +444,8 @@ fn run_turn_and_respond(
 
         let backend_req = AiBackendRequest {
             messages: conv.clone(),
-            system: system.clone(),
-            tools: all_tools.clone(),
+            system: Arc::clone(&system),
+            tools: Arc::clone(&all_tools),
             model_tier: Some(request.model_tier),
         };
 
@@ -464,9 +477,10 @@ fn run_turn_and_respond(
                     break;
                 }
 
-                // Append assistant tool-call message.
-                let tc_json: Vec<serde_json::Value> = result
-                    .tool_calls
+                // Append assistant tool-call message. Build tc_json while the
+                // tool_calls vec is still intact, then consume it below.
+                let tool_calls = result.tool_calls;
+                let tc_json: Vec<serde_json::Value> = tool_calls
                     .iter()
                     .map(|tc| {
                         serde_json::json!({
@@ -494,7 +508,7 @@ fn run_turn_and_respond(
                             request.app_id
                         );
                         // Append error result for each call so the model can recover.
-                        for tc in &result.tool_calls {
+                        for tc in &tool_calls {
                             conv.push(serde_json::json!({
                                 "role": "tool",
                                 "tool_call_id": tc.id,
@@ -505,20 +519,18 @@ fn run_turn_and_respond(
                     }
                 };
 
-                // Dispatch all tool calls (sequentially for now — parallel
-                // dispatch would require spawning threads and joining, adding
-                // complexity for marginal gain on typical 1-2 tool call batches).
-                let mut call_counter: u64 = 0;
-                for tc in &result.tool_calls {
-                    call_counter += 1;
-                    let call_id = format!("{}-{call_counter}", tc.id);
+                // Consume tool_calls so we can move tc.arguments directly into
+                // dispatch_call without cloning (sequential dispatch — parallel
+                // would need threads + join, adding complexity for marginal gain
+                // on typical 1-2 call batches).
+                for (i, tc) in tool_calls.into_iter().enumerate() {
+                    let call_id = format!("{}-{}", tc.id, i + 1);
                     log::debug!(
                         "ai_broker[{}]: dispatching tool '{}' call_id={call_id}",
                         request.app_id,
                         tc.name,
                     );
-                    let tool_result =
-                        dispatcher.dispatch_call(call_id.clone(), &tc.name, tc.arguments.clone());
+                    let tool_result = dispatcher.dispatch_call(call_id, &tc.name, tc.arguments);
                     let content = if let Some(out) = tool_result.output_json {
                         out
                     } else {
@@ -881,7 +893,7 @@ mod tests {
                 messages: messages.clone(),
                 tools: vec![],
                 workspace_root: None,
-                open_panes: vec![],
+                open_panes: Arc::new(Vec::new()),
                 tool_dispatcher: None,
             },
             &mut |_| {},
@@ -916,7 +928,7 @@ mod tests {
                 }],
                 tools: vec![],
                 workspace_root: None,
-                open_panes: vec![],
+                open_panes: Arc::new(Vec::new()),
                 tool_dispatcher: None,
             },
             &mut |_| {},
@@ -950,7 +962,7 @@ mod tests {
                 }],
                 tools: vec![],
                 workspace_root: None,
-                open_panes: vec![],
+                open_panes: Arc::new(Vec::new()),
                 tool_dispatcher: None,
             },
             &mut |_| {},
@@ -984,7 +996,7 @@ mod tests {
                 }],
                 tools: vec![],
                 workspace_root: None,
-                open_panes: vec![],
+                open_panes: Arc::new(Vec::new()),
                 tool_dispatcher: None,
             },
             &mut |_| {},
@@ -994,6 +1006,123 @@ mod tests {
             resp.error.as_deref().unwrap_or("").contains("[ai.ollama]"),
             "error must mention missing [ai.ollama] section"
         );
+    }
+
+    /// Verify the tool loop: a backend that returns one tool call on the first
+    /// turn and a text reply on the second. Confirms that `system` and `tools`
+    /// are consistent across iterations (pointer-equality for Arc fields) and
+    /// that the broker accumulates token counts and conversation history
+    /// correctly across both turns.
+    #[test]
+    fn tool_loop_builds_conversation_correctly() {
+        use crate::plexi_ai::backend::{AiBackend, AiBackendError, AiBackendRequest, RawToolCall, StreamEvent};
+        use crate::app_protocol::AiTool;
+        use std::sync::mpsc;
+        use std::sync::{Arc, Mutex};
+
+        /// Backend that returns a tool call on turn 1, final text on turn 2.
+        /// Records which Arc addresses it sees for system/tools so the test can
+        /// verify pointer-sharing (no per-iteration deep copies).
+        struct ToolThenTextBackend {
+            calls: Arc<Mutex<u32>>,
+            system_ptrs: Arc<Mutex<Vec<*const u8>>>,
+            tools_ptrs: Arc<Mutex<Vec<*const AiTool>>>,
+        }
+
+        // SAFETY: raw pointers are only read in the main thread assertions after
+        // the backend drops. No aliasing writes occur after the pointer is stored.
+        unsafe impl Send for ToolThenTextBackend {}
+        unsafe impl Sync for ToolThenTextBackend {}
+
+        impl AiBackend for ToolThenTextBackend {
+            fn name(&self) -> &str { "tool-then-text" }
+
+            fn stream_to_channel(
+                &self,
+                req: AiBackendRequest,
+                tx: mpsc::Sender<StreamEvent>,
+            ) -> Result<(), AiBackendError> {
+                let call_num = {
+                    let mut c = self.calls.lock().unwrap();
+                    *c += 1;
+                    *c
+                };
+                // Record Arc data pointers to verify sharing across iterations.
+                self.system_ptrs.lock().unwrap().push(req.system.as_ptr());
+                self.tools_ptrs.lock().unwrap().push(req.tools.as_ptr());
+
+                assert_eq!(&*req.system, "sys");
+                assert_eq!(req.tools.len(), 1);
+                assert_eq!(req.tools[0].name, "echo");
+
+                if call_num == 1 {
+                    let _ = tx.send(StreamEvent::ToolCalls(vec![RawToolCall {
+                        id: "c1".to_string(),
+                        name: "echo".to_string(),
+                        arguments: "{\"msg\":\"hello\"}".to_string(),
+                    }]));
+                    let _ = tx.send(StreamEvent::Done {
+                        input_tokens: Some(10),
+                        output_tokens: Some(5),
+                        generation_id: None,
+                    });
+                } else {
+                    let _ = tx.send(StreamEvent::Text("final answer".to_string()));
+                    let _ = tx.send(StreamEvent::Done {
+                        input_tokens: Some(20),
+                        output_tokens: Some(8),
+                        generation_id: None,
+                    });
+                }
+                Ok(())
+            }
+        }
+
+        let system_ptrs: Arc<Mutex<Vec<*const u8>>> = Arc::new(Mutex::new(Vec::new()));
+        let tools_ptrs: Arc<Mutex<Vec<*const AiTool>>> = Arc::new(Mutex::new(Vec::new()));
+        let backend = ToolThenTextBackend {
+            calls: Arc::new(Mutex::new(0)),
+            system_ptrs: Arc::clone(&system_ptrs),
+            tools_ptrs: Arc::clone(&tools_ptrs),
+        };
+
+        let tool = AiTool {
+            name: "echo".to_string(),
+            description: "echoes back".to_string(),
+            input_schema: serde_json::json!({"type":"object"}),
+            timeout_ms: None,
+        };
+        // No dispatcher: the broker appends an error tool result and continues to
+        // the next iteration, where the backend returns the final text.
+        let request = AiBrokerRequest {
+            app_id: "test".to_string(),
+            model_tier: crate::app_protocol::ModelTier::Low,
+            system: "sys".to_string(),
+            messages: vec![crate::app_protocol::AiMessage {
+                role: "user".to_string(),
+                content: "go".to_string(),
+            }],
+            tools: vec![tool],
+            workspace_root: None,
+            open_panes: Arc::new(Vec::new()),
+            tool_dispatcher: None,
+        };
+
+        let billing = crate::plexi_ai::backend::BillingModel::Subscription;
+        let resp = run_turn_and_respond(
+            request, &backend, billing, "test-model".to_string(), String::new(), &mut |_| {},
+        );
+        assert!(resp.content.is_some(), "broker must return final text after tool round-trip");
+        assert_eq!(resp.content.as_deref(), Some("final answer"));
+        assert_eq!(resp.tokens_in, 30, "token counts must accumulate across iterations");
+        assert_eq!(resp.tokens_out, 13);
+
+        // Both iterations must have seen the same Arc data pointer — no deep copy.
+        let sp = system_ptrs.lock().unwrap();
+        assert_eq!(sp.len(), 2, "backend must be called exactly twice");
+        assert_eq!(sp[0], sp[1], "system Arc must point to the same allocation on both iterations");
+        let tp = tools_ptrs.lock().unwrap();
+        assert_eq!(tp[0], tp[1], "tools Arc must point to the same allocation on both iterations");
     }
 
     /// Verify `fetch_generation_cost` parses total_cost as string or float.


### PR DESCRIPTION
Closes #2028

## Summary

- Replace `Arc<Mutex<Vec<PaneContext>>>` snapshot with a swap pattern (`Mutex<Arc<Vec<PaneContext>>>`): snapshot reads now clone only an Arc pointer instead of the full pane vector
- Change `AiBackendRequest.{system,tools}` from `String`/`Vec<AiTool>` to `Arc<str>`/`Arc<[AiTool]>` (added serde `rc` feature); tool-loop iterations clone pointers instead of deep-copying the system prompt and tool list on every turn
- Consume `result.tool_calls` via `into_iter()` to move `tc.arguments` into `dispatch_call` without cloning
- Add `tool_loop_builds_conversation_correctly` test: verifies Arc pointer sharing across iterations and correct token accumulation

## Done When

- AI broker tests still pass and a multi-turn tool-call test shows the same transcript/tool behavior.
- Snapshot reads no longer clone every `PaneContext`.
- The tool loop no longer clones the full conversation/tools on every iteration unless explicitly required by backend API ownership.