### PR TITLE
ux(cli): group --help subcommands into Workspace/Apps/Panes/AI/System sections (#1826)

### DIFF
--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,0 +1,126 @@
+use clap::CommandFactory;
+
+use crate::cli::args::Cli;
+
+const HELP_GROUPS: &[(&str, &[&str])] = &[
+    (
+        "Workspace",
+        &["run", "workspace", "secret", "routine", "agent", "context"],
+    ),
+    ("Apps", &["app", "account", "registry"]),
+    ("Panes", &["pane", "notify"]),
+    ("AI", &["ai"]),
+    (
+        "System",
+        &[
+            "completions",
+            "config",
+            "notes",
+            "note",
+            "doctor",
+            "demo",
+            "update",
+            "uninstall",
+        ],
+    ),
+];
+
+pub fn print_grouped_help() {
+    let cmd = Cli::command();
+    let no_color = std::env::var_os("NO_COLOR").is_some();
+
+    // Apply ANSI to already-padded text so width counting is based on visible chars.
+    let header = |s: &str| -> String {
+        if no_color {
+            format!("{s}:")
+        } else {
+            format!("\x1b[1;32m{s}:\x1b[0m")
+        }
+    };
+    let lit = |s: String| -> String {
+        if no_color {
+            s
+        } else {
+            format!("\x1b[1;36m{s}\x1b[0m")
+        }
+    };
+    let dim = |s: &str| -> String {
+        if no_color {
+            s.to_string()
+        } else {
+            format!("\x1b[2m{s}\x1b[0m")
+        }
+    };
+
+    // About
+    if let Some(about) = cmd.get_about() {
+        println!("{about}");
+        println!();
+    }
+
+    // Usage
+    let bin = cmd.get_name();
+    println!("{} {bin} [OPTIONS] [COMMAND]", header("Usage"));
+    println!();
+
+    // Visible positional arguments (workspace_path)
+    let visible_positional: Vec<_> = cmd
+        .get_arguments()
+        .filter(|a| !a.is_hide_set() && a.is_positional())
+        .filter(|a| a.get_id() != "help" && a.get_id() != "version")
+        .collect();
+
+    if !visible_positional.is_empty() {
+        println!("{}", header("Arguments"));
+        for arg in &visible_positional {
+            let name = format!("[{}]", arg.get_id().as_str().to_uppercase());
+            let padded = format!("{name:<22}");
+            let help = arg
+                .get_help()
+                .map(|s| s.to_string())
+                .unwrap_or_default();
+            println!("  {} {help}", lit(padded));
+        }
+        println!();
+    }
+
+    // Options: -h and -V only (--profile is hidden)
+    println!("{}", header("Options"));
+    println!("  {} Print help", lit(format!("{:<22}", "-h, --help")));
+    if cmd.get_version().is_some() {
+        println!(
+            "  {} Print version",
+            lit(format!("{:<22}", "-V, --version"))
+        );
+    }
+    println!();
+
+    // Grouped subcommands
+    let col_width = HELP_GROUPS
+        .iter()
+        .flat_map(|(_, names)| names.iter())
+        .filter(|&&n| cmd.find_subcommand(n).is_some())
+        .map(|n| n.len())
+        .max()
+        .unwrap_or(10)
+        + 2;
+
+    for (heading, names) in HELP_GROUPS {
+        println!("{}", header(heading));
+        for &name in *names {
+            if let Some(sub) = cmd.find_subcommand(name) {
+                let about = sub
+                    .get_about()
+                    .map(|s| s.to_string())
+                    .unwrap_or_default();
+                println!("  {} {about}", lit(format!("{name:<col_width$}")));
+            }
+        }
+        println!();
+    }
+
+    // After-help footer
+    if let Some(after) = cmd.get_after_help() {
+        println!("{}", dim(&after.to_string()));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -96,6 +96,7 @@ pub(super) fn is_executable(path: &std::path::Path) -> bool {
 
 pub mod args;
 pub mod crawl;
+pub mod help;
 pub mod registry;
 pub mod setup;
 pub mod subprocess;

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,15 @@ fn main() -> eframe::Result {
     // Parse --profile <name> early so config_dir() resolves correctly for
     // both logging and all downstream I/O.
     let raw_args: Vec<String> = std::env::args().collect();
+
+    // Top-level --help/-h: print grouped subcommand sections before any
+    // logging or config init, so no noise appears alongside help output.
+    // Subcommand help (e.g. `plexi app --help`) is handled by clap below.
+    if top_level_help_flag(&raw_args) {
+        cli::help::print_grouped_help();
+        std::process::exit(0);
+    }
+
     let profile = parse_profile_flag(&raw_args);
     crate::config::set_profile(profile);
     let is_first_launch = crate::config::ensure_profile_initialized();
@@ -1095,6 +1104,28 @@ fn known_subcommands() -> &'static std::collections::HashSet<String> {
 }
 
 /// Scan argv for `--profile <name>`. Returns the name if present.
+/// Returns true when the only meaningful argument (ignoring `--profile <value>`) is `--help`/`-h`.
+fn top_level_help_flag(args: &[String]) -> bool {
+    let mut skip_next = false;
+    let filtered: Vec<&str> = args.iter().skip(1)
+        .filter(|a| {
+            if skip_next {
+                skip_next = false;
+                return false;
+            }
+            if a.as_str() == "--profile" || a.starts_with("--profile=") {
+                if a.as_str() == "--profile" {
+                    skip_next = true;
+                }
+                return false;
+            }
+            true
+        })
+        .map(|s| s.as_str())
+        .collect();
+    matches!(filtered.first().copied(), Some("--help") | Some("-h")) && filtered.len() == 1
+}
+
 fn parse_profile_flag(args: &[String]) -> Option<String> {
     let mut iter = args.iter();
     while let Some(a) = iter.next() {


### PR DESCRIPTION
Closes #1826

## Summary

- Add `src/cli/help.rs` with a custom grouped help printer; `HELP_GROUPS` const defines the five sections (Workspace, Apps, Panes, AI, System) and queries about-texts from the built `Command` at runtime — no brittle hardcoded strings
- Intercept `--help`/`-h` in `main()` before any logging/config init so no log noise appears alongside help output; `plexi app --help` and all subcommand help fall through to clap's built-in rendering unchanged
- `top_level_help_flag()` correctly skips `--profile <value>` pairs when deciding whether a top-level help flag was passed

## Done When

\`plexi --help\` renders with five labeled sections visible in a color terminal (Workspace, Apps, Panes, AI, System) — ✅