### PR TITLE
fix: context root env refresh — sidebar/overlay and CLI tip

### DIFF
--- a/.stint/tasks/0045-v1-cleanup-nord-contrast.md
+++ b/.stint/tasks/0045-v1-cleanup-nord-contrast.md
@@ -1,8 +1,9 @@
 ---
 id: "0045"
 title: "v1 cleanup: Nord theme contrast"
-status: todo
+status: in-progress
 estimate: "3h"
+started_at: "2026-06-13T19:47:18Z"
 sprint: "s11"
 blocked_by: []
 gh_issue:
@@ -14,6 +15,7 @@ tags:
   - "cleanup"
   - "theme"
 ---
+
 
 
 Audit and adjust Nord theme dim/section text contrast where it is hard to read on dark surfaces.

--- a/.stint/tasks/0060-v1-cleanup-context-root-env-refresh.md
+++ b/.stint/tasks/0060-v1-cleanup-context-root-env-refresh.md
@@ -1,8 +1,9 @@
 ---
 id: "0060"
 title: "v1 cleanup: context root env refresh"
-status: todo
+status: in-progress
 estimate: "3h"
+started_at: "2026-06-13T19:47:19Z"
 sprint: "s11"
 blocked_by: []
 gh_issue:
@@ -14,6 +15,7 @@ tags:
   - "cleanup"
   - "context"
 ---
+
 
 
 Make `PLEXI_CONTEXT_ROOT` behavior explicit after `plexi context set-root`, including either live env refresh for existing panes or a user-visible restart/new-pane affordance.

--- a/src/cli/context_cli.rs
+++ b/src/cli/context_cli.rs
@@ -200,6 +200,9 @@ pub fn context_set_root_cli(path: Option<&str>) -> i32 {
         print_tip(
             "you can also press \u{21E7}\u{2318}I to set the context root from the focused pane",
         );
+        print_tip(
+            "PLEXI_CONTEXT_ROOT is set when a pane opens — open a new pane to pick up the change",
+        );
     }
     rc
 }

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -539,6 +539,9 @@ impl PlexiApp {
                     if raw.is_empty() {
                         log::info!("TextInputOverlay: clear context root idx={idx}");
                         self.router.get_mut(idx).root = None;
+                        if idx == self.router.active_idx() {
+                            self.apply_context_transition_effects();
+                        }
                     } else {
                         // Tilde expansion.
                         let expanded = if raw.starts_with("~/") {
@@ -566,7 +569,8 @@ impl PlexiApp {
                             "TextInputOverlay: set context root idx={idx} path={}",
                             resolved.display()
                         );
-                        self.router.get_mut(idx).root = Some(resolved);
+                        let ctx_id = self.router.get(idx).context_id;
+                        self.set_context_root(resolved, Some(ctx_id));
                     }
                     self.save_workspace();
                 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -574,12 +574,16 @@ impl PlexiApp {
                         "sidebar: set context root ctx_idx={i} root={}",
                         path.display()
                     );
-                    self.router.get_mut(i).root = Some(path);
+                    let ctx_id = self.router.get(i).context_id;
+                    self.set_context_root(path, Some(ctx_id));
                     self.save_workspace();
                 }
                 WindowMenuAction::ClearRoot => {
                     log::info!("sidebar: clear context root ctx_idx={i}");
                     self.router.get_mut(i).root = None;
+                    if i == self.router.active_idx() {
+                        self.apply_context_transition_effects();
+                    }
                     self.save_workspace();
                 }
                 WindowMenuAction::OpenRootOverlay => {


### PR DESCRIPTION
Stint task 0060 — no linked GitHub issue.

## Summary

- **CLI tip:** `plexi context set-root` now prints a second tip after success: *"PLEXI_CONTEXT_ROOT is set when a pane opens — open a new pane to pick up the change"*, making the env-var-at-spawn-time contract explicit to the user.
- **Sidebar fix:** `WindowMenuAction::SetRoot` now routes through `set_context_root()` instead of directly mutating `.root`, so registry rescan, watcher restart, and agent reload all fire when the root changes via the sidebar context menu — same as the CLI/keyboard paths.
- **Sidebar + overlay clear fix:** clearing the context root (sidebar `ClearRoot` and the overlay empty-input path) now also calls `apply_context_transition_effects()` when the active context is affected, keeping registry/watcher/agents in sync.

## Done When

- `plexi context set-root <path>` prints a tip explaining PLEXI_CONTEXT_ROOT is set at pane-open time
- Setting/clearing context root via sidebar context menu triggers the same registry rescan and watcher restart as the CLI path
- `cargo test --bin plexi context` green