### PR TITLE
feat(command-palette): surface commands.toml entries with hot reload (#2269)

### DIFF
--- a/docs/security/shell-execution-inventory.md
+++ b/docs/security/shell-execution-inventory.md
@@ -57,6 +57,11 @@ gate is warranted — trust is identical to a shell alias or cron job.
 the workspace secrets store; missing secrets abort with a clear error rather than
 substituting empty strings.
 
+The command palette surfaces these same workspace commands and global scripts
+(`src/overlays/command_palette.rs` — `run_user_command`). Selecting one opens a
+terminal pane that runs `plexi run <name>`, so execution flows through the exact
+path above — the host never re-implements command execution or secret injection.
+
 ### Quick-note destination command templates → `zsh -c` / `sh -c`
 
 | Field | Value |

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -189,6 +189,10 @@ pub struct PlexiApp {
     pub(crate) palette_workspace_root: Option<std::path::PathBuf>,
     /// Notes loaded at palette-open time, cleared on close.
     pub(crate) palette_notes: Vec<crate::notes::NotePickerEntry>,
+    /// User commands (`commands.toml` + global scripts) resolved at palette-open
+    /// time, cleared on close. Re-read on every open so edits hot-reload without
+    /// a restart — same pattern as `palette_notes`.
+    pub(crate) palette_commands: Vec<crate::cli::ResolvedUserCommand>,
     /// TTL cache for the cwd-derived fallback workspace root passed to
     /// `PlexiBehavior` each frame (#2023). The fallback
     /// (`config::active_workspace_root()`) stat-walks the filesystem from the
@@ -832,6 +836,7 @@ impl PlexiApp {
                     palette_selected: 0,
                     palette_workspace_root: None,
                     palette_notes: Vec::new(),
+                    palette_commands: Vec::new(),
                     workspace_root_fallback_cache: None,
                     context_visit_history: Vec::new(),
                     renaming_pane: None,
@@ -1023,6 +1028,7 @@ impl PlexiApp {
             palette_selected: 0,
             palette_workspace_root: None,
             palette_notes: Vec::new(),
+            palette_commands: Vec::new(),
             workspace_root_fallback_cache: None,
             context_visit_history: Vec::new(),
             renaming_pane: None,
@@ -1228,6 +1234,7 @@ impl PlexiApp {
                 palette_selected: 0,
                 palette_workspace_root: None,
                 palette_notes: Vec::new(),
+                palette_commands: Vec::new(),
                 workspace_root_fallback_cache: None,
                 context_visit_history: Vec::new(),
                 renaming_pane: None,
@@ -2988,9 +2995,19 @@ impl eframe::App for PlexiApp {
                         );
                         log::info!("palette: loaded {} notes", palette_notes.len());
                         self.palette_notes = palette_notes;
+                        // Resolve user commands once at open-time (re-read each open
+                        // → hot reload). Mirrors `plexi run` precedence exactly.
+                        self.palette_commands = crate::cli::resolve_user_commands(
+                            self.palette_workspace_root.as_deref(),
+                        );
+                        log::info!(
+                            "palette: loaded {} user command(s)",
+                            self.palette_commands.len()
+                        );
                     } else {
                         self.palette_workspace_root = None;
                         self.palette_notes.clear();
+                        self.palette_commands.clear();
                     }
                 }
                 Action::RenamePane => {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -94,6 +94,109 @@ pub(super) fn is_executable(path: &std::path::Path) -> bool {
     }
 }
 
+/// Scope of a user-authored command surfaced in the command palette.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserCommandScope {
+    /// Defined in the focused workspace's channel-scoped `commands.toml`.
+    Workspace,
+    /// A global profile script under `config_dir()/scripts/`.
+    Global,
+}
+
+/// A user-authored command resolved for the command palette.
+///
+/// Mirrors exactly what `plexi run <name>` would resolve from the given
+/// workspace cwd, so the palette never lists a command `plexi run` cannot
+/// execute.
+#[derive(Debug, Clone)]
+pub struct ResolvedUserCommand {
+    pub name: String,
+    /// Shell snippet for `commands.toml` entries (shown as preview text).
+    /// `None` for global scripts — the run target is the script file itself.
+    pub run: Option<String>,
+    pub description: Option<String>,
+    pub scope: UserCommandScope,
+}
+
+/// Resolve user commands for the command palette, mirroring `plexi run`
+/// precedence: a workspace `commands.toml` shadows global scripts entirely
+/// (same fallback chain as [`run::run_command`]). A present-but-unparseable
+/// `commands.toml` yields no commands rather than silently falling back to
+/// global scripts, because `plexi run` would error in that state.
+///
+/// Reads the file fresh on every call, so the palette hot-reloads on the next
+/// open with no mtime bookkeeping — same pattern as palette note loading.
+pub fn resolve_user_commands(
+    workspace_root: Option<&std::path::Path>,
+) -> Vec<ResolvedUserCommand> {
+    if let Some(root) = workspace_root {
+        let config_path = root.join(commands_file());
+        match std::fs::read_to_string(&config_path) {
+            Ok(contents) => {
+                // commands.toml present — its commands are the entire set; global
+                // scripts are NOT consulted (mirrors run_command's fallback chain).
+                match toml::from_str::<PlexiCommands>(&contents) {
+                    Ok(config) => {
+                        let mut cmds: Vec<ResolvedUserCommand> = config
+                            .commands
+                            .iter()
+                            .map(|(name, entry)| ResolvedUserCommand {
+                                name: name.clone(),
+                                run: Some(entry.run().to_string()),
+                                description: entry.description().map(|s| s.to_string()),
+                                scope: UserCommandScope::Workspace,
+                            })
+                            .collect();
+                        cmds.sort_by(|a, b| a.name.cmp(&b.name));
+                        log::info!(
+                            "palette: resolved {} workspace command(s) from {}",
+                            cmds.len(),
+                            config_path.display()
+                        );
+                        return cmds;
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "palette: failed to parse {}: {e}; no workspace commands surfaced",
+                            config_path.display()
+                        );
+                        return Vec::new();
+                    }
+                }
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // No workspace commands.toml — fall through to global scripts.
+            }
+            Err(e) => {
+                log::warn!(
+                    "palette: could not read {}: {e}; no workspace commands surfaced",
+                    config_path.display()
+                );
+                return Vec::new();
+            }
+        }
+    }
+
+    // Global fallback: scripts dir, same as `plexi run` with no commands.toml.
+    let scripts_dir = crate::config::config_dir().join("scripts");
+    let mut cmds: Vec<ResolvedUserCommand> = list_global_scripts(&scripts_dir)
+        .into_iter()
+        .map(|name| ResolvedUserCommand {
+            name,
+            run: None,
+            description: None,
+            scope: UserCommandScope::Global,
+        })
+        .collect();
+    cmds.sort_by(|a, b| a.name.cmp(&b.name));
+    log::info!(
+        "palette: resolved {} global script(s) from {}",
+        cmds.len(),
+        scripts_dir.display()
+    );
+    cmds
+}
+
 pub mod args;
 pub mod crawl;
 pub mod help;
@@ -249,3 +352,111 @@ pub use workspace::{
     workspace_clean_cli, workspace_init, workspace_secret_delete, workspace_secret_get,
     workspace_secret_list, workspace_secret_set,
 };
+
+#[cfg(test)]
+mod resolve_user_commands_tests {
+    use super::{resolve_user_commands, UserCommandScope};
+
+    /// Build a workspace tempdir whose channel-scoped commands.toml holds `body`.
+    fn workspace_with_commands(body: &str) -> (tempfile::TempDir, crate::config::TestChannelGuard) {
+        let guard = crate::config::set_test_channel("test");
+        let tmp = tempfile::tempdir().unwrap();
+        let chan_dir = tmp.path().join(".plexi-test");
+        std::fs::create_dir_all(&chan_dir).unwrap();
+        std::fs::write(chan_dir.join("commands.toml"), body).unwrap();
+        (tmp, guard)
+    }
+
+    #[test]
+    fn workspace_commands_resolve_sorted_with_scope() {
+        let (tmp, _g) = workspace_with_commands(
+            r#"
+[commands]
+zeta = "echo z"
+build = { run = "cargo build", description = "Build it" }
+"#,
+        );
+        let cmds = resolve_user_commands(Some(tmp.path()));
+        assert_eq!(cmds.len(), 2);
+        assert_eq!(cmds[0].name, "build");
+        assert_eq!(cmds[0].description.as_deref(), Some("Build it"));
+        assert_eq!(cmds[0].run.as_deref(), Some("cargo build"));
+        assert_eq!(cmds[0].scope, UserCommandScope::Workspace);
+        assert_eq!(cmds[1].name, "zeta");
+    }
+
+    #[test]
+    fn workspace_commands_shadow_global_scripts() {
+        // commands.toml present → global scripts must NOT appear (mirrors `plexi run`).
+        let (tmp, _g) = workspace_with_commands("[commands]\nonly = \"echo hi\"\n");
+        let profile = tempfile::tempdir().unwrap();
+        let scripts = profile.path().join("scripts");
+        std::fs::create_dir_all(&scripts).unwrap();
+        write_executable(&scripts.join("global-only"));
+        let _pg = crate::config::set_test_profile_dir(profile.path().to_path_buf());
+
+        let cmds = resolve_user_commands(Some(tmp.path()));
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].name, "only");
+        assert_eq!(cmds[0].scope, UserCommandScope::Workspace);
+    }
+
+    #[test]
+    fn hot_reload_rereads_file_each_call() {
+        let (tmp, _g) = workspace_with_commands("[commands]\nfirst = \"echo 1\"\n");
+        let first = resolve_user_commands(Some(tmp.path()));
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].name, "first");
+
+        std::fs::write(
+            tmp.path().join(".plexi-test").join("commands.toml"),
+            "[commands]\nfirst = \"echo 1\"\nsecond = \"echo 2\"\n",
+        )
+        .unwrap();
+        let second = resolve_user_commands(Some(tmp.path()));
+        assert_eq!(second.len(), 2);
+        assert!(second.iter().any(|c| c.name == "second"));
+    }
+
+    #[test]
+    fn global_scripts_when_no_commands_toml() {
+        let _g = crate::config::set_test_channel("test");
+        let tmp = tempfile::tempdir().unwrap(); // workspace root with no commands.toml
+        let profile = tempfile::tempdir().unwrap();
+        let scripts = profile.path().join("scripts");
+        std::fs::create_dir_all(&scripts).unwrap();
+        write_executable(&scripts.join("deploy"));
+        let _pg = crate::config::set_test_profile_dir(profile.path().to_path_buf());
+
+        let cmds = resolve_user_commands(Some(tmp.path()));
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].name, "deploy");
+        assert_eq!(cmds[0].scope, UserCommandScope::Global);
+        assert!(cmds[0].run.is_none());
+    }
+
+    #[test]
+    fn unparseable_commands_toml_yields_no_commands() {
+        // Present-but-broken commands.toml → empty, never silent global fallback.
+        let (tmp, _g) = workspace_with_commands("this is = not valid toml [[[\n");
+        let profile = tempfile::tempdir().unwrap();
+        let scripts = profile.path().join("scripts");
+        std::fs::create_dir_all(&scripts).unwrap();
+        write_executable(&scripts.join("should-not-appear"));
+        let _pg = crate::config::set_test_profile_dir(profile.path().to_path_buf());
+
+        let cmds = resolve_user_commands(Some(tmp.path()));
+        assert!(cmds.is_empty());
+    }
+
+    fn write_executable(path: &std::path::Path) {
+        std::fs::write(path, "#!/bin/sh\necho hi\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(path, perms).unwrap();
+        }
+    }
+}

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -49,6 +49,15 @@ enum PaletteEntry {
         preview: String,
         search_text: String,
     },
