### PR TITLE
Tabs: truncate titles to one line (stint 0201)

### DIFF
--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -217,7 +217,23 @@ pub(crate) fn paint_tab_bar(
         let content_left = tab_rect.left() + pip_space;
         let max_text_width = (tab_rect.right() - content_left - text_pad).max(0.0);
 
-        let galley = painter.layout(label, font.clone(), text_color, max_text_width);
+        let mut layout_job = egui::text::LayoutJob::default();
+        layout_job.append(
+            &label,
+            0.0,
+            egui::TextFormat {
+                font_id: font.clone(),
+                color: text_color,
+                ..Default::default()
+            },
+        );
+        layout_job.wrap = egui::text::TextWrapping {
+            max_width: max_text_width,
+            max_rows: 1,
+            break_anywhere: true,
+            overflow_character: Some('…'),
+        };
+        let galley = painter.ctx().fonts(|f| f.layout_job(layout_job));
 
         let text_pos = egui::pos2(
             content_left + (tab_rect.right() - content_left) / 2.0 - galley.size().x / 2.0,

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1212,4 +1212,56 @@ mod tests {
             "whitespace-only rename must be discarded"
         );
     }
+
+    /// Regression: tab titles with long names must stay on a single line and show
+    /// a trailing ellipsis rather than wrapping or overflowing the tab bar rect.
+    #[test]
+    fn tab_titles_truncate_to_single_line() {
+
+        let mut h = PlexiUiHarness::new();
+        h.step();
+
+        h.with_app_mut(|app| {
+            let pane_id_a = app.host.alloc_pane_id();
+            let pane_id_b = app.host.alloc_pane_id();
+            for (pane_id, name) in [
+                (pane_id_a, "A very long tab title that should not wrap onto a second line under any circumstances"),
+                (pane_id_b, "Short"),
+            ] {
+                let (process_app, _draw_tx) =
+                    ProcessApp::new_for_test(pane_id, AppPermissions::builtin());
+                let app_pane = AppPane {
+                    pip_status: None,
+                    id: pane_id,
+                    runtime: AppRuntime::Process(Box::new(process_app)),
+                    workspace_root: std::env::temp_dir(),
+                    permissions: AppPermissions::builtin(),
+                    manifest_id: "test".to_string(),
+                    name: name.to_string(),
+                    pane_group: None,
+                    linked_pane_id: None,
+                    overlay_replaced: None,
+                    hidden: false,
+                    agent: None,
+                    slots: std::collections::HashMap::new(),
+                };
+                let win = &mut app.windows[app.active_window];
+                win.panes.insert(pane_id, Pane::App(Box::new(app_pane)));
+            }
+            let win = &mut app.windows[app.active_window];
+            let tile_a = win.tree.tiles.insert_pane(pane_id_a);
+            let tile_b = win.tree.tiles.insert_pane(pane_id_b);
+            let tab_tile = win.tree.tiles.insert_tab_tile(vec![tile_a, tile_b]);
+            win.tree.root = Some(tab_tile);
+            win.focused_pane = Some(tile_a);
+        });
+
+        h.run_steps(2);
+        h.render().expect("tab bar with long title must render without panic");
+        h.save_screenshot("/tmp/plexi_tab_truncation.png")
+            .expect("screenshot failed");
+        println!("Screenshot saved to /tmp/plexi_tab_truncation.png");
+        // Visual: open /tmp/plexi_tab_truncation.png and confirm the long label
+        // ends with '…' on a single line and does not push the tab bar taller.
+    }
 }


### PR DESCRIPTION
No linked GitHub issue — this is a pure stint task.

## Summary

- Replace `painter.layout()` (wraps on word boundaries) with a `LayoutJob` using `max_rows: 1` and `overflow_character: Some('…')` in `paint_tab_bar`, so long tab titles elide to a single line instead of wrapping and breaking the fixed-height tab bar.
- Adds a screenshot regression test (`tab_titles_truncate_to_single_line`) that renders a tab group with a very long title and confirms it renders without panic.

## Done When

- [ ] Long tab labels show a single line ending in `…` instead of wrapping
- [ ] Activity pips, active styling, dividers, and drag reorder are unaffected
- [ ] `cargo test --bin plexi` passes (1221 tests)