### PR TITLE
fix(notes-picker): right-align type chips like the command palette (#2227)

### DIFF
--- a/.stint/tasks/0177-notes-picker-chip-alignment.md
+++ b/.stint/tasks/0177-notes-picker-chip-alignment.md
@@ -1,8 +1,9 @@
 ---
 id: "0177"
 title: "v1 cleanup: notes picker right-aligns type chips like the palette"
-status: todo
+status: in-progress
 estimate: "1h"
+started_at: "2026-06-13T21:40:48Z"
 sprint: "s11"
 blocked_by: []
 gh_issue:
@@ -11,6 +12,7 @@ area:
   - "ui/overlays"
 tags: []
 ---
+
 
 
 ## What

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -483,7 +483,7 @@ impl PlexiApp {
                                 entry.preview.chars().take(50).collect()
                             };
                             let row_response = ListRow::new(&entry.title)
-                                .chip(if entry.inbox { "inbox" } else { "note" })
+                                .metadata_chips(if entry.inbox { &["inbox"] } else { &["note"] })
                                 .secondary(&secondary)
                                 .trailing_action("×")
                                 .danger_trailing(true)


### PR DESCRIPTION
Closes #2227

## Summary

- Swaps `.chip()` (inline after title) to `.metadata_chips()` (right-aligned) in the notes picker row, matching the command palette's visual language
- The trailing `×` delete action coexists correctly alongside the right-aligned chip
- One-line change; existing `notes_picker_overlay_smoke` UI test covers the render path

## Done When

- [ ] Notes picker rows show "inbox"/"note" chip right-aligned, matching command palette style
- [ ] `×` delete action still visible and functional alongside chip

**Test evidence (attempt 1):**
- cargo test: 1136 passed, 0 failed — filters: full bin suite
- PlexiUiHarness render: /tmp/plexi_notes_picker.png — notes picker with "inbox" and "note" chips right-aligned, × delete visible, layout correct
- Conclusion: install skippable — full coverage