+    /// A user-authored command from `commands.toml` or a global script,
+    /// executed via `plexi run <name>` in a new terminal pane.
+    UserCommand {
+        name: String,
+        /// Secondary text: description, run snippet, or "global script".
+        secondary: String,
+        scope: crate::cli::UserCommandScope,
+        search_text: String,
+    },
 }
 
 impl PaletteEntry {
@@ -58,6 +67,7 @@ impl PaletteEntry {
             PaletteEntry::Note { .. } => 1,
             PaletteEntry::App { .. } | PaletteEntry::Builtin { .. } => 2,
             PaletteEntry::Command { .. } => 3,
+            PaletteEntry::UserCommand { .. } => 4,
         }
     }
 
@@ -70,7 +80,8 @@ impl PaletteEntry {
             PaletteEntry::Context { search_text, .. }
             | PaletteEntry::App { search_text, .. }
             | PaletteEntry::Builtin { search_text, .. }
-            | PaletteEntry::Note { search_text, .. } => search_text.as_str(),
+            | PaletteEntry::Note { search_text, .. }
+            | PaletteEntry::UserCommand { search_text, .. } => search_text.as_str(),
         };
         if search_text.starts_with(query) {
             return 0;
@@ -96,7 +107,8 @@ impl PaletteEntry {
             PaletteEntry::Context { search_text, .. }
             | PaletteEntry::App { search_text, .. }
             | PaletteEntry::Builtin { search_text, .. }
-            | PaletteEntry::Note { search_text, .. } => search_text.contains(query),
+            | PaletteEntry::Note { search_text, .. }
+            | PaletteEntry::UserCommand { search_text, .. } => search_text.contains(query),
         }
     }
 }
