### PR TITLE
feat: wire /testing gate into ship lifecycle

### DIFF
--- a/.agents/skills/implement-issue/SKILL.md
+++ b/.agents/skills/implement-issue/SKILL.md
@@ -324,6 +324,7 @@ pipeline_slots_set implement <n> "" pushed "" ""
 - No `todo!()` or `unimplemented!()` outside `#[cfg(test)]`
 - No `#[allow(dead_code)]` or `#[allow(unused)]`
 - `cargo build` must pass after all changes
+- `/testing` is mandatory before pushing when any `src/` host or app code was touched. The `**Test evidence:**` block must be in the Ship Log before `/open-pr` is invoked. For docs-only, skills-only, or config-only changes, write `"docs-only — no test evidence required"` in place of the block.
 - Subagents stage only — orchestrator owns the commit
 - Never dispatch subagent without the Phase 3 spec
 - Every implementation needs a logging plan

--- a/.agents/skills/implement-issue/SKILL.md
+++ b/.agents/skills/implement-issue/SKILL.md
@@ -324,7 +324,7 @@ pipeline_slots_set implement <n> "" pushed "" ""
 - No `todo!()` or `unimplemented!()` outside `#[cfg(test)]`
 - No `#[allow(dead_code)]` or `#[allow(unused)]`
 - `cargo build` must pass after all changes
-- `/testing` is mandatory before pushing when any `src/` host or app code was touched. The `**Test evidence:**` block must be in the Ship Log before `/open-pr` is invoked. For docs-only, skills-only, or config-only changes, write `"docs-only — no test evidence required"` in place of the block.
+- `/testing` is mandatory before pushing when any `src/` host logic or `apps/` Python app code was touched. For `src/` changes, this means `cargo test --bin plexi`; for `apps/` changes, this means the PGAP-layer evidence (real-process headless screenshot). The `**Test evidence:**` block must be in the Ship Log before `/open-pr` is invoked. For docs-only, skills-only, or config-only changes, write `"docs-only — no test evidence required"` in place of the block.
 - Subagents stage only — orchestrator owns the commit
 - Never dispatch subagent without the Phase 3 spec
 - Every implementation needs a logging plan

--- a/.agents/skills/implement-stint/SKILL.md
+++ b/.agents/skills/implement-stint/SKILL.md
@@ -260,6 +260,11 @@ If a linked GitHub issue exists, append or update its Ship Log with:
 **Stint:** started <task-id> from worktree
 **Files changed:** <key files>
 **Spec summary:** <one-line approach>
