### PR TITLE
feat(apps): Terminal manifest type + BrogueCE (#2266)

### DIFF
--- a/apps/brogue/manifest.toml
+++ b/apps/brogue/manifest.toml
@@ -5,7 +5,7 @@ id = "brogue"
 type = "terminal"
 name = "Brogue CE"
 version = "1.0.0"
-description = "BrogueCE — a critically acclaimed minimalist roguelike. Install: brew install brogue-ce"
+description = "BrogueCE — a critically acclaimed minimalist roguelike. Install: brew install brogue"
 exec = "brogue"
 tags = ["game", "roguelike", "tui"]
 

--- a/apps/brogue/manifest.toml
+++ b/apps/brogue/manifest.toml
@@ -6,7 +6,7 @@ type = "terminal"
 name = "Brogue CE"
 version = "1.0.0"
 description = "BrogueCE — a critically acclaimed minimalist roguelike. Install: brew install brogue"
-exec = "brogue"
+exec = "brogue --term"
 tags = ["game", "roguelike", "tui"]
 
 [app.capabilities]

--- a/apps/brogue/manifest.toml
+++ b/apps/brogue/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "brogue"
+type = "terminal"
+name = "Brogue CE"
+version = "1.0.0"
+description = "BrogueCE — a critically acclaimed minimalist roguelike. Install: brew install brogue-ce"
+exec = "brogue"
+tags = ["game", "roguelike", "tui"]
+
+[app.capabilities]
+capabilities = []
+
+[launch]

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -101,6 +101,7 @@ pub struct SecretDecl {
 pub struct AppManifestApp {
     pub id: String,
     pub name: String,
+    #[serde(default)]
     pub entry: String,
     /// Required. Selects host rendering / pane behaviour:
     ///
@@ -150,6 +151,11 @@ pub struct AppManifestApp {
     /// into a per-app venv at `<app_dir>/.venv`. Empty when omitted.
     #[serde(default)]
     pub dependencies: Vec<String>,
+    /// System binary name for `type = "terminal"` apps. Resolved in PATH at
+    /// launch time; host emits a user-visible error if the binary is absent.
+    /// Ignored for App-type apps.
+    #[serde(default)]
+    pub exec: Option<String>,
 }
 
 /// Manifest `[app] type` field — chooses the host rendering surface for
@@ -159,6 +165,8 @@ pub struct AppManifestApp {
 pub enum ManifestType {
     /// Standard draw-canvas app. Host renders whatever the app draws.
     App,
+    /// Terminal app — spawns `exec` binary in a PTY pane. No Python SDK or PGAP.
+    Terminal,
 }
 
 /// Newtype for `[launch] notification_scope` in manifest.toml. Deserialises
@@ -492,7 +500,37 @@ impl AppRegistry {
             ));
         }
 
-        let bin_path = resolve_entry(app_dir, &manifest.app.entry)?;
+        let bin_path = match manifest.app.manifest_type {
+            ManifestType::App => {
+                if manifest.app.entry.is_empty() {
+                    return Err(format!(
+                        "app '{}': App-type manifest must declare an 'entry' field",
+                        manifest.app.id
+                    ));
+                }
+                resolve_entry(app_dir, &manifest.app.entry)?
+            }
+            ManifestType::Terminal => {
+                let exec_empty = manifest
+                    .app
+                    .exec
+                    .as_deref()
+                    .map(|s| s.is_empty())
+                    .unwrap_or(true);
+                if exec_empty {
+                    return Err(format!(
+                        "app '{}': Terminal-type manifest must declare an 'exec' field",
+                        manifest.app.id
+                    ));
+                }
+                log::info!(
+                    "AppRegistry: terminal app '{}' registered exec='{}'",
+                    manifest.app.id,
+                    manifest.app.exec.as_deref().unwrap_or(""),
+                );
+                app_dir.clone()
+            }
+        };
 
         for (name, decl) in &manifest.secrets {
             log::debug!(
@@ -606,6 +644,15 @@ impl AppRegistry {
             installed.manifest.manifest_type,
             installed.source.label(),
         );
+
+        if installed.manifest.manifest_type == ManifestType::Terminal {
+            log::info!(
+                "AppRegistry: '{}' is Terminal type — deferring to PTY pane spawn, exec='{}'",
+                id,
+                installed.manifest.exec.as_deref().unwrap_or(""),
+            );
+            return None;
+        }
 
         // Issue #322: log declared-but-routed status for visibility. The
         // missing-secret prompt fires lazily on first `ctx.secret(...)` call —
@@ -1363,5 +1410,34 @@ entry = "main.py"
         assert!(manifest.app.author.is_none());
         assert!(manifest.app.tags.is_empty());
         assert!(manifest.app.repo.is_none());
+    }
+
+    #[test]
+    fn terminal_manifest_loads_without_entry() {
+        let global = tempfile::tempdir().unwrap();
+        let app_dir = global.path().join("brogue");
+        fs::create_dir_all(&app_dir).unwrap();
+        let manifest = "schema_version = 1\n\n[app]\nid = \"brogue\"\ntype = \"terminal\"\nname = \"Brogue CE\"\nversion = \"1.0.0\"\nexec = \"brogue\"\n\n[app.capabilities]\ncapabilities = []\n";
+        fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
+
+        let workspace = tempfile::tempdir().unwrap();
+        let registry = AppRegistry::load_with_global(workspace.path(), global.path());
+        let app = registry.get("brogue").expect("terminal app must be discoverable");
+        assert_eq!(app.manifest.manifest_type, ManifestType::Terminal);
+        assert_eq!(app.manifest.exec.as_deref(), Some("brogue"));
+        assert!(app.manifest.entry.is_empty(), "terminal app should have empty entry");
+    }
+
+    #[test]
+    fn terminal_manifest_without_exec_fails_to_load() {
+        let global = tempfile::tempdir().unwrap();
+        let app_dir = global.path().join("badterm");
+        fs::create_dir_all(&app_dir).unwrap();
+        let manifest = "schema_version = 1\n\n[app]\nid = \"badterm\"\ntype = \"terminal\"\nname = \"Bad Terminal\"\nversion = \"1.0.0\"\n\n[app.capabilities]\ncapabilities = []\n";
+        fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
+
+        let workspace = tempfile::tempdir().unwrap();
+        let registry = AppRegistry::load_with_global(workspace.path(), global.path());
+        assert!(registry.get("badterm").is_none(), "terminal app without exec must not load");
     }
 }

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -271,6 +271,13 @@ pub struct LaunchSection {
     /// user immediate feedback that the app started. Omit to launch silently.
     #[serde(default)]
     pub startup_message: Option<String>,
+    /// Pane layout used when this app is launched from the palette.
+    /// Valid values: `"window"` (spawn in a split then zoom to fill — default for
+    /// Terminal-type apps), `"split_h"` (horizontal split), `"split_v"` (vertical
+    /// split), `"overlay"` (replace the focused pane, Esc restores it — default
+    /// for App-type apps). Explicit caller-supplied hints always win over this.
+    #[serde(default)]
+    pub layout: Option<String>,
 }
 
 impl AppCapabilities {

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1013,6 +1013,13 @@ pub fn app_render(
             );
             return 1;
         }
+        if manifest.app.manifest_type == crate::app::registry::ManifestType::Terminal {
+            eprintln!(
+                "error: 'plexi app render' is not supported for Terminal-type apps (exec='{}')",
+                manifest.app.exec.as_deref().unwrap_or("?")
+            );
+            return 1;
+        }
         let entry = app_dir.join(&manifest.app.entry);
         if !entry.exists() {
             eprintln!(

--- a/src/cli/app_check.rs
+++ b/src/cli/app_check.rs
@@ -241,6 +241,13 @@ fn load_local_app(app_dir: &Path) -> Result<(AppManifest, PathBuf), String> {
         ));
     }
 
+    if manifest.app.manifest_type == crate::app::registry::ManifestType::Terminal {
+        return Err(format!(
+            "'plexi app check' is not supported for Terminal-type apps (exec='{}')",
+            manifest.app.exec.as_deref().unwrap_or("?")
+        ));
+    }
+
     let entry_path = app_dir.join(&manifest.app.entry);
     if !entry_path.exists() {
         return Err(format!(

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -72,6 +72,10 @@ pub fn completions_installed() -> bool {
 /// Show the completions banner once when the CLI is installed but completions are not.
 /// Dismissed permanently via sentinel; session-only via the banner's "Not now" button.
 pub fn should_prompt_completions() -> bool {
+    if crate::config::build_channel().is_some_and(|channel| channel.starts_with("pr-")) {
+        log::info!("cli_setup: PR build — skipping completions banner");
+        return false;
+    }
     if completions_was_prompted() {
         log::info!("cli_setup: completions sentinel present — skipping banner");
         return false;
@@ -164,4 +168,20 @@ pub fn is_installed() -> bool {
     std::env::var_os("PATH").map_or(false, |path| {
         std::env::split_paths(&path).any(|dir| dir.join(&name).exists())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn pr_builds_skip_completions_prompt() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _profile_guard = crate::config::set_test_profile_dir(tmp.path().to_path_buf());
+        let _channel_guard = crate::config::set_test_channel("pr-2265");
+
+        assert!(!super::should_prompt_completions());
+        assert!(
+            !super::completions_sentinel_path().exists(),
+            "skipping a PR prompt should not create profile state"
+        );
+    }
 }

--- a/src/host/launch_failed.rs
+++ b/src/host/launch_failed.rs
@@ -10,6 +10,9 @@ use egui::RichText;
 pub struct LaunchFailedApp {
     pub app_id: String,
     pub missing: Vec<String>,
+    /// Replaces the default "plexi config edit" footer. Use for Terminal apps
+    /// where the fix is an install command, not a config change.
+    pub footer: Option<String>,
 }
 
 impl App for LaunchFailedApp {
@@ -40,8 +43,12 @@ impl App for LaunchFailedApp {
                 );
             }
             ui.add_space(style::SPACE_SM);
+            let footer_text = self
+                .footer
+                .as_deref()
+                .unwrap_or("plexi config edit");
             ui.label(
-                RichText::new("plexi config edit")
+                RichText::new(footer_text)
                     .size(style::TEXT_CAPTION)
                     .color(colors.text_dim)
                     .monospace(),

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -368,6 +368,7 @@ impl PlexiApp {
         hint: Option<&str>,
         missing: Vec<String>,
         workspace_root: std::path::PathBuf,
+        footer: Option<String>,
     ) {
         let active = self.active_window;
         let share = Self::share_ratio_from_fraction(app_id, None);
@@ -382,6 +383,7 @@ impl PlexiApp {
                     crate::host::launch_failed::LaunchFailedApp {
                         app_id: app_id.to_string(),
                         missing,
+                        footer,
                     },
                 )),
                 workspace_root,
@@ -962,7 +964,7 @@ impl PlexiApp {
         if !missing.is_empty() {
             log::warn!("pre-flight: '{id}' cannot launch — missing: {missing:?}");
             let fail_hint = layout.or_else(|| Some("overlay".to_string()));
-            self.open_launch_failed_pane(id, fail_hint.as_deref(), missing, cwd);
+            self.open_launch_failed_pane(id, fail_hint.as_deref(), missing, cwd, None);
             return Ok(());
         }
 
@@ -983,10 +985,11 @@ impl PlexiApp {
             return Ok(());
         }
 
-        // Terminal app — spawn exec binary directly in a PTY pane.
+        // Terminal app — spawn exec binary via split_focused (same path as builtin "terminal").
         if let Some(installed) = self.registry.get(id) {
             if installed.manifest.manifest_type == crate::app::registry::ManifestType::Terminal {
                 let exec_cmd = installed.manifest.exec.clone().unwrap_or_else(|| id.to_string());
+                let install_footer = Some(installed.manifest.description.clone());
                 if !cli_binary_in_path(&exec_cmd) {
                     log::warn!(
                         "launch_app_by_id: terminal app '{id}' exec='{exec_cmd}' not found in PATH"
@@ -994,31 +997,19 @@ impl PlexiApp {
                     self.open_launch_failed_pane(
                         id,
                         hint.as_deref(),
-                        vec![format!(
-                            "'{exec_cmd}' not found in PATH. Install it first (e.g. brew install brogue-ce)."
-                        )],
+                        vec![format!("'{exec_cmd}' not found in PATH")],
                         cwd,
+                        install_footer,
                     );
                     return Ok(());
                 }
+                let layout_str = hint.as_deref().unwrap_or("split_h");
+                let vertical = matches!(layout_str, "split_v" | "split_below" | "split_above");
+                let new_pane_first = matches!(layout_str, "split_above" | "split_left");
                 log::info!(
-                    "launch_app_by_id: terminal app '{id}' → spawning PTY pane exec='{exec_cmd}'"
+                    "launch_app_by_id: terminal app '{id}' → split_focused exec='{exec_cmd}' layout='{layout_str}'"
                 );
-                let win = self.active_window;
-                if let Some(target) = self.windows[win].focused_pane {
-                    self.spawn_terminal_pane_at(
-                        win,
-                        target,
-                        false,
-                        false,
-                        Some(&exec_cmd),
-                        false,
-                        Some(cwd),
-                        true,
-                    );
-                } else {
-                    log::warn!("launch_app_by_id: terminal app '{id}' — no focused tile, cannot spawn PTY pane");
-                }
+                self.split_focused(vertical, Some(&exec_cmd), false, new_pane_first, Some(cwd));
                 return Ok(());
             }
         }
@@ -1073,7 +1064,7 @@ impl PlexiApp {
             "launch_app_by_path_with_layout: workspace_root={}",
             workspace_root.display()
         );
-        // Terminal apps bypass ProcessApp entirely — spawn exec binary in a PTY pane.
+        // Terminal apps bypass ProcessApp entirely — spawn via split_focused (same path as builtin "terminal").
         if installed.manifest.manifest_type == crate::app::registry::ManifestType::Terminal {
             let exec_cmd = installed.manifest.exec.clone().unwrap_or_else(|| app_id.clone());
             if !cli_binary_in_path(&exec_cmd) {
@@ -1081,27 +1072,16 @@ impl PlexiApp {
                     "launch_app_by_path_with_layout: terminal app '{app_id}' exec='{exec_cmd}' not found in PATH"
                 );
                 return Err(format!(
-                    "'{exec_cmd}' not found in PATH. Install it first (e.g. brew install brogue-ce)."
+                    "'{exec_cmd}' not found in PATH — install it and ensure it is on your PATH."
                 ));
             }
+            let layout_str = layout_hint.as_deref().unwrap_or("split_h");
+            let vertical = matches!(layout_str, "split_v" | "split_below" | "split_above");
+            let new_pane_first = matches!(layout_str, "split_above" | "split_left");
             log::info!(
-                "launch_app_by_path_with_layout: terminal app '{app_id}' → PTY pane exec='{exec_cmd}'"
+                "launch_app_by_path_with_layout: terminal app '{app_id}' → split_focused exec='{exec_cmd}' layout='{layout_str}'"
             );
-            let win = self.active_window;
-            if let Some(target) = self.windows[win].focused_pane {
-                self.spawn_terminal_pane_at(
-                    win,
-                    target,
-                    false,
-                    false,
-                    Some(&exec_cmd),
-                    false,
-                    Some(cwd),
-                    true,
-                );
-            } else {
-                log::warn!("launch_app_by_path_with_layout: terminal app '{app_id}' — no focused tile, cannot spawn PTY pane");
-            }
+            self.split_focused(vertical, Some(&exec_cmd), false, new_pane_first, Some(cwd));
             return Ok(());
         }
 

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -983,6 +983,46 @@ impl PlexiApp {
             return Ok(());
         }
 
+        // Terminal app — spawn exec binary directly in a PTY pane.
+        if let Some(installed) = self.registry.get(id) {
+            if installed.manifest.manifest_type == crate::app::registry::ManifestType::Terminal {
+                let exec_cmd = installed.manifest.exec.clone().unwrap_or_else(|| id.to_string());
+                if !cli_binary_in_path(&exec_cmd) {
+                    log::warn!(
+                        "launch_app_by_id: terminal app '{id}' exec='{exec_cmd}' not found in PATH"
+                    );
+                    self.open_launch_failed_pane(
+                        id,
+                        hint.as_deref(),
+                        vec![format!(
+                            "'{exec_cmd}' not found in PATH. Install it first (e.g. brew install brogue-ce)."
+                        )],
+                        cwd,
+                    );
+                    return Ok(());
+                }
+                log::info!(
+                    "launch_app_by_id: terminal app '{id}' → spawning PTY pane exec='{exec_cmd}'"
+                );
+                let win = self.active_window;
+                if let Some(target) = self.windows[win].focused_pane {
+                    self.spawn_terminal_pane_at(
+                        win,
+                        target,
+                        false,
+                        false,
+                        Some(&exec_cmd),
+                        false,
+                        Some(cwd),
+                        true,
+                    );
+                } else {
+                    log::warn!("launch_app_by_id: terminal app '{id}' — no focused tile, cannot spawn PTY pane");
+                }
+                return Ok(());
+            }
+        }
+
         // Tier 4 — CLI native descriptor (plexi_app field).
         if let Some(process) = self.try_launch_cli_pgap_app(id, &cwd) {
             self.open_process_app_pane(&format!("cli:{id}"), process, cwd, group, hint.as_deref());
@@ -1033,6 +1073,38 @@ impl PlexiApp {
             "launch_app_by_path_with_layout: workspace_root={}",
             workspace_root.display()
         );
+        // Terminal apps bypass ProcessApp entirely — spawn exec binary in a PTY pane.
+        if installed.manifest.manifest_type == crate::app::registry::ManifestType::Terminal {
+            let exec_cmd = installed.manifest.exec.clone().unwrap_or_else(|| app_id.clone());
+            if !cli_binary_in_path(&exec_cmd) {
+                log::warn!(
+                    "launch_app_by_path_with_layout: terminal app '{app_id}' exec='{exec_cmd}' not found in PATH"
+                );
+                return Err(format!(
+                    "'{exec_cmd}' not found in PATH. Install it first (e.g. brew install brogue-ce)."
+                ));
+            }
+            log::info!(
+                "launch_app_by_path_with_layout: terminal app '{app_id}' → PTY pane exec='{exec_cmd}'"
+            );
+            let win = self.active_window;
+            if let Some(target) = self.windows[win].focused_pane {
+                self.spawn_terminal_pane_at(
+                    win,
+                    target,
+                    false,
+                    false,
+                    Some(&exec_cmd),
+                    false,
+                    Some(cwd),
+                    true,
+                );
+            } else {
+                log::warn!("launch_app_by_path_with_layout: terminal app '{app_id}' — no focused tile, cannot spawn PTY pane");
+            }
+            return Ok(());
+        }
+
         match crate::process_app::ProcessApp::launch(
             installed.manifest.id.clone(),
             installed.manifest.name.clone(),

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -991,6 +991,13 @@ impl PlexiApp {
                 let exec_cmd = installed.manifest.exec.clone().unwrap_or_else(|| id.to_string());
                 let exec_bin = exec_cmd.split_whitespace().next().unwrap_or(&exec_cmd);
                 let install_footer = Some(installed.manifest.description.clone());
+                // Caller hint wins; otherwise use manifest layout; Terminal default is "window".
+                let manifest_layout = installed.launch.layout.clone();
+                let effective_layout = hint
+                    .as_deref()
+                    .or(manifest_layout.as_deref())
+                    .unwrap_or("window")
+                    .to_string();
                 if !cli_binary_in_path(exec_bin) {
                     log::warn!(
                         "launch_app_by_id: terminal app '{id}' exec='{exec_cmd}' not found in PATH"
@@ -1004,13 +1011,22 @@ impl PlexiApp {
                     );
                     return Ok(());
                 }
-                let layout_str = hint.as_deref().unwrap_or("split_h");
-                let vertical = matches!(layout_str, "split_v" | "split_below" | "split_above");
-                let new_pane_first = matches!(layout_str, "split_above" | "split_left");
+                // "window" = spawn in a split then zoom the new pane to fill the window.
+                let zoom_after = effective_layout == "window";
+                let split_layout = if zoom_after { "split_h" } else { &effective_layout };
+                let vertical = matches!(split_layout, "split_v" | "split_below" | "split_above");
+                let new_pane_first = matches!(split_layout, "split_above" | "split_left");
                 log::info!(
-                    "launch_app_by_id: terminal app '{id}' → split_focused exec='{exec_cmd}' layout='{layout_str}'"
+                    "launch_app_by_id: terminal app '{id}' → split_focused exec='{exec_cmd}' layout='{effective_layout}' zoom={zoom_after}"
                 );
                 self.split_focused(vertical, Some(&exec_cmd), false, new_pane_first, Some(cwd));
+                if zoom_after {
+                    let active = self.active_window;
+                    if let Some(tile) = self.windows[active].focused_pane {
+                        self.windows[active].zoom_to(tile);
+                        log::info!("launch_app_by_id: zoomed terminal pane {tile:?} for '{id}'");
+                    }
+                }
                 return Ok(());
             }
         }
@@ -1077,13 +1093,29 @@ impl PlexiApp {
                     "'{exec_bin}' not found in PATH — install it and ensure it is on your PATH."
                 ));
             }
-            let layout_str = layout_hint.as_deref().unwrap_or("split_h");
-            let vertical = matches!(layout_str, "split_v" | "split_below" | "split_above");
-            let new_pane_first = matches!(layout_str, "split_above" | "split_left");
+            let manifest_layout = installed.launch.layout.clone();
+            let effective_layout = layout_hint
+                .as_deref()
+                .or(manifest_layout.as_deref())
+                .unwrap_or("window")
+                .to_string();
+            let zoom_after = effective_layout == "window";
+            let split_layout = if zoom_after { "split_h" } else { &effective_layout };
+            let vertical = matches!(split_layout, "split_v" | "split_below" | "split_above");
+            let new_pane_first = matches!(split_layout, "split_above" | "split_left");
             log::info!(
-                "launch_app_by_path_with_layout: terminal app '{app_id}' → split_focused exec='{exec_cmd}' layout='{layout_str}'"
+                "launch_app_by_path_with_layout: terminal app '{app_id}' → split_focused exec='{exec_cmd}' layout='{effective_layout}' zoom={zoom_after}"
             );
             self.split_focused(vertical, Some(&exec_cmd), false, new_pane_first, Some(cwd));
+            if zoom_after {
+                let active = self.active_window;
+                if let Some(tile) = self.windows[active].focused_pane {
+                    self.windows[active].zoom_to(tile);
+                    log::info!(
+                        "launch_app_by_path_with_layout: zoomed terminal pane {tile:?} for '{app_id}'"
+                    );
+                }
+            }
             return Ok(());
         }
 

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -989,15 +989,16 @@ impl PlexiApp {
         if let Some(installed) = self.registry.get(id) {
             if installed.manifest.manifest_type == crate::app::registry::ManifestType::Terminal {
                 let exec_cmd = installed.manifest.exec.clone().unwrap_or_else(|| id.to_string());
+                let exec_bin = exec_cmd.split_whitespace().next().unwrap_or(&exec_cmd);
                 let install_footer = Some(installed.manifest.description.clone());
-                if !cli_binary_in_path(&exec_cmd) {
+                if !cli_binary_in_path(exec_bin) {
                     log::warn!(
                         "launch_app_by_id: terminal app '{id}' exec='{exec_cmd}' not found in PATH"
                     );
                     self.open_launch_failed_pane(
                         id,
                         hint.as_deref(),
-                        vec![format!("'{exec_cmd}' not found in PATH")],
+                        vec![format!("'{exec_bin}' not found in PATH")],
                         cwd,
                         install_footer,
                     );
@@ -1067,12 +1068,13 @@ impl PlexiApp {
         // Terminal apps bypass ProcessApp entirely — spawn via split_focused (same path as builtin "terminal").
         if installed.manifest.manifest_type == crate::app::registry::ManifestType::Terminal {
             let exec_cmd = installed.manifest.exec.clone().unwrap_or_else(|| app_id.clone());
-            if !cli_binary_in_path(&exec_cmd) {
+            let exec_bin = exec_cmd.split_whitespace().next().unwrap_or(&exec_cmd);
+            if !cli_binary_in_path(exec_bin) {
                 log::warn!(
                     "launch_app_by_path_with_layout: terminal app '{app_id}' exec='{exec_cmd}' not found in PATH"
                 );
                 return Err(format!(
-                    "'{exec_cmd}' not found in PATH — install it and ensure it is on your PATH."
+                    "'{exec_bin}' not found in PATH — install it and ensure it is on your PATH."
                 ));
             }
             let layout_str = layout_hint.as_deref().unwrap_or("split_h");


### PR DESCRIPTION
Closes #2266

## Summary

- Adds `ManifestType::Terminal` — a manifest variant that spawns a named system binary in a PTY pane via `split_focused` when launched from the palette. No Python SDK or PGAP required.
- Ships `apps/brogue/` as the first terminal-type app (`exec = "brogue"`, install via `brew install brogue-ce`).
- Guards `plexi app render` and `plexi app check` against terminal apps receiving `app_dir` instead of an entry file.

## Done When

- `plexi app open brogue` (or palette → "Brogue") opens BrogueCE in a PTY pane with the game running
- Launching when `brogue` binary is absent shows a readable error (not a panic or silent failure)
- `cargo test --bin plexi` green
- Existing `App`-type apps unaffected (no regression in manifest loading)