@@ -152,6 +164,13 @@ const PALETTE_COMMANDS: &[PaletteCommandEntry] = &[
 
 fn searchable_text(parts: &[&str]) -> String {
     parts.join(" ").to_lowercase()
+}
+
+/// POSIX single-quote a shell argument: wrap in `'…'` and escape embedded
+/// single quotes as `'\''`. Command names are usually bare identifiers, but
+/// global script filenames may contain spaces.
+fn shell_single_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
 }
 
 fn sort_palette_entries(entries: &mut [PaletteEntry], query: &str) {
@@ -717,6 +736,35 @@ impl PlexiApp {
                 .filter(|entry| entry.matches_query(&query)),
         );
 
+        // ── User commands (commands.toml + global scripts) ──────────────────
+        // Resolved at palette-open time into self.palette_commands; mirrors
+        // `plexi run` precedence. Executed via `plexi run <name>` on select.
+        for cmd in &self.palette_commands {
+            let scope_word = match cmd.scope {
+                crate::cli::UserCommandScope::Workspace => "workspace ws",
+                crate::cli::UserCommandScope::Global => "global script",
+            };
+            let secondary = match (&cmd.description, &cmd.run) {
+                (Some(desc), _) => desc.clone(),
+                (None, Some(run)) => run.clone(),
+                (None, None) => "global script".to_string(),
+            };
+            let search_text = searchable_text(&[
+                cmd.name.as_str(),
+                secondary.as_str(),
+                "run",
+                scope_word,
+            ]);
+            if query.is_empty() || search_text.contains(&query) {
+                entries.push(PaletteEntry::UserCommand {
+                    name: cmd.name.clone(),
+                    secondary,
+                    scope: cmd.scope,
+                    search_text,
+                });
+            }
+        }
+
         sort_palette_entries(&mut entries, &query);
 
         let total = entries.len();
@@ -733,6 +781,10 @@ impl PlexiApp {
             LaunchApp(String),
             LaunchBuiltin(&'static str),
             OpenNote(std::path::PathBuf),
+            RunUserCommand {
+                name: String,
+                scope: crate::cli::UserCommandScope,
+            },
         }
         let mut action: Option<Action> = None;
         let prev_selected = self.palette_selected;
@@ -779,6 +831,12 @@ impl PlexiApp {
                     Some(PaletteEntry::Note { path, .. }) => {
                         action = Some(Action::OpenNote(path.clone()));
                     }
+                    Some(PaletteEntry::UserCommand { name, scope, .. }) => {
+                        action = Some(Action::RunUserCommand {
+                            name: name.clone(),
+                            scope: *scope,
+                        });
+                    }
                     None => {}
                 }
             }
@@ -789,6 +847,12 @@ impl PlexiApp {
                 self.show_command_palette = false;
                 self.palette_query.clear();
                 self.run_palette_command(command);
+                return;
+            }
+            Some(Action::RunUserCommand { name, scope }) => {
+                self.show_command_palette = false;
+                self.palette_query.clear();
+                self.run_user_command(&name, scope);
                 return;
             }
             Some(Action::JumpContext(ctx_idx, context_id, pane_id)) => {
@@ -876,6 +940,7 @@ impl PlexiApp {
                 let mut shown_apps_header = false;
                 let mut shown_notes_header = false;
                 let mut shown_commands_header = false;
+                let mut shown_run_header = false;
 
                 egui::ScrollArea::vertical()
                     // animated(false): required by scroll_row_into_view — see src/ui/list.rs.
@@ -1061,6 +1126,44 @@ impl PlexiApp {
                                         hover_select = Some(i);
                                     }
                                 }
+                                PaletteEntry::UserCommand {
+                                    name,
+                                    secondary,
+                                    scope,
+                                    ..
+                                } => {
+                                    if !shown_run_header {
+                                        shown_run_header = true;
+                                        ui.add_space(style::SPACE_XS);
+                                        ui.label(
+                                            RichText::new("RUN")
+                                                .size(style::TEXT_HINT)
+                                                .color(colors.text_dim),
+                                        );
+                                        ui.add_space(style::SPACE_XS);
+                                    }
+                                    let chips: &[&str] = match scope {
+                                        crate::cli::UserCommandScope::Workspace => &["run", "ws"],
+                                        crate::cli::UserCommandScope::Global => &["run", "global"],
+                                    };
+                                    let row_response = ListRow::new(name.as_str())
+                                        .metadata_chips(chips)
+                                        .secondary(secondary.as_str())
+                                        .selected(is_selected)
+                                        .show(ui, &colors);
+                                    if is_selected {
+                                        row_response.scroll_into_view(ui, should_scroll);
+                                    }
+                                    if row_response.row_clicked() {
+                                        click_action = Some(Action::RunUserCommand {
+                                            name: name.clone(),
+                                            scope: *scope,
+                                        });
+                                    }
+                                    if row_response.row_hovered() {
+                                        hover_select = Some(i);
+                                    }
+                                }
                             }
                         }
                     });
