### PR TITLE
feat(assistant): ESC interrupt-and-fold turn policy + cancel seam (#2204)

### DIFF
--- a/deps/egui_commonmark_backend-0.20.0/src/misc.rs
+++ b/deps/egui_commonmark_backend-0.20.0/src/misc.rs
@@ -199,7 +199,7 @@ impl Link {
 
         let mut layout_job = LayoutJob::default();
         for t in text {
-            t.append_to(
+            t.underline().append_to(
                 &mut layout_job,
                 ui.style(),
                 egui::FontSelection::Default,

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -601,6 +601,7 @@ impl AgentHost {
             workspace_root: Some(self.workspace_root.clone()),
             open_panes: crate::plexi_ai::broker::get_pane_snapshot(),
             tool_dispatcher: Some(dispatcher),
+            cancel: crate::plexi_ai::CancelToken::new(),
         };
         let agent_id = agent.def.id.clone();
         log::info!(

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -28,6 +28,7 @@
 //! land in the agent's transcript, which is the host-visible record of what
 //! the agent said — the Phase D Assistant UI consumes this seam.
 
+use crate::app_protocol::{AiMessage, ModelTier, PayloadMode, TriggerMode};
 use crate::broker::{
     ActorType, Decision, GrantDuration, GrantStore, PermissionPosture, PermissionRequest,
     TargetType,
@@ -35,7 +36,6 @@ use crate::broker::{
 use crate::host::app_timeline::{AppTimeline, EventDelivery};
 use crate::plexi_ai::broker::{AiBroker, AiBrokerRequest};
 use crate::plexi_ai::tool_dispatch::ToolDispatcher;
-use crate::app_protocol::{AiMessage, ModelTier, PayloadMode, TriggerMode};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, Sender};
@@ -146,8 +146,8 @@ impl AgentDefinition {
         if prompt.trim().is_empty() {
             return Err("AGENT.md must be non-empty — it is the agent's system prompt".to_string());
         }
-        let settings: SettingsToml = toml::from_str(settings_toml)
-            .map_err(|e| format!("invalid settings.toml: {e}"))?;
+        let settings: SettingsToml =
+            toml::from_str(settings_toml).map_err(|e| format!("invalid settings.toml: {e}"))?;
         if settings.agent.id.trim().is_empty() {
             return Err("settings.toml: [agent] id must be non-empty".to_string());
         }
@@ -433,9 +433,15 @@ impl AgentHost {
     pub fn tick(&mut self) {
         // 1. Drain completed turns into transcripts.
         while let Ok(outcome) = self.outcome_rx.try_recv() {
-            let Some(agent) = self.agents.iter_mut().find(|a| a.def.id == outcome.agent_id)
+            let Some(agent) = self
+                .agents
+                .iter_mut()
+                .find(|a| a.def.id == outcome.agent_id)
             else {
-                log::warn!("agent: turn outcome for unknown agent '{}'", outcome.agent_id);
+                log::warn!(
+                    "agent: turn outcome for unknown agent '{}'",
+                    outcome.agent_id
+                );
                 continue;
             };
             agent.in_flight = agent.in_flight.saturating_sub(1);
@@ -483,8 +489,8 @@ impl AgentHost {
             // as the actor, or events an app emitted while servicing one of
             // its tool calls (`caused_by`). Without this, a move → move.played
             // → turn → move feedback loop plays the game against itself.
-            let self_caused = d.actor_id == self_id
-                || d.caused_by.as_deref() == Some(self_id.as_str());
+            let self_caused =
+                d.actor_id == self_id || d.caused_by.as_deref() == Some(self_id.as_str());
             if self_caused {
                 log::info!(
                     "agent[{}]: delivery {} of '{}' is self-caused — recorded, no turn",
@@ -586,10 +592,7 @@ impl AgentHost {
             .collect();
         messages.push(AiMessage {
             role: "user".to_string(),
-            content: format!(
-                "App events delivered to you:\n{}",
-                event_lines.join("\n")
-            ),
+            content: format!("App events delivered to you:\n{}", event_lines.join("\n")),
         });
 
         let request = AiBrokerRequest {
@@ -755,8 +758,8 @@ default = "ask"
         assert!(err.contains("AGENT.md"), "{err}");
 
         // Missing [agent] table.
-        let err = AgentDefinition::parse("p", "[permissions]\ndefault_posture = \"ask\"\n")
-            .unwrap_err();
+        let err =
+            AgentDefinition::parse("p", "[permissions]\ndefault_posture = \"ask\"\n").unwrap_err();
         assert!(err.contains("settings.toml"), "{err}");
 
         // Bad tier.
@@ -821,9 +824,7 @@ default_tier = "low"
     /// and switching away detaches them and removes their subscriptions.
     #[test]
     fn reload_workspace_attaches_and_detaches_agents() {
-        use crate::broker::{
-            ActorScope, GrantRecord, GrantSource, ResourceScope,
-        };
+        use crate::broker::{ActorScope, GrantRecord, GrantSource, ResourceScope};
 
         let ws = tempfile::tempdir().unwrap();
         let agent_dir = ws
@@ -896,11 +897,8 @@ default_tier = "low"
         use crate::host::app_timeline::EventDelivery;
 
         let timeline = Arc::new(Mutex::new(AppTimeline::default()));
-        let mut host = AgentHost::new_for_test(
-            timeline,
-            Arc::new(InertAiBroker),
-            std::env::temp_dir(),
-        );
+        let mut host =
+            AgentHost::new_for_test(timeline, Arc::new(InertAiBroker), std::env::temp_dir());
         host.attach(AgentDefinition::parse("prose", SETTINGS).unwrap());
         assert_eq!(host.agents[0].in_flight, 0);
 
@@ -928,16 +926,29 @@ default_tier = "low"
         // Agent's own move (actor_id matches its caller identity): no turn.
         host.handle_deliveries(
             0,
-            vec![delivery(1, AppEventActor::Agent, "agent:chess-opponent", None)],
+            vec![delivery(
+                1,
+                AppEventActor::Agent,
+                "agent:chess-opponent",
+                None,
+            )],
         );
         assert_eq!(host.agents[0].in_flight, 0, "own action must not trigger");
 
         // App-emitted event caused by the agent's tool call: no turn.
         host.handle_deliveries(
             0,
-            vec![delivery(2, AppEventActor::App, "chess", Some("agent:chess-opponent"))],
+            vec![delivery(
+                2,
+                AppEventActor::App,
+                "chess",
+                Some("agent:chess-opponent"),
+            )],
         );
-        assert_eq!(host.agents[0].in_flight, 0, "caused-by-self must not trigger");
+        assert_eq!(
+            host.agents[0].in_flight, 0,
+            "caused-by-self must not trigger"
+        );
 
         // Both still land in the transcript as event lines.
         assert_eq!(host.agents[0].transcript.len(), 2);

--- a/src/app/account.rs
+++ b/src/app/account.rs
@@ -105,7 +105,10 @@ impl AccountStore {
                 Ok(())
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-            Err(e) => Err(format!("could not clear session {}: {e}", self.path.display())),
+            Err(e) => Err(format!(
+                "could not clear session {}: {e}",
+                self.path.display()
+            )),
         }
     }
 }

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -178,7 +178,10 @@ mod tests {
 
         // Idle frame first: no tick.
         let _ = h.app.drain_all_app_commands();
-        assert_eq!(h.app.background_apps["notify-app"].1.background_tick_count, 0);
+        assert_eq!(
+            h.app.background_apps["notify-app"].1.background_tick_count,
+            0
+        );
 
         // App emits a notification: the stdout reader sends the command, then
         // sets draw_pending (and wakes the host via repaint_ctx in prod).
@@ -345,6 +348,7 @@ impl PlexiApp {
         if disposition == crate::app::app_trait::KeyDisposition::Consumed {
             ctx.input_mut(|i| {
                 i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+                i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp);
             });
         }
     }

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -577,10 +577,13 @@ impl PlexiApp {
         let new_colors = crate::ui::theme::Colors::from_config(&theme_cfg);
         if self.colors != new_colors {
             self.colors = new_colors;
-            let dark_mode =
-                !crate::ui::theme::is_light_preset(
-                    fresh.theme.as_ref().and_then(|t| t.preset.as_deref()).unwrap_or(""),
-                );
+            let dark_mode = !crate::ui::theme::is_light_preset(
+                fresh
+                    .theme
+                    .as_ref()
+                    .and_then(|t| t.preset.as_deref())
+                    .unwrap_or(""),
+            );
             crate::ui::theme::setup_style(&self.ctx, &new_colors, dark_mode);
             let window_theme = if dark_mode {
                 egui::SystemTheme::Dark
@@ -657,7 +660,12 @@ impl PlexiApp {
     /// Auto-switch to the paired preset for `system_theme`.
     /// No-ops if the configured preset has no paired variant (e.g. nord, dracula).
     pub(super) fn apply_auto_theme(&mut self, system_theme: egui::Theme) {
-        let current_preset = self.config.theme.as_ref().and_then(|t| t.preset.as_deref()).unwrap_or("");
+        let current_preset = self
+            .config
+            .theme
+            .as_ref()
+            .and_then(|t| t.preset.as_deref())
+            .unwrap_or("");
         let Some(new_preset) = crate::ui::theme::paired_preset(current_preset, system_theme) else {
             return;
         };

--- a/src/app/host_version.rs
+++ b/src/app/host_version.rs
@@ -150,9 +150,15 @@ mod tests {
         assert!(v.is_blocking());
         assert!(matches!(v, VersionVerdict::TooOld { .. }));
         // exactly at min is fine
-        assert_eq!(check(Some("0.0.760"), None, Version(0, 0, 760)), VersionVerdict::Ok);
+        assert_eq!(
+            check(Some("0.0.760"), None, Version(0, 0, 760)),
+            VersionVerdict::Ok
+        );
         // above min is fine
-        assert_eq!(check(Some("0.0.760"), None, Version(0, 1, 0)), VersionVerdict::Ok);
+        assert_eq!(
+            check(Some("0.0.760"), None, Version(0, 1, 0)),
+            VersionVerdict::Ok
+        );
     }
 
     #[test]
@@ -161,14 +167,23 @@ mod tests {
         assert!(!v.is_blocking(), "too-new must warn, not block");
         assert!(matches!(v, VersionVerdict::TooNew { .. }));
         // at or below max is fine
-        assert_eq!(check(None, Some("0.0.760"), Version(0, 0, 760)), VersionVerdict::Ok);
+        assert_eq!(
+            check(None, Some("0.0.760"), Version(0, 0, 760)),
+            VersionVerdict::Ok
+        );
     }
 
     #[test]
     fn malformed_requirement_blocks() {
         let v = check(Some("not-a-version"), None, Version(0, 0, 760));
         assert!(v.is_blocking());
-        assert!(matches!(v, VersionVerdict::Malformed { field: "plexi_min", .. }));
+        assert!(matches!(
+            v,
+            VersionVerdict::Malformed {
+                field: "plexi_min",
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -344,7 +344,10 @@ impl PlexiApp {
                     }
                 }
             }
-            crate::app_protocol::AppRequest::GetPreviousPaneInfo { response_file, steps } => {
+            crate::app_protocol::AppRequest::GetPreviousPaneInfo {
+                response_file,
+                steps,
+            } => {
                 let steps = (*steps).max(1);
                 log::info!(
                     "pane_ipc: kind=get_previous_pane_info steps={steps} response_file={:?}",

--- a/src/app/marketplace.rs
+++ b/src/app/marketplace.rs
@@ -233,7 +233,11 @@ impl RegistryEntry {
             version: report.version.clone(),
             description: String::new(),
             publisher: marketplace.publisher.clone().unwrap_or_default(),
-            capabilities: report.capabilities.iter().map(|c| c.as_str().to_string()).collect(),
+            capabilities: report
+                .capabilities
+                .iter()
+                .map(|c| c.as_str().to_string())
+                .collect(),
             tags,
             trust_label: trust_label.to_string(),
             visibility: marketplace.visibility,
@@ -326,7 +330,10 @@ impl RegistryClient {
 
     /// Fetch and parse the catalog index.
     pub fn fetch_index(&self) -> Result<RegistryIndex, RegistryError> {
-        log::info!("marketplace: fetching registry index from {}", self.index_url);
+        log::info!(
+            "marketplace: fetching registry index from {}",
+            self.index_url
+        );
         let body = Self::agent()
             .get(&self.index_url)
             .call()
@@ -372,14 +379,18 @@ impl RegistryClient {
         dest: &std::path::Path,
     ) -> Result<PathBuf, RegistryError> {
         let url = self.artifact_url(entry);
-        log::info!("marketplace: downloading '{}' artifact from {url}", entry.id);
+        log::info!(
+            "marketplace: downloading '{}' artifact from {url}",
+            entry.id
+        );
         let resp = Self::agent()
             .get(&url)
             .call()
             .map_err(|e| RegistryError::Download(e.to_string()))?;
         if let Some(parent) = dest.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| RegistryError::Download(format!("create {}: {e}", parent.display())))?;
+            std::fs::create_dir_all(parent).map_err(|e| {
+                RegistryError::Download(format!("create {}: {e}", parent.display()))
+            })?;
         }
         let mut reader = resp.into_reader();
         let mut file = std::fs::File::create(dest)
@@ -397,7 +408,11 @@ impl RegistryClient {
                 actual,
             });
         }
-        log::info!("marketplace: downloaded + verified '{}' to {}", entry.id, dest.display());
+        log::info!(
+            "marketplace: downloaded + verified '{}' to {}",
+            entry.id,
+            dest.display()
+        );
         Ok(dest.to_path_buf())
     }
 }
@@ -944,6 +959,9 @@ mod tests {
         );
         let mut e2 = e.clone();
         e2.package_url = Some("https://direct.example/a.plexipkg".to_string());
-        assert_eq!(client.artifact_url(&e2), "https://direct.example/a.plexipkg");
+        assert_eq!(
+            client.artifact_url(&e2),
+            "https://direct.example/a.plexipkg"
+        );
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,9 +1,9 @@
 pub mod account;
 pub mod app_trait;
 mod canvas_bindings;
-pub mod host_version;
 mod dispatch;
 mod focus;
+pub mod host_version;
 mod lifecycle;
 pub mod marketplace;
 pub(crate) mod notification_image;
@@ -3214,7 +3214,10 @@ impl eframe::App for PlexiApp {
                             self.delete_context(idx);
                             self.save_workspace();
                         } else {
-                            log::info!("close_context: ctx={ctx_id} has {} panes, showing confirm dialog", state.items.len());
+                            log::info!(
+                                "close_context: ctx={ctx_id} has {} panes, showing confirm dialog",
+                                state.items.len()
+                            );
                             self.pending_context_close = Some(state);
                         }
                     }

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -371,11 +371,7 @@ impl AppRegistry {
             }
             let local_agents = root.join(&channel_dir).join("agents");
             if local_agents.is_dir() {
-                registry.scan_dir(
-                    &local_agents,
-                    RegistrySource::LocalAgent,
-                    Some(root),
-                );
+                registry.scan_dir(&local_agents, RegistrySource::LocalAgent, Some(root));
             }
         }
 

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -1716,8 +1716,7 @@ fn closing_last_pane_in_subcontext_collapses_and_zooms_out() {
     });
 
     // Zoom Root → child, as sidebar/portal zoom does.
-    app.router
-        .push_depth(root_id, root_win_id, Some(root_tile));
+    app.router.push_depth(root_id, root_win_id, Some(root_tile));
     let child_idx = app.router.position(|c| c.context_id == child_id).unwrap();
     app.switch_workspace(child_idx);
     assert_eq!(app.router.active().context_id, child_id);

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -78,7 +78,11 @@ fn wake_request_is_noop_on_host() {
     h.inject_ipc(crate::app_protocol::AppRequest::Wake);
     h.app.drain_pane_cmd_channel();
 
-    assert_eq!(h.app.windows.len(), windows_before, "wake must not touch windows");
+    assert_eq!(
+        h.app.windows.len(),
+        windows_before,
+        "wake must not touch windows"
+    );
     let panes_after: usize = h.app.windows.iter().map(|w| w.panes.len()).sum();
     assert_eq!(panes_after, panes_before, "wake must not touch panes");
 }

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -386,11 +386,7 @@ enum Durability {
     Fast,
 }
 
-fn write_note_atomically(
-    path: &Path,
-    bytes: &[u8],
-    durability: Durability,
-) -> std::io::Result<()> {
+fn write_note_atomically(path: &Path, bytes: &[u8], durability: Durability) -> std::io::Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -523,19 +519,20 @@ impl App for TextEditorApp {
             .show(ui, |ui| {
                 // egui's caret is hidden (transparent, non-blinking) and
                 // draw_text_caret paints a glyph-height replacement on top.
-                let output = ui.scope(|ui| {
-                    ui.visuals_mut().text_cursor.blink = false;
-                    ui.visuals_mut().text_cursor.stroke.color =
-                        egui::Color32::TRANSPARENT;
-                    egui::TextEdit::multiline(&mut self.content)
-                        .id(te_id)
-                        .font(font_id)
-                        .desired_width(f32::INFINITY)
-                        .desired_rows(min_rows)
-                        .margin(egui::vec2(4.0, 0.0))
-                        .frame(false)
-                        .show(ui)
-                }).inner;
+                let output = ui
+                    .scope(|ui| {
+                        ui.visuals_mut().text_cursor.blink = false;
+                        ui.visuals_mut().text_cursor.stroke.color = egui::Color32::TRANSPARENT;
+                        egui::TextEdit::multiline(&mut self.content)
+                            .id(te_id)
+                            .font(font_id)
+                            .desired_width(f32::INFINITY)
+                            .desired_rows(min_rows)
+                            .margin(egui::vec2(4.0, 0.0))
+                            .frame(false)
+                            .show(ui)
+                    })
+                    .inner;
                 crate::ui::text_field::draw_text_caret(
                     ui,
                     &output,

--- a/src/assistant/commands.rs
+++ b/src/assistant/commands.rs
@@ -17,16 +17,25 @@ pub struct ParsedCommand {
 /// `/clear`, `/new`, and `/help` are implemented in Phase 1; the rest are
 /// recognized and answered with a "not yet implemented" assistant row.
 pub const BUILT_IN_COMMANDS: &[(&str, &str)] = &[
-    ("help", "Show built-in commands, installed skills, and tool packs."),
+    (
+        "help",
+        "Show built-in commands, installed skills, and tool packs.",
+    ),
     ("clear", "Start a new conversation in the same workspace."),
     ("resume", "Open a previous Assistant session."),
-    ("compact", "Summarize older turns and keep the active task context."),
+    (
+        "compact",
+        "Summarize older turns and keep the active task context.",
+    ),
     (
         "context",
         "Show token use, loaded instructions, active pane/app context, and enabled tools.",
     ),
     ("memory", "Show agent prompt files and future memory state."),
-    ("model", "Switch model tier or backend for this session/agent."),
+    (
+        "model",
+        "Switch model tier or backend for this session/agent.",
+    ),
     ("effort", "Switch reasoning effort for this session/agent."),
     ("agent", "Switch, inspect, create, or edit agents."),
     ("settings", "Open Assistant settings."),
@@ -40,8 +49,14 @@ pub const BUILT_IN_COMMANDS: &[(&str, &str)] = &[
         "Show enabled host tools, app connectors, MCP tools, and tool collections.",
     ),
     ("apps", "Show app connectors available in the workspace."),
-    ("skills", "Show installed skills and marketplace skill packs."),
-    ("install", "Install a local or marketplace skill/tool/agent package."),
+    (
+        "skills",
+        "Show installed skills and marketplace skill packs.",
+    ),
+    (
+        "install",
+        "Install a local or marketplace skill/tool/agent package.",
+    ),
     ("hooks", "Show lifecycle hooks and their source."),
     (
         "audit",
@@ -49,10 +64,22 @@ pub const BUILT_IN_COMMANDS: &[(&str, &str)] = &[
     ),
     ("revoke", "Revoke a persisted grant by target id."),
     ("export", "Export the current transcript and tool-call log."),
-    ("rewind", "Restore the conversation to an earlier checkpoint."),
-    ("new", "Create a new named conversation without deleting the current one."),
-    ("history", "Open conversation history and checkpoint browser."),
-    ("thoughts", "Show or hide the model's reasoning for every turn."),
+    (
+        "rewind",
+        "Restore the conversation to an earlier checkpoint.",
+    ),
+    (
+        "new",
+        "Create a new named conversation without deleting the current one.",
+    ),
+    (
+        "history",
+        "Open conversation history and checkpoint browser.",
+    ),
+    (
+        "thoughts",
+        "Show or hide the model's reasoning for every turn.",
+    ),
 ];
 
 /// Commands with a real implementation (Phase 1: help/clear/new; Phase 2:
@@ -193,11 +220,14 @@ mod tests {
         let all = filter_commands("");
         assert_eq!(all.len(), BUILT_IN_COMMANDS.len());
         let hits = filter_commands("perm");
-        assert_eq!(hits, vec![BUILT_IN_COMMANDS
-            .iter()
-            .copied()
-            .find(|(n, _)| *n == "permissions")
-            .unwrap()]);
+        assert_eq!(
+            hits,
+            vec![BUILT_IN_COMMANDS
+                .iter()
+                .copied()
+                .find(|(n, _)| *n == "permissions")
+                .unwrap()]
+        );
         assert!(filter_commands("zzz").is_empty());
     }
 

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -27,6 +27,7 @@ use crate::broker::{
 use crate::host::app_timeline::{AppTimeline, SubscriptionRecord};
 use crate::plexi_ai::broker::{AiBroker, AiBrokerRequest};
 use crate::plexi_ai::turn_loop::TurnDelta;
+use crate::plexi_ai::CancelToken;
 
 /// Owned streaming delta forwarded from the broker worker thread to the UI
 /// thread (`TurnDelta` borrows from the stream buffer and cannot cross the
@@ -57,6 +58,10 @@ you to react when something happens, your FIRST action must be to call \
 host.events.subscribe for that app's relevant events — without a subscription you \
 will never see the user's actions, so do not assume you will be notified. After \
 subscribing, tell the user you are now watching those events. \
+When a delivered event hands you the turn, ACT: if the situation calls for a \
+tool call, make it immediately rather than only describing what you would do. \
+Do not narrate intentions you can carry out — take the action, then report the \
+result. \
 Pane and terminal control arrives in a later phase — when \
 asked to act on panes, explain that those tools are not wired up yet.";
 
@@ -200,6 +205,10 @@ pub struct AssistantApp {
     /// Trigger lines for non-self-caused deliveries that arrived while a
     /// turn was in flight — folded into the next dispatched turn.
     queued_event_lines: Vec<String>,
+    /// Cancellation handle for the in-flight turn. A fresh token is installed
+    /// at each `start_turn`; ESC and event-preempt trip it to abort the
+    /// streaming turn and fold queued context into an immediate follow-up.
+    turn_cancel: CancelToken,
     /// Cached layout state for `egui_commonmark` markdown rendering of
     /// assistant replies. Persists across frames for performance.
     commonmark_cache: egui_commonmark::CommonMarkCache,
@@ -279,6 +288,7 @@ impl AssistantApp {
             live_subs: Vec::new(),
             pending_subscribe: None,
             queued_event_lines: Vec::new(),
+            turn_cancel: CancelToken::new(),
             commonmark_cache: egui_commonmark::CommonMarkCache::default(),
             markdown_text_cache: MarkdownTextCache::default(),
         };
@@ -669,6 +679,10 @@ impl AssistantApp {
     fn start_turn(&mut self, conversation_id: String, _prompt: String) {
         let (delta_tx, delta_rx) = std::sync::mpsc::channel();
         self.delta_rx = Some(delta_rx);
+        // Fresh cancel token per turn — a clone goes to the worker/broker, the
+        // original stays here so ESC and event-preempt can trip this turn only.
+        let cancel = CancelToken::new();
+        self.turn_cancel = cancel.clone();
         let dispatcher = self.gated_dispatcher();
         let request = AiBrokerRequest {
             app_id: "assistant".to_string(),
@@ -679,6 +693,7 @@ impl AssistantApp {
             workspace_root: Some(self.workspace_root.clone()),
             open_panes: crate::plexi_ai::broker::get_pane_snapshot(),
             tool_dispatcher: Some(Arc::new(dispatcher)),
+            cancel,
         };
         log::info!(
             "assistant[{conversation_id}]: dispatching turn ({} message(s))",
@@ -849,11 +864,17 @@ impl AssistantApp {
             return;
         }
         if self.model.streaming.in_flight {
+            // Preempt: the world changed under the in-flight turn (e.g. the
+            // game board moved). Queue the new lines and trip the cancel token
+            // so the current turn ends fast and the pump folds these into an
+            // immediate follow-up that reacts to the latest state — instead of
+            // finishing a now-stale comment (the 6-26s queue-behind lag).
             log::info!(
-                "assistant: {} event line(s) queued — turn in flight",
+                "assistant: {} event line(s) queued, preempting in-flight turn",
                 trigger_lines.len()
             );
             self.queued_event_lines.extend(trigger_lines);
+            self.turn_cancel.cancel();
         } else {
             self.start_event_turn(trigger_lines.len());
         }
@@ -878,6 +899,40 @@ impl AssistantApp {
         self.model.turn_anchor = Some(self.model.turns.len());
         let conversation_id = self.model.conversation_id.clone();
         self.start_turn(conversation_id, String::new());
+    }
+
+    /// User pressed ESC during an in-flight turn. Stop generating, and if the
+    /// composer holds a draft, queue it so the pump folds it into an immediate
+    /// follow-up turn (stop-and-send). With an empty composer this is a plain
+    /// stop. Default typing-while-streaming still queues silently (see
+    /// `AssistantModel::submit`); ESC is the explicit interrupt.
+    fn interrupt_in_flight_turn(&mut self) {
+        if !self.model.streaming.in_flight {
+            return;
+        }
+        // A pending draft becomes a queued user turn first, so the folded
+        // follow-up dispatched after cancel includes it.
+        if !self.model.composer.trim().is_empty() {
+            let effects = self.model.submit();
+            self.execute_effects(effects);
+        }
+        self.turn_cancel.cancel();
+        // Unblock a worker parked on a permission sheet so it observes the
+        // cancel at the next tool-loop boundary instead of hanging.
+        if let Some(tx) = self.pending_reply.take() {
+            let _ = tx.send(PermissionReply::Deny);
+        }
+        if let Some(pending) = self.pending_subscribe.take() {
+            let _ = pending.reply.send(ToolCallResult {
+                output_json: None,
+                error: Some("cancelled: interrupted by user (ESC)".to_string()),
+            });
+        }
+        log::info!(
+            "assistant: ESC interrupt — cancelling in-flight turn ({} queued user message(s), {} queued event line(s))",
+            self.model.queued_user_turns,
+            self.queued_event_lines.len()
+        );
     }
 
     /// Apply the user's permission-sheet decision: record the grant per its
@@ -1226,6 +1281,7 @@ impl App for AssistantApp {
                 let effects = self.model.submit();
                 self.execute_effects(effects);
             }
+            Some(ComposerEvent::Interrupt) => self.interrupt_in_flight_turn(),
             Some(ComposerEvent::Permission(choice)) => self.resolve_permission(choice),
             None => {}
         }
@@ -1849,6 +1905,10 @@ mod tests {
         app.pump_turn_io();
         assert_eq!(event_rows(&app), 1, "row appended even while in flight");
         assert_eq!(app.queued_event_lines.len(), 1);
+        assert!(
+            app.turn_cancel.is_cancelled(),
+            "a mid-turn event must preempt the in-flight turn, not just queue behind it"
+        );
 
         // The turn ends: the queued event triggers the follow-up turn.
         app.model.streaming = model::StreamingState::default();
@@ -1865,6 +1925,104 @@ mod tests {
         );
         wait_for_turn(&mut app);
         assert_eq!(app.model.turns.last().unwrap().text, "echo: ok");
+    }
+
+    /// ESC mid-turn with a pending draft: the in-flight turn is cancelled and
+    /// the draft is folded into an immediate follow-up turn. The cancelled
+    /// turn commits no empty bubble.
+    #[test]
+    fn esc_interrupt_folds_queued_draft_into_followup() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        /// Turn 1 blocks until the cancel token trips (simulating a long
+        /// stream the user ESCs); the folded follow-up replies immediately.
+        struct InterruptibleBroker {
+            dispatched: AtomicUsize,
+        }
+        impl AiBroker for InterruptibleBroker {
+            fn dispatch(
+                &self,
+                request: AiBrokerRequest,
+                on_delta: &mut dyn FnMut(TurnDelta<'_>),
+            ) -> AiBrokerResponse {
+                let n = self.dispatched.fetch_add(1, Ordering::SeqCst) + 1;
+                if n == 1 {
+                    let start = std::time::Instant::now();
+                    while !request.cancel.is_cancelled() {
+                        if start.elapsed() > std::time::Duration::from_secs(5) {
+                            break;
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(1));
+                    }
+                    // Cancelled before any text streamed: empty partial.
+                    return AiBrokerResponse::ok(String::new(), 0, 0);
+                }
+                on_delta(TurnDelta::Text("folded reply"));
+                AiBrokerResponse::ok("folded reply".to_string(), 1, 1)
+            }
+        }
+
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = AssistantApp::new(
+            ws.path().to_path_buf(),
+            Arc::new(InterruptibleBroker {
+                dispatched: AtomicUsize::new(0),
+            }),
+            ws.path(),
+        );
+
+        // Turn 1 starts and parks in the broker.
+        app.model.composer = "start".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        assert!(app.model.streaming.in_flight, "turn 1 must be in flight");
+
+        // User types a follow-up and hits ESC.
+        app.model.composer = "actually do X".to_string();
+        app.interrupt_in_flight_turn();
+        assert!(app.turn_cancel.is_cancelled(), "ESC must trip the cancel token");
+        assert_eq!(
+            app.model.queued_user_turns, 1,
+            "the draft must be queued for the fold"
+        );
+
+        // Drive to idle: turn 1 unblocks (cancelled), the fold dispatches turn 2.
+        let start = std::time::Instant::now();
+        loop {
+            app.pump_turn_io();
+            let idle = !app.model.streaming.in_flight
+                && app.queued_event_lines.is_empty()
+                && app.model.queued_user_turns == 0;
+            if idle {
+                break;
+            }
+            assert!(
+                start.elapsed() < std::time::Duration::from_secs(8),
+                "assistant never reached idle after interrupt"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+
+        // The folded follow-up replied; the draft is in the transcript.
+        assert_eq!(app.model.turns.last().unwrap().text, "folded reply");
+        assert!(
+            app.model
+                .turns
+                .iter()
+                .any(|t| t.role == TurnRole::User && t.text == "actually do X"),
+            "the interrupted-and-folded draft must be in the transcript"
+        );
+        // The cancelled turn left no empty assistant bubble.
+        let empty_assistant = app
+            .model
+            .turns
+            .iter()
+            .filter(|t| t.role == TurnRole::Assistant && t.text.is_empty())
+            .count();
+        assert_eq!(
+            empty_assistant, 0,
+            "a cancelled turn must not commit an empty assistant bubble"
+        );
     }
 
     #[test]

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -410,17 +410,9 @@ impl AssistantApp {
                 // unblock worker threads parked on a permission reply so they
                 // can finish and have their stale outcome dropped.
                 AssistantEffect::CancelTurn => {
-                    if let Some(tx) = self.pending_reply.take() {
-                        let _ = tx.send(PermissionReply::Deny);
-                    }
-                    if let Some(pending) = self.pending_subscribe.take() {
-                        let _ = pending.reply.send(ToolCallResult {
-                            output_json: None,
-                            error: Some(
-                                "cancelled: the conversation was cleared mid-turn".to_string(),
-                            ),
-                        });
-                    }
+                    self.unblock_pending_workers(
+                        "cancelled: the conversation was cleared mid-turn",
+                    );
                     log::info!("assistant: in-flight turn cancelled by conversation switch");
                 }
                 // Phase 3 stub: correctly shaped, logged, never panics.
@@ -919,20 +911,28 @@ impl AssistantApp {
         self.turn_cancel.cancel();
         // Unblock a worker parked on a permission sheet so it observes the
         // cancel at the next tool-loop boundary instead of hanging.
+        self.unblock_pending_workers("cancelled: interrupted by user (ESC)");
+        log::info!(
+            "assistant: ESC interrupt — cancelling in-flight turn ({} queued user message(s), {} queued event line(s))",
+            self.model.queued_user_turns,
+            self.queued_event_lines.len()
+        );
+    }
+
+    /// Unblock any worker thread parked on a permission sheet or pending
+    /// subscribe so it observes the cancel token at the next tool-loop
+    /// boundary instead of hanging. Shared by conversation-switch cancel and
+    /// ESC interrupt. `reason` is surfaced to the blocked subscribe caller.
+    fn unblock_pending_workers(&mut self, reason: &str) {
         if let Some(tx) = self.pending_reply.take() {
             let _ = tx.send(PermissionReply::Deny);
         }
         if let Some(pending) = self.pending_subscribe.take() {
             let _ = pending.reply.send(ToolCallResult {
                 output_json: None,
-                error: Some("cancelled: interrupted by user (ESC)".to_string()),
+                error: Some(reason.to_string()),
             });
         }
-        log::info!(
-            "assistant: ESC interrupt — cancelling in-flight turn ({} queued user message(s), {} queued event line(s))",
-            self.model.queued_user_turns,
-            self.queued_event_lines.len()
-        );
     }
 
     /// Apply the user's permission-sheet decision: record the grant per its

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, Sender, SyncSender};
 use std::sync::{Arc, Mutex};
 
-use crate::app::app_trait::{App, AppRenderContext};
+use crate::app::app_trait::{App, AppRenderContext, KeyDisposition};
 use crate::app_protocol::{AiMessage, AiTool, ModelTier, PayloadMode, TriggerMode};
 use crate::broker::{
     ActorScope, ActorType, Decision, GrantDuration, GrantRecord, GrantSource, GrantStore,
@@ -84,7 +84,9 @@ struct TurnOutcome {
 enum PermissionReply {
     /// Run the call. `remember` lets the in-turn gate skip re-asking for the
     /// same tool (session/always grants).
-    Allow { remember: bool },
+    Allow {
+        remember: bool,
+    },
     Deny,
 }
 
@@ -126,8 +128,8 @@ struct AssistantToolHooks {
 
 impl ToolCallHooks for AssistantToolHooks {
     fn before_call(&self, name: &str, input_json: &str) -> Result<(), String> {
-        let needs_ask = self.ask_tools.contains(name)
-            && !self.session_allowed.lock().unwrap().contains(name);
+        let needs_ask =
+            self.ask_tools.contains(name) && !self.session_allowed.lock().unwrap().contains(name);
         if needs_ask {
             let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel(1);
             self.flow_tx
@@ -348,22 +350,25 @@ impl AssistantApp {
             return;
         }
         let subscription_id = format!("assistant-sub-{}", uuid::Uuid::new_v4());
-        self.timeline.lock().unwrap().add_subscription(SubscriptionRecord {
-            subscription_id: subscription_id.clone(),
-            subscriber_type: ActorType::Agent,
-            subscriber_id: ASSISTANT_ACTOR_ID.to_string(),
-            app_id: app.to_string(),
-            event_names: if event == "*" {
-                Vec::new()
-            } else {
-                vec![event.to_string()]
-            },
-            payload_mode: PayloadMode::Full,
-            trigger_mode: TriggerMode::Conversation,
-            resource_id: None,
-            duration: GrantDuration::Session,
-            created_at: crate::host::event_log::now_timestamp(),
-        });
+        self.timeline
+            .lock()
+            .unwrap()
+            .add_subscription(SubscriptionRecord {
+                subscription_id: subscription_id.clone(),
+                subscriber_type: ActorType::Agent,
+                subscriber_id: ASSISTANT_ACTOR_ID.to_string(),
+                app_id: app.to_string(),
+                event_names: if event == "*" {
+                    Vec::new()
+                } else {
+                    vec![event.to_string()]
+                },
+                payload_mode: PayloadMode::Full,
+                trigger_mode: TriggerMode::Conversation,
+                resource_id: None,
+                duration: GrantDuration::Session,
+                created_at: crate::host::event_log::now_timestamp(),
+            });
         log::info!("assistant: subscribed to '{target}' ({subscription_id})");
         self.live_subs.push((target, subscription_id));
     }
@@ -536,10 +541,10 @@ impl AssistantApp {
 
     /// Persist the active conversation id and the full transcript.
     fn session_write(&mut self) {
-        if let Err(e) = self
-            .store
-            .set_active_conversation(&self.model.conversation_id, self.model.session_name.as_deref())
-        {
+        if let Err(e) = self.store.set_active_conversation(
+            &self.model.conversation_id,
+            self.model.session_name.as_deref(),
+        ) {
             log::error!("assistant: failed to persist active conversation: {e}");
         }
         if let Err(e) = self
@@ -580,7 +585,12 @@ impl AssistantApp {
     /// Execute one `host.events.*` call on the UI thread. Replies on the
     /// worker's channel — except an ask-gated subscribe, which parks the
     /// reply in `pending_subscribe` until the permission sheet resolves.
-    fn handle_host_call(&mut self, tool: &str, input_json: &str, reply: SyncSender<ToolCallResult>) {
+    fn handle_host_call(
+        &mut self,
+        tool: &str,
+        input_json: &str,
+        reply: SyncSender<ToolCallResult>,
+    ) {
         let err = |msg: String| ToolCallResult {
             output_json: None,
             error: Some(msg),
@@ -592,8 +602,14 @@ impl AssistantApp {
         let parsed: Result<serde_json::Value, _> = serde_json::from_str(input_json);
         let (app, event) = match &parsed {
             Ok(v) => (
-                v.get("app").and_then(|a| a.as_str()).unwrap_or("").to_string(),
-                v.get("event").and_then(|e| e.as_str()).unwrap_or("").to_string(),
+                v.get("app")
+                    .and_then(|a| a.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                v.get("event")
+                    .and_then(|e| e.as_str())
+                    .unwrap_or("")
+                    .to_string(),
             ),
             Err(e) => {
                 let _ = reply.send(err(format!("invalid_input: {e}")));
@@ -602,7 +618,7 @@ impl AssistantApp {
         };
         if app.trim().is_empty() || event.trim().is_empty() {
             let _ = reply.send(err(
-                "invalid_input: 'app' and 'event' must be non-empty".to_string(),
+                "invalid_input: 'app' and 'event' must be non-empty".to_string()
             ));
             return;
         }
@@ -637,7 +653,8 @@ impl AssistantApp {
                     }
                     Decision::Ask => {
                         log::info!("assistant: permission sheet shown for stream '{target}'");
-                        self.model.permission_requested(HOST_TOOL_SUBSCRIBE, &target);
+                        self.model
+                            .permission_requested(HOST_TOOL_SUBSCRIBE, &target);
                         self.pending_subscribe = Some(PendingSubscribe {
                             app,
                             event,
@@ -846,7 +863,9 @@ impl AssistantApp {
                     ""
                 }
             );
-            self.model.turns.push(model::Turn::now(TurnRole::Event, line.clone()));
+            self.model
+                .turns
+                .push(model::Turn::now(TurnRole::Event, line.clone()));
             if !self_caused {
                 trigger_lines.push(line);
             }
@@ -948,7 +967,9 @@ impl AssistantApp {
         let target = Self::connector_target(&pending.tool);
         let (decision_str, reply) = match choice {
             PermissionChoice::Deny => ("deny", PermissionReply::Deny),
-            PermissionChoice::AllowOnce => ("allow_once", PermissionReply::Allow { remember: false }),
+            PermissionChoice::AllowOnce => {
+                ("allow_once", PermissionReply::Allow { remember: false })
+            }
             PermissionChoice::AllowSession => {
                 self.record_assistant_grant(
                     TargetType::AppConnector,
@@ -969,7 +990,10 @@ impl AssistantApp {
                 ("allow_always", PermissionReply::Allow { remember: true })
             }
         };
-        log::info!("assistant: permission sheet decision for '{}' = {decision_str}", pending.tool);
+        log::info!(
+            "assistant: permission sheet decision for '{}' = {decision_str}",
+            pending.tool
+        );
         self.audit.append(&AuditEvent::now(
             "permission_decision",
             &target,
@@ -1161,7 +1185,10 @@ impl AssistantApp {
                 )
             })
             .collect();
-        log::info!("assistant: /permissions — {} grant(s) for assistant", lines.len());
+        log::info!(
+            "assistant: /permissions — {} grant(s) for assistant",
+            lines.len()
+        );
         let text = if lines.is_empty() {
             "No persisted grants for the assistant. Tool calls will ask.".to_string()
         } else {
@@ -1252,12 +1279,29 @@ impl App for AssistantApp {
         true
     }
 
+    fn handle_key(&mut self, input: &egui::InputState) -> KeyDisposition {
+        if input.key_pressed(egui::Key::Escape) && self.model.streaming.in_flight {
+            self.interrupt_in_flight_turn();
+            return KeyDisposition::Consumed;
+        }
+        if !input.modifiers.any()
+            && input.key_pressed(egui::Key::ArrowUp)
+            && self.model.recall_previous_user_message()
+        {
+            return KeyDisposition::Consumed;
+        }
+        KeyDisposition::Passthrough
+    }
+
     fn rename_seed(&self) -> Option<String> {
         self.model.session_name.clone()
     }
 
     fn on_pane_renamed(&mut self, name: &str) {
-        log::info!("assistant[{}]: pane renamed to '{name}'", self.model.conversation_id);
+        log::info!(
+            "assistant[{}]: pane renamed to '{name}'",
+            self.model.conversation_id
+        );
         self.model.set_session_name(name);
         self.session_write();
     }
@@ -1266,7 +1310,8 @@ impl App for AssistantApp {
         self.pump_turn_io();
         if self.model.streaming.in_flight {
             // Keep frames coming while a worker thread streams a turn.
-            ui.ctx().request_repaint_after(std::time::Duration::from_millis(50));
+            ui.ctx()
+                .request_repaint_after(std::time::Duration::from_millis(50));
         }
         let event = AssistantRenderer::draw(
             ui,
@@ -1281,7 +1326,6 @@ impl App for AssistantApp {
                 let effects = self.model.submit();
                 self.execute_effects(effects);
             }
-            Some(ComposerEvent::Interrupt) => self.interrupt_in_flight_turn(),
             Some(ComposerEvent::Permission(choice)) => self.resolve_permission(choice),
             None => {}
         }
@@ -1301,7 +1345,9 @@ mod tests {
 
     impl MockBroker {
         fn ok(reply: impl Into<String>) -> Arc<Self> {
-            Arc::new(Self { reply: Some(reply.into()) })
+            Arc::new(Self {
+                reply: Some(reply.into()),
+            })
         }
         fn error() -> Arc<Self> {
             Arc::new(Self { reply: None })
@@ -1403,7 +1449,10 @@ mod tests {
         let prior = app.store.load_turns(&first_id);
         assert_eq!(prior.len(), 2);
         // The new conversation is the persisted active one.
-        assert_eq!(app.store.active_conversation().as_deref(), Some(second_id.as_str()));
+        assert_eq!(
+            app.store.active_conversation().as_deref(),
+            Some(second_id.as_str())
+        );
     }
 
     /// The Tool row role renders through the same Turn shape (Phase 2 seam).
@@ -1493,10 +1542,7 @@ mod tests {
 
     /// Dispatch `tool` on a worker thread (the gate blocks there, never on
     /// the test thread). Returns the result receiver.
-    fn dispatch_on_worker(
-        dispatcher: Arc<ToolDispatcher>,
-        tool: &str,
-    ) -> Receiver<ToolCallResult> {
+    fn dispatch_on_worker(dispatcher: Arc<ToolDispatcher>, tool: &str) -> Receiver<ToolCallResult> {
         dispatch_on_worker_with_input(dispatcher, tool, "{\"x\": 1}")
     }
 
@@ -1530,8 +1576,7 @@ mod tests {
         // t_ask has no grant → default Ask.
 
         let dispatcher = app.gated_dispatcher();
-        let mut visible: Vec<String> =
-            dispatcher.all_tools().into_iter().map(|t| t.name).collect();
+        let mut visible: Vec<String> = dispatcher.all_tools().into_iter().map(|t| t.name).collect();
         visible.sort();
         assert_eq!(
             visible,
@@ -1547,7 +1592,11 @@ mod tests {
         // Denied tool is also uninvocable.
         let result = dispatcher.dispatch_call("c-deny".to_string(), "t_deny", "{}".to_string());
         assert!(
-            result.error.as_deref().unwrap_or("").contains("tool_not_found"),
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("tool_not_found"),
             "denied tool must be uninvocable: {:?}",
             result.error
         );
@@ -1576,11 +1625,18 @@ mod tests {
         let result = result_rx
             .recv_timeout(std::time::Duration::from_secs(5))
             .expect("tool call must complete");
-        assert!(result.error.is_none(), "allowed call must succeed: {:?}", result.error);
+        assert!(
+            result.error.is_none(),
+            "allowed call must succeed: {:?}",
+            result.error
+        );
 
         // The completed tool row lands in the transcript.
         pump_until(&mut app, "tool row", |a| {
-            a.model.turns.iter().any(|t| t.status == Some(ToolStatus::Succeeded))
+            a.model
+                .turns
+                .iter()
+                .any(|t| t.status == Some(ToolStatus::Succeeded))
         });
         // Allow-once persists nothing.
         assert!(
@@ -1589,7 +1645,11 @@ mod tests {
         );
         // Audit: one permission decision + one tool call.
         let events = app.audit.tail(10);
-        assert_eq!(events.len(), 2, "audit must record decision + call: {events:?}");
+        assert_eq!(
+            events.len(),
+            2,
+            "audit must record decision + call: {events:?}"
+        );
         assert_eq!(events[0].kind, "permission_decision");
         assert_eq!(events[0].decision, "allow_once");
         assert_eq!(events[1].kind, "tool_call");
@@ -1624,7 +1684,10 @@ mod tests {
             .expect("allow-always must persist a grant");
         assert_eq!(record.decision, Decision::Allow);
         assert_eq!(record.duration, GrantDuration::Always);
-        assert!(ws.path().join("grants.toml").is_file(), "grant must be saved to disk");
+        assert!(
+            ws.path().join("grants.toml").is_file(),
+            "grant must be saved to disk"
+        );
 
         // Next turn's dispatcher: the tool now evaluates Allow — no sheet.
         let dispatcher2 = Arc::new(app.gated_dispatcher());
@@ -1659,7 +1722,11 @@ mod tests {
             .recv_timeout(std::time::Duration::from_secs(5))
             .expect("denied call must still return");
         assert!(
-            result.error.as_deref().unwrap_or("").contains("permission_denied"),
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("permission_denied"),
             "denial must be a tool error for the model: {:?}",
             result.error
         );
@@ -1670,7 +1737,10 @@ mod tests {
         let events = app.audit.tail(10);
         assert_eq!(events[0].kind, "permission_decision");
         assert_eq!(events[0].decision, "deny");
-        assert!(app.grant_store.records().is_empty(), "deny persists nothing");
+        assert!(
+            app.grant_store.records().is_empty(),
+            "deny persists nothing"
+        );
 
         tool_dispatch::unregister(9103);
     }
@@ -1697,14 +1767,23 @@ mod tests {
         app.model.composer = "/revoke app.view.tool".to_string();
         let effects = app.model.submit();
         app.execute_effects(effects);
-        assert!(app.model.turns.last().unwrap().text.contains("Revoked 1 grant(s)"));
+        assert!(app
+            .model
+            .turns
+            .last()
+            .unwrap()
+            .text
+            .contains("Revoked 1 grant(s)"));
         assert!(app.grant_store.records().is_empty());
 
         app.model.composer = "/audit".to_string();
         let effects = app.model.submit();
         app.execute_effects(effects);
         let audit_row = &app.model.turns.last().unwrap().text;
-        assert!(audit_row.contains("revoke"), "revoke must be audited: {audit_row}");
+        assert!(
+            audit_row.contains("revoke"),
+            "revoke must be audited: {audit_row}"
+        );
 
         tool_dispatch::unregister(9104);
     }
@@ -1811,7 +1890,10 @@ mod tests {
             .unwrap();
         assert!(row.text.contains("chess: move.played"), "{}", row.text);
         assert!(row.text.contains("White played e4"), "{}", row.text);
-        assert!(app.model.streaming.in_flight, "user event must auto-start a turn");
+        assert!(
+            app.model.streaming.in_flight,
+            "user event must auto-start a turn"
+        );
         wait_for_turn(&mut app);
         assert_eq!(app.model.turns.last().unwrap().role, TurnRole::Assistant);
         assert_eq!(app.model.turns.last().unwrap().text, "echo: ok");
@@ -1879,16 +1961,27 @@ mod tests {
         app.subscribe_stream("chess", "move.played");
 
         // The assistant as the event actor: row, no turn.
-        emit_move(&timeline, AppEventActor::Agent, Some("agent:assistant"), None);
+        emit_move(
+            &timeline,
+            AppEventActor::Agent,
+            Some("agent:assistant"),
+            None,
+        );
         app.pump_turn_io();
         assert_eq!(event_rows(&app), 1);
-        assert!(!app.model.streaming.in_flight, "own action must not trigger");
+        assert!(
+            !app.model.streaming.in_flight,
+            "own action must not trigger"
+        );
 
         // App-emitted event caused by the assistant's tool call: row, no turn.
         emit_move(&timeline, AppEventActor::App, None, Some("agent:assistant"));
         app.pump_turn_io();
         assert_eq!(event_rows(&app), 2);
-        assert!(!app.model.streaming.in_flight, "caused-by-self must not trigger");
+        assert!(
+            !app.model.streaming.in_flight,
+            "caused-by-self must not trigger"
+        );
         assert!(app.queued_event_lines.is_empty());
     }
 
@@ -1913,7 +2006,10 @@ mod tests {
         // The turn ends: the queued event triggers the follow-up turn.
         app.model.streaming = model::StreamingState::default();
         app.pump_turn_io();
-        assert!(app.model.streaming.in_flight, "queued event must start the next turn");
+        assert!(
+            app.model.streaming.in_flight,
+            "queued event must start the next turn"
+        );
         assert!(app.queued_event_lines.is_empty());
         // The event line is folded into the dispatched history.
         let history = app.history_messages();
@@ -1980,7 +2076,10 @@ mod tests {
         // User types a follow-up and hits ESC.
         app.model.composer = "actually do X".to_string();
         app.interrupt_in_flight_turn();
-        assert!(app.turn_cancel.is_cancelled(), "ESC must trip the cancel token");
+        assert!(
+            app.turn_cancel.is_cancelled(),
+            "ESC must trip the cancel token"
+        );
         assert_eq!(
             app.model.queued_user_turns, 1,
             "the draft must be queued for the fold"
@@ -2033,11 +2132,7 @@ mod tests {
 
         // Host event tools are visible in the turn snapshot.
         let dispatcher = Arc::new(app.gated_dispatcher());
-        let names: HashSet<String> = dispatcher
-            .all_tools()
-            .into_iter()
-            .map(|t| t.name)
-            .collect();
+        let names: HashSet<String> = dispatcher.all_tools().into_iter().map(|t| t.name).collect();
         assert!(names.contains(HOST_TOOL_SUBSCRIBE));
         assert!(names.contains(HOST_TOOL_UNSUBSCRIBE));
 
@@ -2084,7 +2179,12 @@ mod tests {
         let effects = app.model.submit();
         app.execute_effects(effects);
         assert!(
-            app.model.turns.last().unwrap().text.contains("live subscription"),
+            app.model
+                .turns
+                .last()
+                .unwrap()
+                .text
+                .contains("live subscription"),
             "{}",
             app.model.turns.last().unwrap().text
         );
@@ -2122,13 +2222,20 @@ mod tests {
             .recv_timeout(std::time::Duration::from_secs(5))
             .expect("denied subscribe must still return");
         assert!(
-            result.error.as_deref().unwrap_or("").contains("permission_denied"),
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("permission_denied"),
             "{:?}",
             result.error
         );
         assert!(app.live_subs.is_empty());
         assert!(timeline.lock().unwrap().subscriptions().is_empty());
-        assert!(app.grant_store.records().is_empty(), "deny persists nothing");
+        assert!(
+            app.grant_store.records().is_empty(),
+            "deny persists nothing"
+        );
     }
 
     #[test]
@@ -2157,7 +2264,11 @@ mod tests {
             tx,
         );
         let result = rx.try_recv().unwrap();
-        assert!(result.error.as_deref().unwrap_or("").contains("not_subscribed"));
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("not_subscribed"));
     }
 
     #[test]

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -520,11 +520,18 @@ impl AssistantModel {
                     text.len(),
                     self.streaming.partial_reasoning.len()
                 );
-                let mut turn = Turn::now(TurnRole::Assistant, text);
-                if !self.streaming.partial_reasoning.is_empty() {
-                    turn.thoughts = Some(std::mem::take(&mut self.streaming.partial_reasoning));
+                // An empty reply with no reasoning means nothing was produced —
+                // e.g. a turn cancelled before any text streamed. Don't commit
+                // an empty assistant bubble; just reset and let any folded
+                // follow-up turn do the talking.
+                if !text.is_empty() || !self.streaming.partial_reasoning.is_empty() {
+                    let mut turn = Turn::now(TurnRole::Assistant, text);
+                    if !self.streaming.partial_reasoning.is_empty() {
+                        turn.thoughts =
+                            Some(std::mem::take(&mut self.streaming.partial_reasoning));
+                    }
+                    self.push_flight_turn(turn);
                 }
-                self.push_flight_turn(turn);
             }
             Err(e) => {
                 log::warn!("assistant[{}]: turn failed: {e}", self.conversation_id);

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -158,6 +158,9 @@ pub struct AssistantModel {
     /// Show reasoning ("thoughts") sections in the transcript. Toggled by
     /// `/thoughts`, persisted in the assistant store's `state.toml`.
     pub show_thoughts: bool,
+    /// Shell-style composer history cursor over prior user turns. `None`
+    /// means normal editing; `Some(0)` is the newest user message.
+    history_cursor: Option<usize>,
 }
 
 impl AssistantModel {
@@ -175,6 +178,7 @@ impl AssistantModel {
             queued_user_turns: 0,
             turn_anchor: None,
             show_thoughts: false,
+            history_cursor: None,
         }
     }
 
@@ -218,6 +222,7 @@ impl AssistantModel {
             return Vec::new();
         }
         self.composer.clear();
+        self.history_cursor = None;
         self.picker_selected = 0;
         if let Some(cmd) = commands::parse_slash_command(&input) {
             return self.execute_command(&cmd);
@@ -254,6 +259,44 @@ impl AssistantModel {
                 prompt: input,
             },
         ]
+    }
+
+    /// Recall previous user messages into the composer. The first Up starts
+    /// from the latest submitted user turn; repeated Up walks older turns.
+    /// A non-empty draft is left untouched unless history recall is already
+    /// active, so one accidental Up never overwrites in-progress typing.
+    pub fn recall_previous_user_message(&mut self) -> bool {
+        if self.history_cursor.is_none() && !self.composer.trim().is_empty() {
+            return false;
+        }
+        let history: Vec<&str> = self
+            .turns
+            .iter()
+            .rev()
+            .filter(|t| t.role == TurnRole::User && !t.text.trim().is_empty())
+            .map(|t| t.text.as_str())
+            .collect();
+        if history.is_empty() {
+            return false;
+        }
+        let next = self
+            .history_cursor
+            .map(|idx| (idx + 1).min(history.len() - 1))
+            .unwrap_or(0);
+        self.history_cursor = Some(next);
+        self.composer = history[next].to_string();
+        self.picker_selected = 0;
+        log::info!(
+            "assistant[{}]: recalled composer history entry {} of {}",
+            self.conversation_id,
+            next + 1,
+            history.len()
+        );
+        true
+    }
+
+    pub fn reset_history_recall(&mut self) {
+        self.history_cursor = None;
     }
 
     /// Abandon the in-flight turn for a conversation switch: reset all
@@ -356,7 +399,10 @@ impl AssistantModel {
                         "Thoughts are now hidden. Run /thoughts again to show them."
                     },
                 ));
-                log::info!("assistant: /thoughts — show_thoughts={}", self.show_thoughts);
+                log::info!(
+                    "assistant: /thoughts — show_thoughts={}",
+                    self.show_thoughts
+                );
                 vec![
                     AssistantEffect::PersistShowThoughts(self.show_thoughts),
                     AssistantEffect::SessionWrite {
@@ -527,8 +573,7 @@ impl AssistantModel {
                 if !text.is_empty() || !self.streaming.partial_reasoning.is_empty() {
                     let mut turn = Turn::now(TurnRole::Assistant, text);
                     if !self.streaming.partial_reasoning.is_empty() {
-                        turn.thoughts =
-                            Some(std::mem::take(&mut self.streaming.partial_reasoning));
+                        turn.thoughts = Some(std::mem::take(&mut self.streaming.partial_reasoning));
                     }
                     self.push_flight_turn(turn);
                 }
@@ -605,6 +650,27 @@ mod tests {
     }
 
     #[test]
+    fn up_history_recalls_previous_user_turns_without_overwriting_draft() {
+        let mut m = AssistantModel::fresh();
+        submitted(&mut m, "first");
+        m.finish_turn(&m.conversation_id.clone(), Ok("one".to_string()));
+        submitted(&mut m, "second");
+        m.finish_turn(&m.conversation_id.clone(), Ok("two".to_string()));
+
+        assert!(m.recall_previous_user_message());
+        assert_eq!(m.composer, "second");
+        assert!(m.recall_previous_user_message());
+        assert_eq!(m.composer, "first");
+        assert!(m.recall_previous_user_message());
+        assert_eq!(m.composer, "first", "history clamps at oldest entry");
+
+        m.composer = "draft".to_string();
+        m.reset_history_recall();
+        assert!(!m.recall_previous_user_message());
+        assert_eq!(m.composer, "draft");
+    }
+
+    #[test]
     fn clear_mid_turn_interrupts_and_cancels() {
         let mut m = AssistantModel::fresh();
         submitted(&mut m, "question");
@@ -649,7 +715,9 @@ mod tests {
         assert_eq!(m.streaming, StreamingState::default());
         assert_eq!(m.turns.last().unwrap().role, TurnRole::Assistant);
         assert_eq!(m.turns.last().unwrap().text, "final answer");
-        assert!(matches!(&effects[0], AssistantEffect::SessionWrite { conversation_id } if *conversation_id == id));
+        assert!(
+            matches!(&effects[0], AssistantEffect::SessionWrite { conversation_id } if *conversation_id == id)
+        );
     }
 
     #[test]
@@ -671,7 +739,10 @@ mod tests {
         let id = m.conversation_id.clone();
         m.finish_turn(&id, Ok("hello there".to_string()));
         assert_eq!(m.turns[0].text, "hi");
-        assert_eq!(m.turns[1].text, "hello there", "reply commits at its anchor");
+        assert_eq!(
+            m.turns[1].text, "hello there",
+            "reply commits at its anchor"
+        );
         assert!(m.turns[2].text.contains("Built-in commands"));
         assert_eq!(m.turn_anchor, None);
     }
@@ -728,7 +799,10 @@ mod tests {
         submitted(&mut m, "/clear");
         let effects = m.finish_turn(&old_id, Ok("late answer".to_string()));
         assert!(effects.is_empty());
-        assert!(m.turns.is_empty(), "stale outcome must not land in the cleared conversation");
+        assert!(
+            m.turns.is_empty(),
+            "stale outcome must not land in the cleared conversation"
+        );
     }
 
     #[test]
@@ -740,8 +814,10 @@ mod tests {
         let effects = submitted(&mut m, "/clear");
         assert_ne!(m.conversation_id, old_id);
         assert!(m.turns.is_empty());
-        assert!(matches!(&effects[0], AssistantEffect::SessionWrite { conversation_id }
-            if *conversation_id == m.conversation_id));
+        assert!(
+            matches!(&effects[0], AssistantEffect::SessionWrite { conversation_id }
+            if *conversation_id == m.conversation_id)
+        );
     }
 
     #[test]
@@ -773,12 +849,18 @@ mod tests {
     #[test]
     fn phase2_views_route_to_their_effects() {
         let mut m = AssistantModel::fresh();
-        assert_eq!(submitted(&mut m, "/tools"), vec![AssistantEffect::ListTools]);
+        assert_eq!(
+            submitted(&mut m, "/tools"),
+            vec![AssistantEffect::ListTools]
+        );
         assert_eq!(
             submitted(&mut m, "/permissions"),
             vec![AssistantEffect::ListPermissions]
         );
-        assert_eq!(submitted(&mut m, "/audit"), vec![AssistantEffect::ShowAudit]);
+        assert_eq!(
+            submitted(&mut m, "/audit"),
+            vec![AssistantEffect::ShowAudit]
+        );
         assert_eq!(
             submitted(&mut m, "/revoke app.csv.write_range"),
             vec![AssistantEffect::RevokeGrant {

--- a/src/assistant/render.rs
+++ b/src/assistant/render.rs
@@ -28,9 +28,6 @@ use super::model::{AssistantModel, PermissionChoice, ToolStatus, TurnRole};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ComposerEvent {
     Submit,
-    /// ESC pressed during an in-flight turn: stop generating (and send any
-    /// pending draft as an immediate folded follow-up).
-    Interrupt,
     /// The user decided the pending permission sheet.
     Permission(PermissionChoice),
 }
@@ -65,7 +62,7 @@ impl MarkdownTextCache {
             });
         if entry.source_len != turn.text.len() {
             entry.source_len = turn.text.len();
-            entry.softened = AssistantRenderer::soften_newlines(&turn.text);
+            entry.softened = crate::ui::markdown::harden_soft_breaks(&turn.text);
         }
         &entry.softened
     }
@@ -124,8 +121,8 @@ impl AssistantRenderer {
         // Picker shows up to 10 command rows, clamped so it never overruns
         // the transcript area in a short pane (but always fits at least 3).
         let total_h = ui.available_rect_before_wrap().height();
-        let picker_max_h = (style::LIST_ROW_H * 10.0)
-            .min((total_h * 0.8).max(style::LIST_ROW_H * 3.0));
+        let picker_max_h =
+            (style::LIST_ROW_H * 10.0).min((total_h * 0.8).max(style::LIST_ROW_H * 3.0));
         let mut event = None;
         let mut composer_rect = None;
 
@@ -157,19 +154,21 @@ impl AssistantRenderer {
                     is_focused,
                     total_h * Self::COMPOSER_MAX_FRACTION,
                 ));
-                let hints = [
+                let mut hints = vec![
                     HintGroup::new(&["\u{21b5}"], "send"),
                     HintGroup::new(&["\u{21e7}", "\u{21b5}"], "newline"),
                     HintGroup::new(&["/"], "commands"),
                 ];
+                if model.streaming.in_flight {
+                    hints.push(HintGroup::new(&["Esc"], "stop"));
+                }
                 HintBar::new(&hints).show(ui, colors);
             });
 
         egui::CentralPanel::default()
-            .frame(egui::Frame::new().inner_margin(egui::Margin::symmetric(
-                style::SPACE_MD as i8,
-                0,
-            )))
+            .frame(
+                egui::Frame::new().inner_margin(egui::Margin::symmetric(style::SPACE_MD as i8, 0)),
+            )
             .show_inside(ui, |ui| {
                 Self::draw_transcript(ui, model, md_cache, text_cache, colors);
             });
@@ -199,10 +198,7 @@ impl AssistantRenderer {
             let t = ui.input(|i| i.time);
             let phase = ((t * 2.5).sin() * 0.5 + 0.5) as f32;
             colors.accent.gamma_multiply(0.45 + 0.55 * phase)
-        } else if matches!(
-            model.turns.last().map(|t| t.role),
-            Some(TurnRole::Error)
-        ) {
+        } else if matches!(model.turns.last().map(|t| t.role), Some(TurnRole::Error)) {
             colors.danger
         } else {
             colors.text_dim
@@ -303,29 +299,6 @@ impl AssistantRenderer {
             });
     }
 
-    /// Convert markdown soft breaks to hard breaks: every newline outside a
-    /// fenced code block gets a trailing two-space hard break, so single
-    /// newlines stay visible line breaks (the chat-client convention) instead
-    /// of collapsing into one paragraph. Block structure — lists, headings,
-    /// fences — is decided per line before inline rendering, so the trailing
-    /// spaces never change it.
-    fn soften_newlines(text: &str) -> String {
-        let mut out = String::with_capacity(text.len() + text.lines().count() * 2);
-        let mut in_fence = false;
-        for line in text.lines() {
-            let trimmed = line.trim_start();
-            if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
-                in_fence = !in_fence;
-            }
-            out.push_str(line);
-            if !in_fence && !line.trim().is_empty() {
-                out.push_str("  ");
-            }
-            out.push('\n');
-        }
-        out
-    }
-
     /// Render `text` as markdown (links, emphasis, inline code, fenced
     /// blocks) sized to the chat body scale. Hyperlinks open through egui's
     /// native `open_url`. Raw inline HTML is not interpreted — it renders as
@@ -336,26 +309,14 @@ impl AssistantRenderer {
         colors: &Colors,
         markdown: &str,
     ) {
-        let s = ui.style_mut();
-        s.visuals.override_text_color = Some(colors.text_primary);
-        s.visuals.hyperlink_color = colors.accent;
-        s.text_styles.insert(
-            egui::TextStyle::Body,
-            egui::FontId::proportional(style::TEXT_BODY),
+        crate::ui::markdown::show(
+            ui,
+            md_cache,
+            colors,
+            markdown,
+            colors.text_primary,
+            style::TEXT_BODY,
         );
-        s.text_styles.insert(
-            egui::TextStyle::Heading,
-            egui::FontId::proportional(style::TEXT_BODY * 1.3),
-        );
-        s.text_styles.insert(
-            egui::TextStyle::Monospace,
-            egui::FontId::monospace(style::TEXT_BODY * 0.9),
-        );
-        s.text_styles.insert(
-            egui::TextStyle::Small,
-            egui::FontId::proportional(style::TEXT_HINT),
-        );
-        egui_commonmark::CommonMarkViewer::new().show(ui, md_cache, markdown);
     }
 
     fn draw_turn_row(
@@ -547,7 +508,7 @@ impl AssistantRenderer {
         colors: &Colors,
         add_contents: impl FnOnce(&mut egui::Ui),
     ) {
-        let bubble_max = ui.available_width() * 0.85;
+        let bubble_max = ui.available_width() * Self::BUBBLE_MAX_FRACTION;
         egui::Frame::new()
             .fill(colors.bg_active)
             .corner_radius(style::RADIUS_MD)
@@ -577,7 +538,8 @@ impl AssistantRenderer {
             if model.streaming.partial_answer.is_empty() {
                 Self::draw_thinking_dots(ui, colors);
             } else {
-                let markdown = Self::soften_newlines(&model.streaming.partial_answer);
+                let markdown =
+                    crate::ui::markdown::harden_soft_breaks(&model.streaming.partial_answer);
                 Self::markdown_body(ui, md_cache, colors, &markdown);
             }
         });
@@ -596,10 +558,13 @@ impl AssistantRenderer {
         let t = ui.input(|i| i.time);
         let (rect, _) = ui.allocate_exact_size(egui::vec2(DOTS_W, 18.0), egui::Sense::hover());
         for k in 0..3 {
-            let phase = (((t * 2.2 - k as f64 * 0.45).sin() * 0.5 + 0.5)) as f32;
+            let phase = ((t * 2.2 - k as f64 * 0.45).sin() * 0.5 + 0.5) as f32;
             let color = colors.text_dim.gamma_multiply(0.35 + 0.65 * phase);
             ui.painter().circle_filled(
-                egui::pos2(rect.left() + EDGE_PAD + DOT_R + k as f32 * DOT_GAP, rect.center().y),
+                egui::pos2(
+                    rect.left() + EDGE_PAD + DOT_R + k as f32 * DOT_GAP,
+                    rect.center().y,
+                ),
                 DOT_R,
                 color,
             );
@@ -645,15 +610,6 @@ impl AssistantRenderer {
     ) -> Option<ComposerEvent> {
         if !ui.memory(|m| m.has_focus(te_id)) {
             return None;
-        }
-        // ESC during an in-flight turn interrupts it (stop, or stop-and-send a
-        // queued draft). Consume the key so it does not also propagate to
-        // host-level ESC handling. When no turn is in flight, ESC falls through
-        // untouched, preserving existing behavior.
-        if model.streaming.in_flight
-            && ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape))
-        {
-            return Some(ComposerEvent::Interrupt);
         }
         if model.picker_active() {
             let matches = commands::filter_commands(&model.picker_query());
@@ -712,8 +668,7 @@ impl AssistantRenderer {
             // Shift+Enter inserts a newline (handled natively by the TextEdit's
             // `return_key`); only plain Enter submits. `consume_key` ignores
             // extra Shift, so guard on `!shift` before consuming.
-            if !input.modifiers.shift
-                && input.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
+            if !input.modifiers.shift && input.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
             {
                 submit = true;
             }
@@ -840,7 +795,11 @@ impl AssistantRenderer {
         // Accent outline while the composer holds keyboard focus — same
         // affordance as the host text fields.
         let has_kb_focus = ui.memory(|m| m.has_focus(te_id));
-        let stroke_color = if has_kb_focus { colors.accent } else { colors.border };
+        let stroke_color = if has_kb_focus {
+            colors.accent
+        } else {
+            colors.border
+        };
 
         let mut response = None;
         let frame_response = egui::Frame::new()
@@ -903,6 +862,9 @@ impl AssistantRenderer {
                             row_height,
                             egui::Stroke::new(1.5, colors.accent),
                         );
+                        if output.response.changed() {
+                            model.reset_history_recall();
+                        }
                         response = Some(output.response);
                     });
             });
@@ -921,24 +883,5 @@ impl AssistantRenderer {
             }
         }
         frame_response.response.rect
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::AssistantRenderer;
-
-    #[test]
-    fn soften_newlines_makes_single_breaks_hard_outside_fences() {
-        let out = AssistantRenderer::soften_newlines("line one\nline two\n\nline three");
-        assert_eq!(out, "line one  \nline two  \n\nline three  \n");
-    }
-
-    #[test]
-    fn soften_newlines_leaves_fenced_code_untouched() {
-        let out = AssistantRenderer::soften_newlines("before\n```\nlet x = 1;\nlet y = 2;\n```\nafter");
-        assert!(out.contains("before  \n"));
-        assert!(out.contains("let x = 1;\nlet y = 2;\n"), "code lines must stay byte-identical");
-        assert!(out.contains("after  \n"));
     }
 }

--- a/src/assistant/render.rs
+++ b/src/assistant/render.rs
@@ -28,6 +28,9 @@ use super::model::{AssistantModel, PermissionChoice, ToolStatus, TurnRole};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ComposerEvent {
     Submit,
+    /// ESC pressed during an in-flight turn: stop generating (and send any
+    /// pending draft as an immediate folded follow-up).
+    Interrupt,
     /// The user decided the pending permission sheet.
     Permission(PermissionChoice),
 }
@@ -642,6 +645,15 @@ impl AssistantRenderer {
     ) -> Option<ComposerEvent> {
         if !ui.memory(|m| m.has_focus(te_id)) {
             return None;
+        }
+        // ESC during an in-flight turn interrupts it (stop, or stop-and-send a
+        // queued draft). Consume the key so it does not also propagate to
+        // host-level ESC handling. When no turn is in flight, ESC falls through
+        // untouched, preserving existing behavior.
+        if model.streaming.in_flight
+            && ui.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape))
+        {
+            return Some(ComposerEvent::Interrupt);
         }
         if model.picker_active() {
             let matches = commands::filter_commands(&model.picker_query());

--- a/src/assistant/store.rs
+++ b/src/assistant/store.rs
@@ -80,7 +80,11 @@ impl AssistantStore {
 
     /// Persist `id` as the active conversation, along with an optional
     /// session name. Other persisted preferences are preserved.
-    pub fn set_active_conversation(&self, id: &str, session_name: Option<&str>) -> Result<(), String> {
+    pub fn set_active_conversation(
+        &self,
+        id: &str,
+        session_name: Option<&str>,
+    ) -> Result<(), String> {
         let mut state = self.read_state().unwrap_or(StateToml {
             active_conversation: String::new(),
             session_name: None,
@@ -126,8 +130,8 @@ impl AssistantStore {
         }
         let mut raw = String::new();
         for turn in turns {
-            let line = serde_json::to_string(turn)
-                .map_err(|e| format!("serialize turn for {id}: {e}"))?;
+            let line =
+                serde_json::to_string(turn).map_err(|e| format!("serialize turn for {id}: {e}"))?;
             raw.push_str(&line);
             raw.push('\n');
         }
@@ -250,7 +254,10 @@ mod tests {
         store
             .write_turns(
                 id,
-                &[Turn::now(TurnRole::User, "ok"), Turn::now(TurnRole::User, "after")],
+                &[
+                    Turn::now(TurnRole::User, "ok"),
+                    Turn::now(TurnRole::User, "after"),
+                ],
             )
             .unwrap();
         let path = ws

--- a/src/broker/mod.rs
+++ b/src/broker/mod.rs
@@ -307,8 +307,8 @@ impl PermissionPosture {
     /// `default_posture` is required — no silent fallback. Accepted values:
     /// `allow`, `ask`, `review` (alias for ask), `deny`.
     pub fn from_toml_str(raw: &str) -> Result<Self, String> {
-        let parsed: PostureToml = toml::from_str(raw)
-            .map_err(|e| format!("invalid [permissions] table: {e}"))?;
+        let parsed: PostureToml =
+            toml::from_str(raw).map_err(|e| format!("invalid [permissions] table: {e}"))?;
         let t = parsed.permissions;
         let default_posture = match t.default_posture.as_str() {
             "allow" => Decision::Allow,
@@ -828,7 +828,11 @@ mod tests {
         let mut store = GrantStore::default();
         store.record(agent_grant(Decision::Allow, GrantSource::User));
         store.record(agent_grant(Decision::Deny, GrantSource::User));
-        assert_eq!(store.records().len(), 1, "same identity+source must replace");
+        assert_eq!(
+            store.records().len(),
+            1,
+            "same identity+source must replace"
+        );
         assert_eq!(store.evaluate(&agent_request(), None), Decision::Deny);
     }
 
@@ -1036,11 +1040,13 @@ deny = ["host.secrets.read"]
 
     #[test]
     fn posture_rejects_unknown_default_and_missing_table() {
-        let err = PermissionPosture::from_toml_str(
-            "[permissions]\ndefault_posture = \"sometimes\"\n",
-        )
-        .unwrap_err();
-        assert!(err.contains("sometimes"), "error must name the bad value: {err}");
+        let err =
+            PermissionPosture::from_toml_str("[permissions]\ndefault_posture = \"sometimes\"\n")
+                .unwrap_err();
+        assert!(
+            err.contains("sometimes"),
+            "error must name the bad value: {err}"
+        );
         assert!(
             PermissionPosture::from_toml_str("[other]\nx = 1\n").is_err(),
             "missing [permissions] table must fail, not silently default"

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1149,7 +1149,6 @@ fn to_struct_name(s: &str) -> String {
         .collect::<String>()
 }
 
-
 /// `plexi app update [<id>]` — local version check for installed apps.
 ///
 /// v1: compares `<app_dir>/installed_version.txt` against `manifest.toml`

--- a/src/cli/crawl.rs
+++ b/src/cli/crawl.rs
@@ -199,7 +199,14 @@ pub(crate) fn crawl_with_runner(
     // Recursively enrich each command with its flags, positional args, and
     // nested subcommands by crawling `<cli> <cmd…> --help`.
     let mut budget = CrawlBudget::new();
-    enrich_commands(cli_name, runner, &mut descriptor.commands, &[], 1, &mut budget);
+    enrich_commands(
+        cli_name,
+        runner,
+        &mut descriptor.commands,
+        &[],
+        1,
+        &mut budget,
+    );
 
     let count = descriptor.commands.len();
     let flag_total: usize = count_flags(&descriptor.commands);
@@ -599,7 +606,9 @@ fn looks_like_metavar(tok: &str) -> bool {
     let inner = tok.trim_matches(['<', '>', '[', ']', '.']);
     !inner.is_empty()
         && inner.len() >= 2
-        && inner.chars().all(|c| c.is_ascii_uppercase() || c == '_' || c == '-')
+        && inner
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c == '_' || c == '-')
 }
 
 fn metavar_clean(tok: &str) -> String {
@@ -697,7 +706,11 @@ fn is_flag_ident(name: &str) -> bool {
         && name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-        && name.chars().next().map(|c| c.is_ascii_alphanumeric()).unwrap_or(false)
+        && name
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_alphanumeric())
+            .unwrap_or(false)
 }
 
 /// Parse positional arguments from a command's `--help` ARGUMENTS section.
@@ -739,7 +752,11 @@ fn parse_arg_line(line: &str) -> Option<ArgSpec> {
     let name = token.trim_matches(['<', '>', '[', ']', '.']);
     // Drop ellipsis/variadic markers and empties.
     let name = name.trim_end_matches('.').trim();
-    if name.is_empty() || !name.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-') {
+    if name.is_empty()
+        || !name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+    {
         return None;
     }
 
@@ -981,8 +998,7 @@ collaborate (see also: git help workflows)
     #[test]
     fn crawl_serves_from_cache_on_second_call() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let runner =
-            MapRunner::new(None).with("--help", "COMMANDS\n  go   Do the thing\n");
+        let runner = MapRunner::new(None).with("--help", "COMMANDS\n  go   Do the thing\n");
         let cache_dir = tmp.path().join("cache");
         let _ = crawl_with_runner("cached-cli", &runner, &cache_dir).unwrap();
         let result2 = crawl_with_runner("cached-cli", &runner, &cache_dir).unwrap();
@@ -1045,8 +1061,7 @@ collaborate (see also: git help workflows)
         let cache_dir = tmp.path().join("cache");
         std::fs::create_dir_all(&cache_dir).unwrap();
 
-        let runner =
-            MapRunner::new(None).with("--help", "COMMANDS\n  run   Do the thing\n");
+        let runner = MapRunner::new(None).with("--help", "COMMANDS\n  run   Do the thing\n");
 
         // "../../evil" → each of '.','.','/','.','.','/' is non-alphanumeric → "______evil"
         crawl_with_runner("../../evil", &runner, &cache_dir)
@@ -1093,8 +1108,7 @@ OPTIONS:
             .with("--help", top)
             .with("greet --help", greet);
 
-        let result =
-            crawl_with_runner("demo", &runner, &tmp.path().join("cache")).unwrap();
+        let result = crawl_with_runner("demo", &runner, &tmp.path().join("cache")).unwrap();
         let greet_cmd = result
             .descriptor
             .commands
@@ -1119,7 +1133,11 @@ OPTIONS:
         // --loud is a bool (no metavar); --output takes a path-ish value.
         let loud = greet_cmd.flags.iter().find(|f| f.name == "--loud").unwrap();
         assert_eq!(loud.ty, ArgType::Bool);
-        let output = greet_cmd.flags.iter().find(|f| f.name == "--output").unwrap();
+        let output = greet_cmd
+            .flags
+            .iter()
+            .find(|f| f.name == "--output")
+            .unwrap();
         assert_eq!(output.ty, ArgType::Path);
 
         // Leaf command should be hinted as a form.
@@ -1130,8 +1148,10 @@ OPTIONS:
     fn recursive_crawl_captures_nested_subcommands() {
         let tmp = tempfile::TempDir::new().unwrap();
         let top = "A VCS\n\nCOMMANDS\n  remote   Manage remotes\n";
-        let remote = "Manage remotes\n\nCOMMANDS\n  add      Add a remote\n  remove   Remove a remote\n";
-        let remote_add = "Add a remote\n\nARGUMENTS:\n  <NAME>   Remote name\n  <URL>    Remote URL\n";
+        let remote =
+            "Manage remotes\n\nCOMMANDS\n  add      Add a remote\n  remove   Remove a remote\n";
+        let remote_add =
+            "Add a remote\n\nARGUMENTS:\n  <NAME>   Remote name\n  <URL>    Remote URL\n";
         let runner = MapRunner::new(Some("vcs 2.0.0"))
             .with("--help", top)
             .with("remote --help", remote)

--- a/src/cli/descriptor.rs
+++ b/src/cli/descriptor.rs
@@ -81,7 +81,10 @@ pub fn probe_with_options<R: DescriptorRunner>(
             }
             _ => {}
         }
-        eprintln!("error: no descriptor available for `{command} {}` — native --plexi failed.", args.join(" "));
+        eprintln!(
+            "error: no descriptor available for `{command} {}` — native --plexi failed.",
+            args.join(" ")
+        );
         return 1;
     }
 
@@ -387,8 +390,8 @@ mod descriptor_tests {
     #[test]
     fn resolve_prefers_native_plexi() {
         let mock = ok_descriptor_runner();
-        let resolved = resolve_cli_with(&mock, "fake-cli", true, true)
-            .expect("native descriptor resolves");
+        let resolved =
+            resolve_cli_with(&mock, "fake-cli", true, true).expect("native descriptor resolves");
         assert!(matches!(resolved.source, SummarySource::Native));
         assert_eq!(resolved.descriptor.name, "fake");
         // The native probe must invoke `<cli> --plexi`.

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -75,10 +75,7 @@ pub fn print_grouped_help() {
         for arg in &visible_positional {
             let name = format!("[{}]", arg.get_id().as_str().to_uppercase());
             let padded = format!("{name:<22}");
-            let help = arg
-                .get_help()
-                .map(|s| s.to_string())
-                .unwrap_or_default();
+            let help = arg.get_help().map(|s| s.to_string()).unwrap_or_default();
             println!("  {} {help}", lit(padded));
         }
         println!();
@@ -109,10 +106,7 @@ pub fn print_grouped_help() {
         println!("{}", header(heading));
         for &name in *names {
             if let Some(sub) = cmd.find_subcommand(name) {
-                let about = sub
-                    .get_about()
-                    .map(|s| s.to_string())
-                    .unwrap_or_default();
+                let about = sub.get_about().map(|s| s.to_string()).unwrap_or_default();
                 println!("  {} {about}", lit(format!("{name:<col_width$}")));
             }
         }

--- a/src/cli/marketplace.rs
+++ b/src/cli/marketplace.rs
@@ -12,7 +12,8 @@
 use crate::app::account::AccountStore;
 use crate::app::marketplace::{
     license_gate, payment_provider, LicenseDecision, LicenseStore, MarketplaceManifest,
-    PaymentError, PublishClient, RegistryClient, RegistryEntry, RegistryError, Submission, Visibility,
+    PaymentError, PublishClient, RegistryClient, RegistryEntry, RegistryError, Submission,
+    Visibility,
 };
 use crate::app::package;
 use std::path::{Path, PathBuf};
@@ -67,12 +68,7 @@ pub fn app_search_cli(query: &str) -> i32 {
 }
 
 fn print_entry_table(entries: &[&RegistryEntry]) {
-    let id_w = entries
-        .iter()
-        .map(|e| e.id.len())
-        .max()
-        .unwrap_or(3)
-        .max(3);
+    let id_w = entries.iter().map(|e| e.id.len()).max().unwrap_or(3).max(3);
     let ver_w = entries
         .iter()
         .map(|e| e.version.len())
@@ -159,12 +155,18 @@ pub fn plan_install(app_id: &str) -> InstallPlan {
 
     // Prefer a CDN artifact; fall back to a declared source spec.
     if !entry.checksum.is_empty() {
-        let dest = std::env::temp_dir()
-            .join(format!("plexi-mkt-{}-{}.plexipkg", entry.id, uuid::Uuid::new_v4()));
+        let dest = std::env::temp_dir().join(format!(
+            "plexi-mkt-{}-{}.plexipkg",
+            entry.id,
+            uuid::Uuid::new_v4()
+        ));
         match cli.download_package(&entry, &dest) {
             Ok(path) => return InstallPlan::Package(path),
             Err(e) => {
-                eprintln!("error: could not download '{}' from the marketplace: {e}", entry.id);
+                eprintln!(
+                    "error: could not download '{}' from the marketplace: {e}",
+                    entry.id
+                );
                 return InstallPlan::Blocked;
             }
         }
@@ -202,7 +204,11 @@ fn attempt_purchase(entry: &RegistryEntry, store: &LicenseStore) -> bool {
         eprintln!("error: {}", PaymentError::NotConfigured);
         return false;
     }
-    log::info!("marketplace: purchasing '{}' as {}", entry.id, session.email);
+    log::info!(
+        "marketplace: purchasing '{}' as {}",
+        entry.id,
+        session.email
+    );
     match provider.purchase(entry, &session) {
         Ok(license) => {
             if let Err(e) = store.save(&license) {
@@ -353,7 +359,9 @@ pub fn app_publish_cli(path: &str) -> i32 {
                 "Set [marketplace].submit_url in your config to enable upload, or share the \
                  artifact above directly."
             );
-            crate::cli::print_tip("follow marketplace progress at https://plexiapp.com/docs/marketplace");
+            crate::cli::print_tip(
+                "follow marketplace progress at https://plexiapp.com/docs/marketplace",
+            );
             0
         }
         Err(e) => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -101,6 +101,7 @@ pub mod registry;
 pub mod setup;
 pub mod subprocess;
 
+pub mod account;
 pub mod agent;
 pub mod ai;
 pub mod app;
@@ -112,7 +113,6 @@ pub mod demo;
 pub mod descriptor;
 pub mod doctor;
 pub mod install;
-pub mod account;
 pub mod install_host;
 pub mod list;
 pub mod marketplace;
@@ -204,21 +204,15 @@ pub(super) fn binary_in_path(name: &str) -> bool {
 }
 
 // ── Public re-exports (preserve crate::cli::fn_name() call sites in main.rs) ──
+pub use account::{account_login_cli, account_logout_cli, account_signup_cli, account_status_cli};
 pub use agent::{
     agent_add, agent_hook_install_cli, agent_hook_uninstall_cli, agent_init, agent_list,
     agent_report_cli, agent_status_cli, agent_update,
 };
 pub use ai::{ai_doctor_cli, ai_setup_cli};
 pub use app::{
-    app_action_cli, app_info, app_init, app_inspect_cli, app_install_package,
-    app_install_with_pin, app_list, app_package_cli, app_render, app_uninstall, app_update_cli,
-    InstallConfirm,
-};
-pub use account::{
-    account_login_cli, account_logout_cli, account_signup_cli, account_status_cli,
-};
-pub use marketplace::{
-    app_browse_cli, app_license_list_cli, app_license_show_cli, app_publish_cli, app_search_cli,
+    app_action_cli, app_info, app_init, app_inspect_cli, app_install_package, app_install_with_pin,
+    app_list, app_package_cli, app_render, app_uninstall, app_update_cli, InstallConfirm,
 };
 pub use app_check::app_check_cli;
 pub use completions::{complete_open_cli, complete_run_cli, completions_cli};
@@ -234,6 +228,9 @@ pub use install::{
     self_update_cli, update_cli,
 };
 pub use list::{freeze_cli, parse_notify_choice};
+pub use marketplace::{
+    app_browse_cli, app_license_list_cli, app_license_show_cli, app_publish_cli, app_search_cli,
+};
 pub use notes::{notes_list_cli, notes_open_cli};
 pub use notify::notify_cli;
 pub use open::{

--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -52,11 +52,7 @@ pub fn notes_inbox_cli() -> i32 {
         return 0;
     }
     for note in &notes {
-        let ts = note
-            .frontmatter
-            .captured_at
-            .as_deref()
-            .unwrap_or("unknown");
+        let ts = note.frontmatter.captured_at.as_deref().unwrap_or("unknown");
         let cwd = note.frontmatter.cwd.as_deref().unwrap_or("");
         let preview: String = note.body.trim().chars().take(60).collect();
         println!("{}\t{}\t{}", ts, cwd, preview);
@@ -114,7 +110,11 @@ pub fn notes_list_cli() -> i32 {
         .map(|n| n.to_string_lossy().into_owned());
     let workspace_dir = workspace_slug.map(|slug| notes_base.join(slug));
 
-    log::info!("notes_list: scanning inbox={:?} workspace={:?}", inbox_dir, workspace_dir);
+    log::info!(
+        "notes_list: scanning inbox={:?} workspace={:?}",
+        inbox_dir,
+        workspace_dir
+    );
 
     let mut paths: Vec<(std::time::SystemTime, std::path::PathBuf)> = Vec::new();
 

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -274,7 +274,9 @@ pub fn open_cli_by_name(
 ) -> i32 {
     log::info!("open:cli: resolving `{name}`");
     match crate::cli::descriptor::resolve_cli(name) {
-        Ok(resolved) => open_descriptor_in_renderer(&resolved.descriptor, name, layout, from_pane_id, cwd),
+        Ok(resolved) => {
+            open_descriptor_in_renderer(&resolved.descriptor, name, layout, from_pane_id, cwd)
+        }
         Err(e) => {
             eprintln!("error: could not resolve CLI `{name}`: {e}");
             1

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -51,7 +51,12 @@ impl std::fmt::Display for ConfigDiagnostic {
                     write!(f, "{path}: unknown key `{key}` in [{table}]")
                 }
             }
-            Self::DeprecatedSection { path, section, hint, error } => {
+            Self::DeprecatedSection {
+                path,
+                section,
+                hint,
+                error,
+            } => {
                 let severity = if *error { "error" } else { "warning" };
                 write!(f, "{path}: {severity}: `{section}` is deprecated. {hint}")
             }

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -113,12 +113,7 @@ enum PendingFileOperation {
 /// Elide a path label from the left so the leaf directory stays visible —
 /// `…/projects/plexi/src` reads better than `/Users/ian/Documents/proj…`.
 /// Width-measured against the actual font, not a char-count guess.
-fn elide_path_leading(
-    ui: &egui::Ui,
-    path: &str,
-    font_id: egui::FontId,
-    max_width: f32,
-) -> String {
+fn elide_path_leading(ui: &egui::Ui, path: &str, font_id: egui::FontId, max_width: f32) -> String {
     if max_width <= 0.0 {
         return String::new();
     }
@@ -1948,7 +1943,9 @@ impl FileBrowserApp {
             );
             ui.colored_label(
                 colors.accent,
-                egui::RichText::new(elided).size(style::TEXT_HINT).monospace(),
+                egui::RichText::new(elided)
+                    .size(style::TEXT_HINT)
+                    .monospace(),
             );
         });
         ui.add_space(style::SPACE_XS);
@@ -2663,11 +2660,17 @@ mod tests {
 
         assert!(consumed);
         assert!(app.should_close);
-        let cd_cwd = app.take_pending_commands().into_iter().find_map(|c| match c {
-            AppCommand::CdRequest { cwd, .. } => Some(cwd),
-            _ => None,
-        });
-        assert_eq!(cd_cwd.as_deref(), Some(dir.path().to_string_lossy().as_ref()));
+        let cd_cwd = app
+            .take_pending_commands()
+            .into_iter()
+            .find_map(|c| match c {
+                AppCommand::CdRequest { cwd, .. } => Some(cwd),
+                _ => None,
+            });
+        assert_eq!(
+            cd_cwd.as_deref(),
+            Some(dir.path().to_string_lossy().as_ref())
+        );
     }
 
     #[test]

--- a/src/host/app_timeline.rs
+++ b/src/host/app_timeline.rs
@@ -438,7 +438,11 @@ impl AppTimeline {
     fn route_to_subscriptions(&mut self, app_id: &str, record: &AppEventRecord) -> usize {
         let mut queued = 0;
         let mut new_deliveries = Vec::new();
-        for sub in self.subscriptions.iter().filter(|s| s.matches(app_id, record)) {
+        for sub in self
+            .subscriptions
+            .iter()
+            .filter(|s| s.matches(app_id, record))
+        {
             // `never` = record in the timeline only — no delivery.
             if sub.trigger_mode == TriggerMode::Never {
                 continue;
@@ -447,16 +451,10 @@ impl AppTimeline {
             let (summary, payload, state_ref) = match sub.payload_mode {
                 PayloadMode::Off => (None, None, None),
                 PayloadMode::Summary => (Some(record.summary.clone()), None, None),
-                PayloadMode::Full => (
-                    Some(record.summary.clone()),
-                    record.payload.clone(),
-                    None,
-                ),
-                PayloadMode::StateRef => (
-                    Some(record.summary.clone()),
-                    None,
-                    record.state_ref.clone(),
-                ),
+                PayloadMode::Full => (Some(record.summary.clone()), record.payload.clone(), None),
+                PayloadMode::StateRef => {
+                    (Some(record.summary.clone()), None, record.state_ref.clone())
+                }
             };
             new_deliveries.push(EventDelivery {
                 delivery_id: self.next_delivery_id,
@@ -637,11 +635,13 @@ impl AppTimeline {
         subscriber_id: &str,
     ) -> (usize, usize) {
         let subs_before = self.subscriptions.len();
-        self.subscriptions
-            .retain(|s| !(s.subscriber_type == subscriber_type && s.subscriber_id == subscriber_id));
+        self.subscriptions.retain(|s| {
+            !(s.subscriber_type == subscriber_type && s.subscriber_id == subscriber_id)
+        });
         let dels_before = self.deliveries.len();
-        self.deliveries
-            .retain(|d| !(d.subscriber_type == subscriber_type && d.subscriber_id == subscriber_id));
+        self.deliveries.retain(|d| {
+            !(d.subscriber_type == subscriber_type && d.subscriber_id == subscriber_id)
+        });
         let removed = (
             subs_before - self.subscriptions.len(),
             dels_before - self.deliveries.len(),
@@ -743,7 +743,8 @@ mod tests {
 
     fn timeline_with_stream() -> AppTimeline {
         let mut t = AppTimeline::default();
-        t.declare_streams("chess", vec![decl("move.played")]).unwrap();
+        t.declare_streams("chess", vec![decl("move.played")])
+            .unwrap();
         t
     }
 
@@ -773,13 +774,18 @@ mod tests {
             description: None,
         };
         assert!(t.declare_streams("a", vec![bad]).is_err());
-        assert!(t.declared_streams("a").is_empty(), "nothing partial recorded");
+        assert!(
+            t.declared_streams("a").is_empty(),
+            "nothing partial recorded"
+        );
     }
 
     #[test]
     fn undeclared_stream_is_rejected() {
         let mut t = AppTimeline::default();
-        let err = t.record_event("chess", 1, emitted("move.played")).unwrap_err();
+        let err = t
+            .record_event("chess", 1, emitted("move.played"))
+            .unwrap_err();
         assert!(err.contains("not a declared event stream"), "{err}");
         assert!(t.events().is_empty());
     }
@@ -788,25 +794,46 @@ mod tests {
     fn required_fields_are_enforced() {
         let mut t = timeline_with_stream();
         for (field, mutate) in [
-            ("event", Box::new(|e: &mut EmittedEvent| e.event = String::new())
-                as Box<dyn Fn(&mut EmittedEvent)>),
-            ("summary", Box::new(|e: &mut EmittedEvent| e.summary = "  ".to_string())),
-            ("resource_id", Box::new(|e: &mut EmittedEvent| e.resource_id = String::new())),
-            ("revision_after", Box::new(|e: &mut EmittedEvent| e.revision_after = String::new())),
+            (
+                "event",
+                Box::new(|e: &mut EmittedEvent| e.event = String::new())
+                    as Box<dyn Fn(&mut EmittedEvent)>,
+            ),
+            (
+                "summary",
+                Box::new(|e: &mut EmittedEvent| e.summary = "  ".to_string()),
+            ),
+            (
+                "resource_id",
+                Box::new(|e: &mut EmittedEvent| e.resource_id = String::new()),
+            ),
+            (
+                "revision_after",
+                Box::new(|e: &mut EmittedEvent| e.revision_after = String::new()),
+            ),
         ] {
             let mut e = emitted("move.played");
             mutate(&mut e);
             let err = t.record_event("chess", 1, e).unwrap_err();
-            assert!(err.contains(field), "expected '{field}' in error, got: {err}");
+            assert!(
+                err.contains(field),
+                "expected '{field}' in error, got: {err}"
+            );
         }
-        assert!(t.events().is_empty(), "rejected events must not be recorded");
+        assert!(
+            t.events().is_empty(),
+            "rejected events must not be recorded"
+        );
     }
 
     #[test]
     fn accepted_event_enters_timeline_without_checkpoint() {
         let mut t = timeline_with_stream();
         let out = t.record_event("chess", 7, emitted("move.played")).unwrap();
-        assert_eq!(out.checkpoint_id, None, "no rollback metadata = no checkpoint");
+        assert_eq!(
+            out.checkpoint_id, None,
+            "no rollback metadata = no checkpoint"
+        );
         assert_eq!(t.events().len(), 1);
         let rec = &t.events()[0];
         assert_eq!(rec.app_id, "chess");
@@ -823,7 +850,9 @@ mod tests {
         e.rollback_token = Some("undo-abc".to_string());
         e.changed_resources = vec!["game-abc".to_string()];
         let out = t.record_event("chess", 7, e).unwrap();
-        let ckpt_id = out.checkpoint_id.expect("rollback metadata must checkpoint");
+        let ckpt_id = out
+            .checkpoint_id
+            .expect("rollback metadata must checkpoint");
         let ckpt = &t.checkpoints()[0];
         assert_eq!(ckpt.checkpoint_id, ckpt_id);
         assert_eq!(ckpt.rollback_token, "undo-abc");
@@ -840,7 +869,11 @@ mod tests {
         let mut t = timeline_with_stream();
         let mut e = emitted("move.played");
         e.rollback_token = Some("undo-abc".to_string());
-        let ckpt_id = t.record_event("chess", 7, e).unwrap().checkpoint_id.unwrap();
+        let ckpt_id = t
+            .record_event("chess", 7, e)
+            .unwrap()
+            .checkpoint_id
+            .unwrap();
 
         let verify = t.begin_rollback(&ckpt_id).unwrap();
         assert_eq!(verify.expected_revision, "rev-13");
@@ -865,7 +898,11 @@ mod tests {
         let mut t = timeline_with_stream();
         let mut e = emitted("move.played");
         e.rollback_token = Some("undo-abc".to_string());
-        let ckpt_id = t.record_event("chess", 7, e).unwrap().checkpoint_id.unwrap();
+        let ckpt_id = t
+            .record_event("chess", 7, e)
+            .unwrap()
+            .checkpoint_id
+            .unwrap();
 
         t.begin_rollback(&ckpt_id).unwrap();
         let verdict = t.resolve_rollback_verify(&ckpt_id, "rev-99").unwrap();
@@ -886,7 +923,11 @@ mod tests {
         ));
         let mut e = emitted("move.played");
         e.rollback_token = Some("undo-abc".to_string());
-        let ckpt_id = t.record_event("chess", 7, e).unwrap().checkpoint_id.unwrap();
+        let ckpt_id = t
+            .record_event("chess", 7, e)
+            .unwrap()
+            .checkpoint_id
+            .unwrap();
         t.begin_rollback(&ckpt_id).unwrap();
         assert!(matches!(
             t.begin_rollback(&ckpt_id),
@@ -900,7 +941,8 @@ mod tests {
     #[test]
     fn subscription_routing_filters_event_name_and_resource() {
         let mut t = timeline_with_stream();
-        t.declare_streams("chess", vec![decl("game.ended")]).unwrap();
+        t.declare_streams("chess", vec![decl("game.ended")])
+            .unwrap();
         let mut sub = subscription(PayloadMode::Summary, TriggerMode::Conversation);
         sub.event_names = vec!["game.ended".to_string()];
         t.add_subscription(sub);
@@ -919,7 +961,10 @@ mod tests {
         sub2.resource_id = Some("game-other".to_string());
         t.add_subscription(sub2);
         let out = t.record_event("chess", 1, emitted("move.played")).unwrap();
-        assert_eq!(out.deliveries_queued, 0, "resource mismatch must not deliver");
+        assert_eq!(
+            out.deliveries_queued, 0,
+            "resource mismatch must not deliver"
+        );
 
         // Deliveries for someone else stay queued.
         assert!(t
@@ -939,7 +984,10 @@ mod tests {
         let mut t = timeline_with_stream();
         t.add_subscription(subscription(PayloadMode::Full, TriggerMode::Never));
         let out = t.record_event("chess", 1, emitted("move.played")).unwrap();
-        assert_eq!(out.deliveries_queued, 0, "never = timeline only, no delivery");
+        assert_eq!(
+            out.deliveries_queued, 0,
+            "never = timeline only, no delivery"
+        );
         assert_eq!(t.events().len(), 1);
         assert_eq!(t.pending_delivery_count(), 0);
     }

--- a/src/host/keys.rs
+++ b/src/host/keys.rs
@@ -1203,8 +1203,13 @@ mod tests {
         let mut actions = Vec::new();
         let _ = ctx.run(raw, |ctx| {
             actions = poll_actions(
-                ctx, &table, /* app_active */ true, /* keyboard_capture */ false,
-                /* overlay_open */ false, /* shortcuts_overlay_open */ false, tab_captured,
+                ctx,
+                &table,
+                /* app_active */ true,
+                /* keyboard_capture */ false,
+                /* overlay_open */ false,
+                /* shortcuts_overlay_open */ false,
+                tab_captured,
             );
         });
         actions

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,7 +215,10 @@ fn main() -> eframe::Result {
         Ok(cli) => {
             if let Some(cmd) = cli.command {
                 match cmd {
-                    Commands::Run { command, extra_args } => match command {
+                    Commands::Run {
+                        command,
+                        extra_args,
+                    } => match command {
                         Some(cmd) => std::process::exit(cli::run_command(&cmd, &extra_args)),
                         None => std::process::exit(cli::run_list_commands()),
                     },
@@ -832,7 +835,10 @@ fn main() -> eframe::Result {
                             if json {
                                 let runner = cli::descriptor::RealRunner;
                                 match cli::descriptor::resolve_cli_with(
-                                    &runner, &command, !no_registry, !no_crawl,
+                                    &runner,
+                                    &command,
+                                    !no_registry,
+                                    !no_crawl,
                                 ) {
                                     Ok(resolved) => {
                                         match serde_json::to_string_pretty(&resolved.descriptor) {
@@ -841,7 +847,9 @@ fn main() -> eframe::Result {
                                                 std::process::exit(0);
                                             }
                                             Err(e) => {
-                                                eprintln!("error: could not serialize descriptor: {e}");
+                                                eprintln!(
+                                                    "error: could not serialize descriptor: {e}"
+                                                );
                                                 std::process::exit(1);
                                             }
                                         }
@@ -1107,7 +1115,9 @@ fn known_subcommands() -> &'static std::collections::HashSet<String> {
 /// Returns true when the only meaningful argument (ignoring `--profile <value>`) is `--help`/`-h`.
 fn top_level_help_flag(args: &[String]) -> bool {
     let mut skip_next = false;
-    let filtered: Vec<&str> = args.iter().skip(1)
+    let filtered: Vec<&str> = args
+        .iter()
+        .skip(1)
         .filter(|a| {
             if skip_next {
                 skip_next = false;

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -196,7 +196,9 @@ hidden = true
 /// Load triage actions from `<config_dir>/notes/actions.toml`.
 /// Writes the default template on first open. Returns an empty vec on parse errors.
 pub(crate) fn load_triage_actions() -> Vec<TriageAction> {
-    let actions_path = crate::config::config_dir().join("notes").join("actions.toml");
+    let actions_path = crate::config::config_dir()
+        .join("notes")
+        .join("actions.toml");
 
     if !actions_path.exists() {
         if let Some(parent) = actions_path.parent() {
@@ -276,11 +278,7 @@ fn parse_actions_toml(src: &str) -> Vec<TriageAction> {
 }
 
 /// Substitute {note}, {cwd}, {context_root} tokens in `cmd`.
-pub(crate) fn substitute_action_tokens(
-    cmd: &str,
-    note_body: &str,
-    fm: &NoteFrontmatter,
-) -> String {
+pub(crate) fn substitute_action_tokens(cmd: &str, note_body: &str, fm: &NoteFrontmatter) -> String {
     let quoted_note = crate::host::shell::shell_quote(note_body.trim());
     let cwd_str = fm
         .cwd
@@ -334,11 +332,7 @@ pub(crate) fn scan_inbox() -> Vec<InboxNote> {
 
     let mut paths: Vec<(std::time::SystemTime, PathBuf)> = entries
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path()
-                .extension()
-                .map_or(false, |x| x == "md")
-        })
+        .filter(|e| e.path().extension().map_or(false, |x| x == "md"))
         .filter_map(|e| {
             let mtime = e.metadata().and_then(|m| m.modified()).ok()?;
             Some((mtime, e.path()))
@@ -442,8 +436,7 @@ mod tests {
 
     #[test]
     fn picker_entry_title_fallbacks() {
-        let dir =
-            std::env::temp_dir().join(format!("plexi-notes-entry-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("plexi-notes-entry-{}", std::process::id()));
         std::fs::create_dir_all(&dir).expect("create temp dir");
 
         let titled = dir.join("titled.md");

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -214,7 +214,11 @@ fn palette_pane_rows_for_context(
                 pips: ListRowPips {
                     count: 1,
                     focused_idx: (Some(pane_id) == focused_pane_id).then_some(0),
-                    hidden_indices: if pane.is_hidden() { vec![0] } else { Vec::new() },
+                    hidden_indices: if pane.is_hidden() {
+                        vec![0]
+                    } else {
+                        Vec::new()
+                    },
                     activities: vec![pane.effective_activity().cloned()],
                 },
             });
@@ -319,21 +323,21 @@ impl PlexiApp {
                 if ctx_meta.parked {
                     continue;
                 }
-                let resolved = self
-                    .context_active_window
-                    .get(&ctx_meta.context_id)
-                    .copied()
-                    .and_then(|id| {
-                        self.windows.iter().enumerate().find(|(_, w)| {
-                            w.window_id == id && w.context_id == ctx_meta.context_id
+                let resolved =
+                    self.context_active_window
+                        .get(&ctx_meta.context_id)
+                        .copied()
+                        .and_then(|id| {
+                            self.windows.iter().enumerate().find(|(_, w)| {
+                                w.window_id == id && w.context_id == ctx_meta.context_id
+                            })
                         })
-                    })
-                    .or_else(|| {
-                        self.windows
-                            .iter()
-                            .enumerate()
-                            .find(|(_, w)| w.context_id == ctx_meta.context_id)
-                    });
+                        .or_else(|| {
+                            self.windows
+                                .iter()
+                                .enumerate()
+                                .find(|(_, w)| w.context_id == ctx_meta.context_id)
+                        });
                 let Some((win_idx, win)) = resolved else {
                     continue;
                 };
@@ -598,19 +602,14 @@ impl PlexiApp {
                 self.palette_query.clear();
                 let active = self.active_window;
                 let path_str = path.display().to_string();
-                if let Some((existing_tile_id, _)) =
-                    self.find_open_text_editor_tile(active, &path)
+                if let Some((existing_tile_id, _)) = self.find_open_text_editor_tile(active, &path)
                 {
                     log::info!("palette: note already open, focusing pane");
                     self.set_window_focused_pane(active, existing_tile_id);
                 } else {
                     log::info!("palette: opening note {:?} in new pane", path);
-                    let _ = self.launch_app_by_id_with_layout(
-                        "text-editor",
-                        None,
-                        &[path_str],
-                        None,
-                    );
+                    let _ =
+                        self.launch_app_by_id_with_layout("text-editor", None, &[path_str], None);
                 }
                 return;
             }
@@ -774,7 +773,11 @@ impl PlexiApp {
                                         hover_select = Some(i);
                                     }
                                 }
-                                PaletteEntry::Note { path, title, preview } => {
+                                PaletteEntry::Note {
+                                    path,
+                                    title,
+                                    preview,
+                                } => {
                                     if !shown_notes_header {
                                         shown_notes_header = true;
                                         ui.add_space(style::SPACE_XS);
@@ -794,8 +797,7 @@ impl PlexiApp {
                                         row_response.scroll_into_view(ui, should_scroll);
                                     }
                                     if row_response.row_clicked() {
-                                        click_action =
-                                            Some(Action::OpenNote(path.clone()));
+                                        click_action = Some(Action::OpenNote(path.clone()));
                                     }
                                     if row_response.row_hovered() {
                                         hover_select = Some(i);
@@ -844,15 +846,10 @@ impl PlexiApp {
                             if let Some((existing_tile_id, _)) =
                                 self.find_open_text_editor_tile(active, &path)
                             {
-                                log::info!(
-                                    "palette: note already open, focusing pane"
-                                );
+                                log::info!("palette: note already open, focusing pane");
                                 self.set_window_focused_pane(active, existing_tile_id);
                             } else {
-                                log::info!(
-                                    "palette: opening note {:?} in new pane",
-                                    path
-                                );
+                                log::info!("palette: opening note {:?} in new pane", path);
                                 let _ = self.launch_app_by_id_with_layout(
                                     "text-editor",
                                     None,
@@ -885,9 +882,7 @@ impl PlexiApp {
     /// If `pane_id` is provided, also focuses that specific pane in the window.
     fn jump_to_context(&mut self, ctx_idx: usize, win_id: u64, pane_id: Option<u64>) {
         let target_ctx_id = self.windows[ctx_idx].context_id;
-        log::info!(
-            "palette: jump to context {target_ctx_id} (window {win_id}, pane {pane_id:?})"
-        );
+        log::info!("palette: jump to context {target_ctx_id} (window {win_id}, pane {pane_id:?})");
         if let Some(ctx_idx_sidebar) = self.router.position(|c| c.context_id == target_ctx_id) {
             if ctx_idx_sidebar != self.router.active_idx() {
                 // switch_workspace → pick_active_context_from_workspace sets

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -381,11 +381,7 @@ impl PlexiApp {
         let filtered = self.notes_picker_filtered();
         let selected = self.notes_picker_selected;
         let total = self.notes_picker_entries.len();
-        let inbox_total = self
-            .notes_picker_entries
-            .iter()
-            .filter(|e| e.inbox)
-            .count();
+        let inbox_total = self.notes_picker_entries.iter().filter(|e| e.inbox).count();
         let filtering = self.notes_picker_filtering;
         let renaming = self.notes_picker_rename.is_some();
 
@@ -458,8 +454,8 @@ impl PlexiApp {
                                 shown_inbox_header = true;
                                 ui.label(
                                     egui::RichText::new(format!("Inbox ({inbox_total})"))
-                                    .size(style::TEXT_CAPTION)
-                                    .color(colors.text_dim),
+                                        .size(style::TEXT_CAPTION)
+                                        .color(colors.text_dim),
                                 );
                                 ui.add_space(style::SPACE_XS);
                             }

--- a/src/overlays/notes_triage.rs
+++ b/src/overlays/notes_triage.rs
@@ -102,14 +102,22 @@ impl PlexiApp {
                 self.notes_triage_back_to_picker();
             }
             Some(TriageKey::Keep) => {
-                if let Some(note) = self.notes_triage_notes.get(self.notes_triage_index).cloned() {
+                if let Some(note) = self
+                    .notes_triage_notes
+                    .get(self.notes_triage_index)
+                    .cloned()
+                {
                     log::info!("notes_triage: s — keeping {:?}", note.path);
                     self.notes_triage_keep(&note);
                     self.notes_triage_advance();
                 }
             }
             Some(TriageKey::Trash) => {
-                if let Some(note) = self.notes_triage_notes.get(self.notes_triage_index).cloned() {
+                if let Some(note) = self
+                    .notes_triage_notes
+                    .get(self.notes_triage_index)
+                    .cloned()
+                {
                     log::info!("notes_triage: d/x — trashing {:?}", note.path);
                     self.notes_triage_trash(&note);
                     self.notes_triage_advance();
@@ -135,7 +143,9 @@ impl PlexiApp {
                     .cloned();
                 if let (Some(action), Some(note)) = (
                     action,
-                    self.notes_triage_notes.get(self.notes_triage_index).cloned(),
+                    self.notes_triage_notes
+                        .get(self.notes_triage_index)
+                        .cloned(),
                 ) {
                     log::info!(
                         "notes_triage: {} — running action '{}' on {:?}",
@@ -320,9 +330,7 @@ impl PlexiApp {
 
     /// Move `note` to `notes/<workspace>/` using an explicit workspace slug.
     pub(crate) fn notes_triage_keep_to(&self, note: &InboxNote, workspace: &str) {
-        let dest_dir = crate::config::config_dir()
-            .join("notes")
-            .join(workspace);
+        let dest_dir = crate::config::config_dir().join("notes").join(workspace);
         if let Err(e) = std::fs::create_dir_all(&dest_dir) {
             log::warn!("notes_triage: keep — failed to create {:?}: {e}", dest_dir);
             return;
@@ -336,11 +344,7 @@ impl PlexiApp {
                 match std::fs::copy(&note.path, &dest) {
                     Ok(_) => {
                         let _ = std::fs::remove_file(&note.path);
-                        log::info!(
-                            "notes_triage: kept (copy) {:?} → {:?}",
-                            note.path,
-                            dest
-                        );
+                        log::info!("notes_triage: kept (copy) {:?} → {:?}", note.path, dest);
                     }
                     Err(e2) => {
                         log::warn!(
@@ -357,7 +361,10 @@ impl PlexiApp {
     pub(crate) fn notes_triage_trash(&self, note: &InboxNote) {
         let trash_dir = crate::config::config_dir().join("notes").join("trash");
         if let Err(e) = std::fs::create_dir_all(&trash_dir) {
-            log::warn!("notes_triage: trash — failed to create {:?}: {e}", trash_dir);
+            log::warn!(
+                "notes_triage: trash — failed to create {:?}: {e}",
+                trash_dir
+            );
             // Fallback: just delete.
             let _ = std::fs::remove_file(&note.path);
             return;
@@ -366,25 +373,19 @@ impl PlexiApp {
         let dest = trash_dir.join(file_name);
         match std::fs::rename(&note.path, &dest) {
             Ok(_) => log::info!("notes_triage: trashed {:?} → {:?}", note.path, dest),
-            Err(_) => {
-                match std::fs::copy(&note.path, &dest) {
-                    Ok(_) => {
-                        let _ = std::fs::remove_file(&note.path);
-                        log::info!(
-                            "notes_triage: trashed (copy) {:?} → {:?}",
-                            note.path,
-                            dest
-                        );
-                    }
-                    Err(e2) => {
-                        log::warn!(
-                            "notes_triage: trash failed {:?}: {e2} — deleting directly",
-                            note.path
-                        );
-                        let _ = std::fs::remove_file(&note.path);
-                    }
+            Err(_) => match std::fs::copy(&note.path, &dest) {
+                Ok(_) => {
+                    let _ = std::fs::remove_file(&note.path);
+                    log::info!("notes_triage: trashed (copy) {:?} → {:?}", note.path, dest);
                 }
-            }
+                Err(e2) => {
+                    log::warn!(
+                        "notes_triage: trash failed {:?}: {e2} — deleting directly",
+                        note.path
+                    );
+                    let _ = std::fs::remove_file(&note.path);
+                }
+            },
         }
     }
 
@@ -412,7 +413,7 @@ impl PlexiApp {
                 self.spawn_terminal_pane_at(
                     win_idx,
                     focused_tile,
-                    true,  // split vertically
+                    true, // split vertically
                     false,
                     Some(&cmd),
                     false, // keep pane open after exit

--- a/src/overlays/notification_modal.rs
+++ b/src/overlays/notification_modal.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::ui::button::{ButtonKind, chrome_button, choice_button};
+use crate::ui::button::{choice_button, chrome_button, ButtonKind};
 
 /// Maximum displayed image height inside the notification card. Width is
 /// constrained by the card's available width; aspect ratio is preserved.
@@ -284,200 +284,203 @@ impl PlexiApp {
                         ui.allocate_exact_size(Vec2::new(10.0, 10.0), egui::Sense::hover());
                     ui.painter()
                         .circle_filled(dot_rect.center(), 5.0, level_color);
-                            ui.add_space(style::SPACE_SM);
-                            let kind_label = match notif.kind {
-                                NotifyKind::Message => "MESSAGE",
-                                NotifyKind::Choice => "CHOICE",
-                                NotifyKind::Input => "INPUT",
-                            };
+                    ui.add_space(style::SPACE_SM);
+                    let kind_label = match notif.kind {
+                        NotifyKind::Message => "MESSAGE",
+                        NotifyKind::Choice => "CHOICE",
+                        NotifyKind::Input => "INPUT",
+                    };
+                    ui.label(
+                        RichText::new(format!("{}  ·  {}", notif.level.to_uppercase(), kind_label))
+                            .size(style::TEXT_HINT)
+                            .color(self.colors.text_dim)
+                            .strong(),
+                    );
+                    ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                        if queue_len > 1 {
+                            // RTL layout: L first (rightmost), then H.
+                            crate::ui::shortcuts::key_chip(
+                                ui,
+                                "L",
+                                &self.colors,
+                                egui::FontId::monospace(crate::ui::style::TEXT_CAPTION),
+                            );
+                            ui.add_space(4.0);
+                            crate::ui::shortcuts::key_chip(
+                                ui,
+                                "H",
+                                &self.colors,
+                                egui::FontId::monospace(crate::ui::style::TEXT_CAPTION),
+                            );
+                            ui.add_space(8.0);
                             ui.label(
-                                RichText::new(format!(
-                                    "{}  ·  {}",
-                                    notif.level.to_uppercase(),
-                                    kind_label
-                                ))
-                                .size(style::TEXT_HINT)
+                                RichText::new(format!("{position_idx} of {queue_len}  ·  cycle"))
+                                    .size(style::TEXT_HINT)
+                                    .color(self.colors.text_dim),
+                            );
+                        }
+                    });
+                });
+
+                ui.add_space(style::SPACE_XL);
+
+                // Title — centered, large.
+                ui.vertical_centered(|ui| {
+                    ui.label(
+                        RichText::new(&notif.title)
+                            .size(style::TEXT_TITLE_XL)
+                            .color(self.colors.text_primary)
+                            .strong(),
+                    );
+                });
+
+                // Body — centered under the title.
+                if !notif.body.is_empty() {
+                    ui.add_space(style::SPACE_MD);
+                    ui.vertical_centered(|ui| {
+                        ui.set_max_width(style::MODAL_WIDTH_NOTIFY - 120.0);
+                        ui.label(
+                            RichText::new(&notif.body)
+                                .size(style::TEXT_BODY)
+                                .color(self.colors.text_primary),
+                        );
+                    });
+                }
+
+                // Image attachment (#74) — renders above the
+                // kind-specific body / action buttons. Sized to fit
+                // the modal width with aspect ratio preserved, max
+                // height 200 px. Placeholder badges render the
+                // user-visible reason text.
+                if let Some(state) = &image_state {
+                    ui.add_space(style::SPACE_MD);
+                    ui.vertical_centered(|ui| {
+                        draw_notification_image(ui, state, &self.colors);
+                    });
+                }
+
+                ui.add_space(style::SPACE_XL);
+
+                if notif.tombstoned {
+                    // Source ended — show a dim label and a plain Dismiss button.
+                    // Action buttons are hidden since the app can no longer respond.
+                    ui.add_space(style::SPACE_SM);
+                    ui.vertical_centered(|ui| {
+                        ui.label(
+                            RichText::new("Source ended")
+                                .size(style::TEXT_BODY)
                                 .color(self.colors.text_dim)
-                                .strong(),
-                            );
-                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                                if queue_len > 1 {
-                                    // RTL layout: L first (rightmost), then H.
-                                    crate::ui::shortcuts::key_chip(
-                                        ui, "L", &self.colors,
-                                        egui::FontId::monospace(crate::ui::style::TEXT_CAPTION),
-                                    );
-                                    ui.add_space(4.0);
-                                    crate::ui::shortcuts::key_chip(
-                                        ui, "H", &self.colors,
-                                        egui::FontId::monospace(crate::ui::style::TEXT_CAPTION),
-                                    );
-                                    ui.add_space(8.0);
-                                    ui.label(
-                                        RichText::new(format!(
-                                            "{position_idx} of {queue_len}  ·  cycle"
-                                        ))
-                                        .size(style::TEXT_HINT)
-                                        .color(self.colors.text_dim),
-                                    );
-                                }
-                            });
-                        });
-
-                        ui.add_space(style::SPACE_XL);
-
-                        // Title — centered, large.
-                        ui.vertical_centered(|ui| {
-                            ui.label(
-                                RichText::new(&notif.title)
-                                    .size(style::TEXT_TITLE_XL)
-                                    .color(self.colors.text_primary)
-                                    .strong(),
-                            );
-                        });
-
-                        // Body — centered under the title.
-                        if !notif.body.is_empty() {
-                            ui.add_space(style::SPACE_MD);
-                            ui.vertical_centered(|ui| {
-                                ui.set_max_width(style::MODAL_WIDTH_NOTIFY - 120.0);
-                                ui.label(
-                                    RichText::new(&notif.body)
-                                        .size(style::TEXT_BODY)
-                                        .color(self.colors.text_primary),
-                                );
-                            });
-                        }
-
-                        // Image attachment (#74) — renders above the
-                        // kind-specific body / action buttons. Sized to fit
-                        // the modal width with aspect ratio preserved, max
-                        // height 200 px. Placeholder badges render the
-                        // user-visible reason text.
-                        if let Some(state) = &image_state {
-                            ui.add_space(style::SPACE_MD);
-                            ui.vertical_centered(|ui| {
-                                draw_notification_image(ui, state, &self.colors);
-                            });
-                        }
-
-                        ui.add_space(style::SPACE_XL);
-
-                        if notif.tombstoned {
-                            // Source ended — show a dim label and a plain Dismiss button.
-                            // Action buttons are hidden since the app can no longer respond.
-                            ui.add_space(style::SPACE_SM);
-                            ui.vertical_centered(|ui| {
-                                ui.label(
-                                    RichText::new("Source ended")
-                                        .size(style::TEXT_BODY)
-                                        .color(self.colors.text_dim)
-                                        .italics(),
-                                );
-                            });
-                            ui.add_space(style::SPACE_SM);
-                            ui.add_space(style::SPACE_MD);
-                            ui.vertical_centered(|ui| {
-                                let resp = chrome_button(ui, "Dismiss", ButtonKind::Accent, &self.colors, 180.0);
-                                if resp.clicked() {
-                                    if let Some(n) = self.pending_notifications
-                                        .iter()
-                                        .find(|n| n.notify_id == current_id)
-                                        .cloned()
-                                    {
-                                        self.pending_notifications
-                                            .retain(|x| x.notify_id != current_id);
-                                        self.save_notifications();
-                                        self.current_notify_id = None;
-                                        if !n.notify_id.is_empty()
-                                            && !n.notify_id.starts_with("__host__:")
-                                        {
-                                            action_cmd =
-                                                Some(AppCommand::DeliverNotifyAction {
-                                                    pane_id: n.sender_pane_id,
-                                                    notify_id: n.notify_id.clone(),
-                                                    action_label: "tombstone_dismiss"
-                                                        .to_string(),
-                                                    value: Some(
-                                                        "tombstone_dismiss".to_string(),
-                                                    ),
-                                                    response_file: n.response_file,
-                                                    host_action: None,
-                                                });
-                                        }
-                                    }
-                                }
-                            });
-                            ui.add_space(style::SPACE_MD);
-                        } else {
-                        // Kind-specific body.
-                        match notif.kind {
-                            NotifyKind::Message => {}
-                            NotifyKind::Choice => {
-                                for (idx, opt) in notif.options.iter().enumerate() {
-                                    let focused = idx == self.modal_focused_option;
-                                    let shortcut_hint = opt
-                                        .shortcut
-                                        .as_ref()
-                                        .map(|s| format!("[{}]", s.to_uppercase()))
-                                        .unwrap_or_else(|| format!("[{}]", idx + 1));
-                                    let resp = choice_button(
-                                        ui,
-                                        &opt.label,
-                                        &shortcut_hint,
-                                        focused,
-                                        &self.colors,
-                                    );
-                                    if resp.clicked() {
-                                        let value = if opt.value.is_empty() {
-                                            opt.label.clone()
-                                        } else {
-                                            opt.value.clone()
-                                        };
-                                        action_cmd = Some(AppCommand::DeliverNotifyAction {
-                                            pane_id: notif.sender_pane_id,
-                                            notify_id: notif.notify_id.clone(),
-                                            action_label: opt.label.clone(),
-                                            value: Some(value),
-                                            response_file: notif.response_file.clone(),
-                                            host_action: opt.host_action.clone(),
-                                        });
-                                    }
-                                    ui.add_space(style::SPACE_SM);
+                                .italics(),
+                        );
+                    });
+                    ui.add_space(style::SPACE_SM);
+                    ui.add_space(style::SPACE_MD);
+                    ui.vertical_centered(|ui| {
+                        let resp =
+                            chrome_button(ui, "Dismiss", ButtonKind::Accent, &self.colors, 180.0);
+                        if resp.clicked() {
+                            if let Some(n) = self
+                                .pending_notifications
+                                .iter()
+                                .find(|n| n.notify_id == current_id)
+                                .cloned()
+                            {
+                                self.pending_notifications
+                                    .retain(|x| x.notify_id != current_id);
+                                self.save_notifications();
+                                self.current_notify_id = None;
+                                if !n.notify_id.is_empty() && !n.notify_id.starts_with("__host__:")
+                                {
+                                    action_cmd = Some(AppCommand::DeliverNotifyAction {
+                                        pane_id: n.sender_pane_id,
+                                        notify_id: n.notify_id.clone(),
+                                        action_label: "tombstone_dismiss".to_string(),
+                                        value: Some("tombstone_dismiss".to_string()),
+                                        response_file: n.response_file,
+                                        host_action: None,
+                                    });
                                 }
                             }
-                            NotifyKind::Input => {
-                                if let Some(prompt) = &notif.input_prompt {
-                                    ui.vertical_centered(|ui| {
-                                        ui.label(
-                                            RichText::new(prompt)
-                                                .size(style::TEXT_CAPTION)
-                                                .color(self.colors.text_dim),
-                                        );
+                        }
+                    });
+                    ui.add_space(style::SPACE_MD);
+                } else {
+                    // Kind-specific body.
+                    match notif.kind {
+                        NotifyKind::Message => {}
+                        NotifyKind::Choice => {
+                            for (idx, opt) in notif.options.iter().enumerate() {
+                                let focused = idx == self.modal_focused_option;
+                                let shortcut_hint = opt
+                                    .shortcut
+                                    .as_ref()
+                                    .map(|s| format!("[{}]", s.to_uppercase()))
+                                    .unwrap_or_else(|| format!("[{}]", idx + 1));
+                                let resp = choice_button(
+                                    ui,
+                                    &opt.label,
+                                    &shortcut_hint,
+                                    focused,
+                                    &self.colors,
+                                );
+                                if resp.clicked() {
+                                    let value = if opt.value.is_empty() {
+                                        opt.label.clone()
+                                    } else {
+                                        opt.value.clone()
+                                    };
+                                    action_cmd = Some(AppCommand::DeliverNotifyAction {
+                                        pane_id: notif.sender_pane_id,
+                                        notify_id: notif.notify_id.clone(),
+                                        action_label: opt.label.clone(),
+                                        value: Some(value),
+                                        response_file: notif.response_file.clone(),
+                                        host_action: opt.host_action.clone(),
                                     });
-                                    ui.add_space(style::SPACE_SM);
                                 }
-                                // Multiline editor: Enter inserts a newline,
-                                // Cmd+Enter submits (handled in the keyboard
-                                // pre-pass below). Scrolls vertically once it
-                                // exceeds the visible row count.
-                                let resp = ui.scope(|ui| {
+                                ui.add_space(style::SPACE_SM);
+                            }
+                        }
+                        NotifyKind::Input => {
+                            if let Some(prompt) = &notif.input_prompt {
+                                ui.vertical_centered(|ui| {
+                                    ui.label(
+                                        RichText::new(prompt)
+                                            .size(style::TEXT_CAPTION)
+                                            .color(self.colors.text_dim),
+                                    );
+                                });
+                                ui.add_space(style::SPACE_SM);
+                            }
+                            // Multiline editor: Enter inserts a newline,
+                            // Cmd+Enter submits (handled in the keyboard
+                            // pre-pass below). Scrolls vertically once it
+                            // exceeds the visible row count.
+                            let resp = ui
+                                .scope(|ui| {
                                     // egui's caret is hidden (transparent, non-blinking);
                                     // draw_text_caret paints a glyph-height replacement on top.
                                     ui.visuals_mut().text_cursor.blink = false;
-                                    ui.visuals_mut().text_cursor.stroke.color = egui::Color32::TRANSPARENT;
+                                    ui.visuals_mut().text_cursor.stroke.color =
+                                        egui::Color32::TRANSPARENT;
                                     ui.visuals_mut().extreme_bg_color = self.colors.bg_active;
-                                    ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, self.colors.accent);
-                                    ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, self.colors.border);
+                                    ui.visuals_mut().widgets.active.bg_stroke =
+                                        egui::Stroke::new(1.0, self.colors.accent);
+                                    ui.visuals_mut().widgets.inactive.bg_stroke =
+                                        egui::Stroke::new(1.0, self.colors.border);
                                     let font_id = egui::FontId::proportional(16.0);
                                     let row_height = ui.fonts(|f| f.row_height(&font_id));
-                                    let output = egui::TextEdit::multiline(&mut self.modal_input_buffer)
-                                        .desired_width(f32::INFINITY)
-                                        .desired_rows(6)
-                                        .font(font_id)
-                                        .margin(egui::Margin::symmetric(12, 10))
-                                        .hint_text("Type. Enter for newline, \u{2318}\u{21B5} to submit.")
-                                        .show(ui);
+                                    let output = egui::TextEdit::multiline(
+                                        &mut self.modal_input_buffer,
+                                    )
+                                    .desired_width(f32::INFINITY)
+                                    .desired_rows(6)
+                                    .font(font_id)
+                                    .margin(egui::Margin::symmetric(12, 10))
+                                    .hint_text(
+                                        "Type. Enter for newline, \u{2318}\u{21B5} to submit.",
+                                    )
+                                    .show(ui);
                                     crate::ui::text_field::draw_text_caret(
                                         ui,
                                         &output,
@@ -486,116 +489,121 @@ impl PlexiApp {
                                         egui::Stroke::new(1.5, self.colors.accent),
                                     );
                                     output.response
-                                }).inner;
-                                resp.request_focus();
-                            }
+                                })
+                                .inner;
+                            resp.request_focus();
                         }
+                    }
 
+                    ui.add_space(style::SPACE_MD);
+
+                    // Footer: primary action for message kind, plus a
+                    // centered hint row describing keyboard shortcuts.
+                    if matches!(notif.kind, NotifyKind::Message) {
+                        ui.vertical_centered(|ui| {
+                            let resp = chrome_button(
+                                ui,
+                                "Acknowledge",
+                                ButtonKind::Accent,
+                                &self.colors,
+                                180.0,
+                            );
+                            if resp.clicked() {
+                                action_cmd = Some(AppCommand::DeliverNotifyAction {
+                                    pane_id: notif.sender_pane_id,
+                                    notify_id: notif.notify_id.clone(),
+                                    action_label: "acknowledge".to_string(),
+                                    value: None,
+                                    response_file: notif.response_file.clone(),
+                                    host_action: None,
+                                });
+                            }
+                        });
                         ui.add_space(style::SPACE_MD);
+                    }
+                } // end !tombstoned
 
-                        // Footer: primary action for message kind, plus a
-                        // centered hint row describing keyboard shortcuts.
-                        if matches!(notif.kind, NotifyKind::Message) {
-                            ui.vertical_centered(|ui| {
-                                let resp = chrome_button(ui, "Acknowledge", ButtonKind::Accent, &self.colors, 180.0);
-                                if resp.clicked() {
-                                    action_cmd = Some(AppCommand::DeliverNotifyAction {
-                                        pane_id: notif.sender_pane_id,
-                                        notify_id: notif.notify_id.clone(),
-                                        action_label: "acknowledge".to_string(),
-                                        value: None,
-                                        response_file: notif.response_file.clone(),
-                                        host_action: None,
-                                    });
-                                }
-                            });
-                            ui.add_space(style::SPACE_MD);
+                // Footer keyboard hints — separator + centered hint row per kind.
+                // Not shown for tombstoned notifications (only a Dismiss button).
+                //
+                // Centering strategy: egui's vertical_centered expands all child
+                // rects to full available width (Layout::top_down(Center) sets
+                // frame_size.x = max(desired, available)), so placing a ui.horizontal
+                // inside vertical_centered does NOT center it — content paints at x=0.
+                // Fix: pre-measure the row width with ui.fonts, then use
+                // allocate_ui_with_layout(exact_size) — justify_and_align then places
+                // the child rect at center_x − hint_w/2, which IS centered.
+                if !notif.tombstoned {
+                    ui.add_space(style::SPACE_SM);
+                    ui.separator();
+                    match notif.kind {
+                        NotifyKind::Message if notif.required => {
+                            let hints = [crate::ui::hints::HintGroup::alternatives(
+                                &[&["Enter"], &["Space"]],
+                                "acknowledge",
+                            )];
+                            crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
                         }
-                        } // end !tombstoned
-
-                        // Footer keyboard hints — separator + centered hint row per kind.
-                        // Not shown for tombstoned notifications (only a Dismiss button).
-                        //
-                        // Centering strategy: egui's vertical_centered expands all child
-                        // rects to full available width (Layout::top_down(Center) sets
-                        // frame_size.x = max(desired, available)), so placing a ui.horizontal
-                        // inside vertical_centered does NOT center it — content paints at x=0.
-                        // Fix: pre-measure the row width with ui.fonts, then use
-                        // allocate_ui_with_layout(exact_size) — justify_and_align then places
-                        // the child rect at center_x − hint_w/2, which IS centered.
-                        if !notif.tombstoned {
-                            ui.add_space(style::SPACE_SM);
-                            ui.separator();
-                            match notif.kind {
-                                NotifyKind::Message if notif.required => {
-                                    let hints = [
-                                        crate::ui::hints::HintGroup::alternatives(
-                                            &[&["Enter"], &["Space"]],
-                                            "acknowledge",
-                                        ),
-                                    ];
-                                    crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
-                                }
-                                NotifyKind::Message => {
-                                    let hints = [
-                                        crate::ui::hints::HintGroup::alternatives(
-                                            &[&["Enter"], &["Space"]],
-                                            "acknowledge",
-                                        ),
-                                        crate::ui::hints::HintGroup::new(&["Esc"], "dismiss"),
-                                    ];
-                                    crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
-                                }
-                                NotifyKind::Choice if notif.required => {
-                                    let hints = [
-                                        crate::ui::hints::HintGroup::alternatives(
-                                            &[&["↑↓"], &["j/k"]],
-                                            "navigate",
-                                        ),
-                                        crate::ui::hints::HintGroup::alternatives(
-                                            &[&["Enter"], &["1-9"]],
-                                            "select",
-                                        ),
-                                    ];
-                                    crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
-                                }
-                                NotifyKind::Choice => {
-                                    let hints = [
-                                        crate::ui::hints::HintGroup::alternatives(
-                                            &[&["↑↓"], &["j/k"]],
-                                            "navigate",
-                                        ),
-                                        crate::ui::hints::HintGroup::alternatives(
-                                            &[&["Enter"], &["1-9"]],
-                                            "select",
-                                        ),
-                                        crate::ui::hints::HintGroup::new(&["Esc"], "dismiss"),
-                                    ];
-                                    crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
-                                }
-                                NotifyKind::Input if notif.required => {
-                                    let hints = [
-                                        crate::ui::hints::HintGroup::new(&["Enter"], "newline"),
-                                        crate::ui::hints::HintGroup::new(
-                                            &["\u{2318}", "\u{21B5}"],
-                                            "submit",
-                                        ),
-                                    ];
-                                    crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
-                                }
-                                NotifyKind::Input => {
-                                    let hints = [
-                                        crate::ui::hints::HintGroup::new(&["Enter"], "newline"),
-                                        crate::ui::hints::HintGroup::new(
-                                            &["\u{2318}", "\u{21B5}"],
-                                            "submit",
-                                        ),
-                                        crate::ui::hints::HintGroup::new(&["Esc"], "dismiss"),
-                                    ];
-                                    crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
-                                }
-                            }
-                        } // end !tombstoned keyboard hint
+                        NotifyKind::Message => {
+                            let hints = [
+                                crate::ui::hints::HintGroup::alternatives(
+                                    &[&["Enter"], &["Space"]],
+                                    "acknowledge",
+                                ),
+                                crate::ui::hints::HintGroup::new(&["Esc"], "dismiss"),
+                            ];
+                            crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
+                        }
+                        NotifyKind::Choice if notif.required => {
+                            let hints = [
+                                crate::ui::hints::HintGroup::alternatives(
+                                    &[&["↑↓"], &["j/k"]],
+                                    "navigate",
+                                ),
+                                crate::ui::hints::HintGroup::alternatives(
+                                    &[&["Enter"], &["1-9"]],
+                                    "select",
+                                ),
+                            ];
+                            crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
+                        }
+                        NotifyKind::Choice => {
+                            let hints = [
+                                crate::ui::hints::HintGroup::alternatives(
+                                    &[&["↑↓"], &["j/k"]],
+                                    "navigate",
+                                ),
+                                crate::ui::hints::HintGroup::alternatives(
+                                    &[&["Enter"], &["1-9"]],
+                                    "select",
+                                ),
+                                crate::ui::hints::HintGroup::new(&["Esc"], "dismiss"),
+                            ];
+                            crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
+                        }
+                        NotifyKind::Input if notif.required => {
+                            let hints = [
+                                crate::ui::hints::HintGroup::new(&["Enter"], "newline"),
+                                crate::ui::hints::HintGroup::new(
+                                    &["\u{2318}", "\u{21B5}"],
+                                    "submit",
+                                ),
+                            ];
+                            crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
+                        }
+                        NotifyKind::Input => {
+                            let hints = [
+                                crate::ui::hints::HintGroup::new(&["Enter"], "newline"),
+                                crate::ui::hints::HintGroup::new(
+                                    &["\u{2318}", "\u{21B5}"],
+                                    "submit",
+                                ),
+                                crate::ui::hints::HintGroup::new(&["Esc"], "dismiss"),
+                            ];
+                            crate::ui::hints::HintBar::new(&hints).show(ui, &self.colors);
+                        }
+                    }
+                } // end !tombstoned keyboard hint
             });
 
         // ── Resolve keyboard input into an action_cmd (only if not already

--- a/src/overlays/quick_note.rs
+++ b/src/overlays/quick_note.rs
@@ -99,10 +99,12 @@ impl PlexiApp {
                     {
                         // Hint
                         ui.label(
-                            RichText::new("Enter to save  ·  Shift+Enter for new line  ·  Esc to discard")
-                                .color(self.colors.text_dim.linear_multiply(0.5))
-                                .size(style::TEXT_HINT)
-                                .family(egui::FontFamily::Monospace),
+                            RichText::new(
+                                "Enter to save  ·  Shift+Enter for new line  ·  Esc to discard",
+                            )
+                            .color(self.colors.text_dim.linear_multiply(0.5))
+                            .size(style::TEXT_HINT)
+                            .family(egui::FontFamily::Monospace),
                         );
                         ui.add_space(style::SPACE_SM);
 
@@ -120,25 +122,23 @@ impl PlexiApp {
 
                                     let te_id = egui::Id::new("quick_note_text");
                                     let qn_font_id = egui::FontId::monospace(style::TEXT_BODY);
-                                    let qn_row_height =
-                                        ui.fonts(|f| f.row_height(&qn_font_id));
-                                    let output = egui::TextEdit::multiline(
-                                        &mut self.quick_note_text,
-                                    )
-                                    .id(te_id)
-                                    .font(qn_font_id)
-                                    .text_color(self.colors.text_primary)
-                                    .desired_width(f32::INFINITY)
-                                    .desired_rows(initial_rows)
-                                    .frame(false)
-                                    .hint_text(
-                                        RichText::new("What's on your mind?")
-                                            .color(
-                                                self.colors.text_dim.linear_multiply(0.3),
+                                    let qn_row_height = ui.fonts(|f| f.row_height(&qn_font_id));
+                                    let output =
+                                        egui::TextEdit::multiline(&mut self.quick_note_text)
+                                            .id(te_id)
+                                            .font(qn_font_id)
+                                            .text_color(self.colors.text_primary)
+                                            .desired_width(f32::INFINITY)
+                                            .desired_rows(initial_rows)
+                                            .frame(false)
+                                            .hint_text(
+                                                RichText::new("What's on your mind?")
+                                                    .color(
+                                                        self.colors.text_dim.linear_multiply(0.3),
+                                                    )
+                                                    .size(style::TEXT_BODY),
                                             )
-                                            .size(style::TEXT_BODY),
-                                    )
-                                    .show(ui);
+                                            .show(ui);
                                     crate::ui::text_field::draw_text_caret(
                                         ui,
                                         &output,

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1940,14 +1940,21 @@ mod tests {
         h.app.open_scratchpad();
 
         // Overlay replaces in-place: still 1 pane in the map.
-        assert_eq!(h.pane_count(), 1, "overlay replaces in-place; count must stay 1");
+        assert_eq!(
+            h.pane_count(),
+            1,
+            "overlay replaces in-place; count must stay 1"
+        );
 
         // Top of the overlay chain — second scratchpad call.
         let win = &h.app.windows[0];
         let Pane::App(top) = &win.panes[&base_pane] else {
             panic!("expected App pane at overlay top");
         };
-        assert_eq!(top.manifest_id, "text-editor", "top pane must be text-editor");
+        assert_eq!(
+            top.manifest_id, "text-editor",
+            "top pane must be text-editor"
+        );
         let path2 = top
             .runtime
             .serialize_state()
@@ -1962,14 +1969,20 @@ mod tests {
         else {
             panic!("overlay_replaced must be an App pane");
         };
-        assert_eq!(inner.manifest_id, "text-editor", "inner pane must be text-editor");
+        assert_eq!(
+            inner.manifest_id, "text-editor",
+            "inner pane must be text-editor"
+        );
         let path1 = inner
             .runtime
             .serialize_state()
             .and_then(|v| v.get("path").and_then(|p| p.as_str()).map(|s| s.to_owned()))
             .expect("first scratchpad pane must have a path");
 
-        assert_ne!(path1, path2, "each scratchpad call must create a unique note file");
+        assert_ne!(
+            path1, path2,
+            "each scratchpad call must create a unique note file"
+        );
         assert!(path1.contains("inbox"), "path1 must be an inbox note");
         assert!(path2.contains("inbox"), "path2 must be an inbox note");
     }
@@ -1994,8 +2007,12 @@ mod quick_note_tests {
     fn write_inbox_note_creates_file_with_frontmatter() {
         let dir = tempfile::tempdir().expect("tempdir");
         let c = ctx("/tmp/myproject");
-        let path = PlexiApp::write_inbox_note("hello inbox", "quick-note", &dir.path().to_path_buf(), &c);
-        assert!(path.is_some(), "write_inbox_note must return the path on success");
+        let path =
+            PlexiApp::write_inbox_note("hello inbox", "quick-note", &dir.path().to_path_buf(), &c);
+        assert!(
+            path.is_some(),
+            "write_inbox_note must return the path on success"
+        );
 
         let entries: Vec<_> = std::fs::read_dir(dir.path())
             .unwrap()
@@ -2004,10 +2021,19 @@ mod quick_note_tests {
         assert_eq!(entries.len(), 1, "exactly one file must be created");
 
         let content = std::fs::read_to_string(entries[0].path()).unwrap();
-        assert!(content.contains("source: \"quick-note\""), "frontmatter must include source: quick-note");
-        assert!(content.contains("captured_at:"), "frontmatter must include captured_at");
+        assert!(
+            content.contains("source: \"quick-note\""),
+            "frontmatter must include source: quick-note"
+        );
+        assert!(
+            content.contains("captured_at:"),
+            "frontmatter must include captured_at"
+        );
         assert!(content.contains("hello inbox"), "note body must be present");
-        assert!(content.starts_with("---\n"), "must start with frontmatter delimiter");
+        assert!(
+            content.starts_with("---\n"),
+            "must start with frontmatter delimiter"
+        );
     }
 
     // ── Agent context spawning tests (#1518) ─────────────────────────────────
@@ -2177,10 +2203,7 @@ mod quick_note_tests {
 
 /// Build a fresh timestamped note path in `notes/inbox/`. Does not create the file.
 fn new_inbox_note_path() -> PathBuf {
-    let filename = format!(
-        "note-{}.md",
-        chrono::Utc::now().format("%Y%m%d-%H%M%S%.3f")
-    );
+    let filename = format!("note-{}.md", chrono::Utc::now().format("%Y%m%d-%H%M%S%.3f"));
     crate::config::config_dir()
         .join("notes")
         .join("inbox")

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -580,10 +580,10 @@ impl PlexiApp {
         }
     }
 
-
     pub(crate) fn switch_to_tab(&mut self, container_tile: TileId, idx: usize) {
         let ctx = &self.windows[self.active_window];
-        let Some(Tile::Container(Container::Tabs(tabs))) = ctx.tree.tiles.get(container_tile) else {
+        let Some(Tile::Container(Container::Tabs(tabs))) = ctx.tree.tiles.get(container_tile)
+        else {
             return;
         };
         let children = &tabs.children;
@@ -593,7 +593,8 @@ impl PlexiApp {
         let target = children[idx];
 
         let ctx = &mut self.windows[self.active_window];
-        if let Some(Tile::Container(Container::Tabs(tabs))) = ctx.tree.tiles.get_mut(container_tile) {
+        if let Some(Tile::Container(Container::Tabs(tabs))) = ctx.tree.tiles.get_mut(container_tile)
+        {
             tabs.set_active(target);
         }
 

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -931,9 +931,7 @@ impl PlexiApp {
             let zoomed_out = self.zoom_out_of_context();
             if !zoomed_out || self.router.active().context_id == ctx_id {
                 // No usable depth-stack entry — land on the parent directly.
-                if let Some(parent_idx) =
-                    self.router.position(|c| c.context_id == parent_ctx_id)
-                {
+                if let Some(parent_idx) = self.router.position(|c| c.context_id == parent_ctx_id) {
                     self.switch_workspace(parent_idx);
                 }
             }

--- a/src/platform/frame_diag.rs
+++ b/src/platform/frame_diag.rs
@@ -352,9 +352,7 @@ mod tests {
         );
 
         // Truncation appends the overflow count.
-        let many: Vec<(String, u32)> = (0..10)
-            .map(|i| (format!("src/f.rs:{i}"), 10 - i))
-            .collect();
+        let many: Vec<(String, u32)> = (0..10).map(|i| (format!("src/f.rs:{i}"), 10 - i)).collect();
         let line = egui_summary_line(&many, 8);
         assert!(line.ends_with(" (+2 more)"), "got: {line}");
         assert!(line.contains("src/f.rs:0=10"));

--- a/src/platform/logging.rs
+++ b/src/platform/logging.rs
@@ -441,7 +441,11 @@ mod tests {
             log::Level::Info,
             log::LevelFilter::Debug
         ));
-        assert!(!log_allowed("appkit", log::Level::Info, log::LevelFilter::Debug));
+        assert!(!log_allowed(
+            "appkit",
+            log::Level::Info,
+            log::LevelFilter::Debug
+        ));
     }
 
     /// set_level reports whether the level actually changed and round-trips

--- a/src/plexi_ai/backend/mod.rs
+++ b/src/plexi_ai/backend/mod.rs
@@ -90,6 +90,10 @@ pub struct AiBackendRequest {
     /// Model tier from the broker request. Used by backends to apply
     /// tier-specific request parameters (e.g. disabling reasoning for Low).
     pub model_tier: Option<ModelTier>,
+    /// Cooperative cancellation handle. The streaming read loop checks this
+    /// each chunk and aborts (drops `tx`) when tripped, so an interrupted turn
+    /// stops consuming the network stream instead of running to completion.
+    pub cancel: crate::plexi_ai::CancelToken,
 }
 
 /// Error returned when a backend call cannot start.

--- a/src/plexi_ai/backend/ollama.rs
+++ b/src/plexi_ai/backend/ollama.rs
@@ -141,6 +141,12 @@ fn stream_ollama(
     let mut output_tokens: Option<u32> = None;
 
     for line_result in reader.lines() {
+        // Cooperative cancel: stop reading and drop `tx` so the turn loop
+        // returns the partial text rather than draining the full stream.
+        if request.cancel.is_cancelled() {
+            log::info!("ollama: stream cancelled by caller — aborting read mid-stream");
+            return;
+        }
         let line = match line_result {
             Ok(l) => l,
             Err(e) => {

--- a/src/plexi_ai/backend/openrouter.rs
+++ b/src/plexi_ai/backend/openrouter.rs
@@ -202,6 +202,13 @@ fn stream_openrouter(
     let mut partial_tool_calls: HashMap<usize, PartialToolCall> = HashMap::new();
 
     for line_result in reader.lines() {
+        // Cooperative cancel: the caller (e.g. ESC or an event preempt) tripped
+        // the token. Stop reading and drop `tx` — the turn loop returns the
+        // partial text accumulated so far rather than draining the full stream.
+        if request.cancel.is_cancelled() {
+            log::info!("openrouter: stream cancelled by caller — aborting read mid-stream");
+            return;
+        }
         let line = match line_result {
             Ok(l) => l,
             Err(e) => {

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -1060,8 +1060,10 @@ mod tests {
     /// correctly across both turns.
     #[test]
     fn tool_loop_builds_conversation_correctly() {
-        use crate::plexi_ai::backend::{AiBackend, AiBackendError, AiBackendRequest, RawToolCall, StreamEvent};
         use crate::app_protocol::AiTool;
+        use crate::plexi_ai::backend::{
+            AiBackend, AiBackendError, AiBackendRequest, RawToolCall, StreamEvent,
+        };
         use std::sync::mpsc;
         use std::sync::{Arc, Mutex};
 
@@ -1075,7 +1077,9 @@ mod tests {
         }
 
         impl AiBackend for ToolThenTextBackend {
-            fn name(&self) -> &str { "tool-then-text" }
+            fn name(&self) -> &str {
+                "tool-then-text"
+            }
 
             fn stream_to_channel(
                 &self,
@@ -1088,7 +1092,10 @@ mod tests {
                     *c
                 };
                 // Clone the Arc itself so we can check pointer identity later.
-                self.seen_systems.lock().unwrap().push(Arc::clone(&req.system));
+                self.seen_systems
+                    .lock()
+                    .unwrap()
+                    .push(Arc::clone(&req.system));
                 self.seen_tools.lock().unwrap().push(Arc::clone(&req.tools));
 
                 assert_eq!(&*req.system, "sys");
@@ -1151,19 +1158,36 @@ mod tests {
 
         let billing = crate::plexi_ai::backend::BillingModel::Subscription;
         let resp = run_turn_and_respond(
-            request, &backend, billing, "test-model".to_string(), String::new(), &mut |_| {},
+            request,
+            &backend,
+            billing,
+            "test-model".to_string(),
+            String::new(),
+            &mut |_| {},
         );
-        assert!(resp.content.is_some(), "broker must return final text after tool round-trip");
+        assert!(
+            resp.content.is_some(),
+            "broker must return final text after tool round-trip"
+        );
         assert_eq!(resp.content.as_deref(), Some("final answer"));
-        assert_eq!(resp.tokens_in, 30, "token counts must accumulate across iterations");
+        assert_eq!(
+            resp.tokens_in, 30,
+            "token counts must accumulate across iterations"
+        );
         assert_eq!(resp.tokens_out, 13);
 
         // Both iterations must have received the same Arc allocation — no deep copy.
         let ss = seen_systems.lock().unwrap();
         assert_eq!(ss.len(), 2, "backend must be called exactly twice");
-        assert!(Arc::ptr_eq(&ss[0], &ss[1]), "system Arc must be the same allocation on both iterations");
+        assert!(
+            Arc::ptr_eq(&ss[0], &ss[1]),
+            "system Arc must be the same allocation on both iterations"
+        );
         let st = seen_tools.lock().unwrap();
-        assert!(Arc::ptr_eq(&st[0], &st[1]), "tools Arc must be the same allocation on both iterations");
+        assert!(
+            Arc::ptr_eq(&st[0], &st[1]),
+            "tools Arc must be the same allocation on both iterations"
+        );
     }
 
     /// A pre-tripped cancel token must short-circuit the tool loop before the

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -26,6 +26,7 @@ use crate::plexi_ai::backend::{AiBackend, AiBackendRequest, BillingModel};
 use crate::plexi_ai::ledger::{self, LedgerRow};
 use crate::plexi_ai::tool_dispatch::ToolDispatcher;
 use crate::plexi_ai::turn_loop::{self, TurnError};
+use crate::plexi_ai::CancelToken;
 
 /// Lightweight context for a single open pane (injected into system prompt).
 #[derive(Debug, Clone)]
@@ -81,6 +82,11 @@ pub struct AiBrokerRequest {
     /// Tool dispatcher snapshot. When `Some`, the broker runs a tool loop
     /// and dispatches any tool calls the model makes.
     pub tool_dispatcher: Option<std::sync::Arc<ToolDispatcher>>,
+    /// Cooperative cancellation handle for this turn. The broker checks it at
+    /// each tool-loop boundary and threads a clone into the backend so a
+    /// tripped token aborts both the network stream and any further tool
+    /// rounds. Callers with no interrupt UI pass `CancelToken::new()`.
+    pub cancel: CancelToken,
 }
 
 /// Broker outcome. Either `content` is `Some` (success) or `error` is `Some`
@@ -434,6 +440,17 @@ fn run_turn_and_respond(
     let mut final_text = String::new();
 
     for iteration in 0..=MAX_TOOL_ITERATIONS {
+        // Cancelled between rounds (ESC / event preempt): stop before starting
+        // another turn. `final_text` holds whatever the last completed round
+        // produced — committed as the (possibly empty) partial reply.
+        if request.cancel.is_cancelled() {
+            log::info!(
+                "ai_broker[{}]: turn cancelled before iteration {iteration} — folding partial ({} chars)",
+                request.app_id,
+                final_text.len()
+            );
+            break;
+        }
         if iteration == MAX_TOOL_ITERATIONS {
             log::warn!(
                 "ai_broker[{}]: tool loop hit max iterations ({MAX_TOOL_ITERATIONS}), forcing stop",
@@ -447,6 +464,7 @@ fn run_turn_and_respond(
             system: Arc::clone(&system),
             tools: Arc::clone(&all_tools),
             model_tier: Some(request.model_tier),
+            cancel: request.cancel.clone(),
         };
 
         // Forward every streamed increment live so the app sees tokens as
@@ -456,6 +474,17 @@ fn run_turn_and_respond(
 
         match turn {
             Err(e) => {
+                // A cancel that races the stream surfaces as ChannelClosed
+                // (backend dropped `tx` mid-read). That is a clean interrupt,
+                // not a failure — fold the partial instead of an error row.
+                if request.cancel.is_cancelled() {
+                    log::info!(
+                        "ai_broker[{}]: stream cancelled mid-turn — folding partial ({} chars)",
+                        request.app_id,
+                        final_text.len()
+                    );
+                    break;
+                }
                 log::warn!("ai_broker[{}]: turn failed: {e}", request.app_id);
                 let message = match e {
                     TurnError::BackendError(be) => format!("backend error: {be}"),
@@ -469,6 +498,18 @@ fn run_turn_and_respond(
                 total_tokens_out += result.output_tokens.unwrap_or(0);
                 if result.generation_id.is_some() {
                     last_generation_id = result.generation_id.clone();
+                }
+
+                // Cancelled while this round streamed: commit whatever text the
+                // model produced and stop — do not dispatch tools or loop again.
+                if request.cancel.is_cancelled() {
+                    final_text = result.text;
+                    log::info!(
+                        "ai_broker[{}]: turn cancelled after stream — folding partial ({} chars)",
+                        request.app_id,
+                        final_text.len()
+                    );
+                    break;
                 }
 
                 if result.tool_calls.is_empty() {
@@ -895,6 +936,7 @@ mod tests {
                 workspace_root: None,
                 open_panes: Arc::new(Vec::new()),
                 tool_dispatcher: None,
+                cancel: CancelToken::new(),
             },
             &mut |_| {},
         );
@@ -930,6 +972,7 @@ mod tests {
                 workspace_root: None,
                 open_panes: Arc::new(Vec::new()),
                 tool_dispatcher: None,
+                cancel: CancelToken::new(),
             },
             &mut |_| {},
         );
@@ -964,6 +1007,7 @@ mod tests {
                 workspace_root: None,
                 open_panes: Arc::new(Vec::new()),
                 tool_dispatcher: None,
+                cancel: CancelToken::new(),
             },
             &mut |_| {},
         );
@@ -998,6 +1042,7 @@ mod tests {
                 workspace_root: None,
                 open_panes: Arc::new(Vec::new()),
                 tool_dispatcher: None,
+                cancel: CancelToken::new(),
             },
             &mut |_| {},
         );
@@ -1101,6 +1146,7 @@ mod tests {
             workspace_root: None,
             open_panes: Arc::new(Vec::new()),
             tool_dispatcher: None,
+            cancel: CancelToken::new(),
         };
 
         let billing = crate::plexi_ai::backend::BillingModel::Subscription;
@@ -1118,6 +1164,165 @@ mod tests {
         assert!(Arc::ptr_eq(&ss[0], &ss[1]), "system Arc must be the same allocation on both iterations");
         let st = seen_tools.lock().unwrap();
         assert!(Arc::ptr_eq(&st[0], &st[1]), "tools Arc must be the same allocation on both iterations");
+    }
+
+    /// A pre-tripped cancel token must short-circuit the tool loop before the
+    /// backend is ever called — the turn ends as a clean empty reply, not an
+    /// error, and no network round-trip happens.
+    #[test]
+    fn pretripped_cancel_skips_all_backend_calls() {
+        use crate::plexi_ai::backend::{
+            AiBackend, AiBackendError, AiBackendRequest, RawToolCall, StreamEvent,
+        };
+        use std::sync::mpsc;
+        use std::sync::{Arc, Mutex};
+
+        /// Always asks for a tool call, so an un-cancelled loop would spin.
+        struct CountingBackend {
+            calls: Arc<Mutex<u32>>,
+        }
+        impl AiBackend for CountingBackend {
+            fn name(&self) -> &str {
+                "counting"
+            }
+            fn stream_to_channel(
+                &self,
+                _req: AiBackendRequest,
+                tx: mpsc::Sender<StreamEvent>,
+            ) -> Result<(), AiBackendError> {
+                *self.calls.lock().unwrap() += 1;
+                let _ = tx.send(StreamEvent::ToolCalls(vec![RawToolCall {
+                    id: "c1".to_string(),
+                    name: "x".to_string(),
+                    arguments: "{}".to_string(),
+                }]));
+                let _ = tx.send(StreamEvent::Done {
+                    input_tokens: None,
+                    output_tokens: None,
+                    generation_id: None,
+                });
+                Ok(())
+            }
+        }
+
+        let calls = Arc::new(Mutex::new(0u32));
+        let backend = CountingBackend {
+            calls: Arc::clone(&calls),
+        };
+        let cancel = CancelToken::new();
+        cancel.cancel();
+        let request = AiBrokerRequest {
+            app_id: "test".to_string(),
+            model_tier: ModelTier::Low,
+            system: "sys".to_string(),
+            messages: vec![AiMessage {
+                role: "user".to_string(),
+                content: "go".to_string(),
+            }],
+            tools: vec![],
+            workspace_root: None,
+            open_panes: Arc::new(Vec::new()),
+            tool_dispatcher: None,
+            cancel,
+        };
+        let resp = run_turn_and_respond(
+            request,
+            &backend,
+            BillingModel::Subscription,
+            "m".to_string(),
+            String::new(),
+            &mut |_| {},
+        );
+        assert_eq!(
+            *calls.lock().unwrap(),
+            0,
+            "pre-tripped cancel must skip the backend entirely"
+        );
+        assert!(resp.error.is_none(), "cancel is a clean stop, not an error");
+        assert_eq!(resp.content.as_deref(), Some(""));
+    }
+
+    /// A cancel tripped mid-stream (e.g. ESC after some text arrived) must
+    /// commit the partial text and stop — it must NOT dispatch the tool call
+    /// emitted in that same round or start a second iteration.
+    #[test]
+    fn cancel_during_stream_commits_partial_and_stops() {
+        use crate::plexi_ai::backend::{
+            AiBackend, AiBackendError, AiBackendRequest, RawToolCall, StreamEvent,
+        };
+        use std::sync::mpsc;
+        use std::sync::{Arc, Mutex};
+
+        struct CancelMidStreamBackend {
+            calls: Arc<Mutex<u32>>,
+            cancel: CancelToken,
+        }
+        impl AiBackend for CancelMidStreamBackend {
+            fn name(&self) -> &str {
+                "cancel-mid-stream"
+            }
+            fn stream_to_channel(
+                &self,
+                _req: AiBackendRequest,
+                tx: mpsc::Sender<StreamEvent>,
+            ) -> Result<(), AiBackendError> {
+                *self.calls.lock().unwrap() += 1;
+                let _ = tx.send(StreamEvent::Text("partial answer".to_string()));
+                // The user hits ESC: trip the token before finishing the round.
+                self.cancel.cancel();
+                let _ = tx.send(StreamEvent::ToolCalls(vec![RawToolCall {
+                    id: "c1".to_string(),
+                    name: "should_not_dispatch".to_string(),
+                    arguments: "{}".to_string(),
+                }]));
+                let _ = tx.send(StreamEvent::Done {
+                    input_tokens: Some(3),
+                    output_tokens: Some(2),
+                    generation_id: None,
+                });
+                Ok(())
+            }
+        }
+
+        let calls = Arc::new(Mutex::new(0u32));
+        let cancel = CancelToken::new();
+        let backend = CancelMidStreamBackend {
+            calls: Arc::clone(&calls),
+            cancel: cancel.clone(),
+        };
+        let request = AiBrokerRequest {
+            app_id: "test".to_string(),
+            model_tier: ModelTier::Low,
+            system: "sys".to_string(),
+            messages: vec![AiMessage {
+                role: "user".to_string(),
+                content: "go".to_string(),
+            }],
+            tools: vec![],
+            workspace_root: None,
+            open_panes: Arc::new(Vec::new()),
+            tool_dispatcher: None,
+            cancel,
+        };
+        let resp = run_turn_and_respond(
+            request,
+            &backend,
+            BillingModel::Subscription,
+            "m".to_string(),
+            String::new(),
+            &mut |_| {},
+        );
+        assert_eq!(
+            *calls.lock().unwrap(),
+            1,
+            "cancel must stop the loop after one round — no second iteration"
+        );
+        assert!(resp.error.is_none(), "mid-stream cancel is a clean stop");
+        assert_eq!(
+            resp.content.as_deref(),
+            Some("partial answer"),
+            "the partial text streamed before cancel must be committed"
+        );
     }
 
     /// Verify `fetch_generation_cost` parses total_cost as string or float.

--- a/src/plexi_ai/mod.rs
+++ b/src/plexi_ai/mod.rs
@@ -14,3 +14,36 @@ pub mod ledger;
 pub mod tool_dispatch;
 #[path = "loop.rs"]
 pub mod turn_loop;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+/// Cooperative cancellation handle for an in-flight turn.
+///
+/// Cloned from the caller (e.g. the host Assistant) down into the broker tool
+/// loop and the backend's streaming read loop. Tripping it via [`cancel`]
+/// makes both bail at their next checkpoint: the backend stops reading the SSE
+/// body and drops its sender, and the broker stops before starting another
+/// tool-call round. This is the seam that turns ESC / event-preempt into a
+/// real network abort instead of a UI-only "move on".
+///
+/// [`cancel`]: CancelToken::cancel
+#[derive(Debug, Clone, Default)]
+pub struct CancelToken(Arc<AtomicBool>);
+
+impl CancelToken {
+    /// A fresh token that has not been cancelled.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Trip the token. Every clone observes the cancellation. Idempotent.
+    pub fn cancel(&self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+
+    /// True once any clone of this token has been cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed)
+    }
+}

--- a/src/plexi_ai/tool_dispatch.rs
+++ b/src/plexi_ai/tool_dispatch.rs
@@ -179,7 +179,11 @@ pub(crate) fn unregister(pane_id: u64) {
 /// True when `pane_id` has a registry entry (it exposed tools and is still
 /// open) — i.e. host-routed events can reach it.
 pub(crate) fn pane_reachable(pane_id: u64) -> bool {
-    global_registry().lock().unwrap().sender_for(pane_id).is_some()
+    global_registry()
+        .lock()
+        .unwrap()
+        .sender_for(pane_id)
+        .is_some()
 }
 
 /// Send a `PlexiEvent` to a registered pane's stdin channel (Phase C: the
@@ -697,14 +701,22 @@ mod tests {
 
         let blocked = dispatcher.dispatch_call("c1".to_string(), "gated_tool", "{}".to_string());
         assert!(
-            blocked.error.as_deref().unwrap_or("").contains("permission_denied"),
+            blocked
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("permission_denied"),
             "hook denial must surface as the tool error: {:?}",
             blocked.error
         );
 
         let unknown = dispatcher.dispatch_call("c2".to_string(), "nope", "{}".to_string());
         assert!(
-            unknown.error.as_deref().unwrap_or("").contains("tool_not_found"),
+            unknown
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("tool_not_found"),
             "unknown tool must bypass hooks: {:?}",
             unknown.error
         );

--- a/src/process_app/host_bridge.rs
+++ b/src/process_app/host_bridge.rs
@@ -117,10 +117,7 @@ impl ProcessApp {
                     self.type_id, request_id, max_width, max_lines, n_rows, height
                 );
                 self.outbound_events.push_back(
-                    crate::app_protocol::PlexiEvent::TextWrappedMeasured {
-                        request_id,
-                        height,
-                    },
+                    crate::app_protocol::PlexiEvent::TextWrappedMeasured { request_id, height },
                 );
             }
             ControlCommand::SetMinSize { width, height } => {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -880,9 +880,7 @@ impl ProcessApp {
             permission_store: crate::app::permissions::PermissionStore::default(),
             grant_store: crate::broker::GrantStore::default(),
             posture: None,
-            app_timeline: Arc::new(Mutex::new(
-                crate::host::app_timeline::AppTimeline::default(),
-            )),
+            app_timeline: Arc::new(Mutex::new(crate::host::app_timeline::AppTimeline::default())),
             pipe_registry: Arc::new(Mutex::new(TypedPipeRegistry::new(
                 std::env::temp_dir().join(format!("plexi-pipes-{}", uuid::Uuid::new_v4())),
             ))),

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -429,6 +429,7 @@ pub(crate) fn show_prompt_modal(
                                             workspace_root: Some(ws_root_clone),
                                             open_panes,
                                             tool_dispatcher: Some(td),
+                                            cancel: crate::plexi_ai::CancelToken::new(),
                                         },
                                         &mut on_delta,
                                     );

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -941,56 +941,14 @@ pub(crate) fn render_draw_commands(
                         .layout(egui::Layout::top_down(egui::Align::LEFT)),
                 );
                 child.set_clip_rect(md_rect);
-                // Override default text colour so markdown body text matches the
-                // app-specified colour. The vendored fenced-code renderer
-                // clears this override while laying out code so syntax token
-                // colours are not flattened by egui's TextEdit fallback.
-                child.style_mut().visuals.override_text_color = Some(text_color);
-                // Inject PlexiColors so egui_commonmark picks up themed code
-                // surfaces, link colors, and blockquote tints instead of egui
-                // defaults:
-                //   extreme_bg_color -> fenced code block fill
-                //   code_bg_color    -> inline `code` span fill. Left at the
-                //                       default near-black it renders as a harsh
-                //                       box; tint it to the same code surface as
-                //                       blocks for a soft, consistent highlight.
-                //   hyperlink_color  -> inline link color
-                //   faint_bg_color   -> blockquote tint
-                {
-                    let v = child.visuals_mut();
-                    v.extreme_bg_color = colors.bg_active;
-                    v.code_bg_color = colors.bg_active;
-                    v.hyperlink_color = colors.accent;
-                    v.faint_bg_color = colors.bg_hover;
-                    // Render fenced code blocks as defined cards: rounded
-                    // corners and a subtle border instead of an almost-invisible
-                    // flush fill. egui_commonmark reads the block's corner radius
-                    // and stroke from the noninteractive widget visuals.
-                    v.widgets.noninteractive.corner_radius = style::RADIUS_MD;
-                    v.widgets.noninteractive.bg_stroke =
-                        egui::Stroke::new(1.0, colors.border);
-                }
-                // Give block elements vertical breathing room so code blocks and
-                // quotes don't crowd the surrounding prose.
-                child.style_mut().spacing.item_spacing.y = style::SPACE_SM;
-                // Scale body font size to match the app's base_size.
-                child.style_mut().text_styles.insert(
-                    egui::TextStyle::Body,
-                    egui::FontId::proportional(*base_size),
+                crate::ui::markdown::show(
+                    &mut child,
+                    commonmark_cache,
+                    colors,
+                    text,
+                    text_color,
+                    *base_size,
                 );
-                child.style_mut().text_styles.insert(
-                    egui::TextStyle::Small,
-                    egui::FontId::proportional(base_size * 0.85),
-                );
-                child.style_mut().text_styles.insert(
-                    egui::TextStyle::Heading,
-                    egui::FontId::proportional(base_size * 1.4),
-                );
-                child.style_mut().text_styles.insert(
-                    egui::TextStyle::Monospace,
-                    egui::FontId::monospace(base_size * 0.9),
-                );
-                egui_commonmark::CommonMarkViewer::new().show(&mut child, commonmark_cache, text);
             }
 
             // TextInput is rendered as an interactive egui widget by

--- a/src/process_app/render_session.rs
+++ b/src/process_app/render_session.rs
@@ -253,8 +253,7 @@ impl RenderSession {
                     // egui's caret is hidden (transparent, non-blinking);
                     // draw_text_caret paints a glyph-height replacement on top.
                     inner_child.visuals_mut().text_cursor.blink = false;
-                    inner_child.visuals_mut().text_cursor.stroke.color =
-                        egui::Color32::TRANSPARENT;
+                    inner_child.visuals_mut().text_cursor.stroke.color = egui::Color32::TRANSPARENT;
                     let edit = egui::TextEdit::singleline(buffer)
                         .id(widget_id)
                         .desired_width(inner_rect.width())

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -2102,11 +2102,9 @@ impl ProcessApp {
                     self.type_id
                 );
                 let actor_id = self.type_id.clone();
-                if let Err(e) = self.request_rollback(
-                    crate::broker::ActorType::App,
-                    &actor_id,
-                    &checkpoint_id,
-                ) {
+                if let Err(e) =
+                    self.request_rollback(crate::broker::ActorType::App, &actor_id, &checkpoint_id)
+                {
                     log::warn!(
                         "ProcessApp[{}]: RequestRollback rejected — {e}",
                         self.type_id

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1185,6 +1185,7 @@ impl ProcessApp {
                                 workspace_root: Some(workspace_root),
                                 open_panes,
                                 tool_dispatcher: Some(tool_dispatcher),
+                                cancel: crate::plexi_ai::CancelToken::new(),
                             },
                             &mut on_delta,
                         );

--- a/src/process_app/tests/render_session_tests.rs
+++ b/src/process_app/tests/render_session_tests.rs
@@ -145,12 +145,7 @@ fn render_session_pgap_frame_stable_output_no_spurious_events() {
                         max_length: 0,
                     },
                     UiNode::Raw {
-                        command: Box::new(text_cmd(
-                            0.0,
-                            "raw node text".to_string(),
-                            None,
-                            None,
-                        )),
+                        command: Box::new(text_cmd(0.0, "raw node text".to_string(), None, None)),
                     },
                 ],
                 gap: 4.0,

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -4003,7 +4003,10 @@ mod ai_stream_chunk_tests {
         let json = r#"{"type":"get_previous_pane_info","response_file":"/tmp/prev.json"}"#;
         let req: AppRequest = serde_json::from_str(json).expect("deserialise");
         match &req {
-            AppRequest::GetPreviousPaneInfo { response_file, steps } => {
+            AppRequest::GetPreviousPaneInfo {
+                response_file,
+                steps,
+            } => {
                 assert_eq!(response_file, "/tmp/prev.json");
                 assert_eq!(*steps, 1, "default steps must be 1");
             }
@@ -4127,7 +4130,10 @@ mod pip_status_tests {
             serde_json::from_str(r#"{"type":"set_pip_status","status":"red"}"#).unwrap();
         match req {
             AppRequest::SetPipStatus { pane_id, status } => {
-                assert_eq!(pane_id, 0, "omitted pane_id must default to 0 for host stamping");
+                assert_eq!(
+                    pane_id, 0,
+                    "omitted pane_id must default to 0 for host stamping"
+                );
                 assert_eq!(status, PipStatus::Red);
             }
             other => panic!("expected SetPipStatus, got {other:?}"),

--- a/src/render/app_pane.rs
+++ b/src/render/app_pane.rs
@@ -22,8 +22,11 @@ const OVERTAKE_BAR_HEIGHT: f32 = 24.0;
 
 /// Total height consumed by visible host chrome bands.
 pub(crate) fn chrome_height(has_overtake: bool, has_nav: bool) -> f32 {
-    (if has_overtake { OVERTAKE_BAR_HEIGHT } else { 0.0 })
-        + (if has_nav { NAV_BAR_HEIGHT } else { 0.0 })
+    (if has_overtake {
+        OVERTAKE_BAR_HEIGHT
+    } else {
+        0.0
+    }) + (if has_nav { NAV_BAR_HEIGHT } else { 0.0 })
 }
 
 pub fn render(

--- a/src/render/app_render.rs
+++ b/src/render/app_render.rs
@@ -414,10 +414,7 @@ fn render_commands_to_png(
     let mut png_data: Vec<u8> = Vec::new();
     image::RgbaImage::from_raw(width, height, pixels)
         .ok_or_else(|| "PNG encoding failed: buffer size mismatch".to_string())?
-        .write_to(
-            &mut Cursor::new(&mut png_data),
-            image::ImageFormat::Png,
-        )
+        .write_to(&mut Cursor::new(&mut png_data), image::ImageFormat::Png)
         .map_err(|e| format!("PNG encoding failed: {e}"))?;
     log::info!(
         "app_render: encoded {} bytes for {width}×{height}",

--- a/src/render/cli_renderer_app.rs
+++ b/src/render/cli_renderer_app.rs
@@ -395,30 +395,27 @@ impl CliRendererApp {
         // the command palette, sidebar, and PGAP list views exactly.
         let mut clicked_idx: Option<usize> = None;
         let selection_changed = self.selected != self.last_selected;
-        egui::ScrollArea::vertical()
-            .animated(false)
-            .show(ui, |ui| {
-                for (i, row) in rows.iter().enumerate() {
-                    let is_selected = i == self.selected;
-                    // A trailing "›" marks command groups (rows that drill into
-                    // a sub-list rather than open a form).
-                    let mut list_row = crate::ui::list::ListRow::new(&row.name)
-                        .selected(is_selected);
-                    if let Some(desc) = &row.description {
-                        list_row = list_row.secondary(desc);
-                    }
-                    if row.has_children {
-                        list_row = list_row.chip("›");
-                    }
-                    let resp = list_row.show(ui, colors);
-                    if is_selected {
-                        resp.scroll_into_view(ui, selection_changed);
-                    }
-                    if resp.row_clicked() {
-                        clicked_idx = Some(i);
-                    }
+        egui::ScrollArea::vertical().animated(false).show(ui, |ui| {
+            for (i, row) in rows.iter().enumerate() {
+                let is_selected = i == self.selected;
+                // A trailing "›" marks command groups (rows that drill into
+                // a sub-list rather than open a form).
+                let mut list_row = crate::ui::list::ListRow::new(&row.name).selected(is_selected);
+                if let Some(desc) = &row.description {
+                    list_row = list_row.secondary(desc);
                 }
-            });
+                if row.has_children {
+                    list_row = list_row.chip("›");
+                }
+                let resp = list_row.show(ui, colors);
+                if is_selected {
+                    resp.scroll_into_view(ui, selection_changed);
+                }
+                if resp.row_clicked() {
+                    clicked_idx = Some(i);
+                }
+            }
+        });
         self.last_selected = self.selected;
 
         if let Some(i) = clicked_idx {
@@ -654,10 +651,7 @@ impl CliRendererApp {
                         if want_focus && !resp.has_focus() {
                             resp.request_focus();
                             took_focus = true;
-                            log::info!(
-                                "CliRendererApp: auto-focused field '{}'",
-                                arg.name
-                            );
+                            log::info!("CliRendererApp: auto-focused field '{}'", arg.name);
                         }
                     }
                 }
@@ -871,7 +865,11 @@ mod tests {
         let (app, _dir) = app_from_fixture();
         let d = app.descriptor.as_ref().expect("descriptor loaded");
         assert_eq!(d.name, "demo");
-        let names: Vec<&str> = app.commands_at_path().iter().map(|c| c.name.as_str()).collect();
+        let names: Vec<&str> = app
+            .commands_at_path()
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
         assert_eq!(names, vec!["greet", "remote"]);
     }
 
@@ -889,7 +887,11 @@ mod tests {
         let (mut app, _dir) = app_from_fixture();
         app.navigate_into(1); // remote — has children
         assert_eq!(app.view, View::List);
-        let names: Vec<&str> = app.commands_at_path().iter().map(|c| c.name.as_str()).collect();
+        let names: Vec<&str> = app
+            .commands_at_path()
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
         assert_eq!(names, vec!["add"]);
     }
 
@@ -897,7 +899,8 @@ mod tests {
     fn build_command_string_assembles_flags_and_args() {
         let (mut app, _dir) = app_from_fixture();
         app.navigate_into(0); // greet
-        app.field_values.insert("name".into(), "Ada Lovelace".into());
+        app.field_values
+            .insert("name".into(), "Ada Lovelace".into());
         app.field_values.insert("--loud".into(), "true".into());
         app.field_values.insert("--lang".into(), "fr".into());
         let cmd = app.build_command_string();
@@ -946,7 +949,11 @@ mod tests {
     }
 
     /// Drive `handle_key` with a single key event through a real egui frame.
-    fn press_key(app: &mut CliRendererApp, key: egui::Key, modifiers: egui::Modifiers) -> KeyDisposition {
+    fn press_key(
+        app: &mut CliRendererApp,
+        key: egui::Key,
+        modifiers: egui::Modifiers,
+    ) -> KeyDisposition {
         let ctx = egui::Context::default();
         let mut disposition = KeyDisposition::Passthrough;
         let _ = ctx.run(

--- a/src/render/terminal_pane.rs
+++ b/src/render/terminal_pane.rs
@@ -118,7 +118,17 @@ fn render_name_bar_and_tabs(
             egui::vec2(ui.available_width(), TAB_BAR_HEIGHT),
         );
         ui.advance_cursor_after_rect(bar_rect);
-        if let Some(idx) = paint_tab_bar(ui.ctx(), ui.painter(), bar_rect, group, tab_labels, tab_activities, colors, name_font_size, false) {
+        if let Some(idx) = paint_tab_bar(
+            ui.ctx(),
+            ui.painter(),
+            bar_rect,
+            group,
+            tab_labels,
+            tab_activities,
+            colors,
+            name_font_size,
+            false,
+        ) {
             tab_click = Some((group.container_tile, idx));
         }
 
@@ -131,7 +141,8 @@ fn render_name_bar_and_tabs(
             egui::vec2(ui.available_width(), TAB_BAR_HEIGHT),
         );
         ui.advance_cursor_after_rect(bar_rect);
-        ui.painter().rect_filled(bar_rect, 0.0, colors.pane_header_bg());
+        ui.painter()
+            .rect_filled(bar_rect, 0.0, colors.pane_header_bg());
 
         let agent_state = tab_activities.get(pane_id);
         let pip_space = if agent_state.is_some() {
@@ -173,11 +184,8 @@ fn paint_activity_dot(
     let t = ui.input(|i| i.time);
     let color = crate::ui::activity::dot_color_from_time(state, colors, t, 0);
     let cx = bar_rect.left() + TAB_PIP_MARGIN + TAB_PIP_RADIUS;
-    ui.painter().circle_filled(
-        egui::pos2(cx, bar_rect.center().y),
-        TAB_PIP_RADIUS,
-        color,
-    );
+    ui.painter()
+        .circle_filled(egui::pos2(cx, bar_rect.center().y), TAB_PIP_RADIUS, color);
     if matches!(state, AgentState::Working) {
         ui.ctx()
             .request_repaint_after(std::time::Duration::from_millis(100));

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -326,8 +326,8 @@ impl SceneRunner {
                 // multi-character. No `+`-prefix check needed — a literal `+`
                 // key has len == 1 and must take the Event::Text path.
                 let mut key_chars = key.chars();
-                let is_bare_printable = key_chars.next().is_some_and(|c| !c.is_control())
-                    && key_chars.next().is_none();
+                let is_bare_printable =
+                    key_chars.next().is_some_and(|c| !c.is_control()) && key_chars.next().is_none();
                 if is_bare_printable {
                     self.h
                         .harness()

--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -100,11 +100,7 @@ pub(crate) fn paint_tab_bar(
             let t = ctx.input(|i| i.time);
             let color = crate::ui::activity::dot_color_from_time(state, colors, t, i);
             let cx = tab_rect.left() + TAB_PIP_LEFT_PAD + TAB_PIP_RADIUS;
-            painter.circle_filled(
-                egui::pos2(cx, tab_rect.center().y),
-                TAB_PIP_RADIUS,
-                color,
-            );
+            painter.circle_filled(egui::pos2(cx, tab_rect.center().y), TAB_PIP_RADIUS, color);
             if matches!(state, AgentState::Working) {
                 ctx.request_repaint_after(std::time::Duration::from_millis(100));
             }
@@ -156,7 +152,12 @@ pub(crate) fn paint_tab_bar(
             egui::vec2(chip_w, chip_h),
         );
         painter.rect_filled(chip_rect, egui::CornerRadius::same(3), colors.bg_active);
-        painter.rect_stroke(chip_rect, egui::CornerRadius::same(3), egui::Stroke::new(1.0, colors.border), egui::StrokeKind::Inside);
+        painter.rect_stroke(
+            chip_rect,
+            egui::CornerRadius::same(3),
+            egui::Stroke::new(1.0, colors.border),
+            egui::StrokeKind::Inside,
+        );
         painter.text(
             chip_rect.center(),
             egui::Align2::CENTER_CENTER,
@@ -351,8 +352,15 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                 app_ui.advance_cursor_after_rect(bar_rect);
                 let is_overtaken = app_pane.overlay_replaced.is_some();
                 if let Some(idx) = paint_tab_bar(
-                    app_ui.ctx(), app_ui.painter(), bar_rect, group,
-                    &self.tab_labels, &tab_activities, &self.colors, self.pane_title_font_size, is_overtaken,
+                    app_ui.ctx(),
+                    app_ui.painter(),
+                    bar_rect,
+                    group,
+                    &self.tab_labels,
+                    &tab_activities,
+                    &self.colors,
+                    self.pane_title_font_size,
+                    is_overtaken,
                 ) {
                     self.tab_click = Some((group.container_tile, idx));
                 }
@@ -454,7 +462,13 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                             .request_repaint_after(std::time::Duration::from_millis(100));
                     }
                     let painter = ui.painter();
-                    paint_portal_minimap(painter, map_area, &preview.windows, &colors_for_portal, t);
+                    paint_portal_minimap(
+                        painter,
+                        map_area,
+                        &preview.windows,
+                        &colors_for_portal,
+                        t,
+                    );
                 }
             });
             // Double-click on portal pane to zoom into the sub-context.

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -10,8 +10,8 @@
 
 use crate::app::permissions::AppPermissions;
 use crate::app::PlexiApp;
-use crate::config::set_test_profile_dir;
 use crate::app_protocol::{AiMessage, AppRequest, DrawCommand, ModelTier};
+use crate::config::set_test_profile_dir;
 use crate::host::pane::{AppPane, AppRuntime, Pane};
 use crate::process_app::ProcessApp;
 use crate::spatial::tiling::PaneId;

--- a/src/ui/activity.rs
+++ b/src/ui/activity.rs
@@ -41,15 +41,10 @@ pub fn dot_color_from_time(
     match state {
         AgentState::Working => {
             let stagger = pip_index as f64 * 0.35;
-            let alpha =
-                0.20 + 0.80 * (0.5 + 0.5 * ((time + stagger) * 1.2 * std::f64::consts::PI).sin()) as f32;
+            let alpha = 0.20
+                + 0.80 * (0.5 + 0.5 * ((time + stagger) * 1.2 * std::f64::consts::PI).sin()) as f32;
             let c = colors.pip_working;
-            egui::Color32::from_rgba_unmultiplied(
-                c.r(),
-                c.g(),
-                c.b(),
-                (c.a() as f32 * alpha) as u8,
-            )
+            egui::Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), (c.a() as f32 * alpha) as u8)
         }
         AgentState::Idle => colors.pip_idle,
         AgentState::Blocked => colors.pip_blocked,

--- a/src/ui/button.rs
+++ b/src/ui/button.rs
@@ -93,7 +93,11 @@ pub(crate) fn choice_button(
         ui.allocate_exact_size(Vec2::new(width, style::BUTTON_H_LG), egui::Sense::click());
 
     let (bg, fg, hint_color) = if focused {
-        (colors.accent, Color32::BLACK, Color32::from_black_alpha(140))
+        (
+            colors.accent,
+            Color32::BLACK,
+            Color32::from_black_alpha(140),
+        )
     } else {
         (colors.bg_hover, colors.text_primary, colors.text_dim)
     };

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -89,10 +89,8 @@ impl<'a> ListRow<'a> {
         } else {
             style::LIST_ROW_H
         };
-        let (rect, response) = ui.allocate_exact_size(
-            Vec2::new(ui.available_width(), row_h),
-            egui::Sense::click(),
-        );
+        let (rect, response) =
+            ui.allocate_exact_size(Vec2::new(ui.available_width(), row_h), egui::Sense::click());
         if response.hovered() {
             ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
         }
@@ -252,9 +250,10 @@ impl<'a> ListRow<'a> {
                 .secondary_center_y
                 .unwrap_or(text_metrics.primary_center_y + COMPACT_METADATA_PIP_OFFSET_Y);
             let t = ui.input(|i| i.time);
-            let has_working = pips.activities.iter().any(|s| {
-                matches!(s, Some(crate::app_protocol::AgentState::Working))
-            });
+            let has_working = pips
+                .activities
+                .iter()
+                .any(|s| matches!(s, Some(crate::app_protocol::AgentState::Working)));
             if has_working {
                 // Pulse animation only needs ~10fps; an unconditional
                 // request_repaint pins the window at display refresh.
@@ -708,10 +707,8 @@ mod tests {
                             if i == 10 {
                                 ui.label("SECTION");
                             }
-                            let (rect, resp) = ui.allocate_exact_size(
-                                egui::vec2(120.0, 48.0),
-                                egui::Sense::click(),
-                            );
+                            let (rect, resp) = ui
+                                .allocate_exact_size(egui::vec2(120.0, 48.0), egui::Sense::click());
                             scroll_row_into_view(ui, &resp, i == selected);
                             if i == selected {
                                 visible = ui.clip_rect().contains_rect(rect);

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -1,0 +1,81 @@
+//! Shared markdown rendering style for host and PGAP surfaces.
+
+use crate::ui::style;
+use crate::ui::theme::Colors;
+
+/// Convert chat-style soft breaks to CommonMark hard breaks outside fenced
+/// code blocks, preserving single newlines in assistant replies.
+pub fn harden_soft_breaks(text: &str) -> String {
+    let mut out = String::with_capacity(text.len() + text.lines().count() * 2);
+    let mut in_fence = false;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_fence = !in_fence;
+        }
+        out.push_str(line);
+        if !in_fence && !line.trim().is_empty() {
+            out.push_str("  ");
+        }
+        out.push('\n');
+    }
+    out
+}
+
+pub fn show(
+    ui: &mut egui::Ui,
+    cache: &mut egui_commonmark::CommonMarkCache,
+    colors: &Colors,
+    text: &str,
+    text_color: egui::Color32,
+    base_size: f32,
+) {
+    ui.scope(|ui| {
+        let s = ui.style_mut();
+        s.visuals.override_text_color = Some(text_color);
+        s.visuals.extreme_bg_color = colors.bg_active;
+        s.visuals.code_bg_color = colors.bg_active;
+        s.visuals.hyperlink_color = colors.accent;
+        s.visuals.faint_bg_color = colors.bg_hover;
+        s.visuals.widgets.noninteractive.corner_radius = style::RADIUS_MD;
+        s.visuals.widgets.noninteractive.bg_stroke = egui::Stroke::new(1.0, colors.border);
+        s.spacing.item_spacing.y = style::SPACE_SM;
+        s.text_styles
+            .insert(egui::TextStyle::Body, egui::FontId::proportional(base_size));
+        s.text_styles.insert(
+            egui::TextStyle::Heading,
+            egui::FontId::proportional(base_size * 1.3),
+        );
+        s.text_styles.insert(
+            egui::TextStyle::Monospace,
+            egui::FontId::monospace(base_size * 0.9),
+        );
+        s.text_styles.insert(
+            egui::TextStyle::Small,
+            egui::FontId::proportional(base_size * 0.85),
+        );
+        egui_commonmark::CommonMarkViewer::new().show(ui, cache, text);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::harden_soft_breaks;
+
+    #[test]
+    fn harden_soft_breaks_makes_single_breaks_hard_outside_fences() {
+        let out = harden_soft_breaks("line one\nline two\n\nline three");
+        assert_eq!(out, "line one  \nline two  \n\nline three  \n");
+    }
+
+    #[test]
+    fn harden_soft_breaks_leaves_fenced_code_untouched() {
+        let out = harden_soft_breaks("before\n```\nlet x = 1;\nlet y = 2;\n```\nafter");
+        assert!(out.contains("before  \n"));
+        assert!(
+            out.contains("let x = 1;\nlet y = 2;\n"),
+            "code lines must stay byte-identical"
+        );
+        assert!(out.contains("after  \n"));
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ pub mod focus;
 pub mod hints;
 pub mod labels;
 pub mod list;
+pub mod markdown;
 pub mod overlay;
 pub mod row;
 pub mod shortcuts;

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -146,11 +146,7 @@ impl PlexiApp {
                     if is_hidden {
                         hidden_set.insert(dot_idx);
                     }
-                    activities.push(
-                        pane_opt
-                            .and_then(|p| p.effective_activity())
-                            .cloned(),
-                    );
+                    activities.push(pane_opt.and_then(|p| p.effective_activity()).cloned());
                 }
                 Some(PaneDots {
                     count: pane_count,
@@ -398,8 +394,7 @@ impl PlexiApp {
                 })
                 .response;
 
-            let interact =
-                ui.interact(header_response.rect, divider_id, egui::Sense::click());
+            let interact = ui.interact(header_response.rect, divider_id, egui::Sense::click());
             if interact.clicked() {
                 self.parked_section_expanded = !self.parked_section_expanded;
             }
@@ -432,12 +427,10 @@ impl PlexiApp {
                     for &win_idx in &ctx_windows {
                         let w = &self.windows[win_idx];
                         if let Some(root) = w.tree.root() {
-                            pane_ids.extend(
-                                crate::spatial::tiling::collect_pane_ids_spatial(
-                                    &w.tree.tiles,
-                                    root,
-                                ),
-                            );
+                            pane_ids.extend(crate::spatial::tiling::collect_pane_ids_spatial(
+                                &w.tree.tiles,
+                                root,
+                            ));
                         }
                     }
                     let pane_count = pane_ids.len();
@@ -454,11 +447,7 @@ impl PlexiApp {
                             if is_hidden {
                                 hidden_set.insert(dot_idx);
                             }
-                            activities.push(
-                                pane_opt
-                                    .and_then(|p| p.effective_activity())
-                                    .cloned(),
-                            );
+                            activities.push(pane_opt.and_then(|p| p.effective_activity()).cloned());
                         }
                         Some(PaneDots {
                             count: pane_count,

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -120,8 +120,8 @@ fn draw_pips(
         let is_hidden = dots.hidden_set.contains(&dot_i);
         let agent_state = dots.activities.get(dot_i).and_then(|s| s.as_ref());
         let focused = dots.focused_idx == Some(dot_i);
-        let mut color =
-            crate::ui::activity::pip_color(agent_state, focused, colors, t, dot_i).gamma_multiply(row_alpha);
+        let mut color = crate::ui::activity::pip_color(agent_state, focused, colors, t, dot_i)
+            .gamma_multiply(row_alpha);
         if is_dragging && agent_state.is_none() && !focused {
             color = color.gamma_multiply(0.4);
         }
@@ -133,14 +133,12 @@ fn draw_pips(
         }
     }
     if dots.count > PANE_DOT_MAX {
-        let overflow_x =
-            rect.min.x + (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS * 0.5;
-        let overflow_color =
-            if dots.focused_idx.map_or(false, |idx| idx >= PANE_DOT_MAX) {
-                with_alpha(colors.accent, row_alpha)
-            } else {
-                with_alpha(colors.text_dim, 0.5)
-            };
+        let overflow_x = rect.min.x + (capped as f32) * PANE_DOT_SPACING + PANE_DOT_RADIUS * 0.5;
+        let overflow_color = if dots.focused_idx.map_or(false, |idx| idx >= PANE_DOT_MAX) {
+            with_alpha(colors.accent, row_alpha)
+        } else {
+            with_alpha(colors.text_dim, 0.5)
+        };
         painter.text(
             egui::pos2(overflow_x, cy),
             egui::Align2::LEFT_CENTER,
@@ -205,94 +203,96 @@ impl ContextItem {
 
                 // Content column: name row + optional path row.
                 // Pips live on the name row, right-aligned before the action zone.
-                let name_row_h = ui.vertical(|ui| {
-                    // --- Name row (includes pips right-aligned) ---
-                    let name_y_before = ui.cursor().min.y;
-                    ui.horizontal(|ui| {
-                        // Compute pip strip width so we can budget the name text.
-                        let pip_strip_w = if let Some(ref dots) = pane_dots {
-                            if dots.count > 0 {
-                                let capped = dots.count.min(PANE_DOT_MAX);
-                                let mut w = (capped as f32) * PANE_DOT_SPACING;
-                                if dots.count > PANE_DOT_MAX {
-                                    w += 20.0;
+                let name_row_h = ui
+                    .vertical(|ui| {
+                        // --- Name row (includes pips right-aligned) ---
+                        let name_y_before = ui.cursor().min.y;
+                        ui.horizontal(|ui| {
+                            // Compute pip strip width so we can budget the name text.
+                            let pip_strip_w = if let Some(ref dots) = pane_dots {
+                                if dots.count > 0 {
+                                    let capped = dots.count.min(PANE_DOT_MAX);
+                                    let mut w = (capped as f32) * PANE_DOT_SPACING;
+                                    if dots.count > PANE_DOT_MAX {
+                                        w += 20.0;
+                                    }
+                                    w + 6.0 // gap between name text and dots
+                                } else {
+                                    0.0
                                 }
-                                w + 6.0 // gap between name text and dots
                             } else {
                                 0.0
-                            }
-                        } else {
-                            0.0
-                        };
+                            };
 
-                        let right_reserve = if action_enabled {
-                            ACTION_ZONE_WIDTH + 4.0
-                        } else {
-                            8.0
-                        };
-                        let badge_w = if badge_count > 0 { 26.0 } else { 0.0 };
-                        let text_max = (ui.available_width()
-                            - right_reserve
-                            - badge_w
-                            - pip_strip_w)
-                            .max(0.0);
+                            let right_reserve = if action_enabled {
+                                ACTION_ZONE_WIDTH + 4.0
+                            } else {
+                                8.0
+                            };
+                            let badge_w = if badge_count > 0 { 26.0 } else { 0.0 };
+                            let text_max =
+                                (ui.available_width() - right_reserve - badge_w - pip_strip_w)
+                                    .max(0.0);
 
-                        ui.scope(|ui| {
-                            ui.set_max_width(text_max);
-                            ui.add(
-                                egui::Label::new(
-                                    egui::RichText::new(&ctx_name)
-                                        .size(13.0)
-                                        .color(text_color),
-                                )
-                                .selectable(false)
-                                .truncate(),
-                            );
-                        });
-
-                        // Pips: rendered inline right of the name, before badge/action.
-                        draw_pips(ui, &pane_dots, &colors, row_alpha, is_dragging);
-
-                        ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                            ui.add_space(if action_enabled { ACTION_ZONE_WIDTH } else { 0.0 });
-                            if badge_count > 0 {
-                                let badge_text = if badge_count > 9 {
-                                    "9+".to_string()
-                                } else {
-                                    badge_count.to_string()
-                                };
-                                ui.label(
-                                    egui::RichText::new(badge_text)
-                                        .size(10.0)
-                                        .color(with_alpha(accent_color, row_alpha)),
-                                );
-                            }
-                        });
-                    });
-                    // Capture name-row height before the subtitle row is added.
-                    let name_h = ui.cursor().min.y - name_y_before;
-
-                    // --- Path row (subtitle only, no pips) ---
-                    if let Some(ref path) = subtitle {
-                        ui.horizontal(|ui| {
-                            let path_max = (ui.available_width() - 8.0).max(0.0);
                             ui.scope(|ui| {
-                                ui.set_max_width(path_max);
+                                ui.set_max_width(text_max);
                                 ui.add(
                                     egui::Label::new(
-                                        egui::RichText::new(shorten_path(path))
-                                            .size(10.0)
-                                            .color(with_alpha(text_dim, row_alpha * 0.7)),
+                                        egui::RichText::new(&ctx_name).size(13.0).color(text_color),
                                     )
                                     .selectable(false)
                                     .truncate(),
                                 );
                             });
-                        });
-                    }
 
-                    name_h
-                }).inner;
+                            // Pips: rendered inline right of the name, before badge/action.
+                            draw_pips(ui, &pane_dots, &colors, row_alpha, is_dragging);
+
+                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                                ui.add_space(if action_enabled {
+                                    ACTION_ZONE_WIDTH
+                                } else {
+                                    0.0
+                                });
+                                if badge_count > 0 {
+                                    let badge_text = if badge_count > 9 {
+                                        "9+".to_string()
+                                    } else {
+                                        badge_count.to_string()
+                                    };
+                                    ui.label(
+                                        egui::RichText::new(badge_text)
+                                            .size(10.0)
+                                            .color(with_alpha(accent_color, row_alpha)),
+                                    );
+                                }
+                            });
+                        });
+                        // Capture name-row height before the subtitle row is added.
+                        let name_h = ui.cursor().min.y - name_y_before;
+
+                        // --- Path row (subtitle only, no pips) ---
+                        if let Some(ref path) = subtitle {
+                            ui.horizontal(|ui| {
+                                let path_max = (ui.available_width() - 8.0).max(0.0);
+                                ui.scope(|ui| {
+                                    ui.set_max_width(path_max);
+                                    ui.add(
+                                        egui::Label::new(
+                                            egui::RichText::new(shorten_path(path))
+                                                .size(10.0)
+                                                .color(with_alpha(text_dim, row_alpha * 0.7)),
+                                        )
+                                        .selectable(false)
+                                        .truncate(),
+                                    );
+                                });
+                            });
+                        }
+
+                        name_h
+                    })
+                    .inner;
                 name_row_h_capture = name_row_h;
             });
 

--- a/src/ui/text_field.rs
+++ b/src/ui/text_field.rs
@@ -115,7 +115,10 @@ pub(crate) fn draw_text_caret(
         let start_y = row_top + (row_h - caret_height) * 0.5;
         let cx = output.galley_pos.x + cursor_pos.center().x;
         ui.painter().line_segment(
-            [egui::pos2(cx, start_y), egui::pos2(cx, start_y + caret_height)],
+            [
+                egui::pos2(cx, start_y),
+                egui::pos2(cx, start_y + caret_height),
+            ],
             stroke,
         );
         ui.ctx().request_repaint_after_secs((ON - t) as f32);


### PR DESCRIPTION
Closes #2204

Implements stint 0168. Re-scoped from the original "auto-interrupt on any message" to a user-triggered ESC interrupt (default queue, ESC = explicit stop/stop-and-send), which is the standard coding-agent idiom and avoids nuking in-flight work the user wants to keep.

## Summary

- **Cancel seam:** new `CancelToken` (`src/plexi_ai/mod.rs`) threaded worker → broker tool loop → backend SSE/NDJSON reader. A tripped token aborts the live network stream and stops further tool rounds — interruption is a real abort, not a UI-only "move on".
- **ESC interrupt-and-fold:** ESC during an in-flight turn interrupts it. Empty composer = stop; a pending draft is folded into an immediate follow-up turn (stop-and-send). Default typing-while-streaming still queues silently.
- **Event preempt:** app events delivered mid-turn now trip the cancel token and fold into one follow-up that reacts to the latest state — replacing queue-behind (the 6-26s chess-testing lag).
- **No empty bubble:** `finish_turn` skips committing an empty assistant row for a turn cancelled before any text streamed.
- **act-on-your-turn prompt:** `ASSISTANT_SYSTEM_PROMPT` now directs the assistant to call the tool when a delivered event hands it the turn, instead of only commenting.
- Non-interrupt callers (PGAP routing, deferred prompts, AgentHost) pass a neutral `CancelToken::new()` and keep queue-behind.

## Test evidence (attempt 1)
- `cargo test --bin plexi`: **1147 passed, 0 failed, 1 ignored** (full bin suite)
- New: `pretripped_cancel_skips_all_backend_calls`, `cancel_during_stream_commits_partial_and_stops`, `esc_interrupt_folds_queued_draft_into_followup`; extended `event_during_in_flight_turn_is_queued_into_next_turn` with a preempt assertion.
- No screenshot: no new visual element (ESC consumes a key). Existing assistant UI render test still green.
- Conclusion: **binary install required** — the ESC key-capture path (egui input → `ComposerEvent::Interrupt` in `render.rs`) is only observable in the installed bundle. All cancel/fold/preempt logic has full headless coverage.