### PR TITLE
V1 polish consolidation

### DIFF
--- a/.stint/tasks/0031-v1-security-and-trust-wording-audit.md
+++ b/.stint/tasks/0031-v1-security-and-trust-wording-audit.md
@@ -1,9 +1,11 @@
 ---
 id: "0031"
 title: "v1: security and trust wording audit"
-status: todo
+status: done
 estimate: "8h"
-sprint: "s14"
+actual: "45m"
+started_at: "2026-06-15T08:05:48Z"
+completed_at: "2026-06-15T08:13:09Z"
 blocked_by:
   - 28
 gh_issue: []
@@ -17,6 +19,8 @@ tags:
 ---
 
 
+
+
 Audit product, docs, install screens, trust labels, and marketplace wording so v1 accurately describes Python apps as reviewed native processes with capability-gated host APIs, not sandboxed code.
 
 ## Why
@@ -27,3 +31,7 @@ Trust labeling is only useful if the language is blunt about what is enforced no
 
 - `Sandboxed WASM` must not appear as an available v1 trust label unless enforcement exists.
 - Keep v2 runtime-lane wording clearly separate from v1 guarantees.
+
+## Variance
+
+Audit found the public security wording already mostly correct. This pass added regression coverage so docs do not claim Python sandboxing later.

--- a/.stint/tasks/0066-v1-ui-command-palette-search-cache.md
+++ b/.stint/tasks/0066-v1-ui-command-palette-search-cache.md
@@ -1,9 +1,11 @@
 ---
 id: "0066"
 title: "v1 UI: command palette search cache"
-status: todo
+status: done
 estimate: "3h"
-sprint: "s5"
+actual: "45m"
+started_at: "2026-06-15T07:49:36Z"
+completed_at: "2026-06-15T08:12:51Z"
 blocked_by: []
 gh_issue:
   - "1734"
@@ -17,8 +19,14 @@ tags:
 ---
 
 
+
+
 Remove avoidable per-keystroke command-palette allocations by precomputing searchable lowercase haystacks after aliases land.
 
 ## Note
 
 The issue references old `poc/gpui-ui` paths; the current implementation lives in `src/overlays/command_palette.rs`.
+
+## Variance
+
+Completed with the aliases task by adding cached lowercase haystacks to the existing palette entries instead of introducing a separate cache layer.

--- a/.stint/tasks/0067-v1-ui-command-palette-aliases.md
+++ b/.stint/tasks/0067-v1-ui-command-palette-aliases.md
@@ -1,9 +1,11 @@
 ---
 id: "0067"
 title: "v1 UI: command palette aliases"
-status: todo
+status: done
 estimate: "3h"
-sprint: "s5"
+actual: "30m"
+started_at: "2026-06-15T07:49:33Z"
+completed_at: "2026-06-15T08:12:48Z"
 blocked_by:
   - 147
 gh_issue:
@@ -17,6 +19,8 @@ tags:
 ---
 
 
+
+
 Add command-palette aliases so natural synonyms like `shell`, `console`, `hsplit`, and `config` resolve to the expected Plexi commands.
 
 Sequenced after `0147` because validation handoff reliability is the immediate ship-pipeline CLI blocker.
@@ -24,3 +28,7 @@ Sequenced after `0147` because validation handoff reliability is the immediate s
 ## Note
 
 The issue references old `poc/gpui-ui` paths; the current implementation lives in `src/overlays/command_palette.rs`.
+
+## Variance
+
+Completed with the search-cache task because both changes share the same command-palette entry model. The old path mismatch was the main audit cost.

--- a/.stint/tasks/0069-v1-docs-alpha-config-discipline.md
+++ b/.stint/tasks/0069-v1-docs-alpha-config-discipline.md
@@ -1,9 +1,11 @@
 ---
 id: "0069"
 title: "v1 docs: alpha config discipline"
-status: todo
+status: done
 estimate: "3h"
-sprint: "s14"
+actual: "30m"
+started_at: "2026-06-15T08:05:54Z"
+completed_at: "2026-06-15T08:13:12Z"
 blocked_by: []
 gh_issue:
   - "1690"
@@ -17,4 +19,10 @@ tags:
 ---
 
 
+
+
 Document alpha config as the default PR-channel template, beta config as the migration staging ground, and the expected config migration strategy.
+
+## Variance
+
+The repo already had the channel model in operational instructions. This pass copied the user-facing alpha/beta/PR config discipline into config docs and added doc assertions.

--- a/.stint/tasks/0153-syntax-highlighting-primitive.md
+++ b/.stint/tasks/0153-syntax-highlighting-primitive.md
@@ -1,9 +1,11 @@
 ---
 id: "0153"
 title: "Syntax highlighting primitive and ReadOnlyCodeViewer widget"
-status: todo
+status: done
 estimate: "12h"
-sprint: "s9"
+actual: "2h"
+started_at: "2026-06-15T07:55:27Z"
+completed_at: "2026-06-15T08:12:57Z"
 blocked_by: []
 gh_issue:
   - "2168"
@@ -18,6 +20,8 @@ tags:
 ---
 
 
+
+
 Build the shared syntax highlighting foundation:
 
 1. Add `inkjet` (tree-sitter wrapper) to `Cargo.toml`
@@ -29,3 +33,11 @@ Build the shared syntax highlighting foundation:
 This is the foundation for the text editor — the same `SyntaxHighlighter` feeds editor highlighting when that work begins.
 
 First step: resolve the open question in #2168 about whether egui_commonmark exposes a code block hook or whether we need to parse fenced blocks ourselves before passing body text to egui_commonmark.
+
+## Implementation Note
+
+Current alpha already had fenced-code highlighting through the egui markdown stack, so this pass added the shared `SyntaxHighlighter` and `ReadOnlyCodeViewer` primitives without replacing markdown rendering or adding `inkjet`.
+
+## Variance
+
+Estimate assumed a new tree-sitter/markdown hook path. The shipped slice reused `egui_extras` syntax highlighting already aligned with egui and proved the primitive in Host UI Gallery.

--- a/.stint/tasks/0157-ui-harden-gallery-visual-smoke.md
+++ b/.stint/tasks/0157-ui-harden-gallery-visual-smoke.md
@@ -1,9 +1,11 @@
 ---
 id: "0157"
 title: "UI hardening: host UI gallery visual smoke coverage"
-status: todo
+status: done
 estimate: "8h"
-sprint: "s31"
+actual: "0m"
+started_at: "2026-06-15T07:48:49Z"
+completed_at: "2026-06-15T07:48:49Z"
 blocked_by: []
 gh_issue:
   - "2175"
@@ -17,6 +19,7 @@ tags:
   - "gallery"
   - "testing"
 ---
+
 
 
 Add a lightweight visual smoke path for Host UI Gallery and key host overlays.
@@ -37,3 +40,7 @@ The host UI kit is now split and centralized, but build-only verification will n
 - `src/ui_tests.rs`
 - `src/testing/mod.rs`
 - `.agents/skills/validate-pr/SKILL.md`
+
+## Reconciliation
+
+Marked done in this branch after auditing current alpha. The implementation had already landed: `src/overlays/ui_gallery.rs` renders the host gallery and `src/ui_tests.rs` includes `screenshot_host_ui_gallery_trust_states`.

--- a/.stint/tasks/0159-ui-harden-multiline-host-textfield.md
+++ b/.stint/tasks/0159-ui-harden-multiline-host-textfield.md
@@ -1,9 +1,11 @@
 ---
 id: "0159"
 title: "UI hardening: multiline host TextField"
-status: todo
+status: done
 estimate: "12h"
-sprint: "s31"
+actual: "0m"
+started_at: "2026-06-15T07:48:49Z"
+completed_at: "2026-06-15T07:48:49Z"
 blocked_by: []
 gh_issue:
   - "2173"
@@ -16,6 +18,7 @@ tags:
   - "text-field"
   - "focus"
 ---
+
 
 
 Add a multiline host TextField primitive and migrate text-owning overlays that still hand-style multiline `TextEdit`.
@@ -38,3 +41,7 @@ Single-line host inputs are centralized, but QuickNote compose, notification pro
 - `src/overlays/notification_modal.rs`
 - `src/overlays/misc.rs`
 - `GOTCHAS.md`
+
+## Reconciliation
+
+Marked done in this branch after auditing current alpha. The implementation had already landed: `src/ui/text_field.rs` provides `TextArea::multiline`, and QuickNote, notification input, and edit-description overlays use it instead of raw multiline `TextEdit`.

--- a/.stint/tasks/0160-ui-harden-notification-modal-chrome.md
+++ b/.stint/tasks/0160-ui-harden-notification-modal-chrome.md
@@ -1,9 +1,11 @@
 ---
 id: "0160"
 title: "UI hardening: notification modal footer and action chrome"
-status: todo
+status: done
 estimate: "12h"
-sprint: "s31"
+actual: "0m"
+started_at: "2026-06-15T07:48:49Z"
+completed_at: "2026-06-15T07:48:49Z"
 blocked_by: []
 gh_issue:
   - "2174"
@@ -17,6 +19,7 @@ tags:
   - "notifications"
   - "modal"
 ---
+
 
 
 Move notification modal footer and action-row chrome onto shared host UI primitives.
@@ -38,3 +41,7 @@ The notification modal now uses `ModalShell`, but it still has the densest custo
 - `src/ui/hints.rs`
 - `src/ui/row.rs`
 - `src/ui/surface.rs`
+
+## Reconciliation
+
+Marked done in this branch after auditing current alpha. The implementation had already landed: notification prompts use `TextArea::multiline`, action rows use shared `choice_button`, and footer shortcuts use `HintBar`.

--- a/.stint/tasks/0189-v1-shallow-tab-drag-reorder.md
+++ b/.stint/tasks/0189-v1-shallow-tab-drag-reorder.md
@@ -1,9 +1,11 @@
 ---
 id: "0189"
 title: "v1: shallow tab drag reorder"
-status: todo
+status: done
 estimate: "4h"
-sprint: "s31"
+actual: "90m"
+started_at: "2026-06-15T07:57:56Z"
+completed_at: "2026-06-15T08:13:01Z"
 blocked_by: []
 gh_issue: []
 area:
@@ -15,6 +17,8 @@ tags:
   - "tabs"
   - "drag"
 ---
+
+
 
 Add shallow drag reordering inside an existing tab bar without changing the broader pane docking model.
 
@@ -43,3 +47,6 @@ This gives users the immediate missing tab affordance while keeping the change r
 - `src/app/render.rs`
 - `src/pane_ops/layout.rs`
 
+## Variance
+
+Kept the scope shallow: same-container reorder only, no drag preview or docking model changes. The pure pane operation and tests covered the risky state preservation path.

--- a/.stint/tasks/0195-catppuccin-latte-theme-is-broken.md
+++ b/.stint/tasks/0195-catppuccin-latte-theme-is-broken.md
@@ -1,11 +1,19 @@
 ---
 id: "0195"
 title: "catppuccin-latte theme is broken"
-status: todo
+status: done
+actual: "45m"
 created_at: "2026-06-14T20:39:28Z"
+started_at: "2026-06-15T08:03:00Z"
+completed_at: "2026-06-15T08:13:05Z"
+blocked_by: []
+gh_issue: []
+area: []
+tags: []
 ---
 
-## Why
-idk
 
+
+## Why
+Catppuccin Latte used very light secondary text against light Plexi surfaces, making dim labels and section text hard to read even though primary text was acceptable.
 

--- a/.stint/tasks/0197-command-palette-commands-toml-hot-reload.md
+++ b/.stint/tasks/0197-command-palette-commands-toml-hot-reload.md
@@ -1,0 +1,37 @@
+---
+id: "0197"
+title: "command palette: commands.toml entries with hot reload"
+status: backlog
+estimate: "8h"
+created_at: "2026-06-15T17:04:26Z"
+sprint: "s33"
+blocked_by: []
+gh_issue:
+  - "2269"
+area:
+  - "ui/overlays"
+  - "cli/commands"
+  - "host/config"
+tags:
+  - "v1"
+  - "palette"
+  - "commands"
+---
+
+Surface workspace and global `commands.toml` entries in the command palette without creating a second command registry.
+
+## Why
+
+`plexi run` already gives users and agents a structured command layer over shell aliases. The palette should make those commands discoverable inside Plexi with scope chips, fuzzy search, and hot reload.
+
+## Scope
+
+1. Reuse the existing `plexi run` parser and execution semantics from `src/cli/mod.rs` and `src/cli/run.rs`.
+2. Resolve channel-scoped workspace commands from the active workspace root and global fallback commands/scripts from the profile.
+3. Cache command rows at palette-open time, then invalidate on focused workspace or command-file mtime changes.
+4. Render workspace/global command rows in `src/overlays/command_palette.rs` with scope chips.
+5. Add unit/HostHarness coverage for precedence, hot reload, fuzzy ordering, and selection dispatch plus one `PlexiUiHarness` screenshot.
+
+## Notes
+
+Task `0185` already implemented dynamic shell completions from `commands.toml`; reuse its scope assumptions instead of deriving channel paths again.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3376,6 +3376,7 @@ dependencies = [
  "egui",
  "egui-wgpu",
  "egui_commonmark",
+ "egui_extras",
  "egui_kittest",
  "egui_term",
  "egui_tiles",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 egui = { version = "0.31", features = ["accesskit"] }
 eframe = { version = "0.31", default-features = false, features = ["default_fonts", "wgpu", "accesskit"] }
+egui_extras = "0.31"
 egui_tiles = { version = "0.12.0", features = ["serde"] }
 egui_term = { path = "deps/egui_term" }
 dirs = "6"

--- a/apps/csv_viewer/csv_viewer.py
+++ b/apps/csv_viewer/csv_viewer.py
@@ -3,6 +3,7 @@
 
 import csv
 from pathlib import Path
+from typing import Optional
 
 from plexi_sdk import App, Arg
 from plexi_sdk.ui import (
@@ -16,7 +17,7 @@ ROW_H = 24.0
 
 
 class CsvViewer(App):
-    file: Arg[str | None] = Arg(positional=True, default=None)
+    file: Arg[Optional[str]] = Arg(positional=True, default=None)
 
     def on_init(self) -> None:
         launch_dir = Path(self.workspace_root) if self.workspace_root else Path.cwd()

--- a/apps/github-issues/main.py
+++ b/apps/github-issues/main.py
@@ -12,6 +12,7 @@ Keys: j/k navigate · Enter open detail · Esc back · o open in browser
 import asyncio
 import json
 import subprocess
+from typing import Optional
 
 from plexi_sdk import (
     App, RenderContext, Arg,
@@ -51,7 +52,7 @@ class _MarkdownBlock(Component):
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def _gh(*args: str, cwd: str | None = None, timeout: float = 15.0) -> tuple[int, str, str]:
+def _gh(*args: str, cwd: Optional[str] = None, timeout: float = 15.0) -> tuple[int, str, str]:
     """Run gh CLI. Returns (returncode, stdout, stderr). Never raises."""
     try:
         p = subprocess.run(
@@ -172,7 +173,7 @@ class GhIssues(App):
     VIEW_DETAIL = "detail"
     VIEW_PICKER = "picker"
 
-    repo_dir: Arg[str | None] = Arg("--repo-dir", default=lambda ctx: ctx.workspace_root)
+    repo_dir: Arg[Optional[str]] = Arg("--repo-dir", default=lambda ctx: ctx.workspace_root)
 
     async def on_init(self) -> None:
         self._view           = self.VIEW_LIST
@@ -231,14 +232,14 @@ class GhIssues(App):
         visible = self._visible_issues()
         self._sel = max(0, min(self._sel, len(visible) - 1)) if visible else 0
 
-    def _selected_issue(self) -> dict | None:
+    def _selected_issue(self) -> Optional[dict]:
         visible = self._visible_issues()
         if not visible:
             return None
         self._sel = max(0, min(self._sel, len(visible) - 1))
         return visible[self._sel]
 
-    def _select_issue_number(self, number: int | None) -> None:
+    def _select_issue_number(self, number: Optional[int]) -> None:
         visible = self._visible_issues()
         if number is not None:
             for idx, issue in enumerate(visible):

--- a/apps/snake/snake.py
+++ b/apps/snake/snake.py
@@ -6,6 +6,8 @@ separate Rust sub-project. The spec allows either; Python is 80 lines vs a
 new cargo crate + cross-compile setup. This is the intentional choice.
 """
 
+from typing import Optional
+
 from plexi_sdk import App, RenderContext, Arg, Pipe
 from plexi_sdk.ui import Column, AppBar, FooterKeys, Component
 
@@ -66,7 +68,7 @@ class _SnakeCanvas(Component):
 
 
 class SnakeApp(App):
-    pipe_id: Arg[str | None] = Arg("--pipe", default=None)
+    pipe_id: Arg[Optional[str]] = Arg("--pipe", default=None)
 
     def on_init(self) -> None:
         self._pipe: "Pipe | None" = None

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -8,6 +8,14 @@ Online: https://plexiapp.com/docs/config
 
 ---
 
+## Channel discipline
+
+- Alpha config stays default. `just install` refreshes `~/.plexi-alpha/config.toml` from the built-in template, and PR builds seed from alpha.
+- Beta config is the staging ground. `~/.plexi-beta/config.toml` is not reset by alpha installs, so use it for migration testing, advanced settings, and personal overrides.
+- PR builds are isolated. A PR build reads `~/.plexi-pr-<N>/config.toml`; use `plexi-pr-<N>` when testing PR-specific config behavior.
+
+---
+
 ## Top-level keys
 
 | Key | Type | Default | Description |
@@ -66,7 +74,7 @@ Apply a named preset and optionally override individual color tokens.
 | `pip_blocked` | hex color | `red` | Status pip color for Blocked state. Defaults to the `red` ANSI color. |
 | `pip_dim` | float | 0.45 | Opacity multiplier applied to status pips on unfocused panes. Range: 0.0–1.0. |
 
-**Available presets:** `catppuccin-mocha`, `catppuccin-latte`, `dracula`, `tokyo-night`, `gruvbox-dark`, `nord`, `solarized-dark`, `solarized-light`
+**Available presets:** `catppuccin-mocha`, `catppuccin-latte`, `dracula`, `tokyo-night`, `tokyo-day`, `gruvbox-dark`, `gruvbox-light`, `nord`, `solarized-dark`, `solarized-light`
 
 Example:
 ```toml

--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -16,7 +16,7 @@ osc_pane_title = true
 
 [theme]
 preset = "catppuccin-mocha"
-# Presets: catppuccin-mocha, catppuccin-latte, dracula, tokyo-night, gruvbox-dark, nord, solarized-dark, solarized-light
+# Presets: catppuccin-mocha, catppuccin-latte, dracula, tokyo-night, tokyo-day, gruvbox-dark, gruvbox-light, nord, solarized-dark, solarized-light
 # Uncomment to override individual colors:
 # accent       = "#89b4fa"
 # bg_darkest   = "#11111b"

--- a/sdk/python/plexi_sdk/_app.py
+++ b/sdk/python/plexi_sdk/_app.py
@@ -1456,11 +1456,20 @@ class App:
         blocking is a realistic concern, or move blocking work to a thread via
         ``threading.Thread`` + ``emit.run_sync()``.
         """
-        if inspect.iscoroutinefunction(hook):
-            await hook(*args)
-        else:
-            with _sync_hook_scope():
-                hook(*args)
+        try:
+            if inspect.iscoroutinefunction(hook):
+                await hook(*args)
+            else:
+                with _sync_hook_scope():
+                    hook(*args)
+        except TypeError as exc:
+            if "must be called with 'await' from an 'async def' hook" in str(exc):
+                raise
+            hook_name = getattr(hook, "__qualname__", getattr(hook, "__name__", repr(hook)))
+            raise TypeError(f"{hook_name} failed: {exc}") from exc
+        except BaseException as exc:
+            hook_name = getattr(hook, "__qualname__", getattr(hook, "__name__", repr(hook)))
+            raise RuntimeError(f"{hook_name} failed: {exc}") from exc
 
     def _dispatch_hook_task(self, hook: "Any", *args: Any) -> None:
         """Dispatch a lifecycle hook as a non-blocking background task.

--- a/sdk/python/plexi_sdk/testing.py
+++ b/sdk/python/plexi_sdk/testing.py
@@ -14,6 +14,7 @@ import threading
 import time
 import zlib
 from pathlib import Path
+from typing import Union
 
 DEFAULT_BG = "#1e1e2e"
 
@@ -245,7 +246,7 @@ def assert_pixel(
     png_bytes: bytes,
     x: int,
     y: int,
-    expected: str | tuple[int, int, int, int],
+    expected: Union[str, tuple[int, int, int, int]],
     tolerance: int = 4,
 ) -> None:
     """Assert the pixel at (x, y) matches the expected color within per-channel tolerance.
@@ -285,7 +286,7 @@ def assert_pixel(
 # Snapshot file helper
 # ---------------------------------------------------------------------------
 
-def save_snapshot(png_bytes: bytes, path: str | Path) -> None:
+def save_snapshot(png_bytes: bytes, path: Union[str, Path]) -> None:
     """Write PNG bytes to path. Creates parent directories as needed."""
     p = Path(path)
     try:

--- a/sdk/python/plexi_sdk/widgets/text_area.py
+++ b/sdk/python/plexi_sdk/widgets/text_area.py
@@ -7,6 +7,7 @@ render viewport passed to render().
 """
 
 from dataclasses import dataclass
+from typing import Optional
 
 
 from plexi_sdk.widgets.scroll import ScrollState
@@ -37,8 +38,8 @@ class TextArea:
     def __init__(
         self,
         buffer: TextBuffer,
-        scroll: ScrollState | None = None,
-        theme: TextAreaTheme | None = None,
+        scroll: Optional[ScrollState] = None,
+        theme: Optional[TextAreaTheme] = None,
     ) -> None:
         self.buffer = buffer
         self.theme = theme or TextAreaTheme()

--- a/sdk/python/tests/test_sdk_init.py
+++ b/sdk/python/tests/test_sdk_init.py
@@ -31,6 +31,14 @@ def test_subclass_with_super_init_still_works() -> None:
     assert app.custom_value == 99
 
 
+def test_testing_helpers_import_on_supported_python_versions() -> None:
+    """Runtime-evaluated annotations in testing helpers must not break Python 3.9."""
+    from plexi_sdk.testing import AppHarness, assert_pixel
+
+    assert AppHarness is not None
+    assert assert_pixel is not None
+
+
 def test_no_super_subclass_runs_without_error() -> None:
     """Instantiating App subclass without super() must not raise any error."""
     class MyApp(App):

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -537,7 +537,7 @@ impl PlexiApp {
                     theme: self.theme.clone(),
                     new_focused: None,
                     close_exited: None,
-                    tab_click: None,
+                    tab_action: None,
                     tab_info,
                     tab_labels,
                     zoomed_pane,
@@ -613,11 +613,14 @@ impl PlexiApp {
                 // needs &mut ctx but behavior holds &mut ctx.panes).
                 let new_focused = behavior.new_focused;
                 let should_close_exited = behavior.close_exited.is_some();
-                let tab_click = behavior.tab_click.take();
+                let tab_action = behavior.tab_action.take();
                 let portal_zoom = behavior.portal_zoom_request.take();
 
                 // Draw zoom overlay if a pane is zoomed
-                let mut zoomed_tab_click: Option<(TileId, usize)> = None;
+                let mut zoomed_tab_action: Option<(
+                    TileId,
+                    crate::spatial::tiling::TabBarAction,
+                )> = None;
                 if let Some(zoomed_tile) = zoomed_pane {
                     if let Some(Tile::Pane(pane_id)) = ctx.tree.tiles.get(zoomed_tile) {
                         let pane_id = *pane_id;
@@ -707,7 +710,7 @@ impl PlexiApp {
                                 self.colors.pane_header_bg(),
                             );
                             if let Some(ref group) = zoomed_tab_info {
-                                if let Some(idx) = crate::spatial::tiling::paint_tab_bar(
+                                if let Some(action) = crate::spatial::tiling::paint_tab_bar(
                                     ui.ctx(),
                                     ui.painter(),
                                     bar_rect,
@@ -718,7 +721,7 @@ impl PlexiApp {
                                     self.config.pane_title_font_size.unwrap_or(11.0),
                                     is_overtaken_app,
                                 ) {
-                                    zoomed_tab_click = Some((group.container_tile, idx));
+                                    zoomed_tab_action = Some((group.container_tile, action));
                                 }
                             } else if let Some(ref name) = zoomed_pane_name {
                                 ui.painter().text(
@@ -924,9 +927,18 @@ impl PlexiApp {
                     }
                 }
 
-                let effective_tab_click = tab_click.or(zoomed_tab_click);
-                if let Some((container_tile, clicked_idx)) = effective_tab_click {
-                    self.switch_to_tab(container_tile, clicked_idx);
+                let effective_tab_action = tab_action.or(zoomed_tab_action);
+                if let Some((container_tile, action)) = effective_tab_action {
+                    match action {
+                        crate::spatial::tiling::TabBarAction::Switch(idx) => {
+                            self.switch_to_tab(container_tile, idx);
+                        }
+                        crate::spatial::tiling::TabBarAction::Reorder { from_idx, to_idx } => {
+                            if self.reorder_tab(container_tile, from_idx, to_idx) {
+                                self.save_workspace();
+                            }
+                        }
+                    }
                 }
 
                 if should_close_exited {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1854,4 +1854,34 @@ mod tests {
             "version should be added: {result}"
         );
     }
+
+    #[test]
+    fn config_docs_explain_channel_discipline() {
+        for doc in [
+            include_str!("../../docs/CONFIG.md"),
+            include_str!("../../website/src/content/docs/config.md"),
+        ] {
+            assert!(doc.contains("Alpha config stays default"));
+            assert!(doc.contains("Beta config is the staging ground"));
+            assert!(doc.contains("PR builds are isolated"));
+            assert!(doc.contains("~/.plexi-pr-<N>/config.toml"));
+        }
+    }
+
+    #[test]
+    fn public_security_docs_do_not_claim_python_sandboxing() {
+        for doc in [
+            include_str!("../../README.md"),
+            include_str!("../../docs/SECURITY_MODEL.md"),
+            include_str!("../../website/src/content/docs/apps.md"),
+            include_str!("../../website/src/content/docs/sdk.md"),
+            include_str!("../../website/src/content/docs/pgap.md"),
+        ] {
+            assert!(doc.contains("not") && doc.contains("sandbox"));
+            assert!(
+                !doc.contains("Python apps are sandboxed")
+                    && !doc.contains("sandboxed Python apps")
+            );
+        }
+    }
 }

--- a/src/host/keys.rs
+++ b/src/host/keys.rs
@@ -1184,12 +1184,8 @@ mod tests {
         let mut actions = Vec::new();
         let _ = ctx.run(raw, |ctx| {
             actions = poll_actions(
-                ctx,
-                &table,
-                /* app_active */ true,
-                /* keyboard_capture */ false,
-                /* overlay_open */ false,
-                /* shortcuts_overlay_open */ false,
+                ctx, &table, /* app_active */ true, /* keyboard_capture */ false,
+                /* overlay_open */ false, /* shortcuts_overlay_open */ false,
             );
         });
         actions

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -11,6 +11,12 @@ use crate::ui::{
 };
 
 enum PaletteEntry {
+    Command {
+        command: PaletteCommand,
+        name: &'static str,
+        description: &'static str,
+        search_text: &'static str,
+    },
     Context {
         ctx_idx: usize,
         context_id: u64,
@@ -20,6 +26,7 @@ enum PaletteEntry {
         pane_pips: Option<ListRowPips>,
         /// If set, focus this specific pane after navigating to the window.
         pane_id: Option<u64>,
+        search_text: String,
     },
     App {
         id: String,
@@ -27,18 +34,137 @@ enum PaletteEntry {
         description: String,
         running_in_background: bool,
         is_workspace_local: bool,
+        search_text: String,
     },
     /// Host-native builtin app (no registry manifest), launched by id.
     Builtin {
         id: &'static str,
         name: &'static str,
         description: &'static str,
+        search_text: String,
     },
     Note {
         path: std::path::PathBuf,
         title: String,
         preview: String,
+        search_text: String,
     },
+}
+
+impl PaletteEntry {
+    fn group_rank(&self) -> usize {
+        match self {
+            PaletteEntry::Context { .. } => 0,
+            PaletteEntry::Note { .. } => 1,
+            PaletteEntry::App { .. } | PaletteEntry::Builtin { .. } => 2,
+            PaletteEntry::Command { .. } => 3,
+        }
+    }
+
+    fn query_rank(&self, query: &str) -> usize {
+        if query.is_empty() {
+            return self.group_rank();
+        }
+        let search_text = match self {
+            PaletteEntry::Command { search_text, .. } => *search_text,
+            PaletteEntry::Context { search_text, .. }
+            | PaletteEntry::App { search_text, .. }
+            | PaletteEntry::Builtin { search_text, .. }
+            | PaletteEntry::Note { search_text, .. } => search_text.as_str(),
+        };
+        if search_text.starts_with(query) {
+            return 0;
+        }
+        if search_text
+            .split_whitespace()
+            .any(|part| part.starts_with(query))
+        {
+            return 1;
+        }
+        search_text
+            .find(query)
+            .map(|idx| idx + 2)
+            .unwrap_or(usize::MAX)
+    }
+
+    fn matches_query(&self, query: &str) -> bool {
+        if query.is_empty() {
+            return true;
+        }
+        match self {
+            PaletteEntry::Command { search_text, .. } => search_text.contains(query),
+            PaletteEntry::Context { search_text, .. }
+            | PaletteEntry::App { search_text, .. }
+            | PaletteEntry::Builtin { search_text, .. }
+            | PaletteEntry::Note { search_text, .. } => search_text.contains(query),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PaletteCommand {
+    SplitRight,
+    SplitDown,
+    OpenConfig,
+    OpenQuickNote,
+    OpenScratchpad,
+}
+
+struct PaletteCommandEntry {
+    command: PaletteCommand,
+    name: &'static str,
+    description: &'static str,
+    search_text: &'static str,
+}
+
+const PALETTE_COMMANDS: &[PaletteCommandEntry] = &[
+    PaletteCommandEntry {
+        command: PaletteCommand::SplitRight,
+        name: "Split right",
+        description: "Open a new terminal beside the focused pane",
+        search_text: "split right new terminal shell console pane vsplit vertical",
+    },
+    PaletteCommandEntry {
+        command: PaletteCommand::SplitDown,
+        name: "Split down",
+        description: "Open a new terminal below the focused pane",
+        search_text: "split down below new terminal shell console pane hsplit horizontal",
+    },
+    PaletteCommandEntry {
+        command: PaletteCommand::OpenConfig,
+        name: "Open config",
+        description: "Edit the active Plexi config file",
+        search_text: "open config settings preferences config.toml configuration",
+    },
+    PaletteCommandEntry {
+        command: PaletteCommand::OpenQuickNote,
+        name: "Quick Note",
+        description: "Capture a note in the current context",
+        search_text: "quick note capture inbox memo",
+    },
+    PaletteCommandEntry {
+        command: PaletteCommand::OpenScratchpad,
+        name: "Scratch Pad",
+        description: "Open a fresh scratch note editor",
+        search_text: "scratch pad scratchpad note editor inbox memo",
+    },
+];
+
+fn searchable_text(parts: &[&str]) -> String {
+    parts.join(" ").to_lowercase()
+}
+
+fn sort_palette_entries(entries: &mut [PaletteEntry], query: &str) {
+    entries.sort_by_key(|entry| (entry.query_rank(query), entry.group_rank()));
+}
+
+#[cfg(test)]
+fn palette_command_matches(query: &str) -> Vec<PaletteCommand> {
+    PALETTE_COMMANDS
+        .iter()
+        .filter(|entry| query.is_empty() || entry.search_text.contains(query))
+        .map(|entry| entry.command)
+        .collect()
 }
 
 /// Builtin host apps surfaced in the palette alongside registry apps.
@@ -338,7 +464,9 @@ impl PlexiApp {
             (tier, recency)
         };
 
-        let mut entries: Vec<PaletteEntry> = {
+        let mut entries: Vec<PaletteEntry> = Vec::new();
+
+        let ctx_entries: Vec<PaletteEntry> = {
             // Context-scoped unpacking: the ACTIVE context expands to one row
             // per pane (each carrying a single status pip), while every OTHER
             // context collapses to one `ctx` row carrying its full pip strip.
@@ -406,10 +534,8 @@ impl PlexiApp {
                         active_focused_tile,
                         &self.pane_focus_history,
                     ) {
-                        if query.is_empty()
-                            || row.name.to_lowercase().contains(&query)
-                            || c.name.to_lowercase().contains(&query)
-                        {
+                        let search_text = searchable_text(&[row.name.as_str(), c.name.as_str()]);
+                        if query.is_empty() || search_text.contains(&query) {
                             ctx_entries.push(PaletteEntry::Context {
                                 ctx_idx: row.win_idx,
                                 context_id: row.window_id,
@@ -418,12 +544,14 @@ impl PlexiApp {
                                 metadata_chip: row.chip,
                                 pane_pips: Some(row.pips),
                                 pane_id: Some(row.pane_id),
+                                search_text,
                             });
                         }
                     }
                 } else {
                     // Inactive context — one collapsed row, full pip strip.
-                    if query.is_empty() || c.name.to_lowercase().contains(&query) {
+                    let search_text = searchable_text(&[c.name.as_str()]);
+                    if query.is_empty() || search_text.contains(&query) {
                         ctx_entries.push(PaletteEntry::Context {
                             ctx_idx: c.win_idx,
                             context_id: c.window_id,
@@ -437,6 +565,7 @@ impl PlexiApp {
                                 Some(active_win_id),
                             ),
                             pane_id: None,
+                            search_text,
                         });
                     }
                     if !query.is_empty() {
@@ -451,7 +580,9 @@ impl PlexiApp {
                             active_focused_tile,
                             &self.pane_focus_history,
                         ) {
-                            if row.name.to_lowercase().contains(&query) {
+                            let search_text =
+                                searchable_text(&[row.name.as_str(), c.name.as_str()]);
+                            if search_text.contains(&query) {
                                 ctx_entries.push(PaletteEntry::Context {
                                     ctx_idx: row.win_idx,
                                     context_id: row.window_id,
@@ -460,6 +591,7 @@ impl PlexiApp {
                                     metadata_chip: row.chip,
                                     pane_pips: Some(row.pips),
                                     pane_id: Some(row.pane_id),
+                                    search_text,
                                 });
                             }
                         }
@@ -469,17 +601,18 @@ impl PlexiApp {
 
             ctx_entries
         };
+        entries.extend(ctx_entries);
 
         // ── Note entries ────────────────────────────────────────────────────
         for note in &self.palette_notes {
-            let matches = query.is_empty()
-                || note.title.to_lowercase().contains(&query)
-                || note.search_text.contains(&query);
+            let search_text = searchable_text(&[note.title.as_str(), note.search_text.as_str()]);
+            let matches = query.is_empty() || search_text.contains(&query);
             if matches {
                 entries.push(PaletteEntry::Note {
                     path: note.path.clone(),
                     title: note.title.clone(),
                     preview: note.preview.clone(),
+                    search_text,
                 });
             }
         }
@@ -505,11 +638,11 @@ impl PlexiApp {
             self.registry = crate::app::registry::AppRegistry::load(rescan_cwd);
         }
 
-        let app_entries: Vec<(String, String, String, bool)> = self
+        let app_entries: Vec<(String, String, String, bool, String)> = self
             .registry
             .list()
             .into_iter()
-            .filter(|app| {
+            .filter_map(|app| {
                 // Local apps are visible only when the focused pane is in their workspace.
                 // Use the same explicit predicate here as in the badge below — no wildcard.
                 let workspace_visible = match app.source {
@@ -519,24 +652,29 @@ impl PlexiApp {
                         app.workspace_root.as_ref() == focused_workspace_root
                     }
                 };
-                workspace_visible
-                    && (query.is_empty()
-                        || app.manifest.name.to_lowercase().contains(&query)
-                        || app.manifest.id.to_lowercase().contains(&query)
-                        || app.manifest.description.to_lowercase().contains(&query))
-            })
-            .map(|app| {
+                if !workspace_visible {
+                    return None;
+                }
+                let search_text = searchable_text(&[
+                    app.manifest.name.as_str(),
+                    app.manifest.id.as_str(),
+                    app.manifest.description.as_str(),
+                ]);
+                if !query.is_empty() && !search_text.contains(&query) {
+                    return None;
+                }
                 let is_local = matches!(
                     app.source,
                     crate::app::registry::RegistrySource::LocalApp
                         | crate::app::registry::RegistrySource::LocalAgent
                 );
-                (
+                Some((
                     app.manifest.id.clone(),
                     app.manifest.name.clone(),
                     app.manifest.description.clone(),
                     is_local,
-                )
+                    search_text,
+                ))
             })
             .collect();
 
@@ -544,20 +682,18 @@ impl PlexiApp {
             if !crate::release::feature_enabled(gate) {
                 continue;
             }
-            if query.is_empty()
-                || name.to_lowercase().contains(&query)
-                || id.to_lowercase().contains(&query)
-                || description.to_lowercase().contains(&query)
-            {
+            let search_text = searchable_text(&[name, id, description]);
+            if query.is_empty() || search_text.contains(&query) {
                 entries.push(PaletteEntry::Builtin {
                     id,
                     name,
                     description,
+                    search_text,
                 });
             }
         }
 
-        for (id, name, description, is_workspace_local) in app_entries {
+        for (id, name, description, is_workspace_local, search_text) in app_entries {
             let running_in_background = self.background_apps.contains_key(&id);
             entries.push(PaletteEntry::App {
                 id,
@@ -565,8 +701,23 @@ impl PlexiApp {
                 description,
                 running_in_background,
                 is_workspace_local,
+                search_text,
             });
         }
+
+        entries.extend(
+            PALETTE_COMMANDS
+                .iter()
+                .map(|entry| PaletteEntry::Command {
+                    command: entry.command,
+                    name: entry.name,
+                    description: entry.description,
+                    search_text: entry.search_text,
+                })
+                .filter(|entry| entry.matches_query(&query)),
+        );
+
+        sort_palette_entries(&mut entries, &query);
 
         let total = entries.len();
 
@@ -577,6 +728,7 @@ impl PlexiApp {
         // ── Keyboard nav ───────────────────────────────────────────────────
         #[derive(Clone)]
         enum Action {
+            RunCommand(PaletteCommand),
             JumpContext(usize, u64, Option<u64>),
             LaunchApp(String),
             LaunchBuiltin(&'static str),
@@ -607,6 +759,9 @@ impl PlexiApp {
             }
             if input.consume_key(egui::Modifiers::NONE, egui::Key::Enter) {
                 match entries.get(self.palette_selected) {
+                    Some(PaletteEntry::Command { command, .. }) => {
+                        action = Some(Action::RunCommand(*command));
+                    }
                     Some(PaletteEntry::Context {
                         ctx_idx,
                         context_id,
@@ -630,6 +785,12 @@ impl PlexiApp {
         });
 
         match action {
+            Some(Action::RunCommand(command)) => {
+                self.show_command_palette = false;
+                self.palette_query.clear();
+                self.run_palette_command(command);
+                return;
+            }
             Some(Action::JumpContext(ctx_idx, context_id, pane_id)) => {
                 self.jump_to_context(ctx_idx, context_id, pane_id);
                 self.show_command_palette = false;
@@ -714,6 +875,7 @@ impl PlexiApp {
                 let should_scroll = self.palette_selected != prev_selected;
                 let mut shown_apps_header = false;
                 let mut shown_notes_header = false;
+                let mut shown_commands_header = false;
 
                 egui::ScrollArea::vertical()
                     // animated(false): required by scroll_row_into_view — see src/ui/list.rs.
@@ -732,6 +894,37 @@ impl PlexiApp {
                             let is_selected = i == self.palette_selected;
 
                             match entry {
+                                PaletteEntry::Command {
+                                    command,
+                                    name,
+                                    description,
+                                    ..
+                                } => {
+                                    if !shown_commands_header {
+                                        shown_commands_header = true;
+                                        ui.add_space(style::SPACE_XS);
+                                        ui.label(
+                                            RichText::new("COMMANDS")
+                                                .size(style::TEXT_HINT)
+                                                .color(colors.text_dim),
+                                        );
+                                        ui.add_space(style::SPACE_XS);
+                                    }
+                                    let row_response = ListRow::new(name)
+                                        .metadata_chips(&["cmd"])
+                                        .secondary(description)
+                                        .selected(is_selected)
+                                        .show(ui, &colors);
+                                    if is_selected {
+                                        row_response.scroll_into_view(ui, should_scroll);
+                                    }
+                                    if row_response.row_clicked() {
+                                        click_action = Some(Action::RunCommand(*command));
+                                    }
+                                    if row_response.row_hovered() {
+                                        hover_select = Some(i);
+                                    }
+                                }
                                 PaletteEntry::Context {
                                     ctx_idx,
                                     context_id,
@@ -740,6 +933,7 @@ impl PlexiApp {
                                     metadata_chip,
                                     pane_pips,
                                     pane_id,
+                                    ..
                                 } => {
                                     let mut row = ListRow::new(name.as_str())
                                         .metadata_chips(std::slice::from_ref(metadata_chip))
@@ -770,6 +964,7 @@ impl PlexiApp {
                                     description,
                                     running_in_background,
                                     is_workspace_local,
+                                    ..
                                 } => {
                                     if !shown_apps_header {
                                         shown_apps_header = true;
@@ -806,6 +1001,7 @@ impl PlexiApp {
                                     id,
                                     name,
                                     description,
+                                    ..
                                 } => {
                                     if !shown_apps_header {
                                         shown_apps_header = true;
@@ -838,6 +1034,7 @@ impl PlexiApp {
                                     path,
                                     title,
                                     preview,
+                                    ..
                                 } => {
                                     if !shown_notes_header {
                                         shown_notes_header = true;
@@ -884,6 +1081,11 @@ impl PlexiApp {
 
                 if let Some(act) = click_action {
                     match act {
+                        Action::RunCommand(command) => {
+                            self.show_command_palette = false;
+                            self.palette_query.clear();
+                            self.run_palette_command(command);
+                        }
                         Action::JumpContext(ctx_idx, context_id, pane_id) => {
                             self.jump_to_context(ctx_idx, context_id, pane_id);
                             self.show_command_palette = false;
@@ -945,6 +1147,41 @@ impl PlexiApp {
         }
     }
 
+    fn run_palette_command(&mut self, command: PaletteCommand) {
+        log::info!("palette: running host command {command:?}");
+        match command {
+            PaletteCommand::SplitRight => {
+                self.windows[self.active_window].clear_zoom();
+                self.ctx.memory_mut(|m| {
+                    if let Some(id) = m.focused() {
+                        m.surrender_focus(id);
+                    }
+                });
+                self.split_focused(false, None, false, false, None);
+                self.save_workspace();
+            }
+            PaletteCommand::SplitDown => {
+                self.windows[self.active_window].clear_zoom();
+                self.ctx.memory_mut(|m| {
+                    if let Some(id) = m.focused() {
+                        m.surrender_focus(id);
+                    }
+                });
+                self.split_focused(true, None, false, false, None);
+                self.save_workspace();
+            }
+            PaletteCommand::OpenConfig => {
+                crate::config::open_config_file();
+            }
+            PaletteCommand::OpenQuickNote => {
+                self.open_quick_note_modal();
+            }
+            PaletteCommand::OpenScratchpad => {
+                self.open_scratchpad();
+            }
+        }
+    }
+
     /// Jump to a window by index, switching context if necessary.
     /// If `pane_id` is provided, also focuses that specific pane in the window.
     fn jump_to_context(&mut self, ctx_idx: usize, win_id: u64, pane_id: Option<u64>) {
@@ -991,6 +1228,109 @@ mod tests {
         assert_eq!(app_metadata_chips(false, false), &["app"]);
         assert_eq!(app_metadata_chips(false, true), &["app", "ws"]);
         assert_eq!(app_metadata_chips(true, true), &["app", "bg", "ws"]);
+    }
+
+    #[test]
+    fn palette_command_aliases_match_starter_synonyms() {
+        assert_eq!(
+            palette_command_matches("shell"),
+            vec![PaletteCommand::SplitRight, PaletteCommand::SplitDown]
+        );
+        assert_eq!(
+            palette_command_matches("console"),
+            vec![PaletteCommand::SplitRight, PaletteCommand::SplitDown]
+        );
+        assert_eq!(
+            palette_command_matches("hsplit"),
+            vec![PaletteCommand::SplitDown]
+        );
+        assert_eq!(
+            palette_command_matches("config"),
+            vec![PaletteCommand::OpenConfig]
+        );
+        assert_eq!(
+            palette_command_matches("scratchpad"),
+            vec![PaletteCommand::OpenScratchpad]
+        );
+        assert_eq!(
+            palette_command_matches("scratch pad"),
+            vec![PaletteCommand::OpenScratchpad]
+        );
+    }
+
+    #[test]
+    fn palette_searchable_text_is_cached_lowercase() {
+        assert_eq!(
+            searchable_text(&["Open Config", "Settings", "CONFIG.toml"]),
+            "open config settings config.toml"
+        );
+        for entry in PALETTE_COMMANDS {
+            assert_eq!(
+                entry.search_text,
+                entry.search_text.to_lowercase(),
+                "palette command search text must be pre-lowercased"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_palette_puts_commands_after_apps() {
+        let mut entries = vec![
+            PaletteEntry::Command {
+                command: PaletteCommand::OpenConfig,
+                name: "Open config",
+                description: "Edit config",
+                search_text: "open config",
+            },
+            PaletteEntry::App {
+                id: "balls".to_string(),
+                name: "Balls".to_string(),
+                description: "Demo".to_string(),
+                running_in_background: false,
+                is_workspace_local: false,
+                search_text: "balls demo".to_string(),
+            },
+            PaletteEntry::Context {
+                ctx_idx: 0,
+                context_id: 1,
+                name: "Workspace".to_string(),
+                workspace_name: String::new(),
+                metadata_chip: "ctx",
+                pane_pips: None,
+                pane_id: None,
+                search_text: "workspace".to_string(),
+            },
+        ];
+
+        sort_palette_entries(&mut entries, "");
+
+        assert!(matches!(entries[0], PaletteEntry::Context { .. }));
+        assert!(matches!(entries[1], PaletteEntry::App { .. }));
+        assert!(matches!(entries[2], PaletteEntry::Command { .. }));
+    }
+
+    #[test]
+    fn typed_palette_query_lets_commands_cut_through_group_order() {
+        let mut entries = vec![
+            PaletteEntry::App {
+                id: "config-viewer".to_string(),
+                name: "Config Viewer".to_string(),
+                description: "Demo".to_string(),
+                running_in_background: false,
+                is_workspace_local: false,
+                search_text: "demo config viewer".to_string(),
+            },
+            PaletteEntry::Command {
+                command: PaletteCommand::OpenConfig,
+                name: "Open config",
+                description: "Edit config",
+                search_text: "open config settings preferences",
+            },
+        ];
+
+        sort_palette_entries(&mut entries, "open");
+
+        assert!(matches!(entries[0], PaletteEntry::Command { .. }));
     }
 
     #[test]

--- a/src/overlays/ui_gallery.rs
+++ b/src/overlays/ui_gallery.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::ui::{
     button::{chrome_button, icon_button, toolbar_button, ButtonKind},
+    code_viewer::ReadOnlyCodeViewer,
     hints::{HintBar, HintGroup},
     labels::{chrome_section, description_label},
     list::ListRow,
@@ -50,6 +51,15 @@ impl PlexiApp {
                         });
 
                         chrome_section(ui, "Code and toast surfaces", &colors, |ui| {
+                            ReadOnlyCodeViewer::new(
+                                egui::Id::new("host_ui_gallery_code_viewer"),
+                                "fn main() {\n    println!(\"hello from Plexi\");\n}\n",
+                                "rs",
+                            )
+                            .line_numbers(true)
+                            .max_height(96.0)
+                            .show(ui, &colors);
+                            ui.add_space(style::SPACE_SM);
                             copyable_command(
                                 ui,
                                 egui::Id::new("host_ui_gallery_copyable_command"),

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -616,6 +616,28 @@ impl PlexiApp {
         log::info!("tab_click: switched to tab index={idx} in container={container_tile:?}");
     }
 
+    pub(crate) fn reorder_tab(
+        &mut self,
+        container_tile: TileId,
+        from_idx: usize,
+        to_idx: usize,
+    ) -> bool {
+        let ctx = &mut self.windows[self.active_window];
+        let Some(Tile::Container(Container::Tabs(tabs))) = ctx.tree.tiles.get_mut(container_tile)
+        else {
+            return false;
+        };
+        let len = tabs.children.len();
+        if from_idx >= len || to_idx >= len || from_idx == to_idx {
+            return false;
+        }
+
+        let moved = tabs.children.remove(from_idx);
+        tabs.children.insert(to_idx, moved);
+        log::info!("tab_reorder: container={container_tile:?} from_idx={from_idx} to_idx={to_idx}");
+        true
+    }
+
     pub(crate) fn close_focused(&mut self) {
         let focused = match self.windows[self.active_window].focused_pane {
             Some(f) => f,
@@ -1654,6 +1676,59 @@ mod close_pane_by_id_tests {
             window_id,
             context_id,
         }
+    }
+
+    fn install_tab_tree(app: &mut PlexiApp) -> (TileId, Vec<TileId>) {
+        let tiles = &mut app.windows[0].tree.tiles;
+        let children = vec![
+            tiles.insert_pane(100),
+            tiles.insert_pane(101),
+            tiles.insert_pane(102),
+        ];
+        let tabs_tile = tiles.insert_tab_tile(children.clone());
+        if let Some(Tile::Container(Container::Tabs(tabs))) =
+            app.windows[0].tree.tiles.get_mut(tabs_tile)
+        {
+            tabs.set_active(children[1]);
+        }
+        app.windows[0].tree.root = Some(tabs_tile);
+        app.windows[0].focused_pane = Some(children[1]);
+        app.windows[0].zoomed_pane = Some(children[1]);
+        (tabs_tile, children)
+    }
+
+    #[test]
+    fn reorder_tab_moves_child_without_changing_active_focus_or_zoom() {
+        let mut app = test_app();
+        let (tabs_tile, children) = install_tab_tree(&mut app);
+
+        assert!(app.reorder_tab(tabs_tile, 0, 2));
+
+        let Some(Tile::Container(Container::Tabs(tabs))) = app.windows[0].tree.tiles.get(tabs_tile)
+        else {
+            panic!("expected tabs container");
+        };
+        assert_eq!(
+            tabs.children,
+            vec![children[1], children[2], children[0]],
+            "reorder must move only the selected child tile"
+        );
+        assert_eq!(
+            tabs.active,
+            Some(children[1]),
+            "active tab tile must remain the same after reorder"
+        );
+        assert_eq!(app.windows[0].focused_pane, Some(children[1]));
+        assert_eq!(app.windows[0].zoomed_pane, Some(children[1]));
+    }
+
+    #[test]
+    fn reorder_tab_rejects_invalid_indices_and_non_tabs() {
+        let mut app = test_app();
+        let (tabs_tile, children) = install_tab_tree(&mut app);
+        assert!(!app.reorder_tab(tabs_tile, 0, 0));
+        assert!(!app.reorder_tab(tabs_tile, 0, 99));
+        assert!(!app.reorder_tab(children[0], 0, 1));
     }
 
     /// Regression guard for #917: closing the last pane in a non-active window

--- a/src/render/terminal_pane.rs
+++ b/src/render/terminal_pane.rs
@@ -11,7 +11,7 @@
 
 use crate::app_protocol::AgentState;
 use crate::host::pane::TerminalPane;
-use crate::spatial::tiling::{paint_tab_bar, PaneId, TabGroupInfo, TAB_BAR_HEIGHT};
+use crate::spatial::tiling::{paint_tab_bar, PaneId, TabBarAction, TabGroupInfo, TAB_BAR_HEIGHT};
 use crate::ui::theme::{self, Colors};
 use egui::Vec2;
 use egui_term::{TerminalTheme, TerminalView};
@@ -30,7 +30,7 @@ static LOG_TERMINAL_GLYPH_PADDING: Once = Once::new();
 
 /// Render one frame of a terminal pane. Returns `true` if the process has
 /// exited and the user pressed a key (the caller should close the tile).
-/// Returns (close_exited, tab_click).
+/// Returns (close_exited, tab_action).
 #[allow(clippy::too_many_arguments)]
 pub fn render(
     ui: &mut egui::Ui,
@@ -46,7 +46,7 @@ pub fn render(
     tab_activities: &HashMap<PaneId, AgentState>,
     workspace_root: Option<&Path>,
     pane_title_font_size: f32,
-) -> (bool, Option<(TileId, usize)>) {
+) -> (bool, Option<(TileId, TabBarAction)>) {
     if terminal.exited {
         let rect = ui.max_rect();
         ui.painter().rect_filled(rect, 0.0, colors.terminal_bg);
@@ -65,7 +65,7 @@ pub fn render(
     }
 
     let outside_workspace = is_terminal_outside_workspace(terminal, workspace_root);
-    let tab_click = render_name_bar_and_tabs(
+    let tab_action = render_name_bar_and_tabs(
         ui,
         tile_id,
         pane_id,
@@ -93,7 +93,7 @@ pub fn render(
         .set_size(Vec2::new(ui.available_width(), ui.available_height()));
     ui.add(view);
 
-    (false, tab_click)
+    (false, tab_action)
 }
 
 fn render_name_bar_and_tabs(
@@ -107,10 +107,10 @@ fn render_name_bar_and_tabs(
     colors: &Colors,
     outside_workspace: bool,
     name_font_size: f32,
-) -> Option<(TileId, usize)> {
+) -> Option<(TileId, TabBarAction)> {
     let has_name = pane_names.contains_key(pane_id);
     let tab_group = tab_info.get(&tile_id);
-    let mut tab_click = None;
+    let mut tab_action = None;
 
     if let Some(group) = tab_group {
         let bar_rect = egui::Rect::from_min_size(
@@ -118,7 +118,7 @@ fn render_name_bar_and_tabs(
             egui::vec2(ui.available_width(), TAB_BAR_HEIGHT),
         );
         ui.advance_cursor_after_rect(bar_rect);
-        if let Some(idx) = paint_tab_bar(
+        if let Some(action) = paint_tab_bar(
             ui.ctx(),
             ui.painter(),
             bar_rect,
@@ -129,7 +129,7 @@ fn render_name_bar_and_tabs(
             name_font_size,
             false,
         ) {
-            tab_click = Some((group.container_tile, idx));
+            tab_action = Some((group.container_tile, action));
         }
 
         if outside_workspace {
@@ -172,7 +172,7 @@ fn render_name_bar_and_tabs(
         }
     }
 
-    tab_click
+    tab_action
 }
 
 fn paint_activity_dot(

--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -14,6 +14,19 @@ pub type PaneId = u64;
 
 pub(crate) const TAB_BAR_HEIGHT: f32 = 20.0;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TabBarAction {
+    Switch(usize),
+    Reorder { from_idx: usize, to_idx: usize },
+}
+
+#[derive(Clone, Copy)]
+struct TabDragState {
+    container_tile: TileId,
+    from_idx: usize,
+    start_pos: egui::Pos2,
+}
+
 #[derive(Clone)]
 pub struct TabGroupInfo {
     pub active_idx: usize,
@@ -23,7 +36,31 @@ pub struct TabGroupInfo {
     pub container_tile: TileId,
 }
 
-/// Render a full-width tab bar and return the index of a clicked tab (if any).
+fn tab_drop_marker_x(bar_rect: egui::Rect, tab_width: f32, from_idx: usize, to_idx: usize) -> f32 {
+    let target_left = bar_rect.left() + to_idx as f32 * tab_width;
+    if to_idx > from_idx {
+        target_left + tab_width
+    } else {
+        target_left
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tab_drop_marker_tracks_insert_edge() {
+        let bar = egui::Rect::from_min_size(egui::pos2(10.0, 0.0), egui::vec2(300.0, 20.0));
+        let tab_width = 100.0;
+
+        assert_eq!(tab_drop_marker_x(bar, tab_width, 2, 0), 10.0);
+        assert_eq!(tab_drop_marker_x(bar, tab_width, 0, 2), 310.0);
+        assert_eq!(tab_drop_marker_x(bar, tab_width, 1, 1), 110.0);
+    }
+}
+
+/// Render a full-width tab bar and return a switch/reorder action, if any.
 /// The caller must pre-allocate `bar_rect` (typically `TAB_BAR_HEIGHT` px tall)
 /// and advance the cursor past it.
 pub(crate) fn paint_tab_bar(
@@ -36,7 +73,7 @@ pub(crate) fn paint_tab_bar(
     colors: &Colors,
     font_size: f32,
     overtake_hint: bool,
-) -> Option<usize> {
+) -> Option<TabBarAction> {
     painter.rect_filled(bar_rect, 0.0, colors.pane_header_bg());
 
     let tab_count = group.members.len();
@@ -48,14 +85,80 @@ pub(crate) fn paint_tab_bar(
     let accent_bar_height = 2.0;
     let font = egui::FontId::proportional(font_size);
 
-    let clicked = ctx.input(|i| {
-        if i.pointer.any_pressed() {
-            i.pointer.interact_pos()
-        } else {
-            None
+    let tab_idx_at = |pos: egui::Pos2| -> Option<usize> {
+        if !bar_rect.contains(pos) {
+            return None;
         }
+        Some((((pos.x - bar_rect.left()) / tab_width).floor() as usize).min(tab_count - 1))
+    };
+
+    let drag_id = egui::Id::new(("plexi_tab_drag", group.container_tile));
+    let (pressed, down, released, pos) = ctx.input(|i| {
+        (
+            i.pointer.primary_pressed(),
+            i.pointer.primary_down(),
+            i.pointer.any_released(),
+            i.pointer.interact_pos(),
+        )
     });
-    let mut clicked_idx = None;
+    let mut action = None;
+    let mut drag_marker: Option<(usize, egui::Pos2)> = None;
+
+    if pressed {
+        if let Some(pos) = pos {
+            if let Some(from_idx) = tab_idx_at(pos) {
+                ctx.data_mut(|d| {
+                    d.insert_temp(
+                        drag_id,
+                        TabDragState {
+                            container_tile: group.container_tile,
+                            from_idx,
+                            start_pos: pos,
+                        },
+                    );
+                });
+            }
+        }
+    }
+
+    if released {
+        let state = ctx.data(|d| d.get_temp::<TabDragState>(drag_id));
+        ctx.data_mut(|d| d.remove::<TabDragState>(drag_id));
+        if let (Some(state), Some(pos)) = (state, pos) {
+            if state.container_tile == group.container_tile {
+                let moved = pos.distance_sq(state.start_pos) > 16.0;
+                if moved {
+                    if let Some(to_idx) = tab_idx_at(pos) {
+                        if to_idx != state.from_idx {
+                            action = Some(TabBarAction::Reorder {
+                                from_idx: state.from_idx,
+                                to_idx,
+                            });
+                        }
+                    }
+                } else if let Some(idx) = tab_idx_at(pos) {
+                    if idx != group.active_idx {
+                        action = Some(TabBarAction::Switch(idx));
+                    }
+                }
+            }
+        }
+    } else if !down {
+        ctx.data_mut(|d| d.remove::<TabDragState>(drag_id));
+    } else if let Some(pos) = pos {
+        let state = ctx.data(|d| d.get_temp::<TabDragState>(drag_id));
+        if let Some(state) = state {
+            if state.container_tile == group.container_tile
+                && pos.distance_sq(state.start_pos) > 16.0
+            {
+                if let Some(to_idx) = tab_idx_at(pos) {
+                    if to_idx != state.from_idx {
+                        drag_marker = Some((state.from_idx, pos));
+                    }
+                }
+            }
+        }
+    }
 
     for (i, &pane_id) in group.members.iter().enumerate() {
         let is_active = i == group.active_idx;
@@ -66,12 +169,6 @@ pub(crate) fn paint_tab_bar(
 
         if is_active {
             painter.rect_filled(tab_rect, 0.0, colors.bg_active);
-        }
-
-        if let Some(pos) = clicked {
-            if tab_rect.contains(pos) && !is_active {
-                clicked_idx = Some(i);
-            }
         }
 
         // Vertical divider between tabs (skip before first)
@@ -137,6 +234,17 @@ pub(crate) fn paint_tab_bar(
         }
     }
 
+    if let Some((from_idx, pos)) = drag_marker {
+        if let Some(to_idx) = tab_idx_at(pos) {
+            let x = tab_drop_marker_x(bar_rect, tab_width, from_idx, to_idx);
+            let marker_rect = egui::Rect::from_center_size(
+                egui::pos2(x, bar_rect.center().y),
+                egui::vec2(3.0, TAB_BAR_HEIGHT - 3.0),
+            );
+            painter.rect_filled(marker_rect, 1.5, colors.accent);
+        }
+    }
+
     if overtake_hint {
         let hint_font = egui::FontId::monospace(font_size - 1.0);
         let hint_text = "Esc";
@@ -167,7 +275,7 @@ pub(crate) fn paint_tab_bar(
         );
     }
 
-    clicked_idx
+    action
 }
 
 /// What kind of pane occupies a minimap slot.
@@ -233,8 +341,8 @@ pub struct PlexiBehavior<'a> {
     pub theme: TerminalTheme,
     pub new_focused: Option<TileId>,
     pub close_exited: Option<TileId>,
-    /// Set when a tab bar click selects a different tab: (container_tile, child_index).
-    pub tab_click: Option<(TileId, usize)>,
+    /// Set when a tab bar switches or reorders tabs.
+    pub tab_action: Option<(TileId, TabBarAction)>,
     pub tab_info: HashMap<TileId, TabGroupInfo>,
     /// Pre-computed display label for each pane: user-set name, then app name, then type string.
     pub tab_labels: HashMap<PaneId, String>,
@@ -351,7 +459,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                 );
                 app_ui.advance_cursor_after_rect(bar_rect);
                 let is_overtaken = app_pane.overlay_replaced.is_some();
-                if let Some(idx) = paint_tab_bar(
+                if let Some(action) = paint_tab_bar(
                     app_ui.ctx(),
                     app_ui.painter(),
                     bar_rect,
@@ -362,7 +470,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                     self.pane_title_font_size,
                     is_overtaken,
                 ) {
-                    self.tab_click = Some((group.container_tile, idx));
+                    self.tab_action = Some((group.container_tile, action));
                 }
             }
 
@@ -371,7 +479,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             ui.painter()
                 .rect_filled(pane_rect, 0.0, self.colors.terminal_bg);
             let mut terminal_ui = ui.new_child(egui::UiBuilder::new().max_rect(pane_rect));
-            let (close_exited, tab_click) = render::terminal_pane::render(
+            let (close_exited, tab_action) = render::terminal_pane::render(
                 &mut terminal_ui,
                 terminal,
                 tile_id,
@@ -389,8 +497,8 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             if close_exited {
                 self.close_exited = Some(tile_id);
             }
-            if tab_click.is_some() {
-                self.tab_click = tab_click;
+            if tab_action.is_some() {
+                self.tab_action = tab_action;
             }
         } else if pane.as_portal().is_some() {
             // Portal tile — direct egui rendering.

--- a/src/ui/code_viewer.rs
+++ b/src/ui/code_viewer.rs
@@ -1,0 +1,92 @@
+use crate::ui::{style, syntax::SyntaxHighlighter, theme::Colors};
+
+pub(crate) struct ReadOnlyCodeViewer<'a> {
+    id: egui::Id,
+    code: &'a str,
+    language: &'a str,
+    line_numbers: bool,
+    max_height: Option<f32>,
+}
+
+impl<'a> ReadOnlyCodeViewer<'a> {
+    pub(crate) fn new(id: egui::Id, code: &'a str, language: &'a str) -> Self {
+        Self {
+            id,
+            code,
+            language,
+            line_numbers: false,
+            max_height: None,
+        }
+    }
+
+    pub(crate) fn line_numbers(mut self, line_numbers: bool) -> Self {
+        self.line_numbers = line_numbers;
+        self
+    }
+
+    pub(crate) fn max_height(mut self, max_height: f32) -> Self {
+        self.max_height = Some(max_height);
+        self
+    }
+
+    pub(crate) fn show(self, ui: &mut egui::Ui, colors: &Colors) -> egui::Response {
+        let code = if self.line_numbers {
+            numbered_code(self.code)
+        } else {
+            self.code.to_string()
+        };
+        let language = self.language;
+        let id = self.id;
+        let max_height = self.max_height.unwrap_or(220.0);
+
+        egui::Frame::new()
+            .fill(colors.bg_active)
+            .stroke(egui::Stroke::new(1.0, colors.border))
+            .corner_radius(style::RADIUS_MD)
+            .inner_margin(egui::Margin::symmetric(10, 8))
+            .show(ui, |ui| {
+                egui::ScrollArea::both()
+                    .id_salt(id)
+                    .max_height(max_height)
+                    .auto_shrink([false, false])
+                    .show(ui, |ui| {
+                        let job = SyntaxHighlighter::highlight(
+                            ui.ctx(),
+                            ui.style(),
+                            &code,
+                            language,
+                            colors,
+                        );
+                        ui.add(egui::Label::new(job).selectable(true))
+                    })
+                    .inner
+            })
+            .inner
+    }
+}
+
+fn numbered_code(code: &str) -> String {
+    let line_count = code.lines().count().max(1);
+    let width = line_count.to_string().len();
+    let mut out = String::with_capacity(code.len() + line_count * (width + 3));
+    for (idx, line) in code.lines().enumerate() {
+        use std::fmt::Write as _;
+        let _ = writeln!(&mut out, "{:>width$}  {line}", idx + 1, width = width);
+    }
+    if code.ends_with('\n') {
+        out
+    } else {
+        out.trim_end_matches('\n').to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::numbered_code;
+
+    #[test]
+    fn numbered_code_aligns_line_numbers() {
+        let numbered = numbered_code("one\ntwo\nthree");
+        assert_eq!(numbered, "1  one\n2  two\n3  three");
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 pub mod activity;
 pub mod button;
+pub mod code_viewer;
 pub mod dialog;
 pub mod focus;
 pub mod hints;
@@ -13,6 +14,7 @@ pub mod sidebar;
 pub mod sidebar_row;
 pub mod style;
 pub mod surface;
+pub mod syntax;
 pub mod text_field;
 pub mod theme;
 pub mod toast;

--- a/src/ui/syntax.rs
+++ b/src/ui/syntax.rs
@@ -1,0 +1,53 @@
+use egui::text::LayoutJob;
+
+use crate::ui::theme::Colors;
+
+pub(crate) struct SyntaxHighlighter;
+
+impl SyntaxHighlighter {
+    pub(crate) fn highlight(
+        ctx: &egui::Context,
+        style: &egui::Style,
+        code: &str,
+        language: &str,
+        colors: &Colors,
+    ) -> LayoutJob {
+        let mut style = style.clone();
+        style.visuals.dark_mode = !is_light_theme(colors);
+        style.visuals.override_text_color = Some(colors.text_primary);
+        style.visuals.extreme_bg_color = colors.bg_active;
+        style.visuals.code_bg_color = colors.bg_active;
+        style.visuals.hyperlink_color = colors.accent;
+        style.visuals.selection.bg_fill = colors.accent.gamma_multiply(0.35);
+        style.visuals.selection.stroke.color = colors.text_primary;
+
+        let theme = egui_extras::syntax_highlighting::CodeTheme::from_style(&style);
+        egui_extras::syntax_highlighting::highlight(ctx, &style, &theme, code, language)
+    }
+}
+
+fn is_light_theme(colors: &Colors) -> bool {
+    luminance(colors.bg_darkest) > luminance(colors.text_primary)
+}
+
+fn luminance(color: egui::Color32) -> f32 {
+    let rgba = egui::Rgba::from(color);
+    0.2126 * rgba.r() + 0.7152 * rgba.g() + 0.0722 * rgba.b()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn light_theme_detection_tracks_background_luminance() {
+        let mut cfg = crate::config::ThemeConfig::default();
+        cfg.bg_darkest = Some("#f6f6f6".to_string());
+        cfg.text_primary = Some("#111111".to_string());
+        assert!(is_light_theme(&Colors::from_config(&cfg)));
+
+        cfg.bg_darkest = Some("#111111".to_string());
+        cfg.text_primary = Some("#f6f6f6".to_string());
+        assert!(!is_light_theme(&Colors::from_config(&cfg)));
+    }
+}

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -69,7 +69,14 @@ impl Colors {
     pub fn text_on(&self, fill: Color32) -> Color32 {
         fn luminance(c: Color32) -> f32 {
             let rgba = egui::Rgba::from(c);
-            0.2126 * rgba.r() + 0.7152 * rgba.g() + 0.0722 * rgba.b()
+            fn linear(v: f32) -> f32 {
+                if v <= 0.03928 {
+                    v / 12.92
+                } else {
+                    ((v + 0.055) / 1.055).powf(2.4)
+                }
+            }
+            0.2126 * linear(rgba.r()) + 0.7152 * linear(rgba.g()) + 0.0722 * linear(rgba.b())
         }
         fn contrast(a: f32, b: f32) -> f32 {
             let (hi, lo) = if a > b { (a, b) } else { (b, a) };
@@ -239,24 +246,24 @@ pub fn is_light_preset(name: &str) -> bool {
     )
 }
 
-/// Returns the paired preset for `name` under `system_theme`, or `None` if the preset
-/// has no paired variant (nord, dracula), the name is unrecognized, or the preset is
-/// already correct for the current system appearance.
+/// Returns the paired preset for auto-style family aliases under
+/// `system_theme`, or `None` for explicit variants. `catppuccin` may follow
+/// the OS; `catppuccin-latte` and `catppuccin-mocha` mean exactly that flavor.
 pub fn paired_preset(name: &str, system_theme: egui::Theme) -> Option<&'static str> {
-    let canonical = canonical_preset_name(name)?;
+    let normalized = name.trim().to_lowercase().replace([' ', '_'], "-");
     match system_theme {
-        egui::Theme::Dark => match canonical {
-            "catppuccin-latte" => Some("catppuccin-mocha"),
-            "solarized-light" => Some("solarized-dark"),
-            "gruvbox-light" => Some("gruvbox-dark"),
-            "tokyo-day" => Some("tokyo-night"),
+        egui::Theme::Dark => match normalized.as_str() {
+            "catppuccin" => Some("catppuccin-mocha"),
+            "solarized" => Some("solarized-dark"),
+            "gruvbox" => Some("gruvbox-dark"),
+            "tokyo" | "tokyonight" => Some("tokyo-night"),
             _ => None,
         },
-        egui::Theme::Light => match canonical {
-            "catppuccin-mocha" => Some("catppuccin-latte"),
-            "solarized-dark" => Some("solarized-light"),
-            "gruvbox-dark" => Some("gruvbox-light"),
-            "tokyo-night" => Some("tokyo-day"),
+        egui::Theme::Light => match normalized.as_str() {
+            "catppuccin" => Some("catppuccin-latte"),
+            "solarized" => Some("solarized-light"),
+            "gruvbox" => Some("gruvbox-light"),
+            "tokyo" | "tokyonight" => Some("tokyo-day"),
             _ => None,
         },
     }
@@ -289,34 +296,34 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
             bg_darkest: s("#11111b"),
             bg_sidebar: s("#181825"),
             bg_toolbar: s("#181825"),
-            terminal_bg: s("#292a44"),
-            bg_hover: s("#2a2a3c"),
-            bg_sidebar_hover: s("#2e2e48"),
-            bg_active: s("#313144"),
+            terminal_bg: s("#1e1e2e"),
+            bg_hover: s("#313244"),
+            bg_sidebar_hover: s("#45475a"),
+            bg_active: s("#313244"),
             text_primary: s("#cdd6f4"),
-            text_dim: s("#6c7086"),
-            text_section: s("#585b70"),
+            text_dim: s("#a6adc8"),
+            text_section: s("#9399b2"),
             accent: s("#89b4fa"),
-            border: s("#2a2a3c"),
-            foreground: s("#e8e6ed"),
-            background: s("#292a44"),
-            black: s("#12131e"),
-            red: s("#dd7755"),
-            green: s("#04dbb5"),
-            yellow: s("#f2e7b7"),
-            blue: s("#7aa5ff"),
-            magenta: s("#bf9cf9"),
-            cyan: s("#56d3c2"),
-            white: s("#e4e3e9"),
-            bright_black: s("#666699"),
-            bright_red: s("#ff92cd"),
-            bright_green: s("#01eac0"),
-            bright_yellow: s("#fffca8"),
-            bright_blue: s("#69c0fa"),
-            bright_magenta: s("#c17ff8"),
-            bright_cyan: s("#8bfde1"),
-            bright_white: s("#f4f2f9"),
-            bright_foreground: s("#f4f2f9"),
+            border: s("#313244"),
+            foreground: s("#cdd6f4"),
+            background: s("#1e1e2e"),
+            black: s("#45475a"),
+            red: s("#f38ba8"),
+            green: s("#a6e3a1"),
+            yellow: s("#f9e2af"),
+            blue: s("#89b4fa"),
+            magenta: s("#f5c2e7"),
+            cyan: s("#94e2d5"),
+            white: s("#bac2de"),
+            bright_black: s("#6c7086"),
+            bright_red: s("#f38ba8"),
+            bright_green: s("#a6e3a1"),
+            bright_yellow: s("#f9e2af"),
+            bright_blue: s("#89b4fa"),
+            bright_magenta: s("#f5c2e7"),
+            bright_cyan: s("#94e2d5"),
+            bright_white: s("#cdd6f4"),
+            bright_foreground: s("#cdd6f4"),
             ..ThemeConfig::default()
         }),
         "dracula" => Some(ThemeConfig {
@@ -566,16 +573,16 @@ pub fn preset_colors(name: &str) -> Option<ThemeConfig> {
         }),
         "catppuccin-latte" => Some(ThemeConfig {
             preset: None,
-            bg_darkest: s("#e6e9ef"),
+            bg_darkest: s("#dce0e8"),
             bg_sidebar: s("#eff1f5"),
             bg_toolbar: s("#eff1f5"),
             terminal_bg: s("#eff1f5"),
-            bg_hover: s("#dce0e8"),
+            bg_hover: s("#e6e9ef"),
             bg_sidebar_hover: s("#ccd0da"),
-            bg_active: s("#bcc0cc"),
+            bg_active: s("#ccd0da"),
             text_primary: s("#4c4f69"),
-            text_dim: s("#8c8fa1"),
-            text_section: s("#9ca0b0"),
+            text_dim: s("#6c6f85"),
+            text_section: s("#5c5f77"),
             accent: s("#8839ef"),
             border: s("#ccd0da"),
             foreground: s("#4c4f69"),
@@ -970,7 +977,14 @@ mod tests {
     fn text_on_is_legible_on_every_preset_accent_and_danger() {
         fn luminance(c: Color32) -> f32 {
             let rgba = egui::Rgba::from(c);
-            0.2126 * rgba.r() + 0.7152 * rgba.g() + 0.0722 * rgba.b()
+            fn linear(v: f32) -> f32 {
+                if v <= 0.03928 {
+                    v / 12.92
+                } else {
+                    ((v + 0.055) / 1.055).powf(2.4)
+                }
+            }
+            0.2126 * linear(rgba.r()) + 0.7152 * linear(rgba.g()) + 0.0722 * linear(rgba.b())
         }
         fn contrast(a: Color32, b: Color32) -> f32 {
             let (hi, lo) = if luminance(a) > luminance(b) {
@@ -990,6 +1004,89 @@ mod tests {
                     "{name}: text_on({fill:?}) = {text:?} is below 3:1 contrast"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn catppuccin_presets_use_official_flavor_tokens() {
+        let mocha = preset_colors("catppuccin-mocha").unwrap();
+        assert_eq!(mocha.background.as_deref(), Some("#1e1e2e"));
+        assert_eq!(mocha.foreground.as_deref(), Some("#cdd6f4"));
+        assert_eq!(mocha.bg_darkest.as_deref(), Some("#11111b"));
+        assert_eq!(mocha.bg_sidebar.as_deref(), Some("#181825"));
+        assert_eq!(mocha.terminal_bg.as_deref(), Some("#1e1e2e"));
+        assert_eq!(mocha.red.as_deref(), Some("#f38ba8"));
+        assert_eq!(mocha.green.as_deref(), Some("#a6e3a1"));
+        assert_eq!(mocha.blue.as_deref(), Some("#89b4fa"));
+
+        let latte = preset_colors("catppuccin-latte").unwrap();
+        assert_eq!(latte.background.as_deref(), Some("#eff1f5"));
+        assert_eq!(latte.foreground.as_deref(), Some("#4c4f69"));
+        assert_eq!(latte.bg_darkest.as_deref(), Some("#dce0e8"));
+        assert_eq!(latte.bg_sidebar.as_deref(), Some("#eff1f5"));
+        assert_eq!(latte.terminal_bg.as_deref(), Some("#eff1f5"));
+        assert_eq!(latte.red.as_deref(), Some("#d20f39"));
+        assert_eq!(latte.green.as_deref(), Some("#40a02b"));
+        assert_eq!(latte.blue.as_deref(), Some("#1e66f5"));
+    }
+
+    #[test]
+    fn explicit_catppuccin_variants_do_not_auto_flip() {
+        assert_eq!(paired_preset("catppuccin-latte", egui::Theme::Dark), None);
+        assert_eq!(paired_preset("catppuccin-mocha", egui::Theme::Light), None);
+        assert_eq!(
+            paired_preset("catppuccin", egui::Theme::Light),
+            Some("catppuccin-latte")
+        );
+        assert_eq!(
+            paired_preset("catppuccin", egui::Theme::Dark),
+            Some("catppuccin-mocha")
+        );
+    }
+
+    #[test]
+    fn catppuccin_latte_secondary_text_is_legible_on_primary_surfaces() {
+        fn luminance(c: Color32) -> f32 {
+            let rgba = egui::Rgba::from(c);
+            fn linear(v: f32) -> f32 {
+                if v <= 0.03928 {
+                    v / 12.92
+                } else {
+                    ((v + 0.055) / 1.055).powf(2.4)
+                }
+            }
+            0.2126 * linear(rgba.r()) + 0.7152 * linear(rgba.g()) + 0.0722 * linear(rgba.b())
+        }
+        fn contrast(a: Color32, b: Color32) -> f32 {
+            let (hi, lo) = if luminance(a) > luminance(b) {
+                (luminance(a), luminance(b))
+            } else {
+                (luminance(b), luminance(a))
+            };
+            (hi + 0.05) / (lo + 0.05)
+        }
+
+        let cfg = preset_colors("catppuccin-latte").unwrap();
+        let colors = Colors::from_config(&cfg);
+        for surface in [
+            colors.bg_darkest,
+            colors.bg_sidebar,
+            colors.bg_toolbar,
+            colors.terminal_bg,
+            colors.bg_hover,
+        ] {
+            assert!(
+                contrast(colors.text_primary, surface) >= 4.5,
+                "catppuccin-latte: text_primary below 4.5:1 on {surface:?}"
+            );
+            assert!(
+                contrast(colors.text_dim, surface) >= 3.0,
+                "catppuccin-latte: text_dim below 3:1 on {surface:?}"
+            );
+            assert!(
+                contrast(colors.text_section, surface) >= 3.0,
+                "catppuccin-latte: text_section below 3:1 on {surface:?}"
+            );
         }
     }
 }

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -936,6 +936,32 @@ mod tests {
     }
 
     #[test]
+    fn screenshot_catppuccin_latte_command_palette() {
+        let mut h = PlexiUiHarness::new_sized(1168.0, 720.0);
+        add_focused_pane(&mut h);
+        h.with_app_mut(|app| {
+            let cfg = crate::ui::theme::preset_colors("catppuccin-latte")
+                .expect("catppuccin latte preset must exist");
+            app.colors = crate::ui::theme::Colors::from_config(&cfg);
+            app.theme = crate::ui::theme::terminal_theme(&cfg);
+            crate::ui::theme::setup_style(&app.ctx, &app.colors, false);
+            app.show_command_palette = true;
+            app.sync_command_palette_focus();
+        });
+        h.run_steps(3);
+        let img = h.render().expect("render failed");
+        img.save("/tmp/plexi_catppuccin_latte_palette.png")
+            .expect("save screenshot");
+        let center = img.get_pixel(img.width() / 2, img.height() / 2).0;
+        let center_luma = (u16::from(center[0]) + u16::from(center[1]) + u16::from(center[2])) / 3;
+        assert!(
+            center_luma > 180,
+            "Catppuccin Latte palette center should be light, got rgba={center:?}"
+        );
+        println!("Screenshot saved to /tmp/plexi_catppuccin_latte_palette.png");
+    }
+
+    #[test]
     fn command_palette_keeps_search_focus_after_scrolled_down_nav() {
         let mut h = PlexiUiHarness::new_sized(1168.0, 720.0);
         add_focused_pane(&mut h);

--- a/website/src/content/docs/config.md
+++ b/website/src/content/docs/config.md
@@ -9,6 +9,14 @@ Plexi reads `config.toml` from the active channel profile. Alpha uses `~/.plexi-
 
 Changes take effect on the next launch unless a command says otherwise.
 
+## Channel discipline
+
+Alpha config stays default. `just install` refreshes `~/.plexi-alpha/config.toml` from the built-in template, and PR builds seed from alpha. Do not use alpha for personal overrides you expect to keep.
+
+Beta config is the staging ground. `~/.plexi-beta/config.toml` is not reset by alpha installs, so it is the right place to test migrations, advanced settings, and personal config before promoting a release.
+
+PR builds are isolated. A PR build reads `~/.plexi-pr-<N>/config.toml`; use the `plexi-pr-<N>` binary when checking a PR-specific config behavior.
+
 ## Commands
 
 ```sh
@@ -27,7 +35,7 @@ Pick a preset at the top level:
 theme_preset = "catppuccin-mocha"
 ```
 
-Available presets: `catppuccin-mocha`, `catppuccin-latte`, `dracula`, `tokyo-night`, `gruvbox-dark`, `nord`, `solarized-dark`, `solarized-light`.
+Available presets: `catppuccin-mocha`, `catppuccin-latte`, `dracula`, `tokyo-night`, `tokyo-day`, `gruvbox-dark`, `gruvbox-light`, `nord`, `solarized-dark`, `solarized-light`.
 
 Override individual colors under `[theme]`:
 
@@ -153,7 +161,7 @@ font_size = 14.0
 # pane_title_font_size = 11
 
 # ── Theme ──────────────────────────────────────────────────────
-# Presets: catppuccin-mocha, catppuccin-latte, dracula, tokyo-night, gruvbox-dark, nord, solarized-dark, solarized-light
+# Presets: catppuccin-mocha, catppuccin-latte, dracula, tokyo-night, tokyo-day, gruvbox-dark, gruvbox-light, nord, solarized-dark, solarized-light
 theme_preset = "catppuccin-mocha"
 
 # ── Confirmation Dialogs ───────────────────────────────────────


### PR DESCRIPTION
## Summary
- Audited ready .stint tasks before implementation; marked 0157, 0159, and 0160 done because current alpha already had those changes.
- Adds command palette host command aliases/search haystacks, shared syntax highlighter/read-only code viewer, shallow same-tab reorder, Catppuccin preset fixes, and config/security docs guards.
- Follow-up polish: empty palette now keeps host commands below apps, adds Scratch Pad as a host command, paints a tab drag insertion marker, and locks explicit Catppuccin Latte/Mocha against system-theme auto-flip.
- Fixes Python 3.9 runtime annotation failures exposed by SDK smoke in maintained apps/SDK helpers.
- Marks completed stint tasks 0031, 0066, 0067, 0069, 0153, 0189, and 0195 done with timing/variance notes; adds a backlog task for the follow-up issue commands.toml palette hot reload.

## Test evidence
- cargo build
- cargo test --bin plexi (1192 passed, 0 failed, 1 ignored)
- cargo test --bin plexi palette (17 passed)
- cargo test --bin plexi catppuccin (4 passed)
- cargo test --bin plexi tab_drop_marker_tracks_insert_edge (1 passed)
- cargo test --bin plexi process_app::tests::reload_tests::render_events_coalesced_non_render_events_preserved -- --nocapture (focused rerun of first-run flake from earlier pass)
- just sdk-smoke (7 passed)
- uv run --project sdk/python --with pytest --with pytest-asyncio pytest sdk/python/tests -q (202 passed earlier in this PR)
- stint check

## Screenshot evidence
- /tmp/plexi_catppuccin_latte_palette.png — inspected locally; shows light Catppuccin Latte palette with purple accent, app row first, COMMANDS section below it, Quick Note and Scratch Pad rows present.

## Spot checks
- Command palette empty state: context/app/note rows stay above COMMANDS; host commands are no longer pinned to the top.
- Command palette fuzzy search: search shell, console, hsplit, config, quick, and scratch; confirm matching host commands can still cut through ordering and execute.
- Scratch Pad command: select it from the palette and confirm a fresh text-editor scratch note opens.
- Drag tabs within one tab group; confirm the accent insertion marker appears while dragging and active/focused/zoomed panes remain stable after drop.
- Host UI Gallery code viewer: confirm highlighted code and line numbers look acceptable in light and dark themes.
- Catppuccin Latte/Mocha: confirm explicit preset selection does not flip based on macOS appearance, and Latte dim/section text is readable on toolbar, sidebar, and terminal surfaces.
- Core app smoke: open Snake, CSV Viewer, and GitHub Issues on the PR build to confirm Python 3.9-compatible annotations do not block startup.
- Docs: verify config channel wording and preset lists match alpha-default, beta-staging, PR-isolated policy, and the shipped preset table.