@@ -1085,6 +1188,11 @@ impl PlexiApp {
                             self.show_command_palette = false;
                             self.palette_query.clear();
                             self.run_palette_command(command);
+                        }
+                        Action::RunUserCommand { name, scope } => {
+                            self.show_command_palette = false;
+                            self.palette_query.clear();
+                            self.run_user_command(&name, scope);
                         }
                         Action::JumpContext(ctx_idx, context_id, pane_id) => {
                             self.jump_to_context(ctx_idx, context_id, pane_id);
@@ -1180,6 +1288,26 @@ impl PlexiApp {
                 self.open_scratchpad();
             }
         }
+    }
+
+    /// Execute a user-authored command by opening a terminal pane that runs
+    /// `plexi run <name>` in the focused workspace cwd. Routing through the CLI
+    /// keeps secret injection, workspace scoping, and the security inventory
+    /// true — the host never re-implements command execution.
+    fn run_user_command(&mut self, name: &str, scope: crate::cli::UserCommandScope) {
+        let cwd = self.palette_workspace_root.clone();
+        log::info!(
+            "palette: running user command '{name}' scope={scope:?} cwd={cwd:?}"
+        );
+        self.windows[self.active_window].clear_zoom();
+        self.ctx.memory_mut(|m| {
+            if let Some(id) = m.focused() {
+                m.surrender_focus(id);
+            }
+        });
+        let initial_cmd = format!("plexi run {}", shell_single_quote(name));
+        self.split_focused(false, Some(&initial_cmd), false, false, cwd);
+        self.save_workspace();
     }
 
     /// Jump to a window by index, switching context if necessary.
