### PR TITLE
feat(host/context): collapsible subcontexts with stable top-level numbering (#2281)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -99,7 +99,7 @@ use crate::ui::theme::{self, Colors};
 use crate::workspace::WorkspaceFile;
 use egui_term::{BackendSettings, PtyEvent, TerminalTheme};
 use egui_tiles::{Tile, Tree};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::mpsc;
 
@@ -179,6 +179,8 @@ pub struct PlexiApp {
     pub(crate) drag_context: Option<usize>,
     /// Whether the "Parked (N)" section in the sidebar is expanded.
     pub(crate) parked_section_expanded: bool,
+    /// Parent context ids whose child rows are collapsed in the sidebar.
+    pub(crate) collapsed_contexts: HashSet<u64>,
     pub(crate) registry: AppRegistry,
     pub(crate) show_command_palette: bool,
     pub(crate) palette_query: String,
@@ -831,6 +833,7 @@ impl PlexiApp {
                     description_focus_requested: false,
                     drag_context: None,
                     parked_section_expanded: false,
+                    collapsed_contexts: ws.collapsed_contexts,
                     show_command_palette: false,
                     palette_query: String::new(),
                     palette_selected: 0,
@@ -1068,6 +1071,7 @@ impl PlexiApp {
             description_focus_requested: false,
             drag_context: None,
             parked_section_expanded: false,
+            collapsed_contexts: HashSet::new(),
             show_command_palette: false,
             palette_query: String::new(),
             palette_selected: 0,
@@ -1274,6 +1278,7 @@ impl PlexiApp {
                 description_focus_requested: false,
                 drag_context: None,
                 parked_section_expanded: false,
+                collapsed_contexts: HashSet::new(),
                 show_command_palette: false,
                 palette_query: String::new(),
                 palette_selected: 0,
@@ -3080,31 +3085,7 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 Action::SwitchContext(n) => {
-                    // Map display position n (0-indexed) to the actual router index by
-                    // computing the same active display order the sidebar renders.
-                    let num = self.router.len();
-                    let mut display_order: Vec<usize> = Vec::with_capacity(num);
-                    for i in 0..num {
-                        if self.router.get(i).parent_id.is_none() {
-                            display_order.push(i);
-                            let ctx_id = self.router.get(i).context_id;
-                            for j in 0..num {
-                                if self.router.get(j).parent_id == Some(ctx_id) {
-                                    display_order.push(j);
-                                }
-                            }
-                        }
-                    }
-                    for i in 0..num {
-                        if !display_order.contains(&i) {
-                            display_order.push(i);
-                        }
-                    }
-                    let active_order: Vec<usize> = display_order
-                        .into_iter()
-                        .filter(|&i| !self.router.get(i).parked)
-                        .collect();
-                    if let Some(&router_idx) = active_order.get(n) {
+                    if let Some(&router_idx) = self.sidebar_top_level_active_order().get(n) {
                         let target_parent = self.router.get(router_idx).parent_id;
                         let current_ctx_id = self.router.active().context_id;
                         if target_parent == Some(current_ctx_id) {

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -1210,6 +1210,83 @@ fn test_context(id: u64, parent_id: u64, name: &str) -> crate::host::context::Co
     }
 }
 
+#[test]
+fn top_level_shortcuts_ignore_subcontexts() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let root_id = app.router.active().context_id;
+    app.router.push(test_context(42, root_id, "child"));
+    app.router.push(crate::host::context::Context {
+        name: "second-root".to_string(),
+        path: std::path::PathBuf::from("/tmp/second-root"),
+        root: None,
+        description: None,
+        context_id: 43,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+
+    let top_level = app.sidebar_top_level_active_order();
+    assert_eq!(
+        top_level,
+        vec![0, 2],
+        "only top-level contexts should consume Cmd+1..9"
+    );
+
+    let rows = app.sidebar_visible_rows(false);
+    let summary: Vec<_> = rows
+        .iter()
+        .map(|row| (row.router_idx, row.top_level_number))
+        .collect();
+    assert_eq!(
+        summary,
+        vec![(0, Some(0)), (1, None), (2, Some(1))],
+        "child rows stay visible but do not take a global sidebar number"
+    );
+
+    app.switch_workspace(top_level[1]);
+    assert_eq!(
+        app.router.active().context_id,
+        43,
+        "the second top-level shortcut target should stay stable even with a visible child row"
+    );
+}
+
+#[test]
+fn collapsing_parent_hides_children_without_renumbering_top_level_contexts() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let root_id = app.router.active().context_id;
+    app.router.push(test_context(52, root_id, "child"));
+    app.router.push(crate::host::context::Context {
+        name: "second-root".to_string(),
+        path: std::path::PathBuf::from("/tmp/second-root"),
+        root: None,
+        description: None,
+        context_id: 53,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    app.collapsed_contexts.insert(root_id);
+
+    let rows = app.sidebar_visible_rows(false);
+    let summary: Vec<_> = rows
+        .iter()
+        .map(|row| (row.router_idx, row.top_level_number))
+        .collect();
+    assert_eq!(
+        summary,
+        vec![(0, Some(0)), (2, Some(1))],
+        "collapsing a parent should hide only its child rows and preserve top-level numbering"
+    );
+}
+
 /// Issue #2108: dissolving a one-window sub-context should graft that child's
 /// tile tree into the exact Portal slot instead of flattening child panes into
 /// the parent container.
@@ -1986,10 +2063,7 @@ fn push_pane_ipc_unknown_pane_falls_back_to_focused() {
 /// not at the end — even when another sibling context (child2) already exists.
 #[test]
 fn push_pane_to_subcontext_inserts_grandchild_after_parent_not_at_end() {
-    fn push_ipc(
-        h: &mut crate::testing::HostHarness,
-        pane_id: crate::spatial::tiling::PaneId,
-    ) {
+    fn push_ipc(h: &mut crate::testing::HostHarness, pane_id: crate::spatial::tiling::PaneId) {
         let req: crate::app_protocol::AppRequest = serde_json::from_value(serde_json::json!({
             "type": "push_pane_to_subcontext",
             "pane_id": pane_id,
@@ -2020,7 +2094,11 @@ fn push_pane_to_subcontext_inserts_grandchild_after_parent_not_at_end() {
     // [root, child1, grandchild, child2].
     // Without the fix, grandchild would append at the end: [root, child1, child2, grandchild].
     push_ipc(&mut h, pane_a);
-    assert_eq!(h.app.router.len(), 4, "root + child1 + grandchild + child2 = 4 contexts");
+    assert_eq!(
+        h.app.router.len(),
+        4,
+        "root + child1 + grandchild + child2 = 4 contexts"
+    );
 
     let ids: Vec<u64> = h.app.router.iter().map(|c| c.context_id).collect();
     let grandchild = h
@@ -2032,7 +2110,10 @@ fn push_pane_to_subcontext_inserts_grandchild_after_parent_not_at_end() {
     assert_eq!(grandchild.depth, 2, "grandchild depth must be 2");
 
     let child1_pos = ids.iter().position(|&id| id == child1_id).unwrap();
-    let grandchild_pos = ids.iter().position(|&id| id == grandchild.context_id).unwrap();
+    let grandchild_pos = ids
+        .iter()
+        .position(|&id| id == grandchild.context_id)
+        .unwrap();
     let child2_pos = ids.iter().position(|&id| id == child2_id).unwrap();
     let root_pos = ids.iter().position(|&id| id == root_id).unwrap();
 

--- a/src/host/context.rs
+++ b/src/host/context.rs
@@ -14,6 +14,8 @@ pub(crate) enum WindowMenuAction {
     MoveUp,
     MoveDown,
     MoveToBottom,
+    MoveIntoContext(u64),
+    PromoteContext,
     Delete,
     SetRoot(PathBuf),
     ClearRoot,

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -144,7 +144,11 @@ impl PlexiApp {
                                         None,
                                         colors,
                                     );
-                                    shortcut_description(ui, "Switch context 1–9", colors);
+                                    shortcut_description(
+                                        ui,
+                                        "Switch top-level context 1–9",
+                                        colors,
+                                    );
                                     ui.end_row();
 
                                     crate::ui::shortcuts::key_combo(

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -1606,6 +1606,7 @@ impl PlexiApp {
             contexts: saved_contexts,
             windows: saved_windows,
             context_active_window: self.context_active_window.clone(),
+            collapsed_contexts: self.collapsed_contexts.clone(),
         };
 
         if let Err(e) = ws.save() {

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -7,6 +7,31 @@ pub struct ListDropdownHeader<'a> {
     label: &'a str,
     expanded: bool,
     indent: f32,
+    label_left: Option<f32>,
+}
+
+pub(crate) fn paint_disclosure_caret(
+    ui: &egui::Ui,
+    center: Pos2,
+    expanded: bool,
+    radius: f32,
+    color: Color32,
+) {
+    let points = if expanded {
+        vec![
+            Pos2::new(center.x - radius, center.y - radius * 0.45),
+            Pos2::new(center.x + radius, center.y - radius * 0.45),
+            Pos2::new(center.x, center.y + radius * 0.65),
+        ]
+    } else {
+        vec![
+            Pos2::new(center.x - radius * 0.45, center.y - radius),
+            Pos2::new(center.x - radius * 0.45, center.y + radius),
+            Pos2::new(center.x + radius * 0.65, center.y),
+        ]
+    };
+    ui.painter()
+        .add(egui::Shape::convex_polygon(points, color, Stroke::NONE));
 }
 
 impl<'a> ListDropdownHeader<'a> {
@@ -15,11 +40,17 @@ impl<'a> ListDropdownHeader<'a> {
             label,
             expanded,
             indent: style::LIST_ROW_PAD_H,
+            label_left: None,
         }
     }
 
     pub fn indent(mut self, indent: f32) -> Self {
         self.indent = indent;
+        self
+    }
+
+    pub fn label_left(mut self, label_left: f32) -> Self {
+        self.label_left = Some(label_left);
         self
     }
 
@@ -43,38 +74,22 @@ impl<'a> ListDropdownHeader<'a> {
             Pos2::new(rect.left() + self.indent, rect.top()),
             Vec2::new(style::LIST_DROPDOWN_CHEVRON_W, rect.height()),
         );
-        let center = chevron_rect.center();
         let chevron_color = if response.hovered() {
             colors.text_primary
         } else {
             colors.text_section
         };
-        let r = 4.5;
-        let points = if self.expanded {
-            vec![
-                Pos2::new(center.x - r, center.y - r * 0.45),
-                Pos2::new(center.x + r, center.y - r * 0.45),
-                Pos2::new(center.x, center.y + r * 0.65),
-            ]
-        } else {
-            vec![
-                Pos2::new(center.x - r * 0.45, center.y - r),
-                Pos2::new(center.x - r * 0.45, center.y + r),
-                Pos2::new(center.x + r * 0.65, center.y),
-            ]
-        };
-        ui.painter().add(egui::Shape::convex_polygon(
-            points,
-            chevron_color,
-            Stroke::NONE,
-        ));
+        paint_disclosure_caret(ui, chevron_rect.center(), self.expanded, 4.5, chevron_color);
 
         paint_text_left_center(
             ui,
             self.label,
             crate::ui::theme::font_medium(style::TEXT_CAPTION),
             colors.text_section,
-            chevron_rect.right() + style::SPACE_XS,
+            rect.left()
+                + self
+                    .label_left
+                    .unwrap_or_else(|| chevron_rect.right() - rect.left() + style::SPACE_XS),
             rect.center().y,
         );
 

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -16,13 +16,29 @@ fn drop_slot_from_rects(rects: &[Rect], mouse_y: f32) -> usize {
     rects.len()
 }
 
+const NEST_DROP_X_OFFSET: f32 = 54.0;
+const NEST_DROP_Y_FRACTION: f32 = 0.25;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum SidebarDropMode {
+    TopLevelSlot,
+    Nest { target_idx: usize },
+}
+
 /// Where a dragged context will land when released: which section (active vs.
-/// parked) and the slot within that section's display list. A drop fully
-/// determines both the context's `parked` flag and its order.
+/// parked), the slot within that section's display list, and whether the drop
+/// means top-level placement or nesting under a specific row.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 struct SidebarDrop {
     parked: bool,
     slot: usize,
+    mode: SidebarDropMode,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SidebarRowInfo {
+    pub(crate) router_idx: usize,
+    pub(crate) top_level_number: Option<usize>,
 }
 
 /// Resolve a dragged context against the current pointer position. The Parked
@@ -38,13 +54,34 @@ fn resolve_drag_drop(
     src_slot: usize,
     parked_header: Option<Rect>,
     pointer: Option<egui::Pos2>,
-    active_rects: &[Rect],
-    parked_rects: &[Rect],
+    active_rects: &[(Rect, usize)],
+    parked_rects: &[(Rect, usize)],
 ) -> Option<SidebarDrop> {
     let pos = pointer?;
     let into_parked = parked_header.map_or(false, |h| pos.y >= h.top());
-    let rects = if into_parked { parked_rects } else { active_rects };
-    let slot = drop_slot_from_rects(rects, pos.y);
+    let rects = if into_parked {
+        parked_rects
+    } else {
+        active_rects
+    };
+    let row_rects: Vec<Rect> = rects.iter().map(|(rect, _)| *rect).collect();
+    for (rect, target_idx) in rects {
+        let middle_top = rect.top() + rect.height() * NEST_DROP_Y_FRACTION;
+        let middle_bottom = rect.bottom() - rect.height() * NEST_DROP_Y_FRACTION;
+        if pos.y >= middle_top
+            && pos.y <= middle_bottom
+            && pos.x >= rect.left() + NEST_DROP_X_OFFSET
+        {
+            return Some(SidebarDrop {
+                parked: into_parked,
+                slot: drop_slot_from_rects(&row_rects, pos.y),
+                mode: SidebarDropMode::Nest {
+                    target_idx: *target_idx,
+                },
+            });
+        }
+    }
+    let slot = drop_slot_from_rects(&row_rects, pos.y);
     // Same-section drop onto the source's own edges leaves it in place.
     if into_parked == src_parked && (slot == src_slot || slot == src_slot + 1) {
         return None;
@@ -52,6 +89,7 @@ fn resolve_drag_drop(
     Some(SidebarDrop {
         parked: into_parked,
         slot,
+        mode: SidebarDropMode::TopLevelSlot,
     })
 }
 
@@ -68,6 +106,169 @@ fn reorder_line_y(rects: &[Rect], slot: usize) -> f32 {
 }
 
 impl PlexiApp {
+    pub(crate) fn sidebar_display_order(&self) -> Vec<usize> {
+        fn append_children(app: &PlexiApp, parent_id: Option<u64>, out: &mut Vec<usize>) {
+            for idx in 0..app.router.len() {
+                if app.router.get(idx).parent_id == parent_id {
+                    out.push(idx);
+                    let ctx_id = app.router.get(idx).context_id;
+                    append_children(app, Some(ctx_id), out);
+                }
+            }
+        }
+
+        let mut order = Vec::with_capacity(self.router.len());
+        append_children(self, None, &mut order);
+        for idx in 0..self.router.len() {
+            if !order.contains(&idx) {
+                order.push(idx);
+            }
+        }
+        order
+    }
+
+    pub(crate) fn sidebar_top_level_active_order(&self) -> Vec<usize> {
+        self.sidebar_display_order()
+            .into_iter()
+            .filter(|&idx| self.router.get(idx).parent_id.is_none() && !self.router.get(idx).parked)
+            .collect()
+    }
+
+    fn sidebar_section_order(&self, parked: bool) -> Vec<usize> {
+        self.sidebar_display_order()
+            .into_iter()
+            .filter(|&idx| self.router.get(idx).parked == parked)
+            .collect()
+    }
+
+    fn sidebar_has_children(&self, router_idx: usize) -> bool {
+        let ctx_id = self.router.get(router_idx).context_id;
+        self.router.iter().any(|ctx| ctx.parent_id == Some(ctx_id))
+    }
+
+    fn sidebar_has_collapsed_ancestor_in_section(&self, router_idx: usize, parked: bool) -> bool {
+        let mut parent_id = self.router.get(router_idx).parent_id;
+        while let Some(pid) = parent_id {
+            let Some(parent_idx) = self.router.position(|ctx| ctx.context_id == pid) else {
+                break;
+            };
+            let parent = self.router.get(parent_idx);
+            if parent.parked == parked && self.collapsed_contexts.contains(&pid) {
+                return true;
+            }
+            parent_id = parent.parent_id;
+        }
+        false
+    }
+
+    pub(crate) fn sidebar_visible_rows(&self, parked: bool) -> Vec<SidebarRowInfo> {
+        let mut top_level_number = 0usize;
+        let mut rows = Vec::new();
+        for router_idx in self.sidebar_section_order(parked) {
+            let ctx = self.router.get(router_idx);
+            let number = if !parked && ctx.parent_id.is_none() {
+                let n = top_level_number;
+                top_level_number += 1;
+                Some(n)
+            } else {
+                None
+            };
+            if self.sidebar_has_collapsed_ancestor_in_section(router_idx, parked) {
+                continue;
+            }
+            rows.push(SidebarRowInfo {
+                router_idx,
+                top_level_number: number,
+            });
+        }
+        rows
+    }
+
+    fn active_context_descends_from(&self, ancestor_context_id: u64) -> bool {
+        let mut current = Some(self.router.active().context_id);
+        while let Some(ctx_id) = current {
+            if ctx_id == ancestor_context_id {
+                return true;
+            }
+            current = self
+                .router
+                .iter()
+                .find(|ctx| ctx.context_id == ctx_id)
+                .and_then(|ctx| ctx.parent_id);
+        }
+        false
+    }
+
+    fn toggle_context_children_collapsed(&mut self, router_idx: usize) {
+        if !self.sidebar_has_children(router_idx) {
+            return;
+        }
+        let context_id = self.router.get(router_idx).context_id;
+        if self.collapsed_contexts.remove(&context_id) {
+            log::info!("sidebar: expanded child rows for context id={context_id}");
+            return;
+        }
+        if self.router.active().context_id != context_id
+            && self.active_context_descends_from(context_id)
+        {
+            self.switch_workspace(router_idx);
+        }
+        self.collapsed_contexts.insert(context_id);
+        log::info!("sidebar: collapsed child rows for context id={context_id}");
+    }
+
+    fn sidebar_previous_top_level_context(&self, router_idx: usize) -> Option<usize> {
+        let parked = self.router.get(router_idx).parked;
+        let display_order = self.sidebar_display_order();
+        let pos = display_order.iter().position(|&idx| idx == router_idx)?;
+        display_order[..pos].iter().rev().copied().find(|&idx| {
+            let ctx = self.router.get(idx);
+            ctx.parent_id.is_none() && ctx.parked == parked
+        })
+    }
+
+    fn sidebar_top_level_insert_index(
+        &self,
+        parked: bool,
+        visible_slot: usize,
+        moving_id: u64,
+    ) -> usize {
+        let visible_rows = self.sidebar_visible_rows(parked);
+        let mut top_level_slot = 0usize;
+        for row in visible_rows.iter().take(visible_slot) {
+            let ctx = self.router.get(row.router_idx);
+            if ctx.parent_id.is_none() && ctx.context_id != moving_id {
+                top_level_slot += 1;
+            }
+        }
+
+        let top_level_indices: Vec<usize> = self
+            .sidebar_display_order()
+            .into_iter()
+            .filter(|&idx| {
+                let ctx = self.router.get(idx);
+                ctx.parked == parked && ctx.parent_id.is_none() && ctx.context_id != moving_id
+            })
+            .collect();
+
+        if let Some(&target_idx) = top_level_indices.get(top_level_slot) {
+            return target_idx;
+        }
+        top_level_indices
+            .last()
+            .map_or(self.router.len(), |&idx| self.router.subtree_end(idx))
+    }
+
+    fn switch_after_drag_park(&mut self, moved_idx: usize) {
+        let len = self.router.len();
+        let next = (1..len)
+            .map(|offset| (moved_idx + offset) % len)
+            .find(|&idx| !self.router.get(idx).parked);
+        if let Some(idx) = next {
+            self.switch_workspace(idx);
+        }
+    }
+
     pub(crate) fn draw_sidebar(&mut self, ui: &mut egui::Ui) {
         let sidebar_width = ui.available_width();
 
@@ -94,8 +295,8 @@ impl PlexiApp {
         let mut clicked_workspace: Option<usize> = None;
         let mut delete_context: Option<usize> = None;
         let mut menu_action: Option<(usize, WindowMenuAction)> = None;
-        let mut active_rects: Vec<Rect> = Vec::with_capacity(num_contexts);
-        let mut parked_rects: Vec<Rect> = Vec::with_capacity(num_contexts);
+        let mut active_rects: Vec<(Rect, usize)> = Vec::with_capacity(num_contexts);
+        let mut parked_rects: Vec<(Rect, usize)> = Vec::with_capacity(num_contexts);
         let mut drag_released = false;
         let mut unpark_context: Option<usize> = None;
 
@@ -105,41 +306,12 @@ impl PlexiApp {
             .and_then(|w| w.focused_pane.map(|tile| (w, tile)))
             .and_then(|(w, tile)| w.get_focused_pane_cwd(tile));
 
-        // Build display order: top-level contexts first, each followed by children.
-        // Separate into active (unparked) and parked lists.
-        let mut display_order: Vec<usize> = Vec::with_capacity(num_contexts);
-        for i in 0..num_contexts {
-            if self.router.get(i).parent_id.is_none() {
-                display_order.push(i);
-                let ctx_id = self.router.get(i).context_id;
-                for j in 0..num_contexts {
-                    if self.router.get(j).parent_id == Some(ctx_id) {
-                        display_order.push(j);
-                    }
-                }
-            }
-        }
-        // Catch orphans whose parent was deleted.
-        for i in 0..num_contexts {
-            if !display_order.contains(&i) {
-                display_order.push(i);
-            }
-        }
-
-        // Partition: active contexts render in the main list, parked ones below.
-        let active_order: Vec<usize> = display_order
-            .iter()
-            .copied()
-            .filter(|&i| !self.router.get(i).parked)
-            .collect();
-        let parked_order: Vec<usize> = display_order
-            .iter()
-            .copied()
-            .filter(|&i| self.router.get(i).parked)
-            .collect();
+        let active_rows = self.sidebar_visible_rows(false);
+        let parked_rows = self.sidebar_visible_rows(true);
 
         // ── Active contexts ─────────────────────────────────────────────
-        for (display_idx, &i) in active_order.iter().enumerate() {
+        for row in active_rows.iter().copied() {
+            let i = row.router_idx;
             let is_active = i == self.router.active_idx();
             let is_renaming = self.renaming_window == Some(i);
             let is_dragging = self.drag_context == Some(i);
@@ -274,7 +446,7 @@ impl PlexiApp {
                     ui.add_space(4.0);
                 });
                 let row_rect = scope.response.rect;
-                active_rects.push(row_rect);
+                active_rects.push((row_rect, i));
                 ui.painter().set(
                     bg_idx,
                     egui::Shape::rect_filled(row_rect, CornerRadius::ZERO, fill),
@@ -310,16 +482,21 @@ impl PlexiApp {
                 any_dragging,
                 action_enabled: num_contexts > 1 && !any_dragging,
                 ctx_name,
-                ctx_index: Some(display_idx),
+                ctx_index: row.top_level_number,
                 badge_count,
                 subtitle,
                 pane_dots,
                 indent,
+                child_toggle: self.sidebar_has_children(i).then_some(
+                    !self
+                        .collapsed_contexts
+                        .contains(&self.router.get(i).context_id),
+                ),
                 draggable: true,
             }
             .draw(ui, egui::Id::new(("ctx", i)), &self.colors);
 
-            active_rects.push(response.rect);
+            active_rects.push((response.rect, i));
 
             match action {
                 SidebarAction::DragStart => {
@@ -335,6 +512,8 @@ impl PlexiApp {
                 let num_ctxs = num_contexts;
                 let cwd_for_menu = focused_cwd.clone();
                 let has_root = self.router.get(i).root.is_some();
+                let prev_top_level = self.sidebar_previous_top_level_context(i);
+                let parent_id = self.router.get(i).parent_id;
                 response.context_menu(|ui| {
                     if ui.button("Rename").clicked() {
                         menu_action = Some((i, WindowMenuAction::Rename));
@@ -362,6 +541,24 @@ impl PlexiApp {
                         }
                         if ui.button("Move to Bottom").clicked() {
                             menu_action = Some((i, WindowMenuAction::MoveToBottom));
+                            ui.close_menu();
+                        }
+                    }
+                    if let Some(target_idx) = prev_top_level {
+                        let target_id = self.router.get(target_idx).context_id;
+                        if parent_id != Some(target_id) {
+                            let label =
+                                format!("Make subcontext of {}", self.router.get(target_idx).name);
+                            if ui.button(label).clicked() {
+                                menu_action =
+                                    Some((i, WindowMenuAction::MoveIntoContext(target_id)));
+                                ui.close_menu();
+                            }
+                        }
+                    }
+                    if parent_id.is_some() {
+                        if ui.button("Promote out one level").clicked() {
+                            menu_action = Some((i, WindowMenuAction::PromoteContext));
                             ui.close_menu();
                         }
                     }
@@ -406,6 +603,10 @@ impl PlexiApp {
                     SidebarAction::Delete => {
                         delete_context = Some(i);
                     }
+                    SidebarAction::ToggleChildren => {
+                        self.toggle_context_children_collapsed(i);
+                        self.save_workspace();
+                    }
                     SidebarAction::Rename => {
                         menu_action = Some((i, WindowMenuAction::Rename));
                     }
@@ -424,7 +625,7 @@ impl PlexiApp {
         // ── Parked section ──────────────────────────────────────────────
         // The header doubles as a drop target: while a context is being
         // dragged, render it even when empty so the drag can release onto it.
-        let parked_count = parked_order.len();
+        let parked_count = self.sidebar_section_order(true).len();
         let mut parked_header_rect: Option<Rect> = None;
         if parked_count > 0 || self.drag_context.is_some() {
             ui.add_space(8.0);
@@ -439,6 +640,7 @@ impl PlexiApp {
 
             let response = ListDropdownHeader::new(&label, expanded)
                 .indent(12.0)
+                .label_left(30.0)
                 .show(ui, divider_id, &self.colors);
             parked_header_rect = Some(response.rect);
             if response.clicked() {
@@ -447,7 +649,8 @@ impl PlexiApp {
             ui.add_space(4.0);
 
             if self.parked_section_expanded {
-                for &i in &parked_order {
+                for row in parked_rows.iter().copied() {
+                    let i = row.router_idx;
                     let ctx = self.router.get(i);
                     let ctx_name = ctx.name.clone();
                     let ctx_id = ctx.context_id;
@@ -513,11 +716,16 @@ impl PlexiApp {
                         subtitle,
                         pane_dots,
                         indent,
+                        child_toggle: self.sidebar_has_children(i).then_some(
+                            !self
+                                .collapsed_contexts
+                                .contains(&self.router.get(i).context_id),
+                        ),
                         draggable: true,
                     }
                     .draw(ui, egui::Id::new(("parked_ctx", i)), &self.colors);
 
-                    parked_rects.push(response.rect);
+                    parked_rects.push((response.rect, i));
 
                     response.context_menu(|ui| {
                         if ui.button("Unpark").clicked() {
@@ -532,6 +740,10 @@ impl PlexiApp {
                         }
                         SidebarAction::DragEnd => {
                             drag_released = true;
+                        }
+                        SidebarAction::ToggleChildren => {
+                            self.toggle_context_children_collapsed(i);
+                            self.save_workspace();
                         }
                         // A plain click must not unpark — parked contexts only
                         // come back via a drag into the active list or the
@@ -551,9 +763,15 @@ impl PlexiApp {
         let src_section = self.drag_context.map(|src| {
             let src_parked = self.router.get(src).parked;
             let src_slot = if src_parked {
-                parked_order.iter().position(|&i| i == src).unwrap_or(0)
+                parked_rows
+                    .iter()
+                    .position(|row| row.router_idx == src)
+                    .unwrap_or(0)
             } else {
-                active_order.iter().position(|&i| i == src).unwrap_or(0)
+                active_rows
+                    .iter()
+                    .position(|row| row.router_idx == src)
+                    .unwrap_or(0)
             };
             (src_parked, src_slot)
         });
@@ -588,83 +806,106 @@ impl PlexiApp {
                     );
                 }
             } else {
-                let line_y = reorder_line_y(target_rects, drop.slot);
-                let x0 = target_rects.first().map_or(0.0, |r| r.min.x);
-                ui.painter().line_segment(
-                    [
-                        egui::pos2(x0, line_y),
-                        egui::pos2(x0 + sidebar_width, line_y),
-                    ],
-                    Stroke::new(2.0, self.colors.accent),
-                );
+                match drop.mode {
+                    SidebarDropMode::TopLevelSlot => {
+                        let rects: Vec<Rect> = target_rects.iter().map(|(rect, _)| *rect).collect();
+                        let line_y = reorder_line_y(&rects, drop.slot);
+                        let x0 = rects.first().map_or(0.0, |r| r.min.x);
+                        ui.painter().line_segment(
+                            [
+                                egui::pos2(x0, line_y),
+                                egui::pos2(x0 + sidebar_width, line_y),
+                            ],
+                            Stroke::new(2.0, self.colors.accent),
+                        );
+                    }
+                    SidebarDropMode::Nest { target_idx } => {
+                        if let Some((rect, _)) =
+                            target_rects.iter().find(|(_, idx)| *idx == target_idx)
+                        {
+                            ui.painter().rect_stroke(
+                                rect.shrink(2.0),
+                                crate::ui::style::RADIUS_SM,
+                                Stroke::new(1.5, self.colors.accent),
+                                egui::StrokeKind::Inside,
+                            );
+                        }
+                    }
+                }
             }
         }
 
         if drag_released {
-            if let (Some(src), Some(drop), Some((src_parked, src_slot))) =
+            if let (Some(src), Some(drop), Some((src_parked, _src_slot))) =
                 (self.drag_context, drop_target, src_section)
             {
-                // Rebuild the active/parked section lists with `src` moved to its
-                // new home, then commit the full ordering + parked flag at once.
-                let mut new_active = active_order.clone();
-                let mut new_parked = parked_order.clone();
-                if src_parked {
-                    new_parked.retain(|&i| i != src);
-                } else {
-                    new_active.retain(|&i| i != src);
-                }
-                let dest = if drop.parked {
-                    &mut new_parked
-                } else {
-                    &mut new_active
-                };
-                // Same-section moves past the source's old slot shift down by one
-                // once it is removed.
-                let slot = if drop.parked == src_parked && drop.slot > src_slot {
-                    drop.slot - 1
-                } else {
-                    drop.slot
-                };
-                dest.insert(slot.min(dest.len()), src);
-
                 let src_id = self.router.get(src).context_id;
                 let was_active = self.router.active_idx() == src;
-                self.router.get_mut(src).parked = drop.parked;
-                let mut new_order = new_active;
-                new_order.extend(new_parked);
-                self.router.apply_order(&new_order);
                 self.renaming_window = None;
 
-                let new_src_idx = self
-                    .router
-                    .position(|c| c.context_id == src_id)
-                    .unwrap_or(self.router.active_idx());
-                if drop.parked && !src_parked {
-                    log::info!("sidebar: drag-park context id={src_id} slot={}", drop.slot);
-                    if was_active {
-                        // Hand focus to the nearest unparked neighbor.
-                        let len = self.router.len();
-                        let next = (1..len)
-                            .map(|o| (new_src_idx + o) % len)
-                            .find(|&i| !self.router.get(i).parked);
-                        if let Some(n) = next {
-                            self.switch_workspace(n);
+                let moved = match drop.mode {
+                    SidebarDropMode::Nest { target_idx } => {
+                        let parent_id = self.router.get(target_idx).context_id;
+                        if self.router.can_move_subtree_to_parent(src, Some(parent_id)) {
+                            let target_parked = self.router.get(target_idx).parked;
+                            self.router.set_subtree_parked(src, target_parked);
+                            let moved = self.router.move_subtree_to_parent(src, Some(parent_id));
+                            if moved {
+                                self.collapsed_contexts.remove(&parent_id);
+                                log::info!(
+                                    "sidebar: drag-nested context id={src_id} under parent id={parent_id}"
+                                );
+                            }
+                            moved
+                        } else {
+                            log::info!(
+                                "sidebar: rejected invalid drag-nest context id={src_id} target_idx={target_idx}"
+                            );
+                            false
                         }
                     }
-                } else if !drop.parked && src_parked {
-                    log::info!(
-                        "sidebar: drag-unpark context id={src_id} slot={}",
-                        drop.slot
-                    );
-                    self.switch_workspace(new_src_idx);
-                } else {
-                    log::info!(
-                        "sidebar: drag-reorder context id={src_id} parked={} slot={}",
-                        drop.parked,
-                        drop.slot
-                    );
+                    SidebarDropMode::TopLevelSlot => {
+                        self.router.set_subtree_parked(src, drop.parked);
+                        let src_after_park = self
+                            .router
+                            .position(|ctx| ctx.context_id == src_id)
+                            .unwrap_or(src);
+                        if self.router.get(src_after_park).parent_id.is_some() {
+                            self.router.move_subtree_to_parent(src_after_park, None);
+                        }
+                        let src_after_promote = self
+                            .router
+                            .position(|ctx| ctx.context_id == src_id)
+                            .unwrap_or(src_after_park);
+                        let insert_pos =
+                            self.sidebar_top_level_insert_index(drop.parked, drop.slot, src_id);
+                        let moved = self
+                            .router
+                            .move_subtree_to_index(src_after_promote, insert_pos);
+                        if moved {
+                            log::info!(
+                                "sidebar: drag-top-level context id={src_id} parked={} slot={}",
+                                drop.parked,
+                                drop.slot
+                            );
+                        }
+                        moved
+                    }
+                };
+
+                if moved {
+                    let new_src_idx = self
+                        .router
+                        .position(|c| c.context_id == src_id)
+                        .unwrap_or(self.router.active_idx());
+                    let now_parked = self.router.get(new_src_idx).parked;
+                    if now_parked && !src_parked && was_active {
+                        self.switch_after_drag_park(new_src_idx);
+                    } else if !now_parked && src_parked {
+                        self.switch_workspace(new_src_idx);
+                    }
+                    self.save_workspace();
                 }
-                self.save_workspace();
             }
             self.drag_context = None;
         }
@@ -699,6 +940,22 @@ impl PlexiApp {
                 WindowMenuAction::MoveToBottom => {
                     self.renaming_window = None;
                     self.router.move_to_back_tracking_active(i);
+                }
+                WindowMenuAction::MoveIntoContext(parent_id) => {
+                    let moved_id = self.router.get(i).context_id;
+                    if self.router.move_subtree_to_parent(i, Some(parent_id)) {
+                        log::info!(
+                            "sidebar: reparent context id={moved_id} under parent id={parent_id}"
+                        );
+                        self.save_workspace();
+                    }
+                }
+                WindowMenuAction::PromoteContext => {
+                    let moved_id = self.router.get(i).context_id;
+                    if self.router.move_subtree_to_parent(i, None) {
+                        log::info!("sidebar: promoted context id={moved_id} out one level");
+                        self.save_workspace();
+                    }
                 }
                 WindowMenuAction::SetRoot(path) => {
                     log::info!(
@@ -766,7 +1023,7 @@ impl PlexiApp {
 
 #[cfg(test)]
 mod tests {
-    use super::{reorder_line_y, resolve_drag_drop, SidebarDrop};
+    use super::{reorder_line_y, resolve_drag_drop, SidebarDrop, SidebarDropMode};
     use egui::{pos2, vec2, Rect};
 
     // Two stacked active rows (y in [0,20] and [20,40]), the Parked header at
@@ -783,6 +1040,13 @@ mod tests {
             Rect::from_min_size(pos2(0.0, 90.0), vec2(100.0, 20.0)),
         ]
     }
+    fn with_ids(rects: Vec<Rect>) -> Vec<(Rect, usize)> {
+        rects
+            .into_iter()
+            .enumerate()
+            .map(|(idx, rect)| (rect, idx))
+            .collect()
+    }
     fn header() -> Rect {
         Rect::from_min_size(pos2(0.0, 50.0), vec2(100.0, 20.0))
     }
@@ -793,13 +1057,14 @@ mod tests {
         pointer_y: f32,
         parked_rects: &[Rect],
     ) -> Option<SidebarDrop> {
+        let parked_rects = with_ids(parked_rects.to_vec());
         resolve_drag_drop(
             src_parked,
             src_slot,
             Some(header()),
             Some(pos2(10.0, pointer_y)),
-            &active_rects(),
-            parked_rects,
+            &with_ids(active_rects()),
+            &parked_rects,
         )
     }
 
@@ -807,35 +1072,90 @@ mod tests {
     fn active_dragged_into_empty_parked_parks() {
         // No parked rows yet; dropping below the header targets parked slot 0.
         let target = resolve(false, 0, 60.0, &[]);
-        assert_eq!(target, Some(SidebarDrop { parked: true, slot: 0 }));
+        assert_eq!(
+            target,
+            Some(SidebarDrop {
+                parked: true,
+                slot: 0,
+                mode: SidebarDropMode::TopLevelSlot,
+            })
+        );
     }
 
     #[test]
     fn active_dragged_between_parked_rows_picks_slot() {
         // Pointer over the gap between the two parked rows → parked slot 1.
         let target = resolve(false, 0, 88.0, &parked_rects());
-        assert_eq!(target, Some(SidebarDrop { parked: true, slot: 1 }));
+        assert_eq!(
+            target,
+            Some(SidebarDrop {
+                parked: true,
+                slot: 1,
+                mode: SidebarDropMode::TopLevelSlot,
+            })
+        );
     }
 
     #[test]
     fn parked_dragged_into_active_unparks_at_slot() {
         // Dragging parked row, pointer over the first active row → active slot 0.
         let target = resolve(true, 0, 5.0, &parked_rects());
-        assert_eq!(target, Some(SidebarDrop { parked: false, slot: 0 }));
+        assert_eq!(
+            target,
+            Some(SidebarDrop {
+                parked: false,
+                slot: 0,
+                mode: SidebarDropMode::TopLevelSlot,
+            })
+        );
     }
 
     #[test]
     fn reorder_within_active_list() {
         // Dragging active row 0 down past the last active row → active slot 2.
         let target = resolve(false, 0, 35.0, &parked_rects());
-        assert_eq!(target, Some(SidebarDrop { parked: false, slot: 2 }));
+        assert_eq!(
+            target,
+            Some(SidebarDrop {
+                parked: false,
+                slot: 2,
+                mode: SidebarDropMode::TopLevelSlot,
+            })
+        );
     }
 
     #[test]
     fn reorder_within_parked_list() {
         // Dragging parked row 0 (src_slot 0) past parked row 1 → parked slot 2.
         let target = resolve(true, 0, 105.0, &parked_rects());
-        assert_eq!(target, Some(SidebarDrop { parked: true, slot: 2 }));
+        assert_eq!(
+            target,
+            Some(SidebarDrop {
+                parked: true,
+                slot: 2,
+                mode: SidebarDropMode::TopLevelSlot,
+            })
+        );
+    }
+
+    #[test]
+    fn dropping_on_row_content_nests_under_that_row() {
+        let target = resolve_drag_drop(
+            false,
+            1,
+            Some(header()),
+            Some(pos2(80.0, 10.0)),
+            &with_ids(active_rects()),
+            &with_ids(parked_rects()),
+        );
+        assert_eq!(
+            target,
+            Some(SidebarDrop {
+                parked: false,
+                slot: 0,
+                mode: SidebarDropMode::Nest { target_idx: 0 },
+            })
+        );
     }
 
     #[test]
@@ -859,8 +1179,8 @@ mod tests {
             0,
             Some(header()),
             None,
-            &active_rects(),
-            &parked_rects(),
+            &with_ids(active_rects()),
+            &with_ids(parked_rects()),
         );
         assert_eq!(target, None);
     }

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -1,4 +1,4 @@
-use crate::ui::list::{paint_selection, paint_text_centered};
+use crate::ui::list::{paint_disclosure_caret, paint_selection, paint_text_centered};
 use crate::ui::style;
 use crate::ui::theme::Colors;
 use egui::{Align, Color32, CornerRadius, CursorIcon, Id, Layout, Rect, Sense, Vec2};
@@ -51,6 +51,7 @@ fn shorten_path(path: &str) -> String {
 pub enum SidebarAction {
     None,
     Activate,
+    ToggleChildren,
     Rename,
     Delete,
     DragStart,
@@ -80,6 +81,9 @@ pub struct ContextItem {
     pub pane_dots: Option<PaneDots>,
     /// Nesting depth for subcontexts (0 = top-level).
     pub indent: u32,
+    /// `Some(expanded)` when the row owns child contexts and should paint a
+    /// chevron beneath the gutter number.
+    pub child_toggle: Option<bool>,
     /// Whether this row supports drag reordering. When false, hover shows
     /// PointingHand instead of Grab and drag actions are suppressed.
     pub draggable: bool,
@@ -178,6 +182,7 @@ impl ContextItem {
         let badge_count = self.badge_count;
         let subtitle = self.subtitle.clone();
         let pane_dots = self.pane_dots;
+        let child_toggle = self.child_toggle;
         let accent_color = colors.accent;
         let text_primary = colors.text_primary;
         let text_dim = colors.text_dim;
@@ -374,6 +379,30 @@ impl ContextItem {
             }
         }
 
+        let chevron_rect = child_toggle.map(|expanded| {
+            let lower_y0 = row_rect.min.y + ROW_PAD_V + name_row_h;
+            let lower_y1 = row_rect.max.y - ROW_PAD_V;
+            let center_y = if lower_y1 > lower_y0 {
+                (lower_y0 + lower_y1) / 2.0
+            } else {
+                row_rect.min.y + ROW_PAD_V + name_row_h + 6.0
+            };
+            let hit_rect = Rect::from_center_size(
+                egui::pos2(row_rect.min.x + indent + GUTTER_W / 2.0, center_y),
+                Vec2::new(24.0, 20.0),
+            );
+            let color = with_alpha(
+                if ui.rect_contains_pointer(hit_rect) {
+                    text_primary
+                } else {
+                    text_dim
+                },
+                row_alpha,
+            );
+            paint_disclosure_caret(ui, hit_rect.center(), expanded, 4.0, color);
+            hit_rect
+        });
+
         let action_zone = if action_enabled {
             Some(Rect::from_min_max(
                 egui::pos2(row_rect.max.x - ACTION_ZONE_WIDTH, row_rect.min.y),
@@ -384,6 +413,7 @@ impl ContextItem {
         };
 
         let in_action = action_zone.map_or(false, |az| ui.rect_contains_pointer(az));
+        let in_chevron = chevron_rect.map_or(false, |rect| ui.rect_contains_pointer(rect));
 
         if let Some(az) = action_zone {
             if hovered && !is_dragging {
@@ -403,7 +433,7 @@ impl ContextItem {
             response.clone().on_hover_text("Delete context");
         }
 
-        if in_action {
+        if in_action || in_chevron {
             ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
         } else {
             let content_max_x = if action_enabled {
@@ -434,6 +464,8 @@ impl ContextItem {
             SidebarAction::DragStart
         } else if self.draggable && response.drag_stopped() {
             SidebarAction::DragEnd
+        } else if response.clicked() && in_chevron {
+            SidebarAction::ToggleChildren
         } else if response.clicked() && in_action && hovered {
             SidebarAction::Delete
         } else if response.clicked() {

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -676,6 +676,76 @@ mod tests {
             .expect("render failed");
     }
 
+    #[test]
+    fn subcontext_chevron_collapses_and_expands_child_rows() {
+        let mut h = PlexiUiHarness::new_sized(900.0, 620.0);
+        h.with_app_mut(|app| {
+            app.sidebar_visible = true;
+            app.router.get_mut(0).root = Some(std::env::temp_dir().join("root-parent"));
+            let root_id = app.router.active().context_id;
+            app.router.push(crate::host::context::Context {
+                name: "child".to_string(),
+                path: std::env::temp_dir().join("child"),
+                root: Some(std::env::temp_dir().join("child")),
+                description: None,
+                context_id: 72_001,
+                parent_id: Some(root_id),
+                depth: 1,
+                parked: false,
+            });
+            app.router.push(crate::host::context::Context {
+                name: "second-root".to_string(),
+                path: std::env::temp_dir().join("second-root"),
+                root: Some(std::env::temp_dir().join("second-root")),
+                description: None,
+                context_id: 72_002,
+                parent_id: None,
+                depth: 0,
+                parked: false,
+            });
+        });
+        h.run_steps(2);
+        h.with_app(|app| {
+            assert_eq!(app.sidebar_visible_rows(false).len(), 3);
+            assert!(app.collapsed_contexts.is_empty());
+        });
+        h.save_screenshot("/tmp/plexi_subcontext_chevron_expanded.png")
+            .expect("render failed");
+
+        let click = egui::pos2(16.0, 100.0);
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::PointerMoved(click));
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::PointerButton {
+                pos: click,
+                button: egui::PointerButton::Primary,
+                pressed: true,
+                modifiers: egui::Modifiers::NONE,
+            });
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::PointerButton {
+                pos: click,
+                button: egui::PointerButton::Primary,
+                pressed: false,
+                modifiers: egui::Modifiers::NONE,
+            });
+        h.run_steps(2);
+
+        h.with_app(|app| {
+            let root_id = app.router.active().context_id;
+            assert!(app.collapsed_contexts.contains(&root_id));
+            assert_eq!(app.sidebar_visible_rows(false).len(), 2);
+        });
+        h.save_screenshot("/tmp/plexi_subcontext_chevron_collapsed.png")
+            .expect("render failed");
+    }
+
     /// While a context is being dragged, the Parked header renders even with
     /// zero parked contexts so the drag has a drop target. Smoke test: set up
     /// an in-progress drag and confirm the sidebar renders without panicking.
@@ -1372,7 +1442,6 @@ mod tests {
     /// a trailing ellipsis rather than wrapping or overflowing the tab bar rect.
     #[test]
     fn tab_titles_truncate_to_single_line() {
-
         let mut h = PlexiUiHarness::new();
         h.step();
 
@@ -1412,7 +1481,8 @@ mod tests {
         });
 
         h.run_steps(2);
-        h.render().expect("tab bar with long title must render without panic");
+        h.render()
+            .expect("tab bar with long title must render without panic");
         h.save_screenshot("/tmp/plexi_tab_truncation.png")
             .expect("screenshot failed");
         println!("Screenshot saved to /tmp/plexi_tab_truncation.png");

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -6,6 +6,7 @@ use crate::spatial::tiling::PaneId;
 use egui_tiles::{TileId, Tree};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::io;
 use std::path::PathBuf;
 
@@ -21,6 +22,9 @@ pub struct WorkspaceFile {
     /// context_id → last active window_id for that context.
     #[serde(default)]
     pub context_active_window: HashMap<u64, u64>,
+    /// Parent context ids whose child rows are collapsed in the sidebar.
+    #[serde(default)]
+    pub collapsed_contexts: HashSet<u64>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/workspace/router.rs
+++ b/src/workspace/router.rs
@@ -17,6 +17,8 @@ pub(crate) struct WorkspaceRouter {
     pub(crate) depth_stack: Vec<(u64, u64, Option<TileId>)>,
 }
 
+const MAX_CONTEXT_DEPTH: u32 = 3;
+
 impl WorkspaceRouter {
     pub(crate) fn new(contexts: Vec<Context>, active: usize) -> Self {
         debug_assert!(
@@ -129,34 +131,6 @@ impl WorkspaceRouter {
         }
     }
 
-    /// Reorder the entire context vec to match `new_order`, a permutation of
-    /// the current indices `0..len`. The active context is tracked by identity,
-    /// so its index is rewritten to wherever it lands. Used by sidebar drag-drop
-    /// to commit a fully re-partitioned (active/parked) ordering atomically.
-    pub(crate) fn apply_order(&mut self, new_order: &[usize]) {
-        debug_assert_eq!(
-            new_order.len(),
-            self.contexts.len(),
-            "apply_order needs a full permutation"
-        );
-        let active_id = self.contexts[self.active].context_id;
-        let mut slots: Vec<Option<Context>> = self.contexts.drain(..).map(Some).collect();
-        let mut reordered: Vec<Context> = Vec::with_capacity(slots.len());
-        for &idx in new_order {
-            reordered.push(
-                slots[idx]
-                    .take()
-                    .expect("apply_order: each index referenced exactly once"),
-            );
-        }
-        self.contexts = reordered;
-        self.active = self
-            .contexts
-            .iter()
-            .position(|c| c.context_id == active_id)
-            .expect("apply_order: active context survives reorder");
-    }
-
     pub(crate) fn move_to_front_tracking_active(&mut self, idx: usize) {
         let ctx = self.contexts.remove(idx);
         self.contexts.insert(0, ctx);
@@ -176,6 +150,182 @@ impl WorkspaceRouter {
         } else if self.active > idx {
             self.active -= 1;
         }
+    }
+
+    pub(crate) fn subtree_end(&self, idx: usize) -> usize {
+        let base_depth = self.contexts[idx].depth;
+        let mut end = idx + 1;
+        while end < self.contexts.len() && self.contexts[end].depth > base_depth {
+            end += 1;
+        }
+        end
+    }
+
+    fn is_descendant_id(&self, descendant_id: u64, ancestor_id: u64) -> bool {
+        let mut current = self
+            .contexts
+            .iter()
+            .find(|ctx| ctx.context_id == descendant_id)
+            .and_then(|ctx| ctx.parent_id);
+        while let Some(parent_id) = current {
+            if parent_id == ancestor_id {
+                return true;
+            }
+            current = self
+                .contexts
+                .iter()
+                .find(|ctx| ctx.context_id == parent_id)
+                .and_then(|ctx| ctx.parent_id);
+        }
+        false
+    }
+
+    pub(crate) fn can_move_subtree_to_parent(
+        &self,
+        idx: usize,
+        new_parent_id: Option<u64>,
+    ) -> bool {
+        if idx >= self.contexts.len() {
+            return false;
+        }
+        let moving_id = self.contexts[idx].context_id;
+        let old_parent_id = self.contexts[idx].parent_id;
+        if old_parent_id == new_parent_id {
+            return false;
+        }
+        let new_depth = match new_parent_id {
+            Some(parent_id) => {
+                if parent_id == moving_id || self.is_descendant_id(parent_id, moving_id) {
+                    return false;
+                }
+                let Some(parent) = self.contexts.iter().find(|ctx| ctx.context_id == parent_id)
+                else {
+                    return false;
+                };
+                parent.depth + 1
+            }
+            None => 0,
+        };
+        let end = self.subtree_end(idx);
+        let old_depth = self.contexts[idx].depth;
+        let deepest_relative = self.contexts[idx..end]
+            .iter()
+            .map(|ctx| ctx.depth.saturating_sub(old_depth))
+            .max()
+            .unwrap_or(0);
+        new_depth + deepest_relative <= MAX_CONTEXT_DEPTH
+    }
+
+    pub(crate) fn move_subtree_to_parent(
+        &mut self,
+        idx: usize,
+        new_parent_id: Option<u64>,
+    ) -> bool {
+        if !self.can_move_subtree_to_parent(idx, new_parent_id) {
+            return false;
+        }
+        let old_parent_id = self.contexts[idx].parent_id;
+
+        let active_id = self.contexts[self.active].context_id;
+        let end = self.subtree_end(idx);
+        let old_depth = self.contexts[idx].depth;
+        let mut subtree: Vec<Context> = self.contexts.drain(idx..end).collect();
+
+        let new_depth = match new_parent_id {
+            Some(parent_id) => self
+                .contexts
+                .iter()
+                .find(|ctx| ctx.context_id == parent_id)
+                .map(|ctx| ctx.depth + 1)
+                .unwrap_or(0),
+            None => 0,
+        };
+        let depth_delta = new_depth as i32 - old_depth as i32;
+        for ctx in &mut subtree {
+            ctx.depth = ((ctx.depth as i32) + depth_delta).max(0) as u32;
+        }
+        subtree[0].parent_id = new_parent_id;
+
+        let insert_pos = match new_parent_id {
+            Some(parent_id) => {
+                let parent_pos = self
+                    .contexts
+                    .iter()
+                    .position(|ctx| ctx.context_id == parent_id)
+                    .expect("validated new parent must still exist after drain");
+                let parent_depth = self.contexts[parent_pos].depth;
+                let mut pos = parent_pos + 1;
+                while pos < self.contexts.len() && self.contexts[pos].depth > parent_depth {
+                    pos += 1;
+                }
+                pos
+            }
+            None => {
+                if let Some(former_parent_id) = old_parent_id {
+                    if let Some(parent_pos) = self
+                        .contexts
+                        .iter()
+                        .position(|ctx| ctx.context_id == former_parent_id)
+                    {
+                        let parent_depth = self.contexts[parent_pos].depth;
+                        let mut pos = parent_pos + 1;
+                        while pos < self.contexts.len() && self.contexts[pos].depth > parent_depth {
+                            pos += 1;
+                        }
+                        pos
+                    } else {
+                        self.contexts.len()
+                    }
+                } else {
+                    self.contexts.len()
+                }
+            }
+        };
+
+        self.contexts.splice(insert_pos..insert_pos, subtree);
+        self.active = self
+            .contexts
+            .iter()
+            .position(|ctx| ctx.context_id == active_id)
+            .expect("move_subtree_to_parent: active context survives move");
+        true
+    }
+
+    pub(crate) fn set_subtree_parked(&mut self, idx: usize, parked: bool) -> bool {
+        if idx >= self.contexts.len() {
+            return false;
+        }
+        let end = self.subtree_end(idx);
+        for ctx in &mut self.contexts[idx..end] {
+            ctx.parked = parked;
+        }
+        true
+    }
+
+    pub(crate) fn move_subtree_to_index(&mut self, idx: usize, insert_pos: usize) -> bool {
+        if idx >= self.contexts.len() || insert_pos > self.contexts.len() {
+            return false;
+        }
+        let end = self.subtree_end(idx);
+        if (idx..end).contains(&insert_pos) {
+            return false;
+        }
+        let active_id = self.contexts[self.active].context_id;
+        let subtree_len = end - idx;
+        let subtree: Vec<Context> = self.contexts.drain(idx..end).collect();
+        let adjusted_insert = if insert_pos > idx {
+            insert_pos - subtree_len
+        } else {
+            insert_pos
+        };
+        self.contexts
+            .splice(adjusted_insert..adjusted_insert, subtree);
+        self.active = self
+            .contexts
+            .iter()
+            .position(|ctx| ctx.context_id == active_id)
+            .expect("move_subtree_to_index: active context survives move");
+        true
     }
 
     // ── Depth stack (fractal zoom navigation) ───────────────────────────────
@@ -237,21 +387,6 @@ mod tests {
     fn depth_stack_empty_pop_returns_none() {
         let mut router = WorkspaceRouter::new(vec![make_ctx(1, None, 0)], 0);
         assert_eq!(router.pop_depth(), None);
-    }
-
-    #[test]
-    fn apply_order_permutes_and_tracks_active_by_identity() {
-        let mut router = WorkspaceRouter::new(
-            vec![make_ctx(10, None, 0), make_ctx(20, None, 0), make_ctx(30, None, 0)],
-            1, // active = ctx 20
-        );
-        // Move ctx 20 (index 1) to the front: new order [20, 10, 30].
-        router.apply_order(&[1, 0, 2]);
-        let ids: Vec<u64> = router.iter().map(|c| c.context_id).collect();
-        assert_eq!(ids, vec![20, 10, 30]);
-        // Active still points at ctx 20, now at index 0.
-        assert_eq!(router.active_idx(), 0);
-        assert_eq!(router.active().context_id, 20);
     }
 
     #[test]
@@ -328,5 +463,148 @@ mod tests {
         router.insert_after_subtree(99, make_ctx(2, None, 0));
         let ids: Vec<u64> = router.contexts.iter().map(|c| c.context_id).collect();
         assert_eq!(ids, vec![1, 2]);
+    }
+
+    #[test]
+    fn move_subtree_to_parent_keeps_descendants_attached() {
+        let mut router = WorkspaceRouter::new(
+            vec![
+                make_ctx(1, None, 0),
+                make_ctx(2, Some(1), 1),
+                make_ctx(3, Some(2), 2),
+                make_ctx(4, None, 0),
+            ],
+            1,
+        );
+
+        assert!(router.move_subtree_to_parent(3, Some(1)));
+        let rows: Vec<(u64, Option<u64>, u32)> = router
+            .iter()
+            .map(|ctx| (ctx.context_id, ctx.parent_id, ctx.depth))
+            .collect();
+        assert_eq!(
+            rows,
+            vec![
+                (1, None, 0),
+                (2, Some(1), 1),
+                (3, Some(2), 2),
+                (4, Some(1), 1),
+            ]
+        );
+        assert_eq!(
+            router.active().context_id,
+            2,
+            "active context tracks by identity"
+        );
+    }
+
+    #[test]
+    fn move_subtree_to_parent_promotes_one_level() {
+        let mut router = WorkspaceRouter::new(
+            vec![
+                make_ctx(1, None, 0),
+                make_ctx(2, Some(1), 1),
+                make_ctx(3, Some(2), 2),
+                make_ctx(4, None, 0),
+            ],
+            2,
+        );
+
+        assert!(router.move_subtree_to_parent(2, None));
+        let rows: Vec<(u64, Option<u64>, u32)> = router
+            .iter()
+            .map(|ctx| (ctx.context_id, ctx.parent_id, ctx.depth))
+            .collect();
+        assert_eq!(
+            rows,
+            vec![(1, None, 0), (2, Some(1), 1), (3, None, 0), (4, None, 0),]
+        );
+        assert_eq!(router.active().context_id, 3);
+    }
+
+    #[test]
+    fn move_subtree_to_parent_rejects_direct_child_cycle() {
+        let mut router =
+            WorkspaceRouter::new(vec![make_ctx(1, None, 0), make_ctx(2, Some(1), 1)], 0);
+
+        assert!(!router.can_move_subtree_to_parent(0, Some(2)));
+        assert!(!router.move_subtree_to_parent(0, Some(2)));
+        let rows: Vec<(u64, Option<u64>, u32)> = router
+            .iter()
+            .map(|ctx| (ctx.context_id, ctx.parent_id, ctx.depth))
+            .collect();
+        assert_eq!(rows, vec![(1, None, 0), (2, Some(1), 1)]);
+    }
+
+    #[test]
+    fn move_subtree_to_parent_rejects_grandchild_cycle() {
+        let mut router = WorkspaceRouter::new(
+            vec![
+                make_ctx(1, None, 0),
+                make_ctx(2, Some(1), 1),
+                make_ctx(3, Some(2), 2),
+            ],
+            0,
+        );
+
+        assert!(!router.can_move_subtree_to_parent(0, Some(3)));
+        assert!(!router.move_subtree_to_parent(0, Some(3)));
+        let rows: Vec<(u64, Option<u64>, u32)> = router
+            .iter()
+            .map(|ctx| (ctx.context_id, ctx.parent_id, ctx.depth))
+            .collect();
+        assert_eq!(rows, vec![(1, None, 0), (2, Some(1), 1), (3, Some(2), 2)]);
+    }
+
+    #[test]
+    fn move_subtree_to_parent_rejects_moves_past_depth_cap() {
+        let mut router = WorkspaceRouter::new(
+            vec![
+                make_ctx(1, None, 0),
+                make_ctx(2, Some(1), 1),
+                make_ctx(3, Some(2), 2),
+                make_ctx(4, Some(3), 3),
+                make_ctx(5, None, 0),
+                make_ctx(6, Some(5), 1),
+            ],
+            0,
+        );
+
+        assert!(!router.can_move_subtree_to_parent(1, Some(6)));
+        assert!(!router.move_subtree_to_parent(1, Some(6)));
+    }
+
+    #[test]
+    fn move_subtree_to_index_keeps_subtree_contiguous() {
+        let mut router = WorkspaceRouter::new(
+            vec![
+                make_ctx(1, None, 0),
+                make_ctx(2, Some(1), 1),
+                make_ctx(3, Some(2), 2),
+                make_ctx(4, None, 0),
+            ],
+            1,
+        );
+
+        assert!(router.move_subtree_to_index(0, 4));
+        let ids: Vec<u64> = router.iter().map(|ctx| ctx.context_id).collect();
+        assert_eq!(ids, vec![4, 1, 2, 3]);
+        assert_eq!(router.active().context_id, 2);
+    }
+
+    #[test]
+    fn set_subtree_parked_updates_descendants() {
+        let mut router = WorkspaceRouter::new(
+            vec![
+                make_ctx(1, None, 0),
+                make_ctx(2, Some(1), 1),
+                make_ctx(3, None, 0),
+            ],
+            0,
+        );
+
+        assert!(router.set_subtree_parked(0, true));
+        let parked: Vec<bool> = router.iter().map(|ctx| ctx.parked).collect();
+        assert_eq!(parked, vec![true, true, false]);
     }
 }


### PR DESCRIPTION
Closes #2281

## Summary
- add a sidebar chevron to collapse and expand child context rows without widening the gutter
- reserve sidebar numbers and `Cmd+1..9` for top-level unparked contexts so subcontexts stop stealing global slots
- make the subcontext chevron hitbox larger and reuse the same filled caret painter for the Parked header
- let sidebar drag/drop move contexts into subcontext folders or promote them back to top-level/parked top-level placement
- route all reparenting through subtree-aware router operations that reject parent-into-child cycles and depth-cap violations

## Testing
- `cargo test --bin plexi move_subtree_to_parent`
- `cargo test --bin plexi ui::sidebar::tests`
- `cargo test --bin plexi subcontext_chevron_collapses_and_expands_child_rows`
- `cargo build`
- `cargo test --bin plexi` — 1237 passed, 0 failed, 1 ignored
- `RUSTC_WRAPPER= just pr-install 2282` — installed `/usr/local/bin/plexi-pr-2282`, `/Applications/Plexi PR2282.app`, config `~/.plexi-pr-2282/`

## Done When
- parent contexts with child contexts show a visible chevron in the sidebar gutter and clicking it collapses or expands child rows
- collapsing a parent hides only its child rows and top-level context numbers stay stable
- `Cmd+1..9` selects top-level unparked contexts only, regardless of how many child contexts are visible
- dragging onto row content nests a context under that row; dragging in the gutter/between rows places it at top level in that section
- dragging a child out to top-level placement promotes the whole subtree without stranding descendants
- invalid moves, including moving a parent into its own child or grandchild, are rejected by `WorkspaceRouter`
- existing child-context entry paths still work: clicking a child row, zooming through a portal, and CLI-driven `plexi context zoom <context_id>` continue to activate the child context
**Merged:** PR #2505 → alpha (current version v0.2.0, 2026-07-28)