### PR TITLE
Gate release features by channel

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -237,6 +237,13 @@ Command templates used when Plexi skills dispatch coding agent panes. `{cmd}` is
 
 Experimental features. Flip any flag to `true` and restart to enable.
 
+Some product features are gated by release channel rather than config. The
+central registry is `src/release.rs`, where each `ReleaseFeature` declares its
+minimum channel. Today `plexi-beta`, `plexi-alpha`, and `plexi-pr-N` can open
+the Assistant, hosted Marketplace/account commands, and CLI/MCP app wrappers.
+The stable `plexi` binary keeps the v1 surface narrow: terminal multiplexing
+plus bundled/installed apps.
+
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `crt` | bool | false | Retro CRT scanlines + green phosphor tint. |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -625,7 +625,12 @@ impl PlexiApp {
                         // dir, so the broker-free factory can't build it. Build
                         // it here where the loaded `config.ai` is available; the
                         // conversation auto-resumes from disk.
-                        if pane_entry.is_none() && app_type == "assistant" {
+                        if pane_entry.is_none()
+                            && app_type == "assistant"
+                            && crate::release::feature_enabled(
+                                crate::release::ReleaseFeature::Assistant,
+                            )
+                        {
                             let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
                                 std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(
                                     config.ai.clone(),
@@ -636,6 +641,11 @@ impl PlexiApp {
                                 broker,
                                 &crate::config::config_dir(),
                             ));
+                        }
+                        if pane_entry.is_none() && app_type == "assistant" {
+                            crate::release::log_feature_blocked(
+                                crate::release::ReleaseFeature::Assistant,
+                            );
                         }
                         if pane_entry.is_none() {
                             if let Some(process) = registry.launch_process(app_type, &app_cwd, &[])

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -230,6 +230,14 @@ pub fn app_init(
 /// `src/cli/marketplace.rs`); `publisher` is the field required to publish.
 const MARKETPLACE_PLACEHOLDER: &str = "\n# Uncomment and fill in to publish with `plexi app publish`:\n# [marketplace]\n# visibility = \"public\"   # public | unlisted | private\n# price = \"free\"          # \"free\", or a price like \"4.99\"\n# publisher = \"your-org\"  # required: your publisher / org slug\n";
 
+fn marketplace_placeholder() -> &'static str {
+    if crate::release::feature_enabled(crate::release::ReleaseFeature::Marketplace) {
+        MARKETPLACE_PLACEHOLDER
+    } else {
+        ""
+    }
+}
+
 fn scaffold_python_app(app_dir: &std::path::Path, name: &str) -> io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
 
@@ -238,7 +246,7 @@ fn scaffold_python_app(app_dir: &std::path::Path, name: &str) -> io::Result<()> 
         "schema_version = 1\n\n[app]\nid = \"{name}\"\ntype = \"app\"\nname = \"{display}\"\nentry = \"main.py\"\nversion = \"0.1.0\"\ndescription = \"A Plexi app\"\nwatch = true\n\n[app.capabilities]\ncapabilities = [\"timer\"]\n\n[launch]\n{mp}",
         name = name,
         display = to_title_case(name),
-        mp = MARKETPLACE_PLACEHOLDER,
+        mp = marketplace_placeholder(),
     ))?;
 
     // main.py — plexi_sdk is injected via PYTHONPATH by the host at launch;
@@ -268,7 +276,7 @@ fn scaffold_agent_python_app(app_dir: &std::path::Path, name: &str) -> io::Resul
         "schema_version = 1\n\n[app]\nid = \"{name}\"\ntype = \"app\"\nname = \"{display}\"\nentry = \"main.py\"\nversion = \"0.1.0\"\ndescription = \"An agent app\"\nwatch = true\n\n[app.capabilities]\ncapabilities = [\"ai.query\"]\n\n[launch]\n{mp}",
         name = name,
         display = to_title_case(name),
-        mp = MARKETPLACE_PLACEHOLDER,
+        mp = marketplace_placeholder(),
     ))?;
 
     let template = include_str!("../../sdk/python/plexi_sdk/templates/agent_init.py");
@@ -295,7 +303,7 @@ fn scaffold_rust_app(app_dir: &std::path::Path, name: &str) -> io::Result<()> {
         "schema_version = 1\n\n[app]\nid = \"{name}\"\ntype = \"app\"\nname = \"{display}\"\nentry = \"bin/plexi-app\"\nversion = \"0.1.0\"\ndescription = \"A Plexi app\"\n\n[app.capabilities]\ncapabilities = []\n\n[launch]\n{mp}",
         name = name,
         display = to_title_case(name),
-        mp = MARKETPLACE_PLACEHOLDER,
+        mp = marketplace_placeholder(),
     ))?;
 
     // Cargo.toml
@@ -1575,9 +1583,9 @@ mod scaffold_marketplace_tests {
     use super::*;
     use tempfile::TempDir;
 
-    /// Every scaffold must emit a commented top-level `[marketplace]` placeholder
-    /// naming `publisher`, and the comment must neither break parsing nor produce
-    /// a live `[marketplace]` section.
+    /// Beta/alpha scaffolds emit a commented top-level `[marketplace]`
+    /// placeholder naming `publisher`. The comment must neither break parsing
+    /// nor produce a live `[marketplace]` section.
     fn assert_placeholder(manifest: &str) {
         assert!(
             manifest.contains("# [marketplace]"),
@@ -1595,6 +1603,16 @@ mod scaffold_marketplace_tests {
         );
     }
 
+    fn assert_no_placeholder(manifest: &str) {
+        assert!(
+            !manifest.contains("# [marketplace]"),
+            "stable scaffolds should not advertise marketplace publishing"
+        );
+        let parsed: crate::app::registry::AppManifest =
+            toml::from_str(manifest).expect("scaffolded manifest must parse");
+        assert!(parsed.marketplace.is_none());
+    }
+
     fn manifest_for(scaffold: fn(&std::path::Path, &str) -> io::Result<()>) -> String {
         let dir = TempDir::new().unwrap();
         let app_dir = dir.path().join("myapp");
@@ -1604,17 +1622,25 @@ mod scaffold_marketplace_tests {
     }
 
     #[test]
-    fn python_scaffold_has_marketplace_placeholder() {
+    fn stable_python_scaffold_omits_marketplace_placeholder() {
+        assert_no_placeholder(&manifest_for(scaffold_python_app));
+    }
+
+    #[test]
+    fn stable_agent_scaffold_omits_marketplace_placeholder() {
+        assert_no_placeholder(&manifest_for(scaffold_agent_python_app));
+    }
+
+    #[test]
+    fn stable_rust_scaffold_omits_marketplace_placeholder() {
+        assert_no_placeholder(&manifest_for(scaffold_rust_app));
+    }
+
+    #[test]
+    fn beta_scaffolds_keep_marketplace_placeholder() {
+        let _channel = crate::config::set_test_channel("beta");
         assert_placeholder(&manifest_for(scaffold_python_app));
-    }
-
-    #[test]
-    fn agent_scaffold_has_marketplace_placeholder() {
         assert_placeholder(&manifest_for(scaffold_agent_python_app));
-    }
-
-    #[test]
-    fn rust_scaffold_has_marketplace_placeholder() {
         assert_placeholder(&manifest_for(scaffold_rust_app));
     }
 }

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -105,6 +105,11 @@ pub fn print_grouped_help() {
     for (heading, names) in HELP_GROUPS {
         println!("{}", header(heading));
         for &name in *names {
+            if name == "account"
+                && !crate::release::feature_enabled(crate::release::ReleaseFeature::Marketplace)
+            {
+                continue;
+            }
             if let Some(sub) = cmd.find_subcommand(name) {
                 let about = sub.get_about().map(|s| s.to_string()).unwrap_or_default();
                 println!("  {} {about}", lit(format!("{name:<col_width$}")));

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -839,6 +839,10 @@ pub fn ensure_profile_initialized() -> bool {
 
 /// Returns the build channel for this binary: the suffix after `plexi-`, or `None` for the bare `plexi` binary (main channel).
 pub fn build_channel() -> Option<String> {
+    #[cfg(test)]
+    if let Some(channel) = test_channel_override() {
+        return Some(channel);
+    }
     let basename = std::env::current_exe()
         .ok()
         .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))?;
@@ -1575,6 +1579,12 @@ mod tests {
     fn config_dir_name_respects_test_channel_override() {
         let _guard = set_test_channel("pr-999");
         assert_eq!(config_dir_name(), ".plexi-pr-999");
+    }
+
+    #[test]
+    fn build_channel_respects_test_channel_override() {
+        let _guard = set_test_channel("beta");
+        assert_eq!(build_channel().as_deref(), Some("beta"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod platform;
 mod plexi_ai;
 mod process_app;
 mod protocol;
+mod release;
 mod render;
 #[cfg(test)]
 mod scenes;
@@ -37,6 +38,16 @@ mod ui_tests;
 mod workspace;
 
 fn main() -> eframe::Result {
+    fn exit_if_feature_disabled(feature: crate::release::ReleaseFeature) {
+        if !crate::release::feature_enabled(feature) {
+            eprintln!(
+                "error: {}",
+                crate::release::feature_unavailable_message(feature)
+            );
+            std::process::exit(1);
+        }
+    }
+
     if std::env::args().nth(1).as_deref() == Some("--render") {
         render_cli();
         std::process::exit(0);
@@ -337,6 +348,9 @@ fn main() -> eframe::Result {
                                     // Prefix routing: cli:, mcp:, app:, or bare name
                                     match cli::parse_prefix(&tid) {
                                         cli::OpenPrefix::Cli(name) => {
+                                            exit_if_feature_disabled(
+                                                crate::release::ReleaseFeature::AppWrappers,
+                                            );
                                             log::info!("app_open:cli: prefix-routed cli:{name}");
                                             std::process::exit(cli::open_cli_by_name(
                                                 &name,
@@ -346,6 +360,9 @@ fn main() -> eframe::Result {
                                             ));
                                         }
                                         cli::OpenPrefix::Mcp(name) => {
+                                            exit_if_feature_disabled(
+                                                crate::release::ReleaseFeature::AppWrappers,
+                                            );
                                             log::info!("app_open:cli: prefix-routed mcp:{name}");
                                             std::process::exit(cli::open_mcp_by_name(
                                                 &name,
@@ -376,6 +393,9 @@ fn main() -> eframe::Result {
                                         }
                                     }
                                 } else if !mcp.is_empty() {
+                                    exit_if_feature_disabled(
+                                        crate::release::ReleaseFeature::AppWrappers,
+                                    );
                                     let title = cli::mcp_pane_title(&mcp);
                                     log::info!("app_open:cli: launching mcp-renderer with command {:?}, auto-title={title:?}", mcp);
                                     let layout_str = layout.as_deref().unwrap_or("split_h");
@@ -393,6 +413,9 @@ fn main() -> eframe::Result {
                                     ));
                                 } else {
                                     let binary = cli_flag.unwrap();
+                                    exit_if_feature_disabled(
+                                        crate::release::ReleaseFeature::AppWrappers,
+                                    );
                                     log::info!("app_open:cli: --cli routing `{binary}` through unified resolver");
                                     std::process::exit(cli::open_cli_by_name(
                                         &binary,
@@ -445,6 +468,9 @@ fn main() -> eframe::Result {
                                                 yes,
                                             ));
                                         } else {
+                                            exit_if_feature_disabled(
+                                                crate::release::ReleaseFeature::Marketplace,
+                                            );
                                             log::info!("app_install:cli: remote spec={s} version={version:?}");
                                             std::process::exit(cli::install_cli(&s));
                                         }
@@ -512,17 +538,34 @@ fn main() -> eframe::Result {
                                 std::process::exit(cli::freeze_cli(&path));
                             }
                             AppCmd::Publish { path } => {
+                                exit_if_feature_disabled(
+                                    crate::release::ReleaseFeature::Marketplace,
+                                );
                                 std::process::exit(cli::app_publish_cli(&path));
                             }
                             AppCmd::Browse => {
+                                exit_if_feature_disabled(
+                                    crate::release::ReleaseFeature::Marketplace,
+                                );
                                 std::process::exit(cli::app_browse_cli());
                             }
                             AppCmd::Search { query } => {
+                                exit_if_feature_disabled(
+                                    crate::release::ReleaseFeature::Marketplace,
+                                );
                                 std::process::exit(cli::app_search_cli(&query));
                             }
                             AppCmd::License { cmd } => match cmd {
-                                LicenseCmd::List => std::process::exit(cli::app_license_list_cli()),
+                                LicenseCmd::List => {
+                                    exit_if_feature_disabled(
+                                        crate::release::ReleaseFeature::Marketplace,
+                                    );
+                                    std::process::exit(cli::app_license_list_cli())
+                                }
                                 LicenseCmd::Show { id } => {
+                                    exit_if_feature_disabled(
+                                        crate::release::ReleaseFeature::Marketplace,
+                                    );
                                     std::process::exit(cli::app_license_show_cli(&id))
                                 }
                             },
@@ -871,16 +914,19 @@ fn main() -> eframe::Result {
                             ));
                         }
                     },
-                    Commands::Account { cmd } => match cmd {
-                        AccountCmd::Status => std::process::exit(cli::account_status_cli()),
-                        AccountCmd::Login { email } => {
-                            std::process::exit(cli::account_login_cli(email.as_deref()))
+                    Commands::Account { cmd } => {
+                        exit_if_feature_disabled(crate::release::ReleaseFeature::Marketplace);
+                        match cmd {
+                            AccountCmd::Status => std::process::exit(cli::account_status_cli()),
+                            AccountCmd::Login { email } => {
+                                std::process::exit(cli::account_login_cli(email.as_deref()))
+                            }
+                            AccountCmd::Signup { email } => {
+                                std::process::exit(cli::account_signup_cli(email.as_deref()))
+                            }
+                            AccountCmd::Logout => std::process::exit(cli::account_logout_cli()),
                         }
-                        AccountCmd::Signup { email } => {
-                            std::process::exit(cli::account_signup_cli(email.as_deref()))
-                        }
-                        AccountCmd::Logout => std::process::exit(cli::account_logout_cli()),
-                    },
+                    }
                     Commands::Registry { cmd } => match cmd {
                         RegistryCmd::Watch { cli: only } => {
                             std::process::exit(cli::registry::watch_cli(only.as_deref()));

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -42,10 +42,11 @@ enum PaletteEntry {
 }
 
 /// Builtin host apps surfaced in the palette alongside registry apps.
-const BUILTIN_APPS: &[(&str, &str, &str)] = &[(
+const BUILTIN_APPS: &[(&str, &str, &str, crate::release::ReleaseFeature)] = &[(
     "assistant",
     "Assistant",
     "Host-native AI chat for this workspace",
+    crate::release::ReleaseFeature::Assistant,
 )];
 
 pub(crate) fn app_metadata_chips(
@@ -478,7 +479,10 @@ impl PlexiApp {
             })
             .collect();
 
-        for &(id, name, description) in BUILTIN_APPS {
+        for &(id, name, description, gate) in BUILTIN_APPS {
+            if !crate::release::feature_enabled(gate) {
+                continue;
+            }
             if query.is_empty()
                 || name.to_lowercase().contains(&query)
                 || id.to_lowercase().contains(&query)
@@ -873,7 +877,13 @@ impl PlexiApp {
     fn launch_builtin_by_id(&mut self, id: &str) {
         log::info!("palette: launching builtin app '{id}'");
         match id {
-            "assistant" => self.open_assistant_pane(),
+            "assistant" => {
+                if crate::release::feature_enabled(crate::release::ReleaseFeature::Assistant) {
+                    self.open_assistant_pane();
+                } else {
+                    log::info!("assistant: palette launch blocked by stable release gate");
+                }
+            }
             other => log::warn!("palette: unknown builtin app id '{other}'"),
         }
     }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1177,6 +1177,10 @@ impl PlexiApp {
     /// duplicate. Conversation state is workspace-scoped on disk, so
     /// close-then-reopen resumes the same conversation.
     pub(crate) fn open_assistant_pane(&mut self) {
+        if !crate::release::feature_enabled(crate::release::ReleaseFeature::Assistant) {
+            crate::release::log_feature_blocked(crate::release::ReleaseFeature::Assistant);
+            return;
+        }
         let active = self.active_window;
         // Focus an existing Assistant pane instead of opening a second one.
         let existing = self.windows[active].panes.iter().find_map(|(id, pane)| {

--- a/src/release.rs
+++ b/src/release.rs
@@ -1,0 +1,135 @@
+//! Release-channel gates for features that are not part of the stable v1 scope.
+//!
+//! Stable v1 is intentionally narrow: terminal multiplexing plus bundled core
+//! apps. Release-gated features stay available in alpha, beta, and PR builds
+//! according to the minimum channel declared here, so they can keep moving
+//! without leaking into the stable product.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReleaseFeature {
+    Assistant,
+    AppWrappers,
+    Marketplace,
+}
+
+impl ReleaseFeature {
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Assistant => "assistant",
+            Self::AppWrappers => "app wrappers",
+            Self::Marketplace => "marketplace",
+        }
+    }
+
+    pub fn minimum_channel(self) -> ReleaseTier {
+        match self {
+            Self::Assistant | Self::AppWrappers | Self::Marketplace => ReleaseTier::Beta,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum ReleaseTier {
+    Stable,
+    Beta,
+    Alpha,
+}
+
+impl ReleaseTier {
+    fn current_for_channel(channel: Option<&str>) -> Option<Self> {
+        match channel {
+            None => Some(Self::Stable),
+            Some("beta") => Some(Self::Beta),
+            Some("alpha") => Some(Self::Alpha),
+            Some(name) if name.starts_with("pr-") => Some(Self::Alpha),
+            Some(_) => None,
+        }
+    }
+
+    fn binary_hint(self) -> &'static str {
+        match self {
+            Self::Stable => "plexi",
+            Self::Beta => "plexi-beta or plexi-alpha",
+            Self::Alpha => "plexi-alpha",
+        }
+    }
+}
+
+pub fn feature_enabled(feature: ReleaseFeature) -> bool {
+    feature_enabled_for_channel(feature, crate::config::build_channel().as_deref())
+}
+
+pub fn log_feature_blocked(feature: ReleaseFeature) {
+    log::info!(
+        "release_gate: blocked access to {} feature; requires {:?}",
+        feature.name(),
+        feature.minimum_channel()
+    );
+}
+
+pub fn feature_unavailable_message(feature: ReleaseFeature) -> String {
+    log_feature_blocked(feature);
+    format!(
+        "{} requires the {} channel and is not part of the stable v1 surface. Use {} to try it.",
+        feature.name(),
+        feature.minimum_channel().label(),
+        feature.minimum_channel().binary_hint()
+    )
+}
+
+impl ReleaseTier {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Stable => "stable",
+            Self::Beta => "beta",
+            Self::Alpha => "alpha",
+        }
+    }
+}
+
+fn feature_enabled_for_channel(feature: ReleaseFeature, channel: Option<&str>) -> bool {
+    ReleaseTier::current_for_channel(channel).is_some_and(|tier| tier >= feature.minimum_channel())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{feature_enabled_for_channel, ReleaseFeature, ReleaseTier};
+
+    #[test]
+    fn stable_main_channel_disables_beta_features() {
+        assert!(!feature_enabled_for_channel(
+            ReleaseFeature::Marketplace,
+            None
+        ));
+    }
+
+    #[test]
+    fn alpha_beta_and_pr_channels_enable_beta_features() {
+        assert!(feature_enabled_for_channel(
+            ReleaseFeature::Marketplace,
+            Some("alpha")
+        ));
+        assert!(feature_enabled_for_channel(
+            ReleaseFeature::Marketplace,
+            Some("beta")
+        ));
+        assert!(feature_enabled_for_channel(
+            ReleaseFeature::Marketplace,
+            Some("pr-2259")
+        ));
+    }
+
+    #[test]
+    fn unknown_named_channels_disable_release_gated_features() {
+        assert!(!feature_enabled_for_channel(
+            ReleaseFeature::Marketplace,
+            Some("client")
+        ));
+    }
+
+    #[test]
+    fn alpha_tier_is_higher_than_beta_for_future_alpha_only_features() {
+        assert!(ReleaseTier::Alpha > ReleaseTier::Beta);
+        assert!(ReleaseTier::Beta > ReleaseTier::Stable);
+    }
+}


### PR DESCRIPTION
## Summary
- add a centralized `ReleaseFeature` registry where each gated feature declares its minimum release channel
- gate Assistant launch/restore, hosted Marketplace/account commands, remote marketplace installs, and CLI/MCP app wrappers to beta+ channels while leaving stable v1 focused on terminal multiplexing plus bundled/installed apps
- omit marketplace publishing hints from stable app scaffolds while preserving them for beta/alpha scaffolds
- document the channel-gated feature contract in `docs/CONFIG.md`

## Test evidence
- `cargo test --bin plexi release::tests -- --nocapture`
- `cargo test --bin plexi`
- `cargo build`