### PR TITLE
Refresh interactive demo CLI

### DIFF
--- a/.stint/tasks/0196-v2-host-event-log-coverage.md
+++ b/.stint/tasks/0196-v2-host-event-log-coverage.md
@@ -1,0 +1,41 @@
+---
+id: "0196"
+title: "v2: host event log coverage audit"
+status: backlog
+estimate: "2h"
+blocked_by: []
+gh_issue: []
+area:
+  - "host/events"
+  - "host/pane-ops"
+  - "ui/overlays"
+tags:
+  - "v2"
+  - "instrumentation"
+---
+
+Make `events.jsonl` close to one-to-one with user-visible host actions, so demos, agent traces, and debugging tools can rely on the host event stream instead of scraping `plexi.log`.
+
+## Scope
+
+- Audit host actions and add missing `HostEvent` emits for app open and close, note save, note open and close, palette open, new window, new context, and pane switches.
+- Make built-in apps and process apps follow the same event contract where possible.
+- Add focused regression coverage that proves each action writes the expected event.
+- Document any intentionally unlogged action and why it is excluded.
+
+## Non-Scope
+
+- Do not build a new analytics UI.
+- Do not change event retention, rotation, or storage format beyond adding event variants needed for coverage.
+
+## Why
+
+Plexi should leave a trustworthy action trail that matches what happened in the app.
+
+## References
+
+- `src/host/event_log.rs` - host event schema and JSONL writer.
+- `src/pane_ops/layout.rs` - pane close, app close, and focus-changing layout paths.
+- `src/pane_ops/create.rs` - app open, scratchpad, and built-in app launch paths.
+- `src/overlays/notes_picker.rs` - notes picker and note-open flows.
+- `src/app/mod.rs` - global shortcut dispatch for palette, notes, windows, contexts, and pane movement.

--- a/justfile
+++ b/justfile
@@ -118,7 +118,7 @@ sdk-dev:
 
 # Headless SDK/app contract smoke: Init -> Ready -> Render -> FrameDone.
 sdk-smoke:
-    uv run --project sdk/python pytest sdk/python/tests/test_app_harness.py -q
+    uv run --project sdk/python --with pytest --with pytest-asyncio pytest sdk/python/tests/test_app_harness.py -q
 
 # Build and install the current worktree as a testable PR build.
 # Installs as "Plexi PR<number>.app" with isolated profile ~/.plexi-pr-<number>/.

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -1051,6 +1051,13 @@ impl PlexiApp {
                 log::info!(
                     "notify:action: pane_id={pane_id} notify_id={notify_id:?} value={value:?} host_action={host_action:?}"
                 );
+                crate::host::event_log::emit(
+                    crate::host::event_log::HostEvent::NotificationActionInvoked {
+                        id: notify_id.clone(),
+                        action: action_label.clone(),
+                        timestamp: crate::host::event_log::now_timestamp(),
+                    },
+                );
                 // Execute host-side action synchronously before writing the response
                 // file so the navigation is complete before the shell unblocks.
                 if let Some(ref action) = host_action {

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -146,6 +146,13 @@ impl PlexiApp {
                         }
                     }
                 }
+                if found {
+                    crate::host::event_log::emit(crate::host::event_log::HostEvent::PaneRenamed {
+                        pane_id: *pane_id,
+                        name: name.clone(),
+                        timestamp: crate::host::event_log::now_timestamp(),
+                    });
+                }
                 if !found {
                     log::warn!("pane_ipc: set_pane_title: pane_id={pane_id} not found");
                 }