+
+**Test evidence (attempt <N>):**
+- cargo test: <passed> passed, <failed> failed — filters: <module list or "full bin suite">
+- PlexiUiHarness render: /tmp/plexi-render-<task>-<name>.png — <what it shows> (omit if no UI layer touched)
+- Conclusion: install skippable — full coverage | binary install required — <why> | docs-only — no test evidence required
 ```
 
 Set labels:

--- a/.agents/skills/validate-pr/SKILL.md
+++ b/.agents/skills/validate-pr/SKILL.md
@@ -119,12 +119,15 @@ gh pr diff $PR_NUMBER
 ```bash
 gh issue view $ISSUE_NUMBER --json body --jq '.body' | grep -A5 "Test evidence"
 ```
-- `Conclusion: install skippable — full coverage` → stay in diff-review mode. Do not install, even if a Rust file changed. Skip to Step 2b.
-- `Conclusion: binary install required — <reason>` → proceed to install triggers below.
-- `Conclusion: docs-only — no test evidence required` → diff-review mode. Skip to Step 2b.
-- Block absent → no test evidence was written during implementation; proceed to install triggers below.
 
-**Apps/ and explicit Done When install requirements always install regardless of test evidence conclusion.**
+Evaluate the conclusion, **then apply overrides**:
+
+| Conclusion | Default decision | Override |
+|---|---|---|
+| `install skippable — full coverage` | diff-review mode | Install anyway if `apps/` files changed or Done When requires binary |
+| `binary install required — <reason>` | install | — |
+| `docs-only — no test evidence required` | diff-review mode | — |
+| block absent | fall through to install-trigger list below | — |
 
 **Do not re-run `cargo test` in validation.** The suite ran during implementation; the Test Evidence block is the authoritative record. Validation owns diff review and user acceptance, not test execution. Never re-run a suite that the Ship Log already reports as green.
 
@@ -133,14 +136,14 @@ gh issue view $ISSUE_NUMBER --json body --jq '.body' | grep -A5 "Test evidence"
 2. Testing block whose pass/fail criteria map to the issue checklist
 3. User manual exercise if the issue is visual or interactive
 
-**Install only when the diff requires a runnable PR build** (and test evidence did not conclude `install skippable`):
+**Install triggers** (apply when test evidence concludes `binary install required`, is absent, or an override fires):
 - Changed files under `apps/` or `apps/dev/` — Python apps are copied to the profile dir on install, not served from source
 - Packaging, bundle, channel, profile-dir, app-copy, or runtime asset changes
 - Behavior cannot be judged from diff and needs the user to launch `plexi-pr-$PR_NUMBER`
 - The issue's Done When explicitly requires validating the installed PR binary
 - Gemini review or a targeted implementation check reports a blocker that requires a rebuilt binary to verify
 
-If install is not required → skip Step 2 and use the diff-review testing block.
+If install is not required → skip Step 2 and proceed to Step 2b (automated quality checks).
 
 ---
 

--- a/.agents/skills/validate-pr/SKILL.md
+++ b/.agents/skills/validate-pr/SKILL.md
@@ -115,21 +115,30 @@ gh pr diff $PR_NUMBER --name-only
 gh pr diff $PR_NUMBER
 ```
 
+**Step 1a — Test evidence gate (check this first).** Read the issue Ship Log for a `**Test evidence:**` block written by the `/testing` skill during implementation:
+```bash
+gh issue view $ISSUE_NUMBER --json body --jq '.body' | grep -A5 "Test evidence"
+```
+- `Conclusion: install skippable — full coverage` → stay in diff-review mode. Do not install, even if a Rust file changed. Skip to Step 2b.
+- `Conclusion: binary install required — <reason>` → proceed to install triggers below.
+- `Conclusion: docs-only — no test evidence required` → diff-review mode. Skip to Step 2b.
+- Block absent → no test evidence was written during implementation; proceed to install triggers below.
+
+**Apps/ and explicit Done When install requirements always install regardless of test evidence conclusion.**
+
+**Do not re-run `cargo test` in validation.** The suite ran during implementation; the Test Evidence block is the authoritative record. Validation owns diff review and user acceptance, not test execution. Never re-run a suite that the Ship Log already reports as green.
+
 **Default mode: diff review only.** Do not install the PR build just because a Rust file changed. For small or obvious diffs, especially one-file edits, validation is:
 1. Gemini review against `alpha`
 2. Testing block whose pass/fail criteria map to the issue checklist
 3. User manual exercise if the issue is visual or interactive
 
-**Install only when the diff requires a runnable PR build**, such as:
+**Install only when the diff requires a runnable PR build** (and test evidence did not conclude `install skippable`):
 - Changed files under `apps/` or `apps/dev/` — Python apps are copied to the profile dir on install, not served from source
 - Packaging, bundle, channel, profile-dir, app-copy, or runtime asset changes
 - Behavior cannot be judged from diff and needs the user to launch `plexi-pr-$PR_NUMBER`
 - The issue's Done When explicitly requires validating the installed PR binary
 - Gemini review or a targeted implementation check reports a blocker that requires a rebuilt binary to verify
-
-**Test evidence gate:** Read the issue Ship Log (or PR body) for a `**Test evidence:**` block from the `/testing` skill. If present and it concludes `install skippable — full coverage`, stay in diff-review mode even when an install trigger above would otherwise fire — unless the trigger is `apps/` file changes or an explicit Done When install requirement, which always install. Evidence concluding `binary install required` means install.
-
-**Do not run cargo tests in validation unless Gemini review finds a specific testable risk.** Implementation already owns the cheapest relevant build/test check before commit — and when a `**Test evidence:**` block reports a green run, never re-run the same suite. Validation owns diff review and user acceptance.
 
 If install is not required → skip Step 2 and use the diff-review testing block.
 

--- a/.stint/tasks/0180-testing-validate-pr-cargo-test-gate.md
+++ b/.stint/tasks/0180-testing-validate-pr-cargo-test-gate.md
@@ -1,8 +1,9 @@
 ---
 id: "0180"
 title: "Testing: cargo test + coverage gate in validate-pr — skip binary install on full coverage"
-status: todo
+status: in-progress
 estimate: "8h"
+started_at: "2026-06-13T19:50:44Z"
 sprint: "s8"
 blocked_by: []
 gh_issue:
@@ -14,6 +15,7 @@ tags:
   - "v1"
   - "testing"
 ---
+
 
 
 Wire `cargo test --bin plexi` and `cargo llvm-cov` into the ship cycle so validate-pr runs the test suite as a pre-gate and can skip the manual binary install for PRs whose diff is fully covered by harness tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ If you can't reproduce it or instrument it, stop and flag it. A fix written agai
 
 **Full reference: [`docs/TESTING.md`](docs/TESTING.md).** The rule: observable state (pane tree, app UI, pixels) → TOML scene in `tests/scenes/` (`just scene <file>`, runner `src/scenes.rs`); return value or internal invariant → Rust test (`HostHarness` in `src/testing/mod.rs` for host logic, plain `#[test]` for pure logic). `PlexiUiHarness` (`src/ui_tests.rs`) is the headless engine under scenes — wgpu Metal, no display, drives real PGAP app processes. The `/testing` skill owns pre-push evidence.
 
-**In progress (epic #2162):** wiring `cargo test --bin plexi` and `cargo llvm-cov` into the ship cycle so validate-pr can skip binary install for PRs with full coverage. Not yet active — for now, always run manually.
+**Active (epic #2162):** `cargo test --bin plexi` is wired into the ship cycle. The `/testing` skill (mandatory in implement-issue/implement-stint before push for any `src/` change) classifies the diff, runs harness tests, and writes a `**Test evidence:**` block into the Ship Log. validate-pr reads that block in Step 1a to decide install vs. diff-review; a `Conclusion: install skippable — full coverage` result skips binary install entirely.
 
 ## Implementation Discipline (no half-refactors)
 


### PR DESCRIPTION
No linked GitHub issue — stint task 0180.

## Summary

- Makes `/testing` mandatory in `implement-issue` and `implement-stint` before push for any `src/` change; docs-only changes state so explicitly
- Adds `**Test evidence:**` block to `implement-stint` Ship Log template (was missing — implement-issue already had it)
- Promotes validate-pr test evidence check to **Step 1a** — checked first, before install triggers — with an explicit `gh issue view | grep` command
- Removes the buried post-hoc "Test evidence gate" note and the conflicting "Do not run cargo tests unless Gemini..." sentence; replaces with a clear "Do not re-run in validation — trust the evidence block"
- Updates CLAUDE.md from "In progress — not yet active" to "Active" with a one-line description of the mechanism

## Done When (stint 0180)

- validate-pr reads the Test Evidence block in Step 1a as its primary install gate
- A PR touching only dispatch logic (no UI) can complete validate-pr without a binary install when the Ship Log says `install skippable — full coverage`
- implement-issue Rules explicitly mandate /testing before push

## Test evidence (attempt 1)

- Conclusion: docs-only — no test evidence required