@@ -1331,6 +1459,70 @@ mod tests {
         sort_palette_entries(&mut entries, "open");
 
         assert!(matches!(entries[0], PaletteEntry::Command { .. }));
+    }
+
+    #[test]
+    fn empty_palette_puts_user_commands_below_host_commands() {
+        let mut entries = vec![
+            PaletteEntry::UserCommand {
+                name: "build".to_string(),
+                secondary: "cargo build".to_string(),
+                scope: crate::cli::UserCommandScope::Workspace,
+                search_text: "build cargo build run workspace ws".to_string(),
+            },
+            PaletteEntry::Command {
+                command: PaletteCommand::OpenConfig,
+                name: "Open config",
+                description: "Edit config",
+                search_text: "open config",
+            },
+            PaletteEntry::App {
+                id: "balls".to_string(),
+                name: "Balls".to_string(),
+                description: "Demo".to_string(),
+                running_in_background: false,
+                is_workspace_local: false,
+                search_text: "balls demo".to_string(),
+            },
+        ];
+
+        sort_palette_entries(&mut entries, "");
+
+        assert!(matches!(entries[0], PaletteEntry::App { .. }));
+        assert!(matches!(entries[1], PaletteEntry::Command { .. }));
+        assert!(matches!(entries[2], PaletteEntry::UserCommand { .. }));
+    }
+
+    #[test]
+    fn typed_query_surfaces_user_command_by_name() {
+        let mut entries = vec![
+            PaletteEntry::App {
+                // Only a substring match for "test" (inside "fastest").
+                id: "fastest".to_string(),
+                name: "Fastest".to_string(),
+                description: "Demo".to_string(),
+                running_in_background: false,
+                is_workspace_local: false,
+                search_text: "fastest demo loader".to_string(),
+            },
+            PaletteEntry::UserCommand {
+                name: "test".to_string(),
+                secondary: "cargo test".to_string(),
+                scope: crate::cli::UserCommandScope::Workspace,
+                search_text: "test cargo test run workspace ws".to_string(),
+            },
+        ];
+
+        // Prefix match on the command name ranks it ahead of the substring app match.
+        sort_palette_entries(&mut entries, "test");
+        assert!(matches!(entries[0], PaletteEntry::UserCommand { .. }));
+    }
+
+    #[test]
+    fn shell_single_quote_escapes_embedded_quotes() {
+        assert_eq!(shell_single_quote("test"), "'test'");
+        assert_eq!(shell_single_quote("my command"), "'my command'");
+        assert_eq!(shell_single_quote("it's"), r"'it'\''s'");
     }
 
     #[test]

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -962,6 +962,45 @@ mod tests {
     }
 
     #[test]