@@ -1393,6 +1400,14 @@ impl PlexiApp {
                     options.len(),
                     scope,
                     response_file
+                );
+                crate::host::event_log::emit(
+                    crate::host::event_log::HostEvent::NotificationPosted {
+                        id: internal_id.clone(),
+                        title: title.clone(),
+                        urgency: level.clone(),
+                        timestamp: crate::host::event_log::now_timestamp(),
+                    },
                 );
                 self.pending_notifications.push(PendingNotification {
                     notify_id: internal_id.clone(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2220,6 +2220,13 @@ impl eframe::App for PlexiApp {
                     log::info!(
                         "notify:action: pane_id={pane_id} notify_id={notify_id:?} value={value:?} host_action={host_action:?}"
                     );
+                    crate::host::event_log::emit(
+                        crate::host::event_log::HostEvent::NotificationActionInvoked {
+                            id: notify_id.clone(),
+                            action: action_label.clone(),
+                            timestamp: crate::host::event_log::now_timestamp(),
+                        },
+                    );
                     // Execute host-side action synchronously before writing the response
                     // file so the navigation is complete before the shell unblocks.
                     if let Some(ref action) = host_action {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3390,6 +3390,11 @@ impl PlexiApp {
             entries.len() - inbox_count,
             notes_dir
         );
+        crate::host::event_log::emit(crate::host::event_log::HostEvent::NotesPickerOpened {
+            inbox_count,
+            kept_count: entries.len() - inbox_count,
+            timestamp: crate::host::event_log::now_timestamp(),
+        });
         self.notes_picker_entries = entries;
         self.notes_picker_selected = 0;
         self.notes_picker_query.clear();

--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -1,6 +1,6 @@
 use super::notes::{print_step_complete, print_step_header};
 
-const TOTAL_STEPS: u8 = 13;
+const TOTAL_STEPS: u8 = 11;
 const CMD: &str = "\u{2318}";
 
 pub fn demo_cli() -> i32 {
@@ -44,7 +44,7 @@ pub fn demo_cli() -> i32 {
         "The pane on the right should be focused now.",
         "Press Command-Shift-D to split that pane below.",
     ]);
-    key(&format!("{CMD}Shift+D"), "split below");
+    key(&format!("{CMD}+Shift+D"), "split below");
     let mut lower_pane_id = 0;
     let after_lower_split = match poll_event(&events_path, after_right_split, |kind, obj| {
         capture_pane_split(kind, obj, &mut lower_pane_id)
@@ -96,29 +96,7 @@ pub fn demo_cli() -> i32 {
     };
     done(4);
 
-    step(5, "Rename this pane");
-    explain(&[
-        "Pane names keep busy workspaces readable.",
-        "Use the rename shortcut, enter Demo terminal, and confirm it.",
-    ]);
-    key(&format!("{CMD}R"), "rename this pane");
-    let after_rename = match poll_event(&events_path, after_close, |kind, obj| {
-        kind == "pane_renamed"
-            && obj
-                .get("pane_id")
-                .and_then(|v| v.as_u64())
-                .is_some_and(|pid| pid == my_pane_id)
-            && obj
-                .get("name")
-                .and_then(|v| v.as_str())
-                .is_some_and(|name| name == "Demo terminal")
-    }) {
-        Ok(offset) => offset,
-        Err(e) => return watch_error(&events_path, e),
-    };
-    done(5);
-
-    step(6, "Open an app from the palette");
+    step(5, "Open an app from the palette");
     explain(&[
         "Split to a fresh terminal, open the command palette, type Balls, and choose the Balls app.",
         "The app should take over that pane. This demo waits for the Balls app to spawn.",
@@ -127,61 +105,79 @@ pub fn demo_cli() -> i32 {
     key(&format!("{CMD}P"), "open the command palette");
     eprintln!("    Type Balls, choose the Balls app, and press Enter.");
     eprintln!();
-    let after_balls = match poll_event(&events_path, after_rename, |kind, obj| {
-        kind == "app_spawned"
+    let mut balls_pane_id = 0;
+    let after_balls = match poll_event(&events_path, after_close, |kind, obj| {
+        if kind != "app_spawned"
+            || !obj
+                .get("type_id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|id| id == "balls")
+        {
+            return false;
+        }
+        if let Some(id) = obj.get("pane_id").and_then(|v| v.as_u64()) {
+            balls_pane_id = id;
+            true
+        } else {
+            false
+        }
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
+    done(5);
+
+    step(6, "Return to the terminal");
+    explain(&[
+        "Congrats, you can press Escape or Command-W to exit and return back to the regular terminal pane.",
+    ]);
+    key("Esc", "exit the app");
+    let after_balls_close = match poll_event(&events_path, after_balls, |kind, obj| {
+        kind == "app_closed"
             && obj
                 .get("type_id")
                 .and_then(|v| v.as_str())
                 .is_some_and(|id| id == "balls")
+            && obj
+                .get("pane_id")
+                .and_then(|v| v.as_u64())
+                .is_some_and(|id| id == balls_pane_id)
     }) {
         Ok(offset) => offset,
         Err(e) => return watch_error(&events_path, e),
     };
     done(6);
 
-    step(7, "Send a notification");
+    step(7, "Rename this app pane");
     explain(&[
-        "Agents can notify you through Plexi instead of relying on terminal output.",
-        "Move back to this demo pane, then run the command below.",
+        "You should be back in the terminal that launched Balls.",
+        "Rename it so the pane list is easier to scan.",
+        "Use the rename shortcut, enter Demo app pane, and confirm it.",
     ]);
-    command("plexi notify --title \"Hello\"");
-    let after_notify = match poll_event(&events_path, after_balls, |kind, obj| {
-        kind == "notification_posted"
+    key(&format!("{CMD}R"), "rename this pane");
+    let after_app_rename = match poll_event(&events_path, after_balls_close, |kind, obj| {
+        kind == "pane_renamed"
             && obj
-                .get("title")
+                .get("pane_id")
+                .and_then(|v| v.as_u64())
+                .is_some_and(|pid| pid == balls_pane_id)
+            && obj
+                .get("name")
                 .and_then(|v| v.as_str())
-                .is_some_and(|title| title == "Hello")
+                .is_some_and(|name| name == "Demo app pane")
     }) {
         Ok(offset) => offset,
         Err(e) => return watch_error(&events_path, e),
     };
     done(7);
 
-    step(8, "Acknowledge it");
+    step(8, "Open File Browser");
     explain(&[
-        "Open notifications with Command-Shift-A and click Acknowledge.",
-        "This is the same surface your agents can use when they need your attention.",
+        "File Browser opens on the current pane.",
+        "Use H J K L, or the arrow keys, to move through the file tree and view files.",
     ]);
-    key(&format!("{CMD}Shift+A"), "open notifications");
-    let after_ack = match poll_event(&events_path, after_notify, |kind, obj| {
-        kind == "notification_action_invoked"
-            && obj
-                .get("action")
-                .and_then(|v| v.as_str())
-                .is_some_and(|action| action == "acknowledge")
-    }) {
-        Ok(offset) => offset,
-        Err(e) => return watch_error(&events_path, e),
-    };
-    done(8);
-
-    step(9, "Open files in a tab");
-    explain(&[
-        "The file explorer is a Plexi app for moving through a project directory.",
-        "This opens it in a tab so your terminal stays next to it.",
-    ]);
-    command("plexi app open --tab file_browser");
-    let after_file = match poll_event(&events_path, after_ack, |kind, obj| {
+    key(&format!("{CMD}E"), "open File Browser");
+    let after_file = match poll_event(&events_path, after_app_rename, |kind, obj| {
         kind == "app_spawned"
             && obj
                 .get("type_id")
@@ -191,71 +187,88 @@ pub fn demo_cli() -> i32 {
         Ok(offset) => offset,
         Err(e) => return watch_error(&events_path, e),
     };
+    done(8);
+
+    step(9, "Split below File Browser");
+    explain(&[
+        "Keep File Browser open and add a terminal underneath it.",
+        "The new terminal should be focused after the split.",
+    ]);
+    key(&format!("{CMD}+Shift+D"), "split below");
+    let mut note_terminal_pane_id = 0;
+    let after_file_split = match poll_event(&events_path, after_file, |kind, obj| {
+        capture_pane_split(kind, obj, &mut note_terminal_pane_id)
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
     done(9);
 
     step(10, "Write a scratch note");
     explain(&[
         "Scratch notes land in your Plexi notes inbox.",
-        "Press Command-Shift-Space, type a line, close it, return here, then press Enter.",
+        "Open one from the terminal under File Browser, type a short note, then press Escape to leave it.",
     ]);
-    key(&format!("{CMD}Shift+Space"), "open a scratch note");
-    wait_for_enter();
-    done(10);
-    let after_note = file_offset(&events_path).unwrap_or(after_file);
-
-    step(11, "Create a context");
-    explain(&[
-        "Contexts group related panes and pages.",
-        "Press Command-Shift-N, name the new context Demo Context, and press Enter.",
-    ]);
-    key(&format!("{CMD}Shift+N"), "create a new context");
-    let mut context_id = 0;
-    let after_context = match poll_event(&events_path, after_note, |kind, obj| {
-        if kind == "context_created" {
-            if let Some(id) = obj.get("context_id").and_then(|v| v.as_u64()) {
-                context_id = id;
-                return true;
-            }
+    key(&format!("{CMD}+Shift+Space"), "open a scratch note");
+    let mut scratch_note_path = String::new();
+    let after_scratch_open = match poll_event(&events_path, after_file_split, |kind, obj| {
+        if kind != "scratchpad_opened" {
+            return false;
         }
-        false
+        if let Some(path) = obj.get("path").and_then(|v| v.as_str()) {
+            scratch_note_path = path.to_string();
+            true
+        } else {
+            false
+        }
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
+    let after_scratch_close = match poll_event(&events_path, after_scratch_open, |kind, obj| {
+        kind == "app_closed"
+            && obj
+                .get("type_id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|id| id == "text-editor")
+            && obj
+                .get("pane_id")
+                .and_then(|v| v.as_u64())
+                .is_some_and(|id| id == note_terminal_pane_id)
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
+    done(10);
+
+    step(11, "Open your notes");
+    explain(&[
+        "From any terminal, Command-O opens your notes.",
+        "Press Enter in the picker to return to the scratch note you just wrote.",
+    ]);
+    key(&format!("{CMD}O"), "open your notes");
+    let after_notes_picker = match poll_event(&events_path, after_scratch_close, |kind, _obj| {
+        kind == "notes_picker_opened"
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
+    let _after_note_open = match poll_event(&events_path, after_notes_picker, |kind, obj| {
+        kind == "note_opened"
+            && obj
+                .get("path")
+                .and_then(|v| v.as_str())
+                .is_some_and(|path| path == scratch_note_path)
     }) {
         Ok(offset) => offset,
         Err(e) => return watch_error(&events_path, e),
     };
     done(11);
 
-    step(12, "Rename the context");
+    eprintln!("  More to cover");
     explain(&[
-        "Press Command-Shift-R, change the context name, and press Enter.",
-        "The demo waits for the rename event in Plexi's event log.",
+        "Here is where the full intro link will go when I actually get around to making it.",
     ]);
-    key(&format!("{CMD}Shift+R"), "rename the active context");
-    let after_context_rename = match poll_event(&events_path, after_context, |kind, obj| {
-        kind == "context_renamed"
-            && obj
-                .get("context_id")
-                .and_then(|v| v.as_u64())
-                .is_some_and(|id| id == context_id)
-    }) {
-        Ok(offset) => offset,
-        Err(e) => return watch_error(&events_path, e),
-    };
-    done(12);
-
-    step(13, "Open the shortcut sheet");
-    explain(&[
-        "Click the button in the top right. It opens the shortcut sheet, where you can also see the Command-/ binding.",
-        "Full intro: https://plexiapp.com/docs/intro",
-        "Hold Command and click the link to open it in your browser.",
-        "If this is not a link, that means I have not uploaded it yet. Try again later.",
-    ]);
-    eprintln!("    Press Enter when you have looked at the shortcut sheet.");
-    eprintln!();
-    wait_for_enter();
-    let _ = after_context_rename;
-    done(13);
-
-    eprintln!("  Done. This covers maybe 20% of what Plexi can do.");
     eprintln!();
     log::info!("demo_cli: tutorial completed for pane_id={my_pane_id}");
     0
@@ -291,12 +304,6 @@ fn explain(lines: &[&str]) {
     for line in lines {
         wrapped("    ", line);
     }
-    eprintln!();
-}
-
-fn command(cmd: &str) {
-    eprintln!("    Run:");
-    wrapped_styled("    ", "\x1b[1m", cmd, "\x1b[0m");
     eprintln!();
 }
 

--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -97,8 +97,11 @@ pub fn demo_cli() -> i32 {
     done(4);
 
     step(5, "Rename this pane");
-    explain(&["Pane names keep busy workspaces readable."]);
-    command("plexi pane name \"Demo terminal\"");
+    explain(&[
+        "Pane names keep busy workspaces readable.",
+        "Use the rename shortcut, enter Demo terminal, and confirm it.",
+    ]);
+    key(&format!("{CMD}R"), "rename this pane");
     let after_rename = match poll_event(&events_path, after_close, |kind, obj| {
         kind == "pane_renamed"
             && obj
@@ -293,7 +296,7 @@ fn explain(lines: &[&str]) {
 
 fn command(cmd: &str) {
     eprintln!("    Run:");
-    wrapped("    \x1b[1m", &format!("{cmd}\x1b[0m"));
+    wrapped_styled("    ", "\x1b[1m", cmd, "\x1b[0m");
     eprintln!();
 }
 
@@ -303,17 +306,21 @@ fn key(keys: &str, action: &str) {
 }
 
 fn wrapped(prefix: &str, text: &str) {
+    wrapped_styled(prefix, "", text, "");
+}
+
+fn wrapped_styled(prefix: &str, style_start: &str, text: &str, style_end: &str) {
     let width = terminal_width().clamp(46, 72);
-    let content_width = width.saturating_sub(4).max(32);
+    let content_width = width.saturating_sub(visible_len(prefix)).max(24);
     let mut line = String::new();
     for word in text.split_whitespace() {
         let next_len = if line.is_empty() {
-            word.len()
+            visible_len(word)
         } else {
-            line.len() + 1 + word.len()
+            visible_len(&line) + 1 + visible_len(word)
         };
         if next_len > content_width && !line.is_empty() {
-            eprintln!("{prefix}{line}");
+            eprintln!("{prefix}{style_start}{line}{style_end}");
             line.clear();
         }
         if !line.is_empty() {
@@ -322,7 +329,7 @@ fn wrapped(prefix: &str, text: &str) {
         line.push_str(word);
     }
     if !line.is_empty() {
-        eprintln!("{prefix}{line}");
+        eprintln!("{prefix}{style_start}{line}{style_end}");
     }
 }
 
@@ -332,10 +339,54 @@ fn wait_for_enter() {
 }
 
 fn terminal_width() -> usize {
-    std::env::var("COLUMNS")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(72)
+    terminal_width_from_tty().unwrap_or_else(|| {
+        std::env::var("COLUMNS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(72)
+    })
+}
+
+#[cfg(unix)]
+fn terminal_width_from_tty() -> Option<usize> {
+    use std::os::fd::AsRawFd;
+
+    let mut size = libc::winsize {
+        ws_row: 0,
+        ws_col: 0,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let fd = std::io::stderr().as_raw_fd();
+    let rc = unsafe { libc::ioctl(fd, libc::TIOCGWINSZ, &mut size) };
+    if rc == 0 && size.ws_col > 0 {
+        Some(size.ws_col as usize)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(unix))]
+fn terminal_width_from_tty() -> Option<usize> {
+    None
+}
+
+fn visible_len(text: &str) -> usize {
+    let mut len = 0;
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\x1b' && chars.peek() == Some(&'[') {
+            chars.next();
+            for code_ch in chars.by_ref() {
+                if code_ch.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            len += 1;
+        }
+    }
+    len
 }
 
 fn file_offset(path: &std::path::Path) -> Option<u64> {

--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -149,12 +149,13 @@ pub fn demo_cli() -> i32 {
     };
     done(6);
 
-    step(7, "Rename the Balls terminal");
+    step(7, "Rename the right pane");
     explain(&[
-        "You should be back in the terminal that just held Balls.",
-        "Rename that terminal so the pane list is easier to scan.",
+        "Rename the pane on the right, the one that just held Balls.",
+        "If focus is back on this demo, press Command-L first to move right.",
         "Use the rename shortcut, enter Demo app pane, and confirm it.",
     ]);
+    key(&format!("{CMD}L"), "focus the pane on the right");
     key(&format!("{CMD}R"), "rename this pane");
     let after_app_rename = match poll_event(&events_path, after_balls_close, |kind, obj| {
         kind == "pane_renamed"

--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -21,6 +21,7 @@ pub fn demo_cli() -> i32 {
     };
 
     log::info!("demo_cli: starting interactive tutorial for pane_id={my_pane_id}");
+    name_demo_pane(my_pane_id);
 
     let events_path = crate::config::config_dir().join("events.jsonl");
     let start_offset = file_offset(&events_path).unwrap_or(0);
@@ -106,7 +107,13 @@ pub fn demo_cli() -> i32 {
     eprintln!("    Type Balls, choose the Balls app, and press Enter.");
     eprintln!();
     let mut balls_pane_id = 0;
-    let after_balls = match poll_event(&events_path, after_close, |kind, obj| {
+    let after_app_split = match poll_event(&events_path, after_close, |kind, obj| {
+        capture_pane_split(kind, obj, &mut balls_pane_id)
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
+    let after_balls = match poll_event(&events_path, after_app_split, |kind, obj| {
         if kind != "app_spawned"
             || !obj
                 .get("type_id")
@@ -115,12 +122,7 @@ pub fn demo_cli() -> i32 {
         {
             return false;
         }
-        if let Some(id) = obj.get("pane_id").and_then(|v| v.as_u64()) {
-            balls_pane_id = id;
-            true
-        } else {
-            false
-        }
+        true
     }) {
         Ok(offset) => offset,
         Err(e) => return watch_error(&events_path, e),
@@ -151,7 +153,7 @@ pub fn demo_cli() -> i32 {
     step(7, "Rename this app pane");
     explain(&[
         "You should be back in the terminal that launched Balls.",
-        "Rename it so the pane list is easier to scan.",
+        "Rename that pane so the pane list is easier to scan.",
         "Use the rename shortcut, enter Demo app pane, and confirm it.",
     ]);
     key(&format!("{CMD}R"), "rename this pane");
@@ -280,6 +282,18 @@ fn print_intro() {
         "Plexi is a local app workspace for terminals, app panes, notes, contexts, notifications, and agent-driven work.",
         "This demo watches Plexi events and advances as you try the core host controls. Keep this terminal visible when you can.",
     ]);
+}
+
+fn name_demo_pane(pane_id: u64) {
+    log::info!("demo_cli: naming demo pane pane_id={pane_id}");
+    let code = super::send_to_socket(serde_json::json!({
+        "type": "set_pane_title",
+        "pane_id": pane_id,
+        "name": "Plexi demo",
+    }));
+    if code != 0 {
+        log::warn!("demo_cli: could not name demo pane pane_id={pane_id}");
+    }
 }
 
 fn step(step: u8, title: &str) {

--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -1,5 +1,8 @@
 use super::notes::{print_step_complete, print_step_header};
 
+const TOTAL_STEPS: u8 = 13;
+const CMD: &str = "\u{2318}";
+
 pub fn demo_cli() -> i32 {
     let pane_id_str = match std::env::var("PLEXI_PANE_ID") {
         Ok(v) => v,
@@ -20,181 +23,338 @@ pub fn demo_cli() -> i32 {
     log::info!("demo_cli: starting interactive tutorial for pane_id={my_pane_id}");
 
     let events_path = crate::config::config_dir().join("events.jsonl");
+    let start_offset = file_offset(&events_path).unwrap_or(0);
 
-    // Seek to end — only watch events that occur after demo starts.
-    let start_offset = match std::fs::metadata(&events_path) {
-        Ok(m) => m.len(),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => 0,
-        Err(e) => {
-            log::warn!("demo_cli: could not read events file metadata: {e}");
-            0
-        }
+    print_intro();
+
+    step(1, "Split right");
+    explain(&["Press Command-D. Plexi splits this pane to the right and focuses the new pane."]);
+    key(&format!("{CMD}D"), "split right");
+    let mut right_pane_id = 0;
+    let after_right_split = match poll_event(&events_path, start_offset, |kind, obj| {
+        capture_pane_split(kind, obj, &mut right_pane_id)
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
     };
+    done(1);
 
-    // Welcome banner
-    eprintln!("\x1b[1;36m");
-    eprintln!("  Plexi — Quick Tutorial");
-    eprintln!("\x1b[0m");
-    eprintln!("  Seven moves. That's all you need to know.");
+    step(2, "Split below");
+    explain(&[
+        "The pane on the right should be focused now.",
+        "Press Command-Shift-D to split that pane below.",
+    ]);
+    key(&format!("{CMD}Shift+D"), "split below");
+    let mut lower_pane_id = 0;
+    let after_lower_split = match poll_event(&events_path, after_right_split, |kind, obj| {
+        capture_pane_split(kind, obj, &mut lower_pane_id)
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
+    done(2);
+
+    step(3, "Move with HJKL");
+    explain(&[
+        "Hold Command and use H J K L to move between panes.",
+        "Your hand naturally rests there during normal typing. Arrow keys work too, but HJKL is worth learning if you spend the day in panes.",
+        "Move around for a moment. Focus each pane at least twice, then come back to this demo pane and press Enter.",
+    ]);
+    eprintln!("        left  down   up  right");
+    eprintln!("          <-    v     ^     ->");
+    eprintln!("          H     J     K     L");
     eprintln!();
+    wait_for_enter();
+    done(3);
+    let after_move = file_offset(&events_path).unwrap_or(after_lower_split);
 
-    // Step 1 — split
-    print_step_header(1, 7, "Split a pane");
-    eprintln!("    Press  \x1b[1m[ \u{2318}D ]\x1b[0m  to split the current pane.");
+    step(4, "Close the extra panes");
+    explain(&[
+        "Close the two panes you created with Command-W.",
+        "Do not close this demo pane. Move back here after each close if you need to.",
+    ]);
+    key(&format!("{CMD}W"), "close the focused extra pane");
+    let mut closed_right = false;
+    let mut closed_lower = false;
+    let after_close = match poll_event(&events_path, after_move, |kind, obj| {
+        if kind != "pane_closed" {
+            return false;
+        }
+        let Some(id) = obj.get("pane_id").and_then(|v| v.as_u64()) else {
+            return false;
+        };
+        if id == right_pane_id {
+            closed_right = true;
+        }
+        if id == lower_pane_id {
+            closed_lower = true;
+        }
+        closed_right && closed_lower
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
+    done(4);
+
+    step(5, "Rename this pane");
+    explain(&["Pane names keep busy workspaces readable."]);
+    command("plexi pane name \"Demo terminal\"");
+    let after_rename = match poll_event(&events_path, after_close, |kind, obj| {
+        kind == "pane_renamed"
+            && obj
+                .get("pane_id")
+                .and_then(|v| v.as_u64())
+                .is_some_and(|pid| pid == my_pane_id)
+            && obj
+                .get("name")
+                .and_then(|v| v.as_str())
+                .is_some_and(|name| name == "Demo terminal")
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
+    done(5);
+
+    step(6, "Open an app from the palette");
+    explain(&[
+        "Split to a fresh terminal, open the command palette, type Balls, and choose the Balls app.",
+        "The app should take over that pane. This demo waits for the Balls app to spawn.",
+    ]);
+    key(&format!("{CMD}D"), "open a new terminal pane");
+    key(&format!("{CMD}P"), "open the command palette");
+    eprintln!("    Type Balls, choose the Balls app, and press Enter.");
     eprintln!();
+    let after_balls = match poll_event(&events_path, after_rename, |kind, obj| {
+        kind == "app_spawned"
+            && obj
+                .get("type_id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|id| id == "balls")
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
+    done(6);
 
-    // Capture the new pane's ID from the split event so step 2 can verify
-    // focus specifically returns from that pane (not a bounce from the split itself).
-    let mut split_pane_id: u64 = 0;
-    let after_split_offset = match poll_event(&events_path, start_offset, |kind, obj| {
-        if kind == "pane_split" {
-            if let Some(id) = obj.get("pane_id").and_then(|v| v.as_u64()) {
-                split_pane_id = id;
+    step(7, "Send a notification");
+    explain(&[
+        "Agents can notify you through Plexi instead of relying on terminal output.",
+        "Move back to this demo pane, then run the command below.",
+    ]);
+    command("plexi notify --title \"Hello\"");
+    let after_notify = match poll_event(&events_path, after_balls, |kind, obj| {
+        kind == "notification_posted"
+            && obj
+                .get("title")
+                .and_then(|v| v.as_str())
+                .is_some_and(|title| title == "Hello")
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
+    done(7);
+
+    step(8, "Acknowledge it");
+    explain(&[
+        "Open notifications with Command-Shift-A and click Acknowledge.",
+        "This is the same surface your agents can use when they need your attention.",
+    ]);
+    key(&format!("{CMD}Shift+A"), "open notifications");
+    let after_ack = match poll_event(&events_path, after_notify, |kind, obj| {
+        kind == "notification_action_invoked"
+            && obj
+                .get("action")
+                .and_then(|v| v.as_str())
+                .is_some_and(|action| action == "acknowledge")
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
+    done(8);
+
+    step(9, "Open files in a tab");
+    explain(&[
+        "The file explorer is a Plexi app for moving through a project directory.",
+        "This opens it in a tab so your terminal stays next to it.",
+    ]);
+    command("plexi app open --tab file_browser");
+    let after_file = match poll_event(&events_path, after_ack, |kind, obj| {
+        kind == "app_spawned"
+            && obj
+                .get("type_id")
+                .and_then(|v| v.as_str())
+                .is_some_and(|id| id == "file_browser")
+    }) {
+        Ok(offset) => offset,
+        Err(e) => return watch_error(&events_path, e),
+    };
+    done(9);
+
+    step(10, "Write a scratch note");
+    explain(&[
+        "Scratch notes land in your Plexi notes inbox.",
+        "Press Command-Shift-Space, type a line, close it, return here, then press Enter.",
+    ]);
+    key(&format!("{CMD}Shift+Space"), "open a scratch note");
+    wait_for_enter();
+    done(10);
+    let after_note = file_offset(&events_path).unwrap_or(after_file);
+
+    step(11, "Create a context");
+    explain(&[
+        "Contexts group related panes and pages.",
+        "Press Command-Shift-N, name the new context Demo Context, and press Enter.",
+    ]);
+    key(&format!("{CMD}Shift+N"), "create a new context");
+    let mut context_id = 0;
+    let after_context = match poll_event(&events_path, after_note, |kind, obj| {
+        if kind == "context_created" {
+            if let Some(id) = obj.get("context_id").and_then(|v| v.as_u64()) {
+                context_id = id;
                 return true;
             }
         }
         false
     }) {
         Ok(offset) => offset,
-        Err(e) => {
-            eprintln!("error watching {}: {e}", events_path.display());
-            return 1;
-        }
+        Err(e) => return watch_error(&events_path, e),
     };
-    print_step_complete(1, 7);
+    done(11);
 
-    // Step 2 — navigate
-    print_step_header(2, 7, "Navigate panes");
-    eprintln!("       \x1b[2m^\x1b[0m");
-    eprintln!("       K");
-    eprintln!("    H     L");
-    eprintln!("       J");
-    eprintln!();
-    eprintln!("    Press  \x1b[1m[ \u{2318}H ]\x1b[0m  to return to this pane, then  \x1b[1m[ \u{2318}L ]\x1b[0m  to go back.");
-    eprintln!();
-
-    // Require a confirmed round-trip between split_pane and demo pane.
-    // After the split, focus is on split_pane_id. The valid event sequence is:
-    //   focus_changed(split_pane_id)  — user left split pane via ⌘H
-    //   focus_changed(my_pane_id)     — user left demo pane via ⌘L
-    // Any other pane ID appearing between these two resets the state so that
-    // a second ⌘D split cannot satisfy the round-trip without actual navigation.
-    let mut saw_split_depart = false;
-    let after_nav_offset = match poll_event(&events_path, after_split_offset, |kind, obj| {
-        if kind != "focus_changed" {
-            return false;
-        }
-        let Some(pid) = obj.get("pane_id").and_then(|v| v.as_u64()) else {
-            return false;
-        };
-        if !saw_split_depart {
-            if pid == split_pane_id {
-                saw_split_depart = true;
-            }
-            false
-        } else if pid == my_pane_id {
-            true
-        } else {
-            saw_split_depart = pid == split_pane_id;
-            false
-        }
+    step(12, "Rename the context");
+    explain(&[
+        "Press Command-Shift-R, change the context name, and press Enter.",
+        "The demo waits for the rename event in Plexi's event log.",
+    ]);
+    key(&format!("{CMD}Shift+R"), "rename the active context");
+    let after_context_rename = match poll_event(&events_path, after_context, |kind, obj| {
+        kind == "context_renamed"
+            && obj
+                .get("context_id")
+                .and_then(|v| v.as_u64())
+                .is_some_and(|id| id == context_id)
     }) {
         Ok(offset) => offset,
-        Err(e) => {
-            eprintln!("error watching {}: {e}", events_path.display());
-            return 1;
-        }
+        Err(e) => return watch_error(&events_path, e),
     };
-    print_step_complete(2, 7);
+    done(12);
 
-    // Step 3 — close pane
-    print_step_header(3, 7, "Close a pane");
-    eprintln!("    Press  \x1b[1m[ \u{2318}W ]\x1b[0m  to close the split pane.");
+    step(13, "Open the shortcut sheet");
+    explain(&[
+        "Click the button in the top right. It opens the shortcut sheet, where you can also see the Command-/ binding.",
+        "Full intro: https://plexiapp.com/docs/intro",
+        "Hold Command and click the link to open it in your browser.",
+        "If this is not a link, that means I have not uploaded it yet. Try again later.",
+    ]);
+    eprintln!("    Press Enter when you have looked at the shortcut sheet.");
     eprintln!();
-    let after_close_offset = match poll_event(&events_path, after_nav_offset, |kind, obj| {
-        if kind == "pane_closed" {
-            if let Some(id) = obj.get("pane_id").and_then(|v| v.as_u64()) {
-                return id == split_pane_id;
-            }
-        }
-        false
-    }) {
-        Ok(offset) => offset,
-        Err(e) => {
-            eprintln!("error watching {}: {e}", events_path.display());
-            return 1;
-        }
-    };
-    print_step_complete(3, 7);
+    wait_for_enter();
+    let _ = after_context_rename;
+    done(13);
 
-    // Step 4 — open an app
-    print_step_header(4, 7, "Open an app");
-    eprintln!("    Open a new split (\x1b[1m\u{2318}D\x1b[0m), then in the new pane run:");
-    eprintln!("    \x1b[1mplexi open balls\x1b[0m");
-    eprintln!();
-    let after_app_offset = match poll_event(&events_path, after_close_offset, |kind, _| {
-        kind == "app_spawned"
-    }) {
-        Ok(offset) => offset,
-        Err(e) => {
-            eprintln!("error watching {}: {e}", events_path.display());
-            return 1;
-        }
-    };
-    print_step_complete(4, 7);
-
-    // Step 5 — send a notification
-    print_step_header(5, 7, "Send a notification");
-    eprintln!("    In any pane, run:");
-    eprintln!("    \x1b[1mplexi notify --title \"Hello\"\x1b[0m");
-    eprintln!();
-    let after_notify_offset = match poll_event(&events_path, after_app_offset, |kind, _| {
-        kind == "notification_posted"
-    }) {
-        Ok(offset) => offset,
-        Err(e) => {
-            eprintln!("error watching {}: {e}", events_path.display());
-            return 1;
-        }
-    };
-    print_step_complete(5, 7);
-
-    // Step 6 — scaffold a new app (keypress-advance; app init has no event log path)
-    print_step_header(6, 7, "Scaffold a new app");
-    eprintln!("    In any pane, run:");
-    eprintln!("    \x1b[1mplexi app init my-app\x1b[0m");
-    eprintln!();
-    eprintln!("    Then switch back here and press  \x1b[1m[Enter]\x1b[0m  to continue.");
-    eprintln!();
-    {
-        use std::io::BufRead;
-        let _ = std::io::stdin().lock().lines().next();
-    }
-    // Snapshot offset after keypress so step 7 only catches context_created events
-    // that follow — not any that may have been emitted during steps 1–6.
-    let after_app_init_offset = std::fs::metadata(&events_path)
-        .map(|m| m.len())
-        .unwrap_or(after_notify_offset);
-    print_step_complete(6, 7);
-
-    // Step 7 — create a new context
-    print_step_header(7, 7, "Create a context");
-    eprintln!("    In any pane, run:");
-    eprintln!("    \x1b[1mplexi context new\x1b[0m");
-    eprintln!();
-    eprintln!("    Contexts are how you organise work in Plexi.");
-    eprintln!();
-    if let Err(e) = poll_event(&events_path, after_app_init_offset, |kind, _| {
-        kind == "context_created"
-    }) {
-        eprintln!("error watching {}: {e}", events_path.display());
-        return 1;
-    }
-
-    eprintln!("  \x1b[1;32m\u{2713} 7/7 \u{2014} Plexi is yours.\x1b[0m");
+    eprintln!("  Done. This covers maybe 20% of what Plexi can do.");
     eprintln!();
     log::info!("demo_cli: tutorial completed for pane_id={my_pane_id}");
     0
+}
+
+fn print_intro() {
+    eprintln!("\x1b[1;36mPlexi - Quick Tutorial\x1b[0m");
+    explain(&[
+        "Plexi is a local app workspace for terminals, app panes, notes, contexts, notifications, and agent-driven work.",
+        "This demo watches Plexi events and advances as you try the core host controls. Keep this terminal visible when you can.",
+    ]);
+}
+
+fn step(step: u8, title: &str) {
+    print_step_header(step, TOTAL_STEPS, title);
+    progress(step - 1);
+}
+
+fn done(step: u8) {
+    print_step_complete(step, TOTAL_STEPS);
+}
+
+fn progress(done: u8) {
+    let mut dots = String::with_capacity(TOTAL_STEPS as usize);
+    for idx in 0..TOTAL_STEPS {
+        dots.push(if idx < done { '●' } else { '○' });
+    }
+    eprintln!("    \x1b[2m{dots} {done}/{TOTAL_STEPS}\x1b[0m");
+    eprintln!();
+}
+
+fn explain(lines: &[&str]) {
+    for line in lines {
+        wrapped("    ", line);
+    }
+    eprintln!();
+}
+
+fn command(cmd: &str) {
+    eprintln!("    Run:");
+    wrapped("    \x1b[1m", &format!("{cmd}\x1b[0m"));
+    eprintln!();
+}
+
+fn key(keys: &str, action: &str) {
+    wrapped("    ", &format!("Press [ {keys} ] to {action}."));
+    eprintln!();
+}
+
+fn wrapped(prefix: &str, text: &str) {
+    let width = terminal_width().clamp(46, 72);
+    let content_width = width.saturating_sub(4).max(32);
+    let mut line = String::new();
+    for word in text.split_whitespace() {
+        let next_len = if line.is_empty() {
+            word.len()
+        } else {
+            line.len() + 1 + word.len()
+        };
+        if next_len > content_width && !line.is_empty() {
+            eprintln!("{prefix}{line}");
+            line.clear();
+        }
+        if !line.is_empty() {
+            line.push(' ');
+        }
+        line.push_str(word);
+    }
+    if !line.is_empty() {
+        eprintln!("{prefix}{line}");
+    }
+}
+
+fn wait_for_enter() {
+    use std::io::BufRead;
+    let _ = std::io::stdin().lock().lines().next();
+}
+
+fn terminal_width() -> usize {
+    std::env::var("COLUMNS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(72)
+}
+
+fn file_offset(path: &std::path::Path) -> Option<u64> {
+    std::fs::metadata(path).map(|m| m.len()).ok()
+}
+
+fn capture_pane_split(kind: &str, obj: &serde_json::Value, out: &mut u64) -> bool {
+    if kind == "pane_split" {
+        if let Some(id) = obj.get("pane_id").and_then(|v| v.as_u64()) {
+            *out = id;
+            return true;
+        }
+    }
+    false
+}
+
+fn watch_error(path: &std::path::Path, error: std::io::Error) -> i32 {
+    eprintln!("error watching {}: {error}", path.display());
+    1
 }
 
 /// Tails `path` from `offset`, advancing the cursor as lines are consumed.
@@ -213,7 +373,6 @@ where
                     f.seek(SeekFrom::Start(offset))?;
                     let mut buf = String::new();
                     f.read_to_string(&mut buf)?;
-                    // Only process lines up to the last newline to avoid partial writes.
                     let process_len = match buf.rfind('\n') {
                         Some(pos) => pos + 1,
                         None => {

--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -208,12 +208,19 @@ pub fn demo_cli() -> i32 {
     step(10, "Write a scratch note");
     explain(&[
         "Scratch notes land in your Plexi notes inbox.",
-        "Open one from the terminal under File Browser, type a short note, then press Escape to leave it.",
+        "Open one from the terminal under File Browser.",
     ]);
     key(&format!("{CMD}+Shift+Space"), "open a scratch note");
     let mut scratch_note_path = String::new();
     let after_scratch_open = match poll_event(&events_path, after_file_split, |kind, obj| {
         if kind != "scratchpad_opened" {
+            return false;
+        }
+        if !obj
+            .get("pane_id")
+            .and_then(|v| v.as_u64())
+            .is_some_and(|id| id == note_terminal_pane_id)
+        {
             return false;
         }
         if let Some(path) = obj.get("path").and_then(|v| v.as_str()) {
@@ -226,29 +233,16 @@ pub fn demo_cli() -> i32 {
         Ok(offset) => offset,
         Err(e) => return watch_error(&events_path, e),
     };
-    let after_scratch_close = match poll_event(&events_path, after_scratch_open, |kind, obj| {
-        kind == "app_closed"
-            && obj
-                .get("type_id")
-                .and_then(|v| v.as_str())
-                .is_some_and(|id| id == "text-editor")
-            && obj
-                .get("pane_id")
-                .and_then(|v| v.as_u64())
-                .is_some_and(|id| id == note_terminal_pane_id)
-    }) {
-        Ok(offset) => offset,
-        Err(e) => return watch_error(&events_path, e),
-    };
     done(10);
 
     step(11, "Open your notes");
     explain(&[
-        "From any terminal, Command-O opens your notes.",
+        "Type hello world in the note, then press Escape to return to the terminal.",
+        "From there, Command-O opens your notes.",
         "Press Enter in the picker to return to the scratch note you just wrote.",
     ]);
     key(&format!("{CMD}O"), "open your notes");
-    let after_notes_picker = match poll_event(&events_path, after_scratch_close, |kind, _obj| {
+    let after_notes_picker = match poll_event(&events_path, after_scratch_open, |kind, _obj| {
         kind == "notes_picker_opened"
     }) {
         Ok(offset) => offset,

--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -152,10 +152,9 @@ pub fn demo_cli() -> i32 {
     step(7, "Rename the right pane");
     explain(&[
         "Rename the pane on the right, the one that just held Balls.",
-        "If focus is back on this demo, press Command-L first to move right.",
-        "Use the rename shortcut, enter Demo app pane, and confirm it.",
+        "It should already be focused after you leave Balls.",
+        "Use the rename shortcut, enter Demo, and confirm it.",
     ]);
-    key(&format!("{CMD}L"), "focus the pane on the right");
     key(&format!("{CMD}R"), "rename the pane to the right");
     let after_app_rename = match poll_event(&events_path, after_balls_close, |kind, obj| {
         kind == "pane_renamed"
@@ -166,7 +165,7 @@ pub fn demo_cli() -> i32 {
             && obj
                 .get("name")
                 .and_then(|v| v.as_str())
-                .is_some_and(|name| name == "Demo app pane")
+                .is_some_and(|name| name == "Demo")
     }) {
         Ok(offset) => offset,
         Err(e) => return watch_error(&events_path, e),

--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -260,9 +260,11 @@ pub fn demo_cli() -> i32 {
     };
     done(11);
 
-    eprintln!("  More to cover");
+    eprintln!("  Great work.");
     explain(&[
-        "Here is where the full intro link will go when I actually get around to making it.",
+        "You covered maybe 10% of what Plexi can do.",
+        "Keep messing around. When the deep dive is ready, this will point to it:",
+        "Watch this full breakdown [working on the video now lol]",
     ]);
     eprintln!();
     log::info!("demo_cli: tutorial completed for pane_id={my_pane_id}");

--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -156,7 +156,7 @@ pub fn demo_cli() -> i32 {
         "Use the rename shortcut, enter Demo app pane, and confirm it.",
     ]);
     key(&format!("{CMD}L"), "focus the pane on the right");
-    key(&format!("{CMD}R"), "rename this pane");
+    key(&format!("{CMD}R"), "rename the pane to the right");
     let after_app_rename = match poll_event(&events_path, after_balls_close, |kind, obj| {
         kind == "pane_renamed"
             && obj

--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -21,7 +21,6 @@ pub fn demo_cli() -> i32 {
     };
 
     log::info!("demo_cli: starting interactive tutorial for pane_id={my_pane_id}");
-    name_demo_pane(my_pane_id);
 
     let events_path = crate::config::config_dir().join("events.jsonl");
     let start_offset = file_offset(&events_path).unwrap_or(0);
@@ -150,10 +149,10 @@ pub fn demo_cli() -> i32 {
     };
     done(6);
 
-    step(7, "Rename this app pane");
+    step(7, "Rename the Balls terminal");
     explain(&[
-        "You should be back in the terminal that launched Balls.",
-        "Rename that pane so the pane list is easier to scan.",
+        "You should be back in the terminal that just held Balls.",
+        "Rename that terminal so the pane list is easier to scan.",
         "Use the rename shortcut, enter Demo app pane, and confirm it.",
     ]);
     key(&format!("{CMD}R"), "rename this pane");
@@ -282,18 +281,6 @@ fn print_intro() {
         "Plexi is a local app workspace for terminals, app panes, notes, contexts, notifications, and agent-driven work.",
         "This demo watches Plexi events and advances as you try the core host controls. Keep this terminal visible when you can.",
     ]);
-}
-
-fn name_demo_pane(pane_id: u64) {
-    log::info!("demo_cli: naming demo pane pane_id={pane_id}");
-    let code = super::send_to_socket(serde_json::json!({
-        "type": "set_pane_title",
-        "pane_id": pane_id,
-        "name": "Plexi demo",
-    }));
-    if code != 0 {
-        log::warn!("demo_cli: could not name demo pane pane_id={pane_id}");
-    }
 }
 
 fn step(step: u8, title: &str) {

--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -263,7 +263,7 @@ pub fn demo_cli() -> i32 {
     eprintln!("  Great work.");
     explain(&[
         "You covered maybe 10% of what Plexi can do.",
-        "Keep messing around. When the deep dive is ready, this will point to it:",
+        "For a full deep dive, Command-click this link:",
         "Watch this full breakdown [working on the video now lol]",
     ]);
     eprintln!();

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -248,7 +248,7 @@ fn open_descriptor_in_renderer(
         return 1;
     }
     let path = tmp.to_string_lossy().to_string();
-    let layout_str = layout.unwrap_or("split_h");
+    let layout_str = layout.unwrap_or("overlay");
     log::info!("open:cli: launching cli-renderer for `{name}` with descriptor at {path}");
     pane_new_cli(
         None,
@@ -305,7 +305,7 @@ pub fn open_mcp_by_name(
                 entry.command
             );
             let title = mcp_pane_title(&entry.command);
-            let layout_str = layout.unwrap_or("split_h");
+            let layout_str = layout.unwrap_or("overlay");
             pane_new_cli(
                 None,
                 Some(&title),
@@ -360,7 +360,7 @@ pub fn open_cli(
         return open_app_by_path(&abs_path, layout, from_pane_id);
     }
 
-    let layout_str = layout.unwrap_or("split_h");
+    let layout_str = layout.unwrap_or("overlay");
     pane_new_cli(
         None,
         None,
@@ -377,7 +377,7 @@ pub fn open_cli(
 
 /// Open an app from a local directory path (replaces the old `app run` command).
 fn open_app_by_path(abs_path: &str, layout: Option<&str>, from_pane_id: Option<u64>) -> i32 {
-    let layout_str = layout.unwrap_or("split_h");
+    let layout_str = layout.unwrap_or("overlay");
     let from_pane_id = from_pane_id.or_else(|| std::env::var("PLEXI_PANE_ID").ok()?.parse().ok());
 
     if std::env::var("PLEXI_SOCKET").is_ok() {
@@ -428,6 +428,68 @@ fn open_app_by_path(abs_path: &str, layout: Option<&str>, from_pane_id: Option<u
     println!("queued: open {abs_path}");
     println!("(running outside a Plexi pane; Plexi will pick this up within a second)");
     0
+}
+
+#[cfg(test)]
+mod open_cli_tests {
+    use super::open_cli;
+    use serde_json::Value;
+    use std::io::{BufRead, BufReader};
+    use std::os::unix::net::UnixListener;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn capture_spawn_payload<F>(run_cli: F) -> (i32, Value)
+    where
+        F: FnOnce() -> i32,
+    {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let socket_path = dir.path().join("open.sock");
+        let listener = UnixListener::bind(&socket_path).expect("bind open socket");
+        std::env::set_var("PLEXI_SOCKET", &socket_path);
+
+        let handle = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept open connection");
+            let mut line = String::new();
+            BufReader::new(stream)
+                .read_line(&mut line)
+                .expect("read open payload");
+            let payload: Value = serde_json::from_str(&line).expect("open payload json");
+            if let Some(response_file) = payload.get("response_file").and_then(|v| v.as_str()) {
+                std::fs::write(response_file, r#"{"pane_id":123}"#).expect("write open response");
+            }
+            payload
+        });
+
+        let code = run_cli();
+        std::env::remove_var("PLEXI_SOCKET");
+        let payload = handle.join().expect("payload thread");
+        (code, payload)
+    }
+
+    #[test]
+    fn app_open_defaults_to_overlay_layout() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let (code, payload) = capture_spawn_payload(|| open_cli("balls", &[], None, None, None));
+
+        assert_eq!(code, 0);
+        assert_eq!(payload["type"], "spawn_pane");
+        assert_eq!(payload["type_id"], "balls");
+        assert_eq!(payload["layout"], "overlay");
+    }
+
+    #[test]
+    fn app_open_explicit_tab_layout_is_preserved() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let (code, payload) =
+            capture_spawn_payload(|| open_cli("file_browser", &[], Some("tab"), None, None));
+
+        assert_eq!(code, 0);
+        assert_eq!(payload["type"], "spawn_pane");
+        assert_eq!(payload["type_id"], "file_browser");
+        assert_eq!(payload["layout"], "tab");
+    }
 }
 
 /// Read a line from stdin with echo disabled (for password-style input).

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -86,7 +86,6 @@ enum FileBrowserAction {
     Copy,
     Cut,
     Paste,
-    Duplicate,
     MoveToTrash,
     Reveal,
     OpenWithDefault,
@@ -168,9 +167,8 @@ fn classify_key(input: &egui::InputState, in_search: bool) -> Option<FileBrowser
     if !in_search && input.modifiers.command && key_pressed_no_repeat(input, egui::Key::V) {
         return Some(FileBrowserAction::Paste);
     }
-    if !in_search && input.modifiers.command && key_pressed_no_repeat(input, egui::Key::D) {
-        return Some(FileBrowserAction::Duplicate);
-    }
+    // Cmd+D and Cmd+Shift+D are host split chords. Do not bind them inside
+    // File Browser unless the full shortcut map is reviewed.
     if !in_search && input.modifiers.command && key_pressed_no_repeat(input, egui::Key::Backspace) {
         return Some(FileBrowserAction::MoveToTrash);
     }
@@ -992,29 +990,6 @@ impl FileBrowserApp {
         self.refresh_preserving_filter();
         if let Some(path) = created.first() {
             self.select_path(path);
-        }
-        Ok(created)
-    }
-
-    fn duplicate_selected(&mut self) -> Result<Vec<PathBuf>, String> {
-        let mut created = Vec::new();
-        for source in self.selected_paths() {
-            let stem = source
-                .file_stem()
-                .and_then(|stem| stem.to_str())
-                .or_else(|| source.file_name().and_then(|name| name.to_str()))
-                .unwrap_or("Untitled");
-            let ext = source.extension().and_then(|ext| ext.to_str());
-            let target = Self::unique_child_path(&self.cwd, &format!("{stem} copy"), ext);
-            Self::copy_path_recursive(&source, &target)?;
-            created.push(target);
-        }
-        log::info!("file_browser: duplicated {} path(s)", created.len());
-        self.refresh_preserving_filter();
-        self.multi_selected = created.iter().cloned().collect();
-        if let Some(first) = created.first() {
-            self.select_path(first);
-            self.multi_selected = created.iter().cloned().collect();
         }
         Ok(created)
     }
@@ -2454,12 +2429,6 @@ impl App for FileBrowserApp {
                 }
                 KeyDisposition::Consumed
             }
-            (Mode::Normal, Some(FileBrowserAction::Duplicate)) => {
-                if let Err(err) = self.duplicate_selected() {
-                    self.error = Some(err);
-                }
-                KeyDisposition::Consumed
-            }
             (Mode::Normal, Some(FileBrowserAction::MoveToTrash)) => {
                 self.request_move_selected_to_trash();
                 KeyDisposition::Consumed
@@ -2955,16 +2924,22 @@ mod tests {
     }
 
     #[test]
-    fn duplicate_selected_file_creates_copy_and_refreshes_entries() {
+    fn command_d_does_not_duplicate_selected_file() {
         let (mut app, dir) = make_three_file_app();
 
-        app.duplicate_selected().expect("duplicate");
+        let consumed = run_handle_key(
+            &mut app,
+            vec![key_event(
+                Key::D,
+                Modifiers {
+                    command: true,
+                    ..Default::default()
+                },
+            )],
+        );
 
-        assert!(dir.path().join("alpha copy.txt").exists());
-        assert!(app
-            .entries
-            .iter()
-            .any(|entry| entry.name == "alpha copy.txt"));
+        assert!(!consumed);
+        assert!(!dir.path().join("alpha copy.txt").exists());
     }
 
     #[test]

--- a/src/host/event_log.rs
+++ b/src/host/event_log.rs
@@ -167,7 +167,11 @@ pub enum HostEvent {
         timestamp: String,
     },
     /// A scratch note was created and opened.
-    ScratchpadOpened { path: String, timestamp: String },
+    ScratchpadOpened {
+        pane_id: u64,
+        path: String,
+        timestamp: String,
+    },
     /// The notes picker was opened.
     NotesPickerOpened {
         inbox_count: usize,

--- a/src/host/event_log.rs
+++ b/src/host/event_log.rs
@@ -166,6 +166,16 @@ pub enum HostEvent {
         name: String,
         timestamp: String,
     },
+    /// A scratch note was created and opened.
+    ScratchpadOpened { path: String, timestamp: String },
+    /// The notes picker was opened.
+    NotesPickerOpened {
+        inbox_count: usize,
+        kept_count: usize,
+        timestamp: String,
+    },
+    /// A note was opened from the notes picker.
+    NoteOpened { path: String, timestamp: String },
 }
 
 // ── Wire envelope ─────────────────────────────────────────────────────────────

--- a/src/host/event_log.rs
+++ b/src/host/event_log.rs
@@ -28,7 +28,7 @@ use std::sync::{mpsc, Arc, OnceLock};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum HostEvent {
-    /// A ProcessApp was successfully spawned.
+    /// An app pane was successfully spawned.
     AppSpawned {
         app_id: String,
         type_id: String,
@@ -148,8 +148,20 @@ pub enum HostEvent {
     },
     /// A pane was closed.
     PaneClosed { pane_id: u64, timestamp: String },
+    /// A pane was renamed.
+    PaneRenamed {
+        pane_id: u64,
+        name: String,
+        timestamp: String,
+    },
     /// A new context was created.
     ContextCreated {
+        context_id: u64,
+        name: String,
+        timestamp: String,
+    },
+    /// A context was renamed.
+    ContextRenamed {
         context_id: u64,
         name: String,
         timestamp: String,

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -568,7 +568,7 @@ impl PlexiApp {
                         None
                     } else {
                         log::info!("rename_pane: pane {pane_id} name locked to {:?}", new_name);
-                        Some(new_name)
+                        Some(new_name.clone())
                     };
                 } else if let Some(a) = pane.as_app_mut() {
                     // Let the app react first — TextEditorApp persists the new
@@ -582,6 +582,11 @@ impl PlexiApp {
                     log::info!("rename_pane: app pane {pane_id} named {:?}", a.name);
                 }
             }
+            crate::host::event_log::emit(crate::host::event_log::HostEvent::PaneRenamed {
+                pane_id,
+                name: new_name,
+                timestamp: crate::host::event_log::now_timestamp(),
+            });
             self.renaming_pane = None;
             self.rename_pane_focus_requested = false;
         }
@@ -638,6 +643,13 @@ impl PlexiApp {
             let new_name = self.rename_buffer.trim().to_string();
             if !new_name.is_empty() {
                 self.router.get_mut(ctx_idx).name = new_name;
+                let context_id = self.router.get(ctx_idx).context_id;
+                let name = self.router.get(ctx_idx).name.clone();
+                crate::host::event_log::emit(crate::host::event_log::HostEvent::ContextRenamed {
+                    context_id,
+                    name,
+                    timestamp: crate::host::event_log::now_timestamp(),
+                });
             }
             self.renaming_window = None;
         }

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -329,6 +329,7 @@ impl PlexiApp {
         {
             log::info!("notes_picker: already open in pane {existing_pane_id}, focusing");
             self.set_window_focused_pane(active, existing_tile_id);
+            emit_note_opened(&path);
             self.pop_focus_layer(&FocusLayer::NotesPicker);
             return;
         }
@@ -351,6 +352,7 @@ impl PlexiApp {
                     if let crate::host::pane::AppRuntime::Builtin(app) = &mut app_pane.runtime {
                         log::info!("notes_picker: opening {:?} in focused pane", path);
                         app.restore_state(&state);
+                        emit_note_opened(&path);
                     }
                 }
                 self.pop_focus_layer(&FocusLayer::NotesPicker);
@@ -372,7 +374,12 @@ impl PlexiApp {
         let path = self.notes_picker_entries[entry_idx].path.clone();
         let path_str = path.display().to_string();
         log::info!("notes_picker: opening {:?} in new text-editor pane", path);
-        let _ = self.launch_app_by_id_with_layout("text-editor", None, &[path_str], None);
+        if self
+            .launch_app_by_id_with_layout("text-editor", None, &[path_str], None)
+            .is_ok()
+        {
+            emit_note_opened(&path);
+        }
         self.pop_focus_layer(&FocusLayer::NotesPicker);
     }
 
@@ -556,6 +563,13 @@ impl PlexiApp {
             self.pop_focus_layer(&FocusLayer::NotesPicker);
         }
     }
+}
+
+fn emit_note_opened(path: &std::path::Path) {
+    crate::host::event_log::emit(crate::host::event_log::HostEvent::NoteOpened {
+        path: path.display().to_string(),
+        timestamp: crate::host::event_log::now_timestamp(),
+    });
 }
 
 #[cfg(test)]

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -665,6 +665,12 @@ impl PlexiApp {
             );
             self.set_window_focused_pane(active, focused_tile);
             log::info!("builtin::{app_name}: launched as overlay on pane {pane_id}");
+            crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
+                app_id: app_type_id.clone(),
+                type_id: app_type_id.clone(),
+                pane_id,
+                timestamp: crate::host::event_log::now_timestamp(),
+            });
             return;
         }
 
@@ -681,6 +687,12 @@ impl PlexiApp {
             new_id,
             new_app_pane(new_id, app, workspace_root, group, linked_pane_id, None),
         );
+        crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
+            app_id: app_type_id.clone(),
+            type_id: app_type_id.clone(),
+            pane_id: new_id,
+            timestamp: crate::host::event_log::now_timestamp(),
+        });
 
         // Empty context: no focused pane means no existing tile to split.
         // Install the new pane directly as the tree root.

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -300,6 +300,12 @@ impl PlexiApp {
             );
             self.set_window_focused_pane(active, focused_tile);
             log::info!("app::{app_id}: launched as overlay on pane {pane_id}");
+            crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
+                app_id: app_id.to_string(),
+                type_id: app_id.to_string(),
+                pane_id,
+                timestamp: crate::host::event_log::now_timestamp(),
+            });
             return Some(pane_id);
         }
 
@@ -317,6 +323,12 @@ impl PlexiApp {
             new_id,
             new_app_pane(new_id, process, workspace_root, group, linked_pane_id, None),
         );
+        crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
+            app_id: app_id.to_string(),
+            type_id: app_id.to_string(),
+            pane_id: new_id,
+            timestamp: crate::host::event_log::now_timestamp(),
+        });
 
         // Hot reload (#83): if the manifest opted in AND the app was
         // discovered from a workspace-local install, begin watching its

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1261,8 +1261,16 @@ impl PlexiApp {
 
         let path_str = path.display().to_string();
         log::info!("scratchpad: opening text-editor pane for {:?}", path);
-        if let Err(e) = self.launch_app_by_id_with_layout("text-editor", None, &[path_str], None) {
-            log::warn!("scratchpad: failed to launch text-editor pane: {e}");
+        match self.launch_app_by_id_with_layout("text-editor", None, &[path_str.clone()], None) {
+            Ok(()) => {
+                crate::host::event_log::emit(crate::host::event_log::HostEvent::ScratchpadOpened {
+                    path: path_str,
+                    timestamp: crate::host::event_log::now_timestamp(),
+                })
+            }
+            Err(e) => {
+                log::warn!("scratchpad: failed to launch text-editor pane: {e}");
+            }
         }
     }
 

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1254,6 +1254,12 @@ impl PlexiApp {
     pub(crate) fn open_scratchpad(&mut self) {
         log::info!("scratchpad: opening new scratch note");
         let active = self.active_window;
+        let target_pane_id = self.windows[active].focused_pane.and_then(|tile_id| {
+            match self.windows[active].tree.tiles.get(tile_id) {
+                Some(Tile::Pane(pane_id)) => Some(*pane_id),
+                _ => None,
+            }
+        });
 
         // Capture context like a quick note so triage shows where it came from.
         let cwd = self.windows[active]
@@ -1275,10 +1281,25 @@ impl PlexiApp {
         log::info!("scratchpad: opening text-editor pane for {:?}", path);
         match self.launch_app_by_id_with_layout("text-editor", None, &[path_str.clone()], None) {
             Ok(()) => {
-                crate::host::event_log::emit(crate::host::event_log::HostEvent::ScratchpadOpened {
-                    path: path_str,
-                    timestamp: crate::host::event_log::now_timestamp(),
-                })
+                let pane_id = target_pane_id.or_else(|| {
+                    self.windows[active].focused_pane.and_then(|tile_id| {
+                        match self.windows[active].tree.tiles.get(tile_id) {
+                            Some(Tile::Pane(pane_id)) => Some(*pane_id),
+                            _ => None,
+                        }
+                    })
+                });
+                if let Some(pane_id) = pane_id {
+                    crate::host::event_log::emit(
+                        crate::host::event_log::HostEvent::ScratchpadOpened {
+                            pane_id,
+                            path: path_str,
+                            timestamp: crate::host::event_log::now_timestamp(),
+                        },
+                    );
+                } else {
+                    log::warn!("scratchpad: opened note but could not resolve pane id");
+                }
             }
             Err(e) => {
                 log::warn!("scratchpad: failed to launch text-editor pane: {e}");

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -39,6 +39,14 @@ pub(super) fn restore_overlay_replacement(
     match pane {
         Pane::App(mut app) => {
             if let Some(replaced) = app.overlay_replaced.take() {
+                let type_id = app.runtime.type_id().to_string();
+                crate::host::event_log::emit(crate::host::event_log::HostEvent::AppClosed {
+                    app_id: type_id.clone(),
+                    type_id,
+                    pane_id,
+                    reason: Some("overlay_restored".to_string()),
+                    timestamp: crate::host::event_log::now_timestamp(),
+                });
                 panes.insert(pane_id, *replaced);
                 true
             } else {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -671,12 +671,6 @@ impl ProcessApp {
         let (http_tx, http_rx) = mpsc::channel::<PlexiEvent>();
         let (file_picker_tx, file_picker_rx) = mpsc::channel::<PlexiEvent>();
 
-        event_log::emit(HostEvent::AppSpawned {
-            app_id: type_id.clone(),
-            type_id: type_id.clone(),
-            pane_id: 0,
-            timestamp: event_log::now_timestamp(),
-        });
         log::info!("app::{}: === SESSION START ===", type_id);
 
         Ok(Self {
@@ -2892,7 +2886,7 @@ impl Drop for ProcessApp {
         event_log::emit(HostEvent::AppClosed {
             app_id: self.type_id.clone(),
             type_id: self.type_id.clone(),
-            pane_id: 0,
+            pane_id: self.pane_id,
             reason: None,
             timestamp: event_log::now_timestamp(),
         });

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -190,7 +190,14 @@ impl PlexiApp {
                             } else {
                                 let new_name = self.rename_buffer.trim().to_string();
                                 if !new_name.is_empty() {
-                                    self.router.get_mut(i).name = new_name;
+                                    self.router.get_mut(i).name = new_name.clone();
+                                    crate::host::event_log::emit(
+                                        crate::host::event_log::HostEvent::ContextRenamed {
+                                            context_id: self.router.get(i).context_id,
+                                            name: new_name,
+                                            timestamp: crate::host::event_log::now_timestamp(),
+                                        },
+                                    );
                                 }
                                 self.renaming_window = None;
                             }


### PR DESCRIPTION
## Summary
- rewrites the interactive demo into a 13-step walkthrough with cleaner intro copy, one progress row per step, wrapped terminal text, HJKL movement practice, app palette launch, notifications, file explorer, notes, pane rename, and context create/rename
- removes the flaky Cmd+N page step from the demo
- changes default plexi app open IPC layout to overlay/current-pane takeover while preserving explicit layouts like --tab
- emits event-log entries for CLI notifications, notification acknowledgement, pane rename, context rename, and built-in app opens so the demo watcher can observe them
- makes sdk-smoke use explicit pytest dependencies so pr-install does not depend on ambient Python packages

## Test evidence
- cargo test --bin plexi open_cli_tests
- cargo build
- just sdk-smoke
- git diff --check