### PR TITLE
Text-editor portal preview icon (stint 0205)

### DIFF
--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -296,7 +296,14 @@ impl PlexiApp {
                                         _ => None,
                                     };
                                     let kind = match pane_ref {
-                                        Some(p) if p.as_app().is_some() => crate::spatial::tiling::PaneKind::App,
+                                        Some(p) if p.as_app().is_some() => {
+                                            let app = p.as_app().expect("as_app checked above");
+                                            if app.manifest_id == "text-editor" {
+                                                crate::spatial::tiling::PaneKind::TextEditor
+                                            } else {
+                                                crate::spatial::tiling::PaneKind::App
+                                            }
+                                        }
                                         Some(p) if p.as_portal().is_some() => crate::spatial::tiling::PaneKind::Portal,
                                         _ => crate::spatial::tiling::PaneKind::Terminal,
                                     };

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -296,14 +296,10 @@ impl PlexiApp {
                                         _ => None,
                                     };
                                     let kind = match pane_ref {
-                                        Some(p) if p.as_app().is_some() => {
-                                            let app = p.as_app().expect("as_app checked above");
-                                            if app.manifest_id == "text-editor" {
-                                                crate::spatial::tiling::PaneKind::TextEditor
-                                            } else {
-                                                crate::spatial::tiling::PaneKind::App
-                                            }
+                                        Some(p) if p.as_app().is_some_and(|a| a.manifest_id == "text-editor") => {
+                                            crate::spatial::tiling::PaneKind::TextEditor
                                         }
+                                        Some(p) if p.as_app().is_some() => crate::spatial::tiling::PaneKind::App,
                                         Some(p) if p.as_portal().is_some() => crate::spatial::tiling::PaneKind::Portal,
                                         _ => crate::spatial::tiling::PaneKind::Terminal,
                                     };

--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -1119,7 +1119,7 @@ pub(crate) fn paint_portal_minimap(
                         colors.text_dim.r(),
                         colors.text_dim.g(),
                         colors.text_dim.b(),
-                        (line_alpha * 2).min(255),
+                        (line_alpha as u32 * 2).min(255) as u8,
                     );
                     let fill = egui::Color32::from_rgba_unmultiplied(
                         colors.text_dim.r(),
@@ -1143,7 +1143,7 @@ pub(crate) fn paint_portal_minimap(
                         paper.left_bottom(),
                     ];
                     painter.add(egui::Shape::convex_polygon(
-                        body.clone(),
+                        body,
                         fill,
                         egui::Stroke::new(1.0, outline),
                     ));
@@ -1198,7 +1198,7 @@ pub(crate) fn paint_portal_minimap(
                         colors.text_dim.r(),
                         colors.text_dim.g(),
                         colors.text_dim.b(),
-                        (line_alpha * 3).min(255),
+                        (line_alpha as u32 * 3).min(255) as u8,
                     );
                     let accent_strong = egui::Color32::from_rgba_unmultiplied(
                         colors.accent.r(),

--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -299,6 +299,9 @@ pub(crate) fn paint_tab_bar(
 pub enum PaneKind {
     Terminal,
     App,
+    /// Text/editor app pane (manifest `text-editor`). Renders a document glyph
+    /// in the minimap instead of the generic app mark.
+    TextEditor,
     Portal,
 }
 
@@ -1094,6 +1097,134 @@ pub(crate) fn paint_portal_minimap(
                             );
                         }
                     }
+                }
+                PaneKind::TextEditor => {
+                    // Portrait sheet with a folded top-right corner plus a short
+                    // pencil laid across the lower-right. Accent stays on the
+                    // pencil tip + metal ferrule so the glyph reads as "edit"
+                    // without growing visually long.
+                    let glyph = (draw_area.width().min(draw_area.height())).clamp(12.0, 56.0);
+                    let pw = glyph * 0.46;
+                    let ph = glyph * 0.60;
+                    // Nudge the sheet slightly up/left so the pencil has room.
+                    let center = egui::pos2(
+                        draw_area.center().x - glyph * 0.05,
+                        draw_area.center().y - glyph * 0.03,
+                    );
+                    let paper =
+                        egui::Rect::from_center_size(center, egui::vec2(pw, ph));
+                    let fold = (pw * 0.34).clamp(2.0, 10.0);
+
+                    let outline = egui::Color32::from_rgba_unmultiplied(
+                        colors.text_dim.r(),
+                        colors.text_dim.g(),
+                        colors.text_dim.b(),
+                        (line_alpha * 2).min(255),
+                    );
+                    let fill = egui::Color32::from_rgba_unmultiplied(
+                        colors.text_dim.r(),
+                        colors.text_dim.g(),
+                        colors.text_dim.b(),
+                        (line_alpha / 2).max(8),
+                    );
+                    let rule = egui::Color32::from_rgba_unmultiplied(
+                        colors.text_dim.r(),
+                        colors.text_dim.g(),
+                        colors.text_dim.b(),
+                        line_alpha,
+                    );
+
+                    // Sheet body (folded corner masked out via two polygons).
+                    let body = vec![
+                        paper.left_top(),
+                        egui::pos2(paper.right() - fold, paper.top()),
+                        egui::pos2(paper.right(), paper.top() + fold),
+                        paper.right_bottom(),
+                        paper.left_bottom(),
+                    ];
+                    painter.add(egui::Shape::convex_polygon(
+                        body.clone(),
+                        fill,
+                        egui::Stroke::new(1.0, outline),
+                    ));
+                    // Folded corner triangle, a touch lighter than the body.
+                    painter.add(egui::Shape::convex_polygon(
+                        vec![
+                            egui::pos2(paper.right() - fold, paper.top()),
+                            egui::pos2(paper.right() - fold, paper.top() + fold),
+                            egui::pos2(paper.right(), paper.top() + fold),
+                        ],
+                        egui::Color32::from_rgba_unmultiplied(
+                            colors.text_dim.r(),
+                            colors.text_dim.g(),
+                            colors.text_dim.b(),
+                            line_alpha,
+                        ),
+                        egui::Stroke::new(1.0, outline),
+                    ));
+
+                    // Text rules — drop the last when the glyph is tiny.
+                    let rule_w = (pw * 0.16).clamp(0.8, 1.6);
+                    let margin = pw * 0.20;
+                    let rule_xs = (paper.left() + margin, paper.right() - margin);
+                    let rows = if ph > 18.0 { 3 } else { 2 };
+                    for i in 0..rows {
+                        let ry = paper.top() + ph * (0.34 + i as f32 * 0.20);
+                        // Last visible rule is shorter, like a paragraph end.
+                        let right = if i == rows - 1 {
+                            rule_xs.0 + (rule_xs.1 - rule_xs.0) * 0.6
+                        } else {
+                            rule_xs.1
+                        };
+                        painter.line_segment(
+                            [egui::pos2(rule_xs.0, ry), egui::pos2(right, ry)],
+                            egui::Stroke::new(rule_w, rule),
+                        );
+                    }
+
+                    // Pencil — short diagonal across the lower-right corner,
+                    // tip pointing down-right.
+                    let pencil_w = (glyph * 0.12).clamp(1.6, 4.0);
+                    let tip = egui::pos2(
+                        paper.right() + glyph * 0.10,
+                        paper.bottom() + glyph * 0.06,
+                    );
+                    let tail = egui::pos2(tip.x - glyph * 0.30, tip.y - glyph * 0.30);
+                    let dir = (tip - tail).normalized();
+                    // Ferrule + tip occupy the last ~30% near the point.
+                    let neck = tip - dir * (pencil_w * 1.6);
+                    let body_end = tip - dir * (pencil_w * 2.8);
+                    let pencil_body = egui::Color32::from_rgba_unmultiplied(
+                        colors.text_dim.r(),
+                        colors.text_dim.g(),
+                        colors.text_dim.b(),
+                        (line_alpha * 3).min(255),
+                    );
+                    let accent_strong = egui::Color32::from_rgba_unmultiplied(
+                        colors.accent.r(),
+                        colors.accent.g(),
+                        colors.accent.b(),
+                        if pane.focused { 200 } else { 150 },
+                    );
+                    // Wood shaft (eraser end → ferrule).
+                    painter.line_segment(
+                        [tail, body_end],
+                        egui::Stroke::new(pencil_w, pencil_body),
+                    );
+                    // Metal ferrule + tip in accent.
+                    painter.line_segment(
+                        [body_end, neck],
+                        egui::Stroke::new(pencil_w, accent_strong),
+                    );
+                    painter.add(egui::Shape::convex_polygon(
+                        vec![
+                            neck + dir.rot90() * (pencil_w * 0.5),
+                            neck - dir.rot90() * (pencil_w * 0.5),
+                            tip,
+                        ],
+                        accent_strong,
+                        egui::Stroke::new(0.0, egui::Color32::TRANSPARENT),
+                    ));
                 }
                 PaneKind::Portal => {
                     // 2x2 window grid, outlines only, bottom-right filled with accent (Plexi logo feel)

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -356,6 +356,103 @@ mod tests {
         println!("Screenshot saved to /tmp/plexi_init.png");
     }
 
+    /// Subcontext portal whose child context holds a `text-editor` pane: the
+    /// minimap must render the document/pencil glyph (stint 0205) instead of the
+    /// generic app grid. Zoom the portal so the icon is legible in the PNG.
+    #[test]
+    fn screenshot_portal_text_editor_icon() {
+        let mut h = PlexiUiHarness::new_sized(900.0, 640.0);
+        let _base = add_focused_pane(&mut h);
+        h.with_app_mut(|app| {
+            let active_ctx_id = app.router.active().context_id;
+            let child_ctx_id = active_ctx_id + 5000;
+            // Register the child context so the portal header shows a real name.
+            app.router.push(crate::host::context::Context {
+                name: "Notes".to_string(),
+                path: std::env::temp_dir(),
+                root: None,
+                description: Some("Editing notes".to_string()),
+                context_id: child_ctx_id,
+                parent_id: Some(active_ctx_id),
+                depth: 1,
+                parked: false,
+            });
+
+            // Child window holding the text-editor pane the portal previews.
+            let editor_pane_id = app.host.alloc_pane_id();
+            let (process_app, _tx) =
+                ProcessApp::new_for_test(editor_pane_id, AppPermissions::builtin());
+            let editor = AppPane {
+                pip_status: None,
+                id: editor_pane_id,
+                runtime: AppRuntime::Process(Box::new(process_app)),
+                workspace_root: std::env::temp_dir(),
+                permissions: AppPermissions::builtin(),
+                manifest_id: "text-editor".to_string(),
+                name: "note.md".to_string(),
+                pane_group: None,
+                linked_pane_id: None,
+                overlay_replaced: None,
+                hidden: false,
+                agent: None,
+                slots: std::collections::HashMap::new(),
+            };
+            let mut child_panes = std::collections::HashMap::new();
+            child_panes.insert(editor_pane_id, Pane::App(Box::new(editor)));
+            let mut child_tiles = egui_tiles::Tiles::default();
+            let child_tile = child_tiles.insert_pane(editor_pane_id);
+            let child_window_id = app.next_window_id;
+            app.next_window_id += 1;
+            app.windows.push(Window {
+                name: "notes window".to_string(),
+                path: std::env::temp_dir(),
+                tree: egui_tiles::Tree::new("notes window", child_tile, child_tiles),
+                panes: child_panes,
+                focused_pane: Some(child_tile),
+                zoomed_pane: None,
+                grid_x: 0,
+                grid_y: 0,
+                window_id: child_window_id,
+                context_id: child_ctx_id,
+            });
+
+            // Portal pane in the active window targeting the child context.
+            let portal_pane_id = app.host.alloc_pane_id();
+            let active_win = app.active_window;
+            let win = &mut app.windows[active_win];
+            win.panes.insert(
+                portal_pane_id,
+                Pane::Portal(Box::new(PortalPane {
+                    pane_id: portal_pane_id,
+                    target_context_id: child_ctx_id,
+                    context_state: None,
+                    hidden: false,
+                })),
+            );
+            let portal_tile = win.tree.tiles.insert_pane(portal_pane_id);
+            if let Some(root) = win.tree.root {
+                let new_root = win
+                    .tree
+                    .tiles
+                    .insert_horizontal_tile(vec![root, portal_tile]);
+                win.tree.root = Some(new_root);
+            }
+            // Zoom the portal so its minimap fills the window.
+            win.zoom_to(portal_tile);
+        });
+        h.run_steps(3);
+        h.save_screenshot("/tmp/plexi_portal_text_editor_icon.png")
+            .expect("render failed");
+        assert!(
+            h.with_app(|app| app.windows[app.active_window]
+                .panes
+                .values()
+                .any(|p| p.portal_target().is_some())),
+            "active window should contain a portal pane previewing the editor"
+        );
+        println!("Screenshot saved to /tmp/plexi_portal_text_editor_icon.png");
+    }
+
     // Visual smoke coverage lives in `tests/scenes/*.toml`, executed by
     // `scenes::tests::scene_suite`. Run one ad hoc with `just scene <file>`.
 


### PR DESCRIPTION
Stint 0205 — Subcontext portals: text icon polish

## Summary

- Text-editor app panes (`manifest_id == "text-editor"`) now render a document/pencil glyph in portal minimap previews instead of the generic app "grid of squares" mark.
- New `PaneKind::TextEditor` variant; `render.rs` maps the editor manifest to it; `paint_portal_minimap` draws a portrait sheet with a folded top-right corner, short text rules, and a stubby diagonal pencil with the accent color kept on the tip/ferrule (so the icon stays compact, not long).
- Theme-driven (`text_dim` / `accent` tokens) so it reads in both light and dark themes and clamps to remain legible at small minimap sizes.

## Test evidence
- `cargo test --bin plexi`: 1221 passed, 0 failed.
- New `PlexiUiHarness` screenshot test `screenshot_portal_text_editor_icon` renders a real portal previewing a text-editor child pane; inspected PNG confirms the folded-corner document + accented pencil glyph.

## Done When
- Text/editor subcontext portal previews show a clear document icon, not a generic app mark.
- Icon reads at small portal/minimap sizes and in both themes.
- Vector painting only (no bitmap assets).
- Focused screenshot smoke check added.