+    fn screenshot_command_palette_user_commands() {
+        let mut h = PlexiUiHarness::new_sized(1168.0, 1000.0);
+        add_focused_pane(&mut h);
+        h.with_app_mut(|app| {
+            app.palette_commands = vec![
+                crate::cli::ResolvedUserCommand {
+                    name: "build".to_string(),
+                    run: Some("cargo build".to_string()),
+                    description: Some("Build the project".to_string()),
+                    scope: crate::cli::UserCommandScope::Workspace,
+                },
+                crate::cli::ResolvedUserCommand {
+                    name: "test".to_string(),
+                    run: Some("cargo test".to_string()),
+                    description: None,
+                    scope: crate::cli::UserCommandScope::Workspace,
+                },
+                crate::cli::ResolvedUserCommand {
+                    name: "deploy".to_string(),
+                    run: None,
+                    description: None,
+                    scope: crate::cli::UserCommandScope::Global,
+                },
+            ];
+            app.show_command_palette = true;
+            app.palette_selected = 0;
+            app.sync_command_palette_focus();
+        });
+        h.run_steps(3);
+        h.save_screenshot("/tmp/plexi_command_palette_user_commands.png")
+            .expect("render failed");
+        assert!(
+            h.with_app(|app| app.show_command_palette && app.palette_commands.len() == 3),
+            "palette should be open with the injected user commands"
+        );
+        println!("Screenshot saved to /tmp/plexi_command_palette_user_commands.png");
+    }
+
+    #[test]
     fn command_palette_keeps_search_focus_after_scrolled_down_nav() {
         let mut h = PlexiUiHarness::new_sized(1168.0, 720.0);
         add_focused_pane(&mut h);


### PR DESCRIPTION
Closes #2269

## Summary

- Surface workspace `commands.toml` entries and global profile scripts in the command palette under a new **RUN** section with scope chips (`run`/`ws`, `run`/`global`).
- `resolve_user_commands()` (src/cli/mod.rs) reuses the existing `PlexiCommands` parser and mirrors `plexi run` precedence exactly: a workspace `commands.toml` shadows global scripts entirely; a present-but-unparseable file yields nothing rather than a silent global fallback — so the palette never lists a command `plexi run` cannot execute.
- Commands are resolved at palette-open time into `palette_commands` (same pattern as `palette_notes`), re-read on every open → **hot reload with no mtime bookkeeping**.
- Selecting a row opens a terminal pane running `plexi run <name>` in the focused workspace cwd, reusing the trusted CLI path (secret injection, workspace scoping, logging). The host never re-implements command execution; the security inventory is updated to note this entry point.

## Done When

- [x] With a workspace `commands.toml` containing a command named `test`, opening the palette in that workspace shows it with a workspace scope chip; fuzzy searching `test` selects it; Enter executes the same resolved command as `plexi run test`.
- [x] Editing `commands.toml` while Plexi is running updates the palette on the next open without restarting.
- [x] Tests cover workspace/global precedence, hot reload, and palette selection dispatch.

**Test evidence (attempt 1):**
- cargo test: 1201 passed, 0 failed — filters: `resolve_user_commands_tests`, `command_palette`, full bin suite
- Resolver unit tests: precedence (workspace shadows global), hot-reload (re-read each call), global-script fallback, parse-error → empty
- Palette tests: user commands sort below host commands (empty query); name prefix-match surfaces ahead of substring app match; shell single-quote escaping
- PlexiUiHarness render: /tmp/plexi_command_palette_user_commands.png — RUN section shows `build`/`test` (run+ws chips) and `deploy` (run+global chip) with correct secondary text
- Conclusion: binary install required — palette→`plexi run` dispatch opens a terminal PTY; the end-to-end execution is only observable in the installed bundle. All resolve/list/render/precedence/hot-reload/sort logic is fully unit/UI-tested.