### PR TITLE
fix(sdk): set Python floor to 3.12 and pin the smoke-test interpreter

### DIFF
--- a/justfile
+++ b/justfile
@@ -117,8 +117,10 @@ sdk-dev:
     uv pip install -e sdk/python
 
 # Headless SDK/app contract smoke: Init -> Ready -> Render -> FrameDone.
+# Pin to the bundled runtime's minor version so uv never falls back to a
+# system Python (e.g. CommandLineTools 3.9) that predates the SDK's floor.
 sdk-smoke:
-    uv run --project sdk/python --with pytest --with pytest-asyncio pytest sdk/python/tests/test_app_harness.py -q
+    uv run --python 3.12 --project sdk/python --with pytest --with pytest-asyncio pytest sdk/python/tests/test_app_harness.py -q
 
 # Build and install the current worktree as a testable PR build.
 # Installs as "Plexi PR<number>.app" with isolated profile ~/.plexi-pr-<number>/.

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -3,7 +3,7 @@ name = "plexi-sdk"
 version = "0.4.0"
 description = "Python SDK for building Plexi apps via the PGAP v3 protocol"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 license = { text = "MIT" }
 authors = [{ name = "Ian Burke", email = "ianjamesburke@gmail.com" }]
 keywords = ["plexi", "pgap", "sdk", "tiling", "window-manager", "apps"]
@@ -12,10 +12,8 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
 ]
 
@@ -35,7 +33,7 @@ packages = ["plexi_sdk"]
 include = ["plexi_sdk/", "README.md"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.12"
 strict = false
 ignore_missing_imports = true
 check_untyped_defs = true

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 
 [[package]]
 name = "plexi-sdk"


### PR DESCRIPTION
## Problem

`just sdk-smoke` (and therefore `just pr-install`) crashed at collection:

```
sdk/python/plexi_sdk/testing.py:248: in <module>
    expected: str | tuple[int, int, int, int],
E   TypeError: unsupported operand type(s) for |: 'type' and 'types.GenericAlias'
```

`testing.py` uses PEP 604 `str | tuple[...]` unions in bare (runtime-evaluated) signatures. PEP 604 only evaluates at runtime on Python 3.10+. The smoke test ran under **system CommandLineTools 3.9** because the SDK declared `requires-python = ">=3.9"` and `uv` selected the first satisfying interpreter on PATH.

## Fix

The host **bundles Python 3.12.13** (`PYTHON_VERSION` in the justfile), so apps run on 3.12 in production — the 3.9 was purely a test-venv accident. Align the SDK with reality rather than adding a `from __future__ import annotations` crutch:

- `requires-python = ">=3.9"` → `">=3.12"` (+ trove classifiers, mypy target).
- Pin `just sdk-smoke` to `--python 3.12` so `uv` never falls back to a pre-3.10 system interpreter.
- `uv.lock` regenerated for the new floor.

No source changes — modern `X | Y` syntax is valid on the 3.12 floor.

## Verification

```
just sdk-smoke
Using CPython 3.12.4 interpreter
7 passed in 0.80s
```
