### PR TITLE
fix(host/context): subcontext sidebar insertion order (#2255)

### DIFF
--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -1981,6 +1981,73 @@ fn push_pane_ipc_unknown_pane_falls_back_to_focused() {
     );
 }
 
+/// Regression for #2255: pushing a pane to a subcontext from within a subcontext
+/// must insert the grandchild immediately after its parent (child1) in the router,
+/// not at the end — even when another sibling context (child2) already exists.
+#[test]
+fn push_pane_to_subcontext_inserts_grandchild_after_parent_not_at_end() {
+    fn push_ipc(
+        h: &mut crate::testing::HostHarness,
+        pane_id: crate::spatial::tiling::PaneId,
+    ) {
+        let req: crate::app_protocol::AppRequest = serde_json::from_value(serde_json::json!({
+            "type": "push_pane_to_subcontext",
+            "pane_id": pane_id,
+        }))
+        .unwrap();
+        h.inject_ipc(req);
+        h.app.drain_pane_cmd_channel();
+    }
+
+    let mut h = crate::testing::HostHarness::new();
+    let pane_a = h.add_test_pane();
+    let pane_b = h.add_test_pane();
+    let root_id = h.app.router.active().context_id;
+
+    // Push pane_a from root -> child1(d1). Router: [root, child1]. Active: child1.
+    push_ipc(&mut h, pane_a);
+    let child1_id = h.app.router.active().context_id;
+
+    // Push pane_b from root's window (IPC targets pane_b explicitly) -> child2(d1).
+    // With insert_after_subtree(root), child2 lands after child1: [root, child1, child2].
+    push_ipc(&mut h, pane_b);
+    let child2_id = h.app.router.active().context_id;
+    assert_eq!(h.app.router.len(), 3, "root + child1 + child2 = 3 contexts");
+    assert_ne!(child2_id, child1_id);
+
+    // Push pane_a from child1's window -> grandchild(d2).
+    // With insert_after_subtree(child1), grandchild lands between child1 and child2:
+    // [root, child1, grandchild, child2].
+    // Without the fix, grandchild would append at the end: [root, child1, child2, grandchild].
+    push_ipc(&mut h, pane_a);
+    assert_eq!(h.app.router.len(), 4, "root + child1 + grandchild + child2 = 4 contexts");
+
+    let ids: Vec<u64> = h.app.router.iter().map(|c| c.context_id).collect();
+    let grandchild = h
+        .app
+        .router
+        .iter()
+        .find(|c| c.parent_id == Some(child1_id))
+        .expect("grandchild must exist");
+    assert_eq!(grandchild.depth, 2, "grandchild depth must be 2");
+
+    let child1_pos = ids.iter().position(|&id| id == child1_id).unwrap();
+    let grandchild_pos = ids.iter().position(|&id| id == grandchild.context_id).unwrap();
+    let child2_pos = ids.iter().position(|&id| id == child2_id).unwrap();
+    let root_pos = ids.iter().position(|&id| id == root_id).unwrap();
+
+    assert!(root_pos < child1_pos, "root before child1");
+    assert_eq!(
+        grandchild_pos,
+        child1_pos + 1,
+        "grandchild must be immediately after child1 (not at end)"
+    );
+    assert!(
+        grandchild_pos < child2_pos,
+        "grandchild must precede sibling child2"
+    );
+}
+
 /// `plexi context describe` sends the caller's PLEXI_CONTEXT_ID — the host
 /// must set the description on THAT context, not the active one.
 #[test]

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -487,16 +487,19 @@ impl PlexiApp {
         let mut child_panes = std::collections::HashMap::new();
         child_panes.insert(pane_id, pane);
 
-        self.router.push(crate::host::context::Context {
-            name: ctx_name,
-            path: parent_path.clone(),
-            root: parent_root,
-            description: None,
-            context_id: ctx_id,
-            parent_id: Some(parent_ctx_id),
-            depth: child_depth,
-            parked: false,
-        });
+        self.router.insert_after_subtree(
+            parent_ctx_id,
+            crate::host::context::Context {
+                name: ctx_name,
+                path: parent_path.clone(),
+                root: parent_root,
+                description: None,
+                context_id: ctx_id,
+                parent_id: Some(parent_ctx_id),
+                depth: child_depth,
+                parked: false,
+            },
+        );
         self.windows.push(Window {
             name: String::new(),
             path: parent_path,
@@ -514,7 +517,10 @@ impl PlexiApp {
         let current_win_id = self.windows[parent_win_idx].window_id;
         self.router
             .push_depth(parent_ctx_id, current_win_id, Some(target_tile));
-        let new_ctx_idx = self.router.len() - 1;
+        let new_ctx_idx = self
+            .router
+            .position(|c| c.context_id == ctx_id)
+            .expect("just-inserted subcontext must be in router");
         self.switch_workspace(new_ctx_idx);
 
         self.save_workspace();

--- a/src/workspace/router.rs
+++ b/src/workspace/router.rs
@@ -70,6 +70,26 @@ impl WorkspaceRouter {
         self.contexts.push(ctx);
     }
 
+    /// Insert `ctx` immediately after all existing descendants of `parent_id`.
+    /// Descendants are detected by walking forward from the parent position while
+    /// `depth > parent_depth`. Falls back to `push` if the parent is not found.
+    /// Adjusts the active index to remain coherent.
+    pub(crate) fn insert_after_subtree(&mut self, parent_id: u64, ctx: Context) {
+        let Some(parent_pos) = self.contexts.iter().position(|c| c.context_id == parent_id) else {
+            self.contexts.push(ctx);
+            return;
+        };
+        let parent_depth = self.contexts[parent_pos].depth;
+        let mut insert_pos = parent_pos + 1;
+        while insert_pos < self.contexts.len() && self.contexts[insert_pos].depth > parent_depth {
+            insert_pos += 1;
+        }
+        self.contexts.insert(insert_pos, ctx);
+        if self.active >= insert_pos {
+            self.active += 1;
+        }
+    }
+
     /// Set active to the last context (call after push for new-context flow).
     pub(crate) fn activate_last(&mut self) {
         self.active = self.contexts.len().saturating_sub(1);
@@ -215,5 +235,68 @@ mod tests {
         assert_eq!(router.current_depth(), 2);
         let remaining: Vec<u64> = router.depth_stack.iter().map(|(c, _, _)| *c).collect();
         assert_eq!(remaining, vec![1, 3]);
+    }
+
+    #[test]
+    fn insert_after_subtree_no_existing_children() {
+        // [A(d0)] -> insert child B(d1) under A -> [A, B]
+        let mut router = WorkspaceRouter::new(vec![make_ctx(1, None, 0)], 0);
+        router.insert_after_subtree(1, make_ctx(2, Some(1), 1));
+        let ids: Vec<u64> = router.contexts.iter().map(|c| c.context_id).collect();
+        assert_eq!(ids, vec![1, 2]);
+    }
+
+    #[test]
+    fn insert_after_subtree_after_existing_sibling() {
+        // [A(d0), B(d1)] -> insert C(d1) under A -> [A, B, C]
+        let a = make_ctx(1, None, 0);
+        let b = make_ctx(2, Some(1), 1);
+        let mut router = WorkspaceRouter::new(vec![a, b], 0);
+        router.insert_after_subtree(1, make_ctx(3, Some(1), 1));
+        let ids: Vec<u64> = router.contexts.iter().map(|c| c.context_id).collect();
+        assert_eq!(ids, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn insert_after_subtree_skips_deep_descendants() {
+        // [A(d0), B(d1), C(d2)] -> insert D(d1) under A -> [A, B, C, D]
+        // C is a grandchild of A (via B), so D lands after C.
+        let a = make_ctx(1, None, 0);
+        let b = make_ctx(2, Some(1), 1);
+        let c = make_ctx(3, Some(2), 2);
+        let mut router = WorkspaceRouter::new(vec![a, b, c], 0);
+        router.insert_after_subtree(1, make_ctx(4, Some(1), 1));
+        let ids: Vec<u64> = router.contexts.iter().map(|c| c.context_id).collect();
+        assert_eq!(ids, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn insert_after_subtree_between_top_level_contexts() {
+        // [A(d0), B(d0)] -> insert C(d1) under A -> [A, C, B]
+        let a = make_ctx(1, None, 0);
+        let b = make_ctx(2, None, 0);
+        let mut router = WorkspaceRouter::new(vec![a, b], 0);
+        router.insert_after_subtree(1, make_ctx(3, Some(1), 1));
+        let ids: Vec<u64> = router.contexts.iter().map(|c| c.context_id).collect();
+        assert_eq!(ids, vec![1, 3, 2]);
+    }
+
+    #[test]
+    fn insert_after_subtree_adjusts_active_index() {
+        // [A(d0), B(d0)] active=1 (B) -> insert C under A -> [A, C, B] active=2
+        let a = make_ctx(1, None, 0);
+        let b = make_ctx(2, None, 0);
+        let mut router = WorkspaceRouter::new(vec![a, b], 1);
+        router.insert_after_subtree(1, make_ctx(3, Some(1), 1));
+        assert_eq!(router.active_idx(), 2);
+        assert_eq!(router.active().context_id, 2);
+    }
+
+    #[test]
+    fn insert_after_subtree_unknown_parent_falls_back_to_push() {
+        let mut router = WorkspaceRouter::new(vec![make_ctx(1, None, 0)], 0);
+        router.insert_after_subtree(99, make_ctx(2, None, 0));
+        let ids: Vec<u64> = router.contexts.iter().map(|c| c.context_id).collect();
+        assert_eq!(ids, vec![1, 2]);
     }
 }


### PR DESCRIPTION
Closes #2255

## Summary

- Added `insert_after_subtree(parent_id, ctx)` to `WorkspaceRouter` — scans forward from the parent's position past all descendants (depth > parent_depth) and inserts there, keeping the sidebar list in DFS tree order.
- Replaced `self.router.push(...)` with `self.router.insert_after_subtree(parent_ctx_id, ...)` in `push_pane_to_subcontext`.
- Fixed `new_ctx_idx` lookup to use `position(|c| c.context_id == ctx_id)` instead of `len()-1` (the old form was only correct when push was the insertion method).

## Done When

- Pushing a pane to a subcontext from within a subcontext places the new context row immediately beneath its parent in the sidebar, indented by depth.
- Pushing from a top-level context still works (depth-1 child appends after all top-level children of that parent).
- Existing reorder (drag, move-up/down) and delete operations are unaffected.
- `cargo test --bin plexi` is green.

**Test evidence (attempt 1):**
- cargo test: 1199 passed, 0 failed — filters: full bin suite
- Conclusion: install skippable — full coverage (6 new `insert_after_subtree` unit tests in `router.rs` + 1 HostHarness regression test verifying grandchild appears between parent and sibling)