### PR TITLE
feat(sidebar): drag contexts to reorder, park, and unpark across sections

### DIFF
--- a/justfile
+++ b/justfile
@@ -117,8 +117,10 @@ sdk-dev:
     uv pip install -e sdk/python
 
 # Headless SDK/app contract smoke: Init -> Ready -> Render -> FrameDone.
+# Pin to the bundled runtime's minor version so uv never falls back to a
+# system Python (e.g. CommandLineTools 3.9) that predates the SDK's floor.
 sdk-smoke:
-    uv run --project sdk/python --with pytest --with pytest-asyncio pytest sdk/python/tests/test_app_harness.py -q
+    uv run --python 3.12 --project sdk/python --with pytest --with pytest-asyncio pytest sdk/python/tests/test_app_harness.py -q
 
 # Build and install the current worktree as a testable PR build.
 # Installs as "Plexi PR<number>.app" with isolated profile ~/.plexi-pr-<number>/.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -3,7 +3,7 @@ name = "plexi-sdk"
 version = "0.4.0"
 description = "Python SDK for building Plexi apps via the PGAP v3 protocol"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 license = { text = "MIT" }
 authors = [{ name = "Ian Burke", email = "ianjamesburke@gmail.com" }]
 keywords = ["plexi", "pgap", "sdk", "tiling", "window-manager", "apps"]
@@ -12,10 +12,8 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
 ]
 
@@ -35,7 +33,7 @@ packages = ["plexi_sdk"]
 include = ["plexi_sdk/", "README.md"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.12"
 strict = false
 ignore_missing_imports = true
 check_untyped_defs = true

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 
 [[package]]
 name = "plexi-sdk"

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -521,15 +521,12 @@ impl PlexiApp {
         // Drop affordances: highlight the Parked header, or draw the reorder line.
         match drop_target {
             Some(SidebarDrop::Park) => {
+                // Outline the Parked header as a drop target. Border only — a
+                // filled rect here paints over the already-drawn header text
+                // (drawn earlier this frame) and would hide the "Parked" label.
                 if let Some(rect) = parked_header_rect {
-                    let inset = rect.shrink(2.0);
-                    ui.painter().rect_filled(
-                        inset,
-                        crate::ui::style::RADIUS_SM,
-                        self.colors.bg_hover,
-                    );
                     ui.painter().rect_stroke(
-                        inset,
+                        rect.shrink(2.0),
                         crate::ui::style::RADIUS_SM,
                         Stroke::new(1.5, self.colors.accent),
                         egui::StrokeKind::Inside,

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -533,9 +533,9 @@ impl PlexiApp {
                         SidebarAction::DragEnd => {
                             drag_released = true;
                         }
-                        SidebarAction::Activate => {
-                            unpark_context = Some(i);
-                        }
+                        // A plain click must not unpark — parked contexts only
+                        // come back via a drag into the active list or the
+                        // right-click "Unpark" action. Clicking is inert.
                         _ => {}
                     }
                 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -16,34 +16,54 @@ fn drop_slot_from_rects(rects: &[Rect], mouse_y: f32) -> usize {
     rects.len()
 }
 
-/// Where a context drag will land when released. `Reorder` carries the raw
-/// drop slot (an index into the active-row boundaries, not the final position).
+/// Where a dragged context will land when released: which section (active vs.
+/// parked) and the slot within that section's display list. A drop fully
+/// determines both the context's `parked` flag and its order.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum SidebarDrop {
-    Park,
-    Reorder(usize),
+struct SidebarDrop {
+    parked: bool,
+    slot: usize,
 }
 
-/// Resolve a dragged context (`src`) against the current pointer position.
-/// Releasing over the Parked header parks; otherwise it reorders. Returns
-/// `None` when the pointer is over the source's own slot (a no-op move).
+/// Resolve a dragged context against the current pointer position. The Parked
+/// header acts as the boundary: anything at or below it targets the parked
+/// section, anything above targets the active section. Within a section the
+/// slot is the insertion index between rows. Returns `None` when the drop would
+/// leave the context exactly where it already is (a no-op).
+///
+/// `src_parked`/`src_slot` describe the dragged context's current position so
+/// same-section no-op drops (onto its own row edges) can be filtered out.
 fn resolve_drag_drop(
-    src: usize,
+    src_parked: bool,
+    src_slot: usize,
     parked_header: Option<Rect>,
     pointer: Option<egui::Pos2>,
-    row_rects: &[Rect],
+    active_rects: &[Rect],
+    parked_rects: &[Rect],
 ) -> Option<SidebarDrop> {
-    if let (Some(rect), Some(pos)) = (parked_header, pointer) {
-        if rect.contains(pos) {
-            return Some(SidebarDrop::Park);
-        }
-    }
     let pos = pointer?;
-    let dst = drop_slot_from_rects(row_rects, pos.y);
-    if dst != src && dst != src + 1 {
-        Some(SidebarDrop::Reorder(dst))
+    let into_parked = parked_header.map_or(false, |h| pos.y >= h.top());
+    let rects = if into_parked { parked_rects } else { active_rects };
+    let slot = drop_slot_from_rects(rects, pos.y);
+    // Same-section drop onto the source's own edges leaves it in place.
+    if into_parked == src_parked && (slot == src_slot || slot == src_slot + 1) {
+        return None;
+    }
+    Some(SidebarDrop {
+        parked: into_parked,
+        slot,
+    })
+}
+
+/// Y coordinate of the reorder indicator line for a drop at `slot` within
+/// `rects` (the section's row rectangles, in display order).
+fn reorder_line_y(rects: &[Rect], slot: usize) -> f32 {
+    if slot == 0 {
+        rects.first().map_or(0.0, |r| r.min.y)
+    } else if slot >= rects.len() {
+        rects.last().map_or(0.0, |r| r.max.y)
     } else {
-        None
+        rects[slot - 1].max.y
     }
 }
 
@@ -74,7 +94,8 @@ impl PlexiApp {
         let mut clicked_workspace: Option<usize> = None;
         let mut delete_context: Option<usize> = None;
         let mut menu_action: Option<(usize, WindowMenuAction)> = None;
-        let mut row_rects: Vec<Rect> = Vec::with_capacity(num_contexts);
+        let mut active_rects: Vec<Rect> = Vec::with_capacity(num_contexts);
+        let mut parked_rects: Vec<Rect> = Vec::with_capacity(num_contexts);
         let mut drag_released = false;
         let mut unpark_context: Option<usize> = None;
 
@@ -253,7 +274,7 @@ impl PlexiApp {
                     ui.add_space(4.0);
                 });
                 let row_rect = scope.response.rect;
-                row_rects.push(row_rect);
+                active_rects.push(row_rect);
                 ui.painter().set(
                     bg_idx,
                     egui::Shape::rect_filled(row_rect, CornerRadius::ZERO, fill),
@@ -298,7 +319,7 @@ impl PlexiApp {
             }
             .draw(ui, egui::Id::new(("ctx", i)), &self.colors);
 
-            row_rects.push(response.rect);
+            active_rects.push(response.rect);
 
             match action {
                 SidebarAction::DragStart => {
@@ -483,8 +504,8 @@ impl PlexiApp {
 
                     let (action, response) = ContextItem {
                         is_active: false,
-                        is_dragging: false,
-                        any_dragging: false,
+                        is_dragging: self.drag_context == Some(i),
+                        any_dragging: self.drag_context.is_some(),
                         action_enabled: false,
                         ctx_name,
                         ctx_index: None,
@@ -492,9 +513,11 @@ impl PlexiApp {
                         subtitle,
                         pane_dots,
                         indent,
-                        draggable: false,
+                        draggable: true,
                     }
                     .draw(ui, egui::Id::new(("parked_ctx", i)), &self.colors);
+
+                    parked_rects.push(response.rect);
 
                     response.context_menu(|ui| {
                         if ui.button("Unpark").clicked() {
@@ -503,27 +526,59 @@ impl PlexiApp {
                         }
                     });
 
-                    if matches!(action, SidebarAction::Activate) {
-                        unpark_context = Some(i);
+                    match action {
+                        SidebarAction::DragStart => {
+                            self.drag_context = Some(i);
+                        }
+                        SidebarAction::DragEnd => {
+                            drag_released = true;
+                        }
+                        SidebarAction::Activate => {
+                            unpark_context = Some(i);
+                        }
+                        _ => {}
                     }
                 }
             }
         }
 
         // Resolve the drag target once and use it for both the drop affordance
-        // and the release action. Releasing over the Parked header parks the
-        // context; otherwise it reorders the active list.
+        // and the release action. The Parked header is the section boundary:
+        // dropping at/below it targets the parked list, above it the active
+        // list — in either case at a chosen slot, so a drag can park, unpark,
+        // and reorder within either list.
         let pointer_pos = ui.input(|i| i.pointer.hover_pos());
-        let drop_target = self
-            .drag_context
-            .and_then(|src| resolve_drag_drop(src, parked_header_rect, pointer_pos, &row_rects));
+        let src_section = self.drag_context.map(|src| {
+            let src_parked = self.router.get(src).parked;
+            let src_slot = if src_parked {
+                parked_order.iter().position(|&i| i == src).unwrap_or(0)
+            } else {
+                active_order.iter().position(|&i| i == src).unwrap_or(0)
+            };
+            (src_parked, src_slot)
+        });
+        let drop_target = src_section.and_then(|(src_parked, src_slot)| {
+            resolve_drag_drop(
+                src_parked,
+                src_slot,
+                parked_header_rect,
+                pointer_pos,
+                &active_rects,
+                &parked_rects,
+            )
+        });
 
-        // Drop affordances: highlight the Parked header, or draw the reorder line.
-        match drop_target {
-            Some(SidebarDrop::Park) => {
-                // Outline the Parked header as a drop target. Border only — a
-                // filled rect here paints over the already-drawn header text
-                // (drawn earlier this frame) and would hide the "Parked" label.
+        // Drop affordance: a reorder line within the target section, or — when
+        // dropping into an empty Parked list — an outline of the header itself.
+        if let Some(drop) = drop_target {
+            let target_rects = if drop.parked {
+                &parked_rects
+            } else {
+                &active_rects
+            };
+            if drop.parked && parked_rects.is_empty() {
+                // Border only — a fill would paint over the header label drawn
+                // earlier this frame and hide the "Parked" text.
                 if let Some(rect) = parked_header_rect {
                     ui.painter().rect_stroke(
                         rect.shrink(2.0),
@@ -532,16 +587,9 @@ impl PlexiApp {
                         egui::StrokeKind::Inside,
                     );
                 }
-            }
-            Some(SidebarDrop::Reorder(dst)) => {
-                let line_y = if dst == 0 {
-                    row_rects.first().map_or(0.0, |r| r.min.y)
-                } else if dst >= row_rects.len() {
-                    row_rects.last().map_or(0.0, |r| r.max.y)
-                } else {
-                    row_rects[dst - 1].max.y
-                };
-                let x0 = row_rects.first().map_or(0.0, |r| r.min.x);
+            } else {
+                let line_y = reorder_line_y(target_rects, drop.slot);
+                let x0 = target_rects.first().map_or(0.0, |r| r.min.x);
                 ui.painter().line_segment(
                     [
                         egui::pos2(x0, line_y),
@@ -550,24 +598,73 @@ impl PlexiApp {
                     Stroke::new(2.0, self.colors.accent),
                 );
             }
-            None => {}
         }
 
         if drag_released {
-            if let Some(src) = self.drag_context {
-                match drop_target {
-                    Some(SidebarDrop::Park) => {
-                        log::info!("sidebar: drag-park context idx={src}");
-                        self.renaming_window = None;
-                        self.park_context(src);
-                    }
-                    Some(SidebarDrop::Reorder(dst)) => {
-                        let effective_dst = if dst > src { dst - 1 } else { dst };
-                        self.renaming_window = None;
-                        self.router.reorder_tracking_active(src, effective_dst);
-                    }
-                    None => {}
+            if let (Some(src), Some(drop), Some((src_parked, src_slot))) =
+                (self.drag_context, drop_target, src_section)
+            {
+                // Rebuild the active/parked section lists with `src` moved to its
+                // new home, then commit the full ordering + parked flag at once.
+                let mut new_active = active_order.clone();
+                let mut new_parked = parked_order.clone();
+                if src_parked {
+                    new_parked.retain(|&i| i != src);
+                } else {
+                    new_active.retain(|&i| i != src);
                 }
+                let dest = if drop.parked {
+                    &mut new_parked
+                } else {
+                    &mut new_active
+                };
+                // Same-section moves past the source's old slot shift down by one
+                // once it is removed.
+                let slot = if drop.parked == src_parked && drop.slot > src_slot {
+                    drop.slot - 1
+                } else {
+                    drop.slot
+                };
+                dest.insert(slot.min(dest.len()), src);
+
+                let src_id = self.router.get(src).context_id;
+                let was_active = self.router.active_idx() == src;
+                self.router.get_mut(src).parked = drop.parked;
+                let mut new_order = new_active;
+                new_order.extend(new_parked);
+                self.router.apply_order(&new_order);
+                self.renaming_window = None;
+
+                let new_src_idx = self
+                    .router
+                    .position(|c| c.context_id == src_id)
+                    .unwrap_or(self.router.active_idx());
+                if drop.parked && !src_parked {
+                    log::info!("sidebar: drag-park context id={src_id} slot={}", drop.slot);
+                    if was_active {
+                        // Hand focus to the nearest unparked neighbor.
+                        let len = self.router.len();
+                        let next = (1..len)
+                            .map(|o| (new_src_idx + o) % len)
+                            .find(|&i| !self.router.get(i).parked);
+                        if let Some(n) = next {
+                            self.switch_workspace(n);
+                        }
+                    }
+                } else if !drop.parked && src_parked {
+                    log::info!(
+                        "sidebar: drag-unpark context id={src_id} slot={}",
+                        drop.slot
+                    );
+                    self.switch_workspace(new_src_idx);
+                } else {
+                    log::info!(
+                        "sidebar: drag-reorder context id={src_id} parked={} slot={}",
+                        drop.parked,
+                        drop.slot
+                    );
+                }
+                self.save_workspace();
             }
             self.drag_context = None;
         }
@@ -669,51 +766,111 @@ impl PlexiApp {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_drag_drop, SidebarDrop};
+    use super::{reorder_line_y, resolve_drag_drop, SidebarDrop};
     use egui::{pos2, vec2, Rect};
 
-    fn rows() -> Vec<Rect> {
-        // Two stacked active rows: centers at y=10 and y=30.
+    // Two stacked active rows (y in [0,20] and [20,40]), the Parked header at
+    // y in [50,70], and two parked rows below it (y in [70,90] and [90,110]).
+    fn active_rects() -> Vec<Rect> {
         vec![
             Rect::from_min_size(pos2(0.0, 0.0), vec2(100.0, 20.0)),
             Rect::from_min_size(pos2(0.0, 20.0), vec2(100.0, 20.0)),
         ]
     }
-
-    // The Parked header sits below the rows: y in [50, 70].
+    fn parked_rects() -> Vec<Rect> {
+        vec![
+            Rect::from_min_size(pos2(0.0, 70.0), vec2(100.0, 20.0)),
+            Rect::from_min_size(pos2(0.0, 90.0), vec2(100.0, 20.0)),
+        ]
+    }
     fn header() -> Rect {
         Rect::from_min_size(pos2(0.0, 50.0), vec2(100.0, 20.0))
     }
 
-    #[test]
-    fn releasing_over_parked_header_parks() {
-        let target = resolve_drag_drop(0, Some(header()), Some(pos2(10.0, 60.0)), &rows());
-        assert_eq!(target, Some(SidebarDrop::Park));
+    fn resolve(
+        src_parked: bool,
+        src_slot: usize,
+        pointer_y: f32,
+        parked_rects: &[Rect],
+    ) -> Option<SidebarDrop> {
+        resolve_drag_drop(
+            src_parked,
+            src_slot,
+            Some(header()),
+            Some(pos2(10.0, pointer_y)),
+            &active_rects(),
+            parked_rects,
+        )
     }
 
     #[test]
-    fn park_takes_priority_when_no_parked_header_exists() {
-        // No header rendered (no parked contexts, not dragging) → never parks.
-        let target = resolve_drag_drop(0, None, Some(pos2(10.0, 60.0)), &rows());
-        assert!(!matches!(target, Some(SidebarDrop::Park)));
+    fn active_dragged_into_empty_parked_parks() {
+        // No parked rows yet; dropping below the header targets parked slot 0.
+        let target = resolve(false, 0, 60.0, &[]);
+        assert_eq!(target, Some(SidebarDrop { parked: true, slot: 0 }));
     }
 
     #[test]
-    fn releasing_below_other_rows_reorders() {
-        // Dragging row 0, pointer past the last row → reorder to the bottom slot.
-        let target = resolve_drag_drop(0, Some(header()), Some(pos2(10.0, 45.0)), &rows());
-        assert_eq!(target, Some(SidebarDrop::Reorder(2)));
+    fn active_dragged_between_parked_rows_picks_slot() {
+        // Pointer over the gap between the two parked rows → parked slot 1.
+        let target = resolve(false, 0, 88.0, &parked_rects());
+        assert_eq!(target, Some(SidebarDrop { parked: true, slot: 1 }));
     }
 
     #[test]
-    fn releasing_on_own_slot_is_a_noop() {
-        // Dragging row 0, pointer still over row 0 → no move.
-        let target = resolve_drag_drop(0, Some(header()), Some(pos2(10.0, 5.0)), &rows());
-        assert_eq!(target, None);
+    fn parked_dragged_into_active_unparks_at_slot() {
+        // Dragging parked row, pointer over the first active row → active slot 0.
+        let target = resolve(true, 0, 5.0, &parked_rects());
+        assert_eq!(target, Some(SidebarDrop { parked: false, slot: 0 }));
+    }
+
+    #[test]
+    fn reorder_within_active_list() {
+        // Dragging active row 0 down past the last active row → active slot 2.
+        let target = resolve(false, 0, 35.0, &parked_rects());
+        assert_eq!(target, Some(SidebarDrop { parked: false, slot: 2 }));
+    }
+
+    #[test]
+    fn reorder_within_parked_list() {
+        // Dragging parked row 0 (src_slot 0) past parked row 1 → parked slot 2.
+        let target = resolve(true, 0, 105.0, &parked_rects());
+        assert_eq!(target, Some(SidebarDrop { parked: true, slot: 2 }));
+    }
+
+    #[test]
+    fn dropping_on_own_active_slot_is_a_noop() {
+        // Active row 0, pointer still over row 0 (slot 0 or 1) → no move.
+        assert_eq!(resolve(false, 0, 5.0, &parked_rects()), None);
+        assert_eq!(resolve(false, 0, 25.0, &parked_rects()), None);
+    }
+
+    #[test]
+    fn dropping_on_own_parked_slot_is_a_noop() {
+        // Parked row 0 (src_slot 0), pointer over its own row edges → no move.
+        assert_eq!(resolve(true, 0, 75.0, &parked_rects()), None);
+        assert_eq!(resolve(true, 0, 95.0, &parked_rects()), None);
     }
 
     #[test]
     fn no_pointer_is_a_noop() {
-        assert_eq!(resolve_drag_drop(0, Some(header()), None, &rows()), None);
+        let target = resolve_drag_drop(
+            false,
+            0,
+            Some(header()),
+            None,
+            &active_rects(),
+            &parked_rects(),
+        );
+        assert_eq!(target, None);
+    }
+
+    #[test]
+    fn reorder_line_y_clamps_to_section_bounds() {
+        let rects = active_rects();
+        assert_eq!(reorder_line_y(&rects, 0), 0.0); // top edge
+        assert_eq!(reorder_line_y(&rects, 1), 20.0); // between rows
+        assert_eq!(reorder_line_y(&rects, 2), 40.0); // bottom edge
+        assert_eq!(reorder_line_y(&rects, 99), 40.0); // past end clamps
     }
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -16,6 +16,37 @@ fn drop_slot_from_rects(rects: &[Rect], mouse_y: f32) -> usize {
     rects.len()
 }
 
+/// Where a context drag will land when released. `Reorder` carries the raw
+/// drop slot (an index into the active-row boundaries, not the final position).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum SidebarDrop {
+    Park,
+    Reorder(usize),
+}
+
+/// Resolve a dragged context (`src`) against the current pointer position.
+/// Releasing over the Parked header parks; otherwise it reorders. Returns
+/// `None` when the pointer is over the source's own slot (a no-op move).
+fn resolve_drag_drop(
+    src: usize,
+    parked_header: Option<Rect>,
+    pointer: Option<egui::Pos2>,
+    row_rects: &[Rect],
+) -> Option<SidebarDrop> {
+    if let (Some(rect), Some(pos)) = (parked_header, pointer) {
+        if rect.contains(pos) {
+            return Some(SidebarDrop::Park);
+        }
+    }
+    let pos = pointer?;
+    let dst = drop_slot_from_rects(row_rects, pos.y);
+    if dst != src && dst != src + 1 {
+        Some(SidebarDrop::Reorder(dst))
+    } else {
+        None
+    }
+}
+
 impl PlexiApp {
     pub(crate) fn draw_sidebar(&mut self, ui: &mut egui::Ui) {
         let sidebar_width = ui.available_width();
@@ -370,16 +401,25 @@ impl PlexiApp {
         }
 
         // ── Parked section ──────────────────────────────────────────────
+        // The header doubles as a drop target: while a context is being
+        // dragged, render it even when empty so the drag can release onto it.
         let parked_count = parked_order.len();
-        if parked_count > 0 {
+        let mut parked_header_rect: Option<Rect> = None;
+        if parked_count > 0 || self.drag_context.is_some() {
             ui.add_space(8.0);
 
             let divider_id = egui::Id::new("parked_divider");
             let expanded = self.parked_section_expanded;
+            let label = if parked_count > 0 {
+                format!("Parked ({parked_count})")
+            } else {
+                "Parked".to_string()
+            };
 
-            let response = ListDropdownHeader::new(&format!("Parked ({parked_count})"), expanded)
+            let response = ListDropdownHeader::new(&label, expanded)
                 .indent(12.0)
                 .show(ui, divider_id, &self.colors);
+            parked_header_rect = Some(response.rect);
             if response.clicked() {
                 self.parked_section_expanded = !self.parked_section_expanded;
             }
@@ -470,27 +510,33 @@ impl PlexiApp {
             }
         }
 
-        // Drop slot + drag reorder
-        let drop_index: Option<usize> = if self.drag_context.is_some() {
-            ui.input(|i| i.pointer.hover_pos())
-                .map(|pos| drop_slot_from_rects(&row_rects, pos.y))
-        } else {
-            None
-        };
+        // Resolve the drag target once and use it for both the drop affordance
+        // and the release action. Releasing over the Parked header parks the
+        // context; otherwise it reorders the active list.
+        let pointer_pos = ui.input(|i| i.pointer.hover_pos());
+        let drop_target = self
+            .drag_context
+            .and_then(|src| resolve_drag_drop(src, parked_header_rect, pointer_pos, &row_rects));
 
-        if drag_released {
-            if let (Some(src), Some(dst)) = (self.drag_context, drop_index) {
-                if dst != src && dst != src + 1 {
-                    let effective_dst = if dst > src { dst - 1 } else { dst };
-                    self.renaming_window = None;
-                    self.router.reorder_tracking_active(src, effective_dst);
+        // Drop affordances: highlight the Parked header, or draw the reorder line.
+        match drop_target {
+            Some(SidebarDrop::Park) => {
+                if let Some(rect) = parked_header_rect {
+                    let inset = rect.shrink(2.0);
+                    ui.painter().rect_filled(
+                        inset,
+                        crate::ui::style::RADIUS_SM,
+                        self.colors.bg_hover,
+                    );
+                    ui.painter().rect_stroke(
+                        inset,
+                        crate::ui::style::RADIUS_SM,
+                        Stroke::new(1.5, self.colors.accent),
+                        egui::StrokeKind::Inside,
+                    );
                 }
             }
-            self.drag_context = None;
-        }
-
-        if let (Some(src), Some(dst)) = (self.drag_context, drop_index) {
-            if dst != src && dst != src + 1 {
+            Some(SidebarDrop::Reorder(dst)) => {
                 let line_y = if dst == 0 {
                     row_rects.first().map_or(0.0, |r| r.min.y)
                 } else if dst >= row_rects.len() {
@@ -507,6 +553,26 @@ impl PlexiApp {
                     Stroke::new(2.0, self.colors.accent),
                 );
             }
+            None => {}
+        }
+
+        if drag_released {
+            if let Some(src) = self.drag_context {
+                match drop_target {
+                    Some(SidebarDrop::Park) => {
+                        log::info!("sidebar: drag-park context idx={src}");
+                        self.renaming_window = None;
+                        self.park_context(src);
+                    }
+                    Some(SidebarDrop::Reorder(dst)) => {
+                        let effective_dst = if dst > src { dst - 1 } else { dst };
+                        self.renaming_window = None;
+                        self.router.reorder_tracking_active(src, effective_dst);
+                    }
+                    None => {}
+                }
+            }
+            self.drag_context = None;
         }
 
         if let Some(i) = unpark_context {
@@ -601,5 +667,56 @@ impl PlexiApp {
         if add_clicked {
             self.new_context();
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_drag_drop, SidebarDrop};
+    use egui::{pos2, vec2, Rect};
+
+    fn rows() -> Vec<Rect> {
+        // Two stacked active rows: centers at y=10 and y=30.
+        vec![
+            Rect::from_min_size(pos2(0.0, 0.0), vec2(100.0, 20.0)),
+            Rect::from_min_size(pos2(0.0, 20.0), vec2(100.0, 20.0)),
+        ]
+    }
+
+    // The Parked header sits below the rows: y in [50, 70].
+    fn header() -> Rect {
+        Rect::from_min_size(pos2(0.0, 50.0), vec2(100.0, 20.0))
+    }
+
+    #[test]
+    fn releasing_over_parked_header_parks() {
+        let target = resolve_drag_drop(0, Some(header()), Some(pos2(10.0, 60.0)), &rows());
+        assert_eq!(target, Some(SidebarDrop::Park));
+    }
+
+    #[test]
+    fn park_takes_priority_when_no_parked_header_exists() {
+        // No header rendered (no parked contexts, not dragging) → never parks.
+        let target = resolve_drag_drop(0, None, Some(pos2(10.0, 60.0)), &rows());
+        assert!(!matches!(target, Some(SidebarDrop::Park)));
+    }
+
+    #[test]
+    fn releasing_below_other_rows_reorders() {
+        // Dragging row 0, pointer past the last row → reorder to the bottom slot.
+        let target = resolve_drag_drop(0, Some(header()), Some(pos2(10.0, 45.0)), &rows());
+        assert_eq!(target, Some(SidebarDrop::Reorder(2)));
+    }
+
+    #[test]
+    fn releasing_on_own_slot_is_a_noop() {
+        // Dragging row 0, pointer still over row 0 → no move.
+        let target = resolve_drag_drop(0, Some(header()), Some(pos2(10.0, 5.0)), &rows());
+        assert_eq!(target, None);
+    }
+
+    #[test]
+    fn no_pointer_is_a_noop() {
+        assert_eq!(resolve_drag_drop(0, Some(header()), None, &rows()), None);
     }
 }

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -521,6 +521,44 @@ mod tests {
             .expect("render failed");
     }
 
+    /// While a context is being dragged, the Parked header renders even with
+    /// zero parked contexts so the drag has a drop target. Smoke test: set up
+    /// an in-progress drag and confirm the sidebar renders without panicking.
+    #[test]
+    fn dragging_context_shows_parked_drop_target() {
+        let mut h = PlexiUiHarness::new_sized(900.0, 620.0);
+        h.with_app_mut(|app| {
+            app.sidebar_visible = true;
+            app.parked_section_expanded = false;
+            // Add a second active context so there is a drag source + a list.
+            app.router.push(crate::host::context::Context {
+                name: "second".to_string(),
+                path: std::env::temp_dir().join("second"),
+                root: None,
+                description: None,
+                context_id: 71_001,
+                parent_id: None,
+                depth: 0,
+                parked: false,
+            });
+            // Simulate an in-progress drag of the first context.
+            app.drag_context = Some(0);
+        });
+        // Hover low in the sidebar where the (empty) Parked header renders.
+        let pos = egui::pos2(28.0, 150.0);
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::PointerMoved(pos));
+        h.run_steps(2);
+        h.with_app(|app| {
+            assert_eq!(app.router.iter().filter(|c| c.parked).count(), 0);
+            assert_eq!(app.drag_context, Some(0));
+        });
+        h.save_screenshot("/tmp/plexi_drag_park_drop_target.png")
+            .expect("render failed");
+    }
+
     /// Notes triage overlay: renders a note, and emptying the inbox returns
     /// to the picker instead of closing outright.
     #[test]

--- a/src/workspace/router.rs
+++ b/src/workspace/router.rs
@@ -129,17 +129,32 @@ impl WorkspaceRouter {
         }
     }
 
-    /// Remove at `src`, insert at `dst` (after removal), tracking active.
-    pub(crate) fn reorder_tracking_active(&mut self, src: usize, dst: usize) {
-        let ctx = self.contexts.remove(src);
-        self.contexts.insert(dst, ctx);
-        if self.active == src {
-            self.active = dst;
-        } else if src < self.active && dst >= self.active {
-            self.active -= 1;
-        } else if src > self.active && dst <= self.active {
-            self.active += 1;
+    /// Reorder the entire context vec to match `new_order`, a permutation of
+    /// the current indices `0..len`. The active context is tracked by identity,
+    /// so its index is rewritten to wherever it lands. Used by sidebar drag-drop
+    /// to commit a fully re-partitioned (active/parked) ordering atomically.
+    pub(crate) fn apply_order(&mut self, new_order: &[usize]) {
+        debug_assert_eq!(
+            new_order.len(),
+            self.contexts.len(),
+            "apply_order needs a full permutation"
+        );
+        let active_id = self.contexts[self.active].context_id;
+        let mut slots: Vec<Option<Context>> = self.contexts.drain(..).map(Some).collect();
+        let mut reordered: Vec<Context> = Vec::with_capacity(slots.len());
+        for &idx in new_order {
+            reordered.push(
+                slots[idx]
+                    .take()
+                    .expect("apply_order: each index referenced exactly once"),
+            );
         }
+        self.contexts = reordered;
+        self.active = self
+            .contexts
+            .iter()
+            .position(|c| c.context_id == active_id)
+            .expect("apply_order: active context survives reorder");
     }
 
     pub(crate) fn move_to_front_tracking_active(&mut self, idx: usize) {
@@ -222,6 +237,21 @@ mod tests {
     fn depth_stack_empty_pop_returns_none() {
         let mut router = WorkspaceRouter::new(vec![make_ctx(1, None, 0)], 0);
         assert_eq!(router.pop_depth(), None);
+    }
+
+    #[test]
+    fn apply_order_permutes_and_tracks_active_by_identity() {
+        let mut router = WorkspaceRouter::new(
+            vec![make_ctx(10, None, 0), make_ctx(20, None, 0), make_ctx(30, None, 0)],
+            1, // active = ctx 20
+        );
+        // Move ctx 20 (index 1) to the front: new order [20, 10, 30].
+        router.apply_order(&[1, 0, 2]);
+        let ids: Vec<u64> = router.iter().map(|c| c.context_id).collect();
+        assert_eq!(ids, vec![20, 10, 30]);
+        // Active still points at ctx 20, now at index 0.
+        assert_eq!(router.active_idx(), 0);
+        assert_eq!(router.active().context_id, 20);
     }
 
     #[test]


### PR DESCRIPTION
## What

Drag an active context onto the **Parked** dropdown header to park it. The header doubles as a drop target.

- Releasing a context drag over the Parked header parks the context (instead of reordering the active list).
- The Parked header renders during *any* context drag, even with zero parked contexts, so the first context can be parked by drag.
- The header highlights (accent border + hover fill) while a drag hovers it, as a drop affordance.

Reuses the existing drag infra (`drag_context`, drag-stop detection) and the existing `park_context(idx)` op (handles active-context focus hand-off + workspace save).

## How

Drop resolution is extracted into a pure `resolve_drag_drop()` helper so the visual affordance and the release action share a single decision. Reorder behavior is preserved exactly.

## Testing

- Unit tests on `resolve_drag_drop`: park-over-header, reorder, no-op-on-own-slot, no-header, no-pointer.
- `PlexiUiHarness` smoke test: mid-drag with zero parked contexts renders the Parked drop target without panic.
- `cargo build --bin plexi` clean; existing `parked_sidebar_dropdown_uses_shared_list_header` still green.

Screenshot (mid-drag, 0 parked — "Parked" header appears below the active contexts):

`/tmp/plexi_drag_park_drop_target.png`
