### PR TITLE
fix: paste in Cmd+F search mode

### DIFF
--- a/.stint/tasks/0187-subcontext-sidebar-insertion-order.md
+++ b/.stint/tasks/0187-subcontext-sidebar-insertion-order.md
@@ -1,12 +1,17 @@
 ---
 id: "0187"
 title: "fix: push-to-subcontext inserts new context under parent in sidebar"
-status: backlog
-sprint: s4
-area: host/context
-estimate: 1h
-gh_issue: ["2255"]
+status: in-progress
+estimate: "1h"
+started_at: "2026-06-15T17:52:04Z"
+blocked_by: []
+gh_issue:
+  - "2255"
+area:
+  - "host/context"
+tags: []
 ---
+
 
 When pushing a subcontext from within a subcontext, the new nested context should be inserted immediately after its parent in the sidebar list, not appended at the end.
 

--- a/.stint/tasks/0194-paste-does-not-work-in-cmd-f-searching.md
+++ b/.stint/tasks/0194-paste-does-not-work-in-cmd-f-searching.md
@@ -1,9 +1,15 @@
 ---
 id: "0194"
 title: "paste does not work in cmd f searching"
-status: backlog
+status: in-progress
 created_at: "2026-06-14T19:49:55Z"
+started_at: "2026-06-15T17:52:26Z"
+blocked_by: []
+gh_issue: []
+area: []
+tags: []
 ---
+
 
 ## Why
 

--- a/deps/egui_term/src/view.rs
+++ b/deps/egui_term/src/view.rs
@@ -1527,8 +1527,15 @@ fn process_search_mode_event(
             sm.query.push_str(text);
             recompile_search(sm, backend);
         },
+        // Paste: append clipboard content to query
+        egui::Event::Paste(text) => {
+            let sm = state.search_mode.as_mut().unwrap();
+            sm.query.push_str(text);
+            log::info!("[search-mode] pasted {} chars into query", text.len());
+            recompile_search(sm, backend);
+        },
         // Absorb all other key events to prevent them reaching the PTY
-        egui::Event::Key { .. } | egui::Event::Copy | egui::Event::Paste(_) => {
+        egui::Event::Key { .. } | egui::Event::Copy => {
         },
         _ => {},
     }


### PR DESCRIPTION
## Summary

- Cmd+V (paste) in Cmd+F terminal search mode was silently discarded — `egui::Event::Paste` was caught by the absorb-all arm without acting on the clipboard content
- Fixed by moving `Paste(text)` to its own arm before the catch-all, appending the pasted text to the search query and recompiling matches
- Adds an `info`-level log trace so paste events in search mode are visible in the log

## Done When

- Cmd+V in Cmd+F search bar appends clipboard text to the query and updates highlighted matches