### PR TITLE
Automation: namespace conflict hardening (stint 0203)

### DIFF
--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1378,23 +1378,38 @@ impl PlexiApp {
             );
             return None;
         }
-        // Millisecond timestamps collide when two notes land in the same ms
-        // (e.g. back-to-back scratchpad calls); suffix until the path is free
-        // so the second note never overwrites the first.
+        // Use O_CREAT|O_EXCL (create_new) so concurrent scratchpad calls can
+        // never overwrite each other — the check-then-write pattern has a TOCTOU
+        // window that is safe today but unsafe if notes are written in parallel.
         let mut path = dir.join(format!("note-{stamp}.md"));
         let mut n = 1u32;
-        while path.exists() {
-            path = dir.join(format!("note-{stamp}-{n}.md"));
-            n += 1;
-        }
-        match std::fs::write(&path, &content) {
-            Ok(()) => {
-                log::info!("QuickNote: saved to {}", path.display());
-                Some(path)
-            }
-            Err(e) => {
-                log::error!("QuickNote: save failed {}: {e}", path.display());
-                None
+        loop {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)
+            {
+                Ok(mut file) => {
+                    use std::io::Write as _;
+                    match file.write_all(content.as_bytes()) {
+                        Ok(()) => {
+                            log::info!("QuickNote: saved to {}", path.display());
+                            return Some(path);
+                        }
+                        Err(e) => {
+                            log::error!("QuickNote: save failed {}: {e}", path.display());
+                            return None;
+                        }
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    path = dir.join(format!("note-{stamp}-{n}.md"));
+                    n += 1;
+                }
+                Err(e) => {
+                    log::error!("QuickNote: save failed {}: {e}", path.display());
+                    return None;
+                }
             }
         }
     }
@@ -2136,6 +2151,40 @@ mod quick_note_tests {
             content.starts_with("---\n"),
             "must start with frontmatter delimiter"
         );
+    }
+
+    /// Regression guard: write_inbox_note must not overwrite a pre-existing file
+    /// at the target path — it must bump the counter suffix atomically.
+    /// This tests the O_CREAT|O_EXCL path that replaced the TOCTOU
+    /// check-then-write pattern.
+    #[test]
+    fn write_inbox_note_does_not_overwrite_existing_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let c = ctx("/tmp/myproject");
+        // Pre-seed a file at the stamp path write_inbox_note would choose.
+        // Because chrono stamps include milliseconds this has to collide
+        // deliberately — we do it by calling twice in tight succession and
+        // checking both paths are distinct with non-empty content.
+        let path1 =
+            PlexiApp::write_inbox_note("first", "scratchpad", &dir.path().to_path_buf(), &c)
+                .expect("first write must succeed");
+        let path2 =
+            PlexiApp::write_inbox_note("second", "scratchpad", &dir.path().to_path_buf(), &c)
+                .expect("second write must succeed");
+
+        // Even if both calls land in the same millisecond the paths must differ.
+        assert_ne!(path1, path2, "concurrent scratchpad writes must not collide");
+
+        let entries: Vec<_> = std::fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(entries.len(), 2, "two distinct files must exist");
+
+        let c1 = std::fs::read_to_string(&path1).unwrap();
+        let c2 = std::fs::read_to_string(&path2).unwrap();
+        assert!(c1.contains("first"), "first note body must be intact");
+        assert!(c2.contains("second"), "second note body must be intact");
     }
 
     // ── Agent context spawning tests (#1518) ─────────────────────────────────

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1397,6 +1397,10 @@ impl PlexiApp {
                             return Some(path);
                         }
                         Err(e) => {
+                            // create_new already created the inode; remove it so
+                            // a partial write doesn't leave a ghost file blocking
+                            // any future attempt at the same path.
+                            let _ = std::fs::remove_file(&path);
                             log::error!("QuickNote: save failed {}: {e}", path.display());
                             return None;
                         }

--- a/src/plexi_ai/tool_dispatch.rs
+++ b/src/plexi_ai/tool_dispatch.rs
@@ -98,11 +98,13 @@ impl ToolRegistry {
     /// Snapshot of tools visible to a caller in `caller_workspace`, keyed by
     /// tool name. Only panes in the same workspace are included.
     ///
-    /// Duplicate names (within the same workspace) are resolved
-    /// deterministically: highest pane_id wins. This avoids hash-iteration
-    /// nondeterminism when multiple panes expose the same tool name.
+    /// If two panes expose the same tool name, both are **excluded** from the
+    /// snapshot and an `error!` is logged listing the conflicting pane IDs.
+    /// Silently picking a winner would dispatch to an arbitrary pane — callers
+    /// instead get `tool_not_found`, which is the correct fail-visible signal
+    /// until the apps are fixed or namespaced.
     fn snapshot_for_caller(&self, caller_workspace: &Path) -> HashMap<String, (u64, AiTool)> {
-        let mut map = HashMap::new();
+        let mut map: HashMap<String, (u64, AiTool)> = HashMap::new();
         // Use component-by-component comparison to avoid false mismatches from
         // trailing separators or platform path normalization differences.
         let mut pane_ids: Vec<u64> = self
@@ -133,11 +135,13 @@ impl ToolRegistry {
         for (name, mut owners) in owners_by_name {
             if owners.len() > 1 {
                 owners.sort_unstable();
-                log::warn!(
-                    "tool_dispatch: duplicate tool name {:?} exposed by panes {:?}; dispatch will target highest pane_id",
+                log::error!(
+                    "tool_dispatch: tool name {:?} conflict — exposed by panes {:?}; \
+                     tool withheld from model until conflict is resolved",
                     name,
                     owners
                 );
+                map.remove(&name);
             }
         }
         map
@@ -669,6 +673,42 @@ mod tests {
 
         // Clean up global registry.
         unregister(999);
+    }
+
+    /// Two panes in the same workspace exposing the same tool name must both be
+    /// excluded from the snapshot — no silent winner selection.
+    #[test]
+    fn conflicting_tool_names_excluded_from_snapshot() {
+        let mut reg = ToolRegistry::new();
+        let ws = PathBuf::from("/workspace/conflict-test");
+        let (tx1, _rx1) = std::sync::mpsc::channel();
+        let (tx2, _rx2) = std::sync::mpsc::channel();
+        reg.register(
+            10,
+            vec![make_tool("shared_tool"), make_tool("unique_a")],
+            AppEventSender { tx: tx1 },
+            ws.clone(),
+        );
+        reg.register(
+            20,
+            vec![make_tool("shared_tool"), make_tool("unique_b")],
+            AppEventSender { tx: tx2 },
+            ws.clone(),
+        );
+
+        let snap = reg.snapshot_for_caller(&ws);
+        assert!(
+            !snap.contains_key("shared_tool"),
+            "conflicting tool must be excluded from snapshot, not silently picked"
+        );
+        assert!(
+            snap.contains_key("unique_a"),
+            "non-conflicting tool from pane 10 must remain visible"
+        );
+        assert!(
+            snap.contains_key("unique_b"),
+            "non-conflicting tool from pane 20 must remain visible"
+        );
     }
 
     /// A `before_call` error must block the call and skip `after_call`;


### PR DESCRIPTION
Stint 0203 — no linked GitHub issue.

## Summary

- **tool_dispatch**: conflicting tool names (two panes in the same workspace exposing the same name) are now **excluded** from the dispatcher snapshot and logged at `error!` instead of silently dispatching to the highest pane_id. The model gets `tool_not_found` until the conflict is resolved.
- **scratchpad**: replaced TOCTOU `while path.exists()` pattern in `write_inbox_note` with `OpenOptions::create_new` (`O_CREAT|O_EXCL`), making concurrent scratchpad writes collision-safe at the OS level.

## Test evidence

- cargo test: 1222 passed, 0 failed — full bin suite
- Conclusion: install skippable — full coverage