### PR TITLE
plexi run: dynamic completions + extra_args forwarding (stint 0185)

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -48,6 +48,9 @@ pub enum Commands {
     Run {
         /// Command name to run (omit to list available commands)
         command: Option<String>,
+        /// Extra arguments forwarded to the command as $1, $2, … positional params
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        extra_args: Vec<String>,
     },
     /// Set up a .plexi/ workspace in your project folder.
     ///
@@ -242,6 +245,9 @@ pub enum Commands {
         /// Prefix to complete: "cli:", "mcp:", "app:", or empty for all
         prefix: String,
     },
+    /// List run completions (hidden, used by shell completions)
+    #[command(hide = true, name = "_complete-run")]
+    CompleteRun,
 }
 
 #[derive(Subcommand)]

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -199,7 +199,7 @@ fn inject_zsh_run_completions(script: &str, binary_name: &str) -> String {
     for line in script.lines() {
         if line.contains("::command") && line.contains("Command name to run") {
             result.push_str(&format!(
-                "':command -- Command name (from commands.toml):__{binary_name}_run_completions' \\",
+                "'::command -- Command name (from commands.toml):__{binary_name}_run_completions' \\",
             ));
             result.push('\n');
             if !injected_helper {

--- a/src/cli/completions.rs
+++ b/src/cli/completions.rs
@@ -75,6 +75,43 @@ pub fn complete_open_cli(prefix: &str) -> i32 {
     0
 }
 
+/// Output completion candidates for `plexi run <TAB>`.
+///
+/// Called by the hidden `_complete-run` subcommand. Emits one name per line.
+/// Sources (in order):
+///  1. Commands from the workspace's channel-scoped `commands.toml` when the current
+///     directory contains one.
+///  2. Global scripts from `config_dir()/scripts/` as a fallback.
+pub fn complete_run_cli() -> i32 {
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(_) => return 1,
+    };
+    let commands_file = super::commands_file();
+    let config_path = cwd.join(&commands_file);
+    if let Ok(contents) = std::fs::read_to_string(&config_path) {
+        if let Ok(config) = toml::from_str::<super::PlexiCommands>(&contents) {
+            let mut names: Vec<&String> = config.commands.keys().collect();
+            names.sort();
+            for name in names {
+                let entry = &config.commands[name];
+                if let Some(desc) = entry.description() {
+                    println!("{name}:{desc}");
+                } else {
+                    println!("{name}");
+                }
+            }
+            return 0;
+        }
+    }
+    // Fallback: global scripts
+    let scripts_dir = crate::config::config_dir().join("scripts");
+    for name in super::list_global_scripts(&scripts_dir) {
+        println!("{name}");
+    }
+    0
+}
+
 pub fn completions_cli(shell: &str, binary_name: &str) -> i32 {
     use clap::CommandFactory;
     use clap_complete::{generate, Shell};
@@ -95,6 +132,7 @@ pub fn completions_cli(shell: &str, binary_name: &str) -> i32 {
         let script = String::from_utf8(buf).unwrap_or_default();
         let script = fix_zsh_workspace_path_conflict(&script);
         let script = inject_zsh_open_completions(&script, binary_name);
+        let script = inject_zsh_run_completions(&script, binary_name);
         print!("{script}");
     } else {
         generate(shell_variant, &mut cmd, binary_name, &mut std::io::stdout());
@@ -145,6 +183,47 @@ __{binary_name}_open_completions() {{
             result.insert_str(pos, &helper);
         } else {
             // No compdef found, append at end
+            result.push_str(&helper);
+        }
+    }
+
+    result
+}
+
+/// Inject a dynamic completion function for `plexi run <TAB>` into the zsh completion script.
+/// Replaces the static `command` positional spec in the `run` subcommand with a call to
+/// the hidden `_complete-run` subcommand, which reads `commands.toml` at runtime.
+fn inject_zsh_run_completions(script: &str, binary_name: &str) -> String {
+    let mut result = String::with_capacity(script.len() + 512);
+    let mut injected_helper = false;
+    for line in script.lines() {
+        if line.contains("::command") && line.contains("Command name to run") {
+            result.push_str(&format!(
+                "':command -- Command name (from commands.toml):__{binary_name}_run_completions' \\",
+            ));
+            result.push('\n');
+            if !injected_helper {
+                injected_helper = true;
+            }
+        } else {
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+
+    if injected_helper {
+        let helper = format!(
+            r#"
+__{binary_name}_run_completions() {{
+    local -a completions
+    completions=(${{(f)"$({binary_name} _complete-run 2>/dev/null)"}})
+    _describe 'command' completions
+}}
+"#,
+        );
+        if let Some(pos) = result.rfind("\ncompdef ") {
+            result.insert_str(pos, &helper);
+        } else {
             result.push_str(&helper);
         }
     }
@@ -231,5 +310,35 @@ mod completions_tests {
         let once = fix_zsh_workspace_path_conflict(&raw);
         let twice = fix_zsh_workspace_path_conflict(&once);
         assert_eq!(once, twice, "fix must be idempotent");
+    }
+
+    #[test]
+    fn zsh_run_completions_injected() {
+        use super::{fix_zsh_workspace_path_conflict, inject_zsh_run_completions};
+        let raw = generated_zsh();
+        let fixed = fix_zsh_workspace_path_conflict(&raw);
+        let patched = inject_zsh_run_completions(&fixed, "plexi");
+        assert!(
+            patched.contains("__plexi_run_completions"),
+            "run helper function must be injected"
+        );
+        assert!(
+            patched.contains("_complete-run"),
+            "helper must invoke _complete-run subcommand"
+        );
+        assert!(
+            !patched.contains("Command name to run"),
+            "static spec must be replaced by dynamic completion"
+        );
+    }
+
+    #[test]
+    fn zsh_run_completions_injection_is_idempotent() {
+        use super::{fix_zsh_workspace_path_conflict, inject_zsh_run_completions};
+        let raw = generated_zsh();
+        let fixed = fix_zsh_workspace_path_conflict(&raw);
+        let once = inject_zsh_run_completions(&fixed, "plexi");
+        let twice = inject_zsh_run_completions(&once, "plexi");
+        assert_eq!(once, twice, "run injection must be idempotent");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -219,7 +219,7 @@ pub use marketplace::{
     app_browse_cli, app_license_list_cli, app_license_show_cli, app_publish_cli, app_search_cli,
 };
 pub use app_check::app_check_cli;
-pub use completions::{complete_open_cli, completions_cli};
+pub use completions::{complete_open_cli, complete_run_cli, completions_cli};
 pub use config_cli::{config_check, config_edit, config_get, config_reset};
 pub use context_cli::{
     context_current_cli, context_describe_cli, context_list_cli, context_new_cli, context_open_cli,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -77,7 +77,7 @@ pub fn run_list_commands() -> i32 {
     0
 }
 
-pub fn run_command(command_name: &str) -> i32 {
+pub fn run_command(command_name: &str, extra_args: &[String]) -> i32 {
     let cwd = match std::env::current_dir() {
         Ok(d) => d,
         Err(e) => {
@@ -98,6 +98,9 @@ pub fn run_command(command_name: &str) -> i32 {
             if script_path.is_file() && is_executable(&script_path) {
                 log::info!("cli: running global script {:?}", script_path);
                 let mut child_cmd = Command::new(&script_path);
+                for arg in extra_args {
+                    child_cmd.arg(arg);
+                }
                 child_cmd.env("PLEXI_CONFIG_DIR", crate::config::config_dir());
                 return match child_cmd.status() {
                     Ok(status) => status.code().unwrap_or(1),
@@ -249,8 +252,13 @@ pub fn run_command(command_name: &str) -> i32 {
 
     // Spawn the command via sh -c with secrets injected as env vars.
     // PLEXI_CONFIG_DIR lets scripts reference channel-correct paths without hardcoding ~/.plexi/.
+    // Extra positional args from `plexi run <cmd> -- arg1 arg2` are passed via `sh -c '...' -- arg1 arg2`,
+    // making them available as $1, $2, … inside the shell snippet.
     let mut child_cmd = Command::new("sh");
-    child_cmd.arg("-c").arg(cmd_entry.run());
+    child_cmd.arg("-c").arg(cmd_entry.run()).arg("--");
+    for arg in extra_args {
+        child_cmd.arg(arg);
+    }
     child_cmd.env("PLEXI_CONFIG_DIR", crate::config::config_dir());
     for (key, value) in &resolved {
         child_cmd.env(key, value);

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,8 +206,8 @@ fn main() -> eframe::Result {
         Ok(cli) => {
             if let Some(cmd) = cli.command {
                 match cmd {
-                    Commands::Run { command } => match command {
-                        Some(cmd) => std::process::exit(cli::run_command(&cmd)),
+                    Commands::Run { command, extra_args } => match command {
+                        Some(cmd) => std::process::exit(cli::run_command(&cmd, &extra_args)),
                         None => std::process::exit(cli::run_list_commands()),
                     },
                     Commands::Workspace { cmd } => match cmd {
@@ -808,6 +808,9 @@ fn main() -> eframe::Result {
                     }
                     Commands::CompleteOpen { prefix } => {
                         std::process::exit(cli::complete_open_cli(&prefix));
+                    }
+                    Commands::CompleteRun => {
+                        std::process::exit(cli::complete_run_cli());
                     }
                     Commands::Descriptor { cmd } => match cmd {
                         DescriptorCmd::Probe {


### PR DESCRIPTION
Stint task 0185: dynamic zsh completions for `plexi run <TAB>`.

## Summary

- Added `extra_args: Vec<String>` to the `Run` CLI variant so arguments after the command name are forwarded positionally (`$1`, `$2`, …) via `sh -c '...' -- arg1 arg2`, enabling `plexi run implement-stint 0045`-style invocations
- Added hidden `_complete-run` subcommand that reads the channel-scoped `commands.toml` (via `workspace_channel_dir()`, never hardcoded `.plexi/`) and emits `name:description` pairs for zsh `_describe`; falls back to global scripts when no workspace file exists
- Added `inject_zsh_run_completions()` post-processor in `completions.rs` that patches the generated zsh script to replace the static `command` positional spec with a dynamic `__<binary>_run_completions()` helper; follows the same pattern as the existing `inject_zsh_open_completions()`
- 6 completion unit tests covering injection, idempotency, and presence of the helper function — all green

## Done When

- `plexi run <TAB>` lists available commands from `commands.toml`
- `plexi run build 0045` passes `0045` as `$1` to the shell command
- Falls back to global scripts when not in a workspace