### PR TITLE
fix: apply workspace config on context switch

### DIFF
--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -2,6 +2,7 @@
 
 use super::PendingNotification;
 use super::PlexiApp;
+use std::path::Path;
 use std::time::Duration;
 
 pub(crate) const FOCUS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15 * 60);
@@ -401,6 +402,7 @@ impl PlexiApp {
             // Sync sidebar: router active must match the context of the window we navigated to.
             if let Some(ctx_idx) = self.router.position(|c| c.context_id == ctx_id) {
                 self.router.set_active(ctx_idx);
+                self.reload_config_for_active_context();
             }
             self.context_active_window.insert(ctx_id, window_id);
             self.restore_minimap_for_context(ctx_id);
@@ -450,6 +452,7 @@ impl PlexiApp {
             // Sync sidebar: router active must match the context of the window we navigated to.
             if let Some(ctx_idx) = self.router.position(|c| c.context_id == ctx_id) {
                 self.router.set_active(ctx_idx);
+                self.reload_config_for_active_context();
             }
             self.context_active_window.insert(ctx_id, window_id);
             self.restore_minimap_for_context(ctx_id);
@@ -490,10 +493,22 @@ impl PlexiApp {
     /// effect without a restart (theme, font size, notification settings,
     /// confirmation toggles). Logs the reload so the user knows it worked.
     pub(crate) fn reload_config(&mut self) {
-        let active_workspace = crate::config::active_workspace_root();
+        self.reload_config_for_active_context();
+    }
 
+    pub(crate) fn reload_config_for_active_context(&mut self) {
+        let active_workspace = self
+            .router
+            .active()
+            .root
+            .clone()
+            .or_else(crate::config::active_workspace_root);
+        self.reload_config_for_workspace(active_workspace.as_deref());
+    }
+
+    pub(crate) fn reload_config_for_workspace(&mut self, active_workspace: Option<&Path>) {
         let mut all_diags = crate::config::validate_from_path(&crate::config::config_path());
-        if let Some(root) = active_workspace.as_ref() {
+        if let Some(root) = active_workspace {
             let project_path = root
                 .join(crate::config::workspace_channel_dir())
                 .join("config.toml");
@@ -560,7 +575,7 @@ impl PlexiApp {
             return;
         }
 
-        let fresh = crate::config::PlexiConfig::load_with_workspace(active_workspace.as_deref());
+        let fresh = crate::config::PlexiConfig::load_with_workspace(active_workspace);
 
         // Log level — applies live; the fern filter reads it atomically per record.
         let new_level = fresh
@@ -654,7 +669,12 @@ impl PlexiApp {
         // Without this, a config reload that restores a disk preset would leave
         // last_system_theme unchanged, silently suppressing the auto-switch.
         self.last_system_theme = None;
-        log::info!("Configuration reloaded from disk.");
+        log::info!(
+            "Configuration reloaded from disk. active_workspace={}",
+            active_workspace
+                .map(|root| root.display().to_string())
+                .unwrap_or_else(|| "<none>".to_string())
+        );
     }
 
     /// Auto-switch to the paired preset for `system_theme`.
@@ -894,6 +914,7 @@ impl PlexiApp {
         // new active context immediately (router.active_idx() drives the highlight).
         if let Some(ctx_idx) = self.router.position(|ctx| ctx.context_id == ctx_id) {
             self.router.set_active(ctx_idx);
+            self.reload_config_for_active_context();
             self.context_active_window
                 .insert(ctx_id, self.windows[idx].window_id);
             self.restore_minimap_for_context(ctx_id);

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -1,4 +1,70 @@
 use super::super::*;
+use crate::host::context::Window;
+
+#[test]
+fn workspace_config_applies_when_switching_contexts() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let root_a = tempfile::tempdir().expect("root a");
+    let root_b = tempfile::tempdir().expect("root b");
+    write_workspace_config(root_a.path(), "#111111");
+    write_workspace_config(root_b.path(), "#22aa44");
+
+    app.router.get_mut(0).root = Some(root_a.path().to_path_buf());
+    app.windows[0].path = root_a.path().to_path_buf();
+    app.reload_config();
+    assert_eq!(
+        app.colors.accent,
+        egui::Color32::from_rgb(0x11, 0x11, 0x11),
+        "initial active context should load root A config"
+    );
+
+    let ctx_b_id = 2;
+    let win_b_id = 2;
+    app.router.push(crate::host::context::Context {
+        name: "Context B".into(),
+        path: root_b.path().to_path_buf(),
+        root: Some(root_b.path().to_path_buf()),
+        description: None,
+        context_id: ctx_b_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    app.windows.push(Window {
+        name: "Context B".into(),
+        path: root_b.path().to_path_buf(),
+        tree: egui_tiles::Tree::empty("workspace_config_b"),
+        panes: HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 1,
+        grid_y: 0,
+        window_id: win_b_id,
+        context_id: ctx_b_id,
+    });
+
+    app.switch_workspace(1);
+
+    assert_eq!(
+        app.colors.accent,
+        egui::Color32::from_rgb(0x22, 0xaa, 0x44),
+        "switching contexts should immediately load root B config"
+    );
+}
+
+fn write_workspace_config(root: &std::path::Path, accent: &str) {
+    let config_dir = root.join(crate::config::workspace_channel_dir());
+    std::fs::create_dir_all(&config_dir).expect("create workspace config dir");
+    std::fs::write(
+        config_dir.join("config.toml"),
+        format!("[theme]\naccent = \"{accent}\"\n"),
+    )
+    .expect("write workspace config");
+}
+
 /// Issue #1392: creating a child context must NOT remove or replace the parent's
 /// focused pane (adoption branch was removed). The parent should have:
 /// (count_before + 1) panes — its original pane(s) plus the new Portal tile.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,7 +1,7 @@
 use clap::{
     builder::styling::{AnsiColor, Effects, Styles},
     builder::ValueHint,
-    Parser, Subcommand,
+    Args, Parser, Subcommand,
 };
 
 fn plexi_styles() -> Styles {
@@ -984,21 +984,77 @@ pub enum ContextCmd {
 #[derive(Subcommand)]
 pub enum ConfigCmd {
     /// Validate your config.toml and report any errors.
-    Check,
+    Check {
+        #[command(flatten)]
+        scope: ConfigScopeArgs,
+    },
     /// Open config.toml in your $EDITOR.
-    Edit,
+    Edit {
+        #[command(flatten)]
+        scope: ConfigScopeArgs,
+    },
     /// Print the resolved value of a config key to stdout.
     ///
     /// Supports dotted keys: agents.low, agents.medium, agents.high.
     /// Returns the effective value (user setting or built-in default).
     Get {
+        #[command(flatten)]
+        scope: ConfigScopeArgs,
         /// Dotted key to retrieve (e.g. agents.medium).
         key: String,
     },
     /// Overwrite config.toml with the built-in default template.
     ///
     /// Creates a backup at config.toml.bak before overwriting.
-    Reset,
+    Reset {
+        #[command(flatten)]
+        scope: ConfigScopeArgs,
+    },
+}
+
+#[derive(Args, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ConfigScopeArgs {
+    /// Use the global channel config.toml only.
+    #[arg(short = 'g', long = "global", conflicts_with = "workspace")]
+    pub global: bool,
+    /// Use the active workspace's channel-scoped config.toml only.
+    #[arg(short = 'w', long = "workspace", visible_alias = "ws")]
+    pub workspace: bool,
+}
+
+impl ConfigScopeArgs {
+    pub fn scope(self) -> ConfigScope {
+        if self.global {
+            ConfigScope::Global
+        } else if self.workspace {
+            ConfigScope::Workspace
+        } else {
+            ConfigScope::Effective
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConfigScope {
+    Effective,
+    Global,
+    Workspace,
+}
+
+pub fn normalize_config_scope_aliases(args: Vec<String>) -> Vec<String> {
+    let Some(config_idx) = args.iter().position(|arg| arg == "config") else {
+        return args;
+    };
+    args.into_iter()
+        .enumerate()
+        .map(|(idx, arg)| {
+            if idx > config_idx && arg == "-ws" {
+                "--workspace".to_string()
+            } else {
+                arg
+            }
+        })
+        .collect()
 }
 
 #[derive(Subcommand)]
@@ -1162,7 +1218,9 @@ pub enum AiCmd {
 
 #[cfg(test)]
 mod tests {
-    use super::{AppCmd, Cli, Commands, SecretCmd};
+    use super::{
+        normalize_config_scope_aliases, AppCmd, Cli, Commands, ConfigCmd, ConfigScope, SecretCmd,
+    };
     use clap::Parser;
 
     #[test]
@@ -1186,6 +1244,53 @@ mod tests {
             panic!("expected secret command");
         };
         assert!(matches!(cmd, SecretCmd::List { global: false }));
+    }
+
+    #[test]
+    fn config_get_accepts_global_scope_flag() {
+        let cli =
+            Cli::try_parse_from(["plexi", "config", "get", "--global", "theme.accent"]).unwrap();
+
+        let Some(Commands::Config { cmd }) = cli.command else {
+            panic!("expected config command");
+        };
+        let ConfigCmd::Get { scope, key } = cmd else {
+            panic!("expected config get command");
+        };
+        assert_eq!(scope.scope(), ConfigScope::Global);
+        assert_eq!(key, "theme.accent");
+    }
+
+    #[test]
+    fn config_check_accepts_workspace_scope_alias() {
+        let cli = Cli::try_parse_from(["plexi", "config", "check", "--ws"]).unwrap();
+
+        let Some(Commands::Config { cmd }) = cli.command else {
+            panic!("expected config command");
+        };
+        let ConfigCmd::Check { scope } = cmd else {
+            panic!("expected config check command");
+        };
+        assert_eq!(scope.scope(), ConfigScope::Workspace);
+    }
+
+    #[test]
+    fn config_check_accepts_single_dash_ws_alias_after_normalization() {
+        let args = normalize_config_scope_aliases(
+            ["plexi", "config", "check", "-ws"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        );
+        let cli = Cli::try_parse_from(args).unwrap();
+
+        let Some(Commands::Config { cmd }) = cli.command else {
+            panic!("expected config command");
+        };
+        let ConfigCmd::Check { scope } = cmd else {
+            panic!("expected config check command");
+        };
+        assert_eq!(scope.scope(), ConfigScope::Workspace);
     }
 
     #[test]

--- a/src/cli/config_cli.rs
+++ b/src/cli/config_cli.rs
@@ -1,14 +1,29 @@
-pub fn config_check() -> i32 {
-    log::info!("config_check: validating config files");
-    let diags = crate::config::validate_all();
+use crate::cli::args::ConfigScope;
+use std::path::PathBuf;
 
+pub fn config_check(scope: ConfigScope) -> i32 {
+    log::info!("config_check: validating config files scope={scope:?}");
+    let paths = match config_paths_for_scope(scope, false) {
+        Ok(paths) => paths,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            return 1;
+        }
+    };
+    let mut diags = if scope == ConfigScope::Effective {
+        crate::config::validate_all()
+    } else {
+        Vec::new()
+    };
+    if scope != ConfigScope::Effective {
+        for path in &paths {
+            diags.extend(crate::config::validate_from_path(path));
+        }
+    }
     if diags.is_empty() {
-        let path = crate::config::config_path();
-        eprintln!("✓ {} is valid", path.display());
-        if let Some(root) = crate::config::active_workspace_root() {
-            let project_path = crate::config::workspace_config_path(&root);
-            if project_path.exists() {
-                eprintln!("✓ {} is valid", project_path.display());
+        for path in paths {
+            if path.exists() {
+                eprintln!("✓ {} is valid", path.display());
             }
         }
         return 0;
@@ -30,9 +45,18 @@ pub fn config_check() -> i32 {
     }
 }
 
-pub fn config_edit() -> i32 {
-    let path = crate::config::ensure_config_exists();
-    log::info!("config_edit: opening {} in editor", path.display());
+pub fn config_edit(scope: ConfigScope) -> i32 {
+    let path = match writable_config_path(scope) {
+        Ok(path) => path,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            return 1;
+        }
+    };
+    log::info!(
+        "config_edit: opening {} in editor scope={scope:?}",
+        path.display()
+    );
 
     if let Ok(editor_env) = std::env::var("EDITOR") {
         if editor_env.trim().is_empty() {
@@ -72,60 +96,67 @@ pub fn config_edit() -> i32 {
     }
 }
 
-pub fn config_get(key: &str) -> i32 {
-    log::info!("config_get: resolving key={key}");
+pub fn config_get(key: &str, scope: ConfigScope) -> i32 {
+    log::info!("config_get: resolving key={key} scope={scope:?}");
 
     // agents.* are special-cased because they have programmatic defaults
     // not stored in config.toml — always return via effective_*() for those.
-    match key {
-        "agents.low" | "agents.medium" | "agents.high" => {
-            let config = crate::config::PlexiConfig::load_with_workspace(
-                crate::config::active_workspace_root().as_deref(),
-            );
-            let agents = config.agents.as_ref();
-            let value = match key {
-                "agents.low" => agents
-                    .map(|a| a.effective_low())
-                    .unwrap_or(crate::config::DEFAULT_AGENT_LOW),
-                "agents.medium" => agents
-                    .map(|a| a.effective_medium())
-                    .unwrap_or(crate::config::DEFAULT_AGENT_MEDIUM),
-                _ => agents
-                    .map(|a| a.effective_high())
-                    .unwrap_or(crate::config::DEFAULT_AGENT_HIGH),
-            };
-            println!("{value}");
-            return 0;
-        }
-        _ => {}
+    if scope == ConfigScope::Effective {
+        match key {
+            "agents.low" | "agents.medium" | "agents.high" => {
+                let config = crate::config::PlexiConfig::load_with_workspace(
+                    crate::config::active_workspace_root().as_deref(),
+                );
+                let agents = config.agents.as_ref();
+                let value = match key {
+                    "agents.low" => agents
+                        .map(|a| a.effective_low())
+                        .unwrap_or(crate::config::DEFAULT_AGENT_LOW),
+                    "agents.medium" => agents
+                        .map(|a| a.effective_medium())
+                        .unwrap_or(crate::config::DEFAULT_AGENT_MEDIUM),
+                    _ => agents
+                        .map(|a| a.effective_high())
+                        .unwrap_or(crate::config::DEFAULT_AGENT_HIGH),
+                };
+                println!("{value}");
+                return 0;
+            }
+            _ => {}
+        };
     }
 
     // Generic path: load config as a raw TOML value and walk the dot-separated key.
-    // Workspace config (if present) overlays the global config at the TOML level.
-    let global_path = crate::config::config_path();
-    let mut root: toml::Value = match std::fs::read_to_string(&global_path) {
-        Ok(data) => match toml::from_str(&data) {
-            Ok(v) => v,
-            Err(e) => {
-                eprintln!("error: could not parse {}: {e}", global_path.display());
-                return 1;
-            }
-        },
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            toml::Value::Table(toml::map::Map::new())
-        }
-        Err(e) => {
-            eprintln!("error: could not read {}: {e}", global_path.display());
+    // Effective scope overlays workspace config on top of the global config.
+    let paths = match config_paths_for_scope(scope, false) {
+        Ok(paths) => paths,
+        Err(msg) => {
+            eprintln!("error: {msg}");
             return 1;
         }
     };
-
-    // Overlay workspace config on top if one exists.
-    if let Some(workspace_root) = crate::config::active_workspace_root() {
-        let project_path = crate::config::workspace_config_path(&workspace_root);
-        if let Ok(data) = std::fs::read_to_string(&project_path) {
-            if let Ok(project_val) = toml::from_str::<toml::Value>(&data) {
-                toml_merge(&mut root, project_val);
+    let mut root = toml::Value::Table(toml::map::Map::new());
+    for path in paths {
+        match std::fs::read_to_string(&path) {
+            Ok(data) => match toml::from_str::<toml::Value>(&data) {
+                Ok(val) => toml_merge(&mut root, val),
+                Err(e) => {
+                    eprintln!("error: could not parse {}: {e}", path.display());
+                    return 1;
+                }
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                if scope == ConfigScope::Workspace {
+                    eprintln!(
+                        "error: workspace config does not exist at {}",
+                        path.display()
+                    );
+                    return 1;
+                }
+            }
+            Err(e) => {
+                eprintln!("error: could not read {}: {e}", path.display());
+                return 1;
             }
         }
     }
@@ -182,34 +213,94 @@ fn toml_value_to_string(v: &toml::Value) -> String {
     }
 }
 
-pub fn config_reset() -> i32 {
-    let path = crate::config::config_path();
-    log::info!("config_reset: writing default config to {}", path.display());
+pub fn config_reset(scope: ConfigScope) -> i32 {
+    let path = match writable_config_path(scope) {
+        Ok(path) => path,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            return 1;
+        }
+    };
+    log::info!(
+        "config_reset: writing default config to {} scope={scope:?}",
+        path.display()
+    );
+    match write_default_config(&path) {
+        Ok(()) => 0,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            1
+        }
+    }
+}
+
+fn writable_config_path(scope: ConfigScope) -> Result<PathBuf, String> {
+    match scope {
+        ConfigScope::Effective | ConfigScope::Global => {
+            let path = crate::config::ensure_config_exists();
+            Ok(path)
+        }
+        ConfigScope::Workspace => {
+            let root = crate::config::active_workspace_root()
+                .ok_or_else(|| "not inside a Plexi workspace".to_string())?;
+            let path = crate::config::workspace_config_path(&root);
+            if !path.exists() {
+                write_default_config(&path)?;
+            }
+            Ok(path)
+        }
+    }
+}
+
+fn config_paths_for_scope(
+    scope: ConfigScope,
+    include_missing_workspace: bool,
+) -> Result<Vec<PathBuf>, String> {
+    let global = crate::config::config_path();
+    match scope {
+        ConfigScope::Global => Ok(vec![global]),
+        ConfigScope::Workspace => {
+            let root = crate::config::active_workspace_root()
+                .ok_or_else(|| "not inside a Plexi workspace".to_string())?;
+            Ok(vec![crate::config::workspace_config_path(&root)])
+        }
+        ConfigScope::Effective => {
+            let mut paths = vec![global];
+            if let Some(root) = crate::config::active_workspace_root() {
+                let workspace = crate::config::workspace_config_path(&root);
+                if include_missing_workspace || workspace.exists() {
+                    paths.push(workspace);
+                }
+            }
+            Ok(paths)
+        }
+    }
+}
+
+fn write_default_config(path: &std::path::Path) -> Result<(), String> {
     if let Some(parent) = path.parent() {
         if let Err(e) = std::fs::create_dir_all(parent) {
-            eprintln!(
-                "error: could not create config dir {}: {e}",
+            return Err(format!(
+                "could not create config dir {}: {e}",
                 parent.display()
-            );
-            return 1;
+            ));
         }
     }
     if path.exists() {
         let bak = path.with_extension("toml.bak");
         if let Err(e) = std::fs::copy(&path, &bak) {
-            eprintln!("error: could not back up config to {}: {e}", bak.display());
-            return 1;
+            return Err(format!(
+                "could not back up config to {}: {e}",
+                bak.display()
+            ));
         }
         eprintln!("backed up existing config to {}", bak.display());
     }
     match std::fs::write(&path, crate::config::CONFIG_TEMPLATE) {
         Ok(()) => {
             eprintln!("✓ wrote default config to {}", path.display());
-            0
+            Ok(())
         }
-        Err(e) => {
-            eprintln!("error: could not write config: {e}");
-            1
-        }
+        Err(e) => Err(format!("could not write config: {e}")),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,6 +210,7 @@ fn main() -> eframe::Result {
         UpdateCmd, WorkspaceCmd,
     };
     use clap::Parser;
+    let args = cli::args::normalize_config_scope_aliases(args);
 
     match Cli::try_parse_from(&args) {
         Ok(cli) => {
@@ -949,17 +950,17 @@ fn main() -> eframe::Result {
                         std::process::exit(cli::completions_cli(s, &binary_name));
                     }
                     Commands::Config { cmd: config_cmd } => match config_cmd {
-                        ConfigCmd::Check => {
-                            std::process::exit(cli::config_check());
+                        ConfigCmd::Check { scope } => {
+                            std::process::exit(cli::config_check(scope.scope()));
                         }
-                        ConfigCmd::Edit => {
-                            std::process::exit(cli::config_edit());
+                        ConfigCmd::Edit { scope } => {
+                            std::process::exit(cli::config_edit(scope.scope()));
                         }
-                        ConfigCmd::Get { key } => {
-                            std::process::exit(cli::config_get(&key));
+                        ConfigCmd::Get { scope, key } => {
+                            std::process::exit(cli::config_get(&key, scope.scope()));
                         }
-                        ConfigCmd::Reset => {
-                            std::process::exit(cli::config_reset());
+                        ConfigCmd::Reset { scope } => {
+                            std::process::exit(cli::config_reset(scope.scope()));
                         }
                     },
                     Commands::Notes { cmd } => match cmd {

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -1106,6 +1106,7 @@ impl PlexiApp {
             .copied()
             .unwrap_or(page_count > 1);
 
+        self.reload_config_for_active_context();
         self.apply_context_transition_effects();
     }
 
@@ -1491,6 +1492,7 @@ impl PlexiApp {
             .unwrap_or(0);
         if let Some(parent_ctx_idx) = self.router.position(|c| c.context_id == parent_ctx_id) {
             self.router.set_active(parent_ctx_idx);
+            self.reload_config_for_active_context();
         }
 
         self.pending_notifications.retain(|n| {


### PR DESCRIPTION
## Summary
- Reload effective config from the active router context root when switching contexts, focus history, pane navigation, or portal dissolution changes the active context.
- Add config CLI scope flags for global vs workspace config: -g/--global, -w/--workspace/--ws, plus exact -ws normalization for plexi config commands.
- Add regression coverage for immediate workspace theme application and config scope parsing.

## Test evidence
- cargo test --bin plexi workspace_config_applies_when_switching_contexts
- cargo test --bin plexi cli::args::tests::config
- cargo build
- cargo test --bin plexi (1163 passed, 1 ignored)

Closes #2262
