### PR TITLE
feat(file-explorer): file-handler routing + launch placement — open files into Plexi apps with OS fallback (#2283)

### DIFF
--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -66,6 +66,19 @@ high   = "claude --dangerously-skip-permissions '{cmd}'"
 [cli]
 tips = true
 
+# [file_handlers]
+# Choose which app opens each file type from the File Explorer (Enter / double-
+# click). Keys are bare, lowercase extensions; values are `kind:value` specs:
+#   "app:<id>"      open in a Plexi app by its registry id (e.g. text-editor)
+#   "os"            hand to the OS default opener (open / xdg-open)
+#   "cmd:<command>" reserved for a future release; falls back to "os" for now
+# A handler here overrides an app's own file_types association. Unmapped types
+# fall through to manifest associations, then builtin media players, then the OS.
+# md   = "app:text-editor"
+# txt  = "app:text-editor"
+# json = "app:text-editor"
+# py   = "os"
+
 # [marketplace]
 # Hosted app catalog + CDN. Defaults point at the official plexiapp.com registry,
 # so leave these unset to use it. Override only to point at a private registry.

--- a/src/app/canvas_bindings.rs
+++ b/src/app/canvas_bindings.rs
@@ -321,10 +321,9 @@ impl PlexiApp {
         log::info!("OpenArtifact: path={path:?} mode={mode:?}");
         match mode {
             ArtifactOpenMode::OpenInPane => {
-                // For v3.5: directories open the file browser; files fall
-                // through to OpenWithDefault. The proper "open .py in text
-                // editor / .png in image viewer" routing wants a content-
-                // type registry — out of scope here.
+                // Directories open the file browser; files run through the
+                // single open resolver (#2283): `[file_handlers]` → manifest
+                // `file_types` → builtin media players → OS default.
                 let p = std::path::PathBuf::from(&path);
                 if p.is_dir() {
                     // Reuse the file-browser open path, but anchored at
@@ -333,7 +332,7 @@ impl PlexiApp {
                     // its body here with our path.
                     self.open_file_browser_at(p);
                 } else {
-                    shell_open(&path, false);
+                    self.open_file_in_app(&path);
                 }
             }
             ArtifactOpenMode::RevealInFinder => shell_open(&path, true),
@@ -373,6 +372,101 @@ impl PlexiApp {
             Some("split_v"),
             Some(0.5),
         );
+    }
+
+    /// The single file-open resolver (#2283). Decides which handler opens
+    /// `path` and launches it. Resolution order, first match wins:
+    ///   (a) user `[file_handlers]` override
+    ///   (b) app manifest `file_types` association
+    ///   (c) builtin media players (`MediaKind`)
+    ///   (d) OS default opener — mandatory fallback
+    /// Any `app:` target that is absent or fails to launch falls through to the
+    /// OS opener rather than silently doing nothing — this is what makes
+    /// "Enter on a video with no installed player" open in the OS player
+    /// instead of vanishing.
+    fn open_file_in_app(&mut self, path: &str) {
+        use crate::app::file_handlers::FileHandler;
+        let ext = std::path::Path::new(path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+
+        // (a) user `[file_handlers]` override.
+        if let Some(spec) = self
+            .config
+            .file_handlers
+            .as_ref()
+            .and_then(|m| m.get(&ext))
+            .cloned()
+        {
+            match FileHandler::parse(&spec) {
+                Some(FileHandler::Os) => {
+                    log::info!("open: '{path}' → OS default (file_handlers override)");
+                    shell_open(path, false);
+                    return;
+                }
+                Some(FileHandler::App(id)) => {
+                    if self.launch_app_with_path(&id, path) {
+                        log::info!("open: '{path}' → app '{id}' (file_handlers override)");
+                        return;
+                    }
+                    log::warn!(
+                        "open: file_handler app '{id}' for .{ext} unavailable — OS fallback for '{path}'"
+                    );
+                    shell_open(path, false);
+                    return;
+                }
+                Some(FileHandler::Cmd(cmd)) => {
+                    log::warn!(
+                        "open: cmd handler '{cmd}' for .{ext} not yet implemented — OS fallback for '{path}'"
+                    );
+                    shell_open(path, false);
+                    return;
+                }
+                None => log::warn!(
+                    "open: invalid file_handler '{spec}' for .{ext} — ignoring, continuing resolution"
+                ),
+            }
+        }
+
+        // (b) app manifest `file_types` association.
+        if let Some(id) = self.registry.handler_for_ext(&ext).map(|s| s.to_string()) {
+            if self.launch_app_with_path(&id, path) {
+                log::info!("open: '{path}' → app '{id}' (manifest file_types)");
+                return;
+            }
+            log::warn!("open: manifest handler '{id}' for .{ext} failed — continuing resolution");
+        }
+
+        // (c) builtin media players.
+        if let Some(id) =
+            crate::file_browser::MediaKind::for_path(std::path::Path::new(path)).player_app_id()
+        {
+            if self.launch_app_with_path(id, path) {
+                log::info!("open: '{path}' → builtin media player '{id}'");
+                return;
+            }
+            log::warn!("open: media player '{id}' not installed — OS fallback for '{path}'");
+        }
+
+        // (d) OS default — mandatory fallback.
+        log::info!("open: '{path}' → OS default (no Plexi handler)");
+        shell_open(path, false);
+    }
+
+    /// Launch app `id` with `path` as its sole arg, using the app's natural
+    /// placement (`None` layout → manifest `[launch] placement` → `overlay`).
+    /// Returns `true` on a successful launch; `false` when the app is not
+    /// available, so the resolver can fall through to the OS opener.
+    fn launch_app_with_path(&mut self, id: &str, path: &str) -> bool {
+        match self.launch_app_by_id_with_layout(id, None, &[path.to_string()], None) {
+            Ok(()) => true,
+            Err(e) => {
+                log::warn!("open: launch of app '{id}' for '{path}' failed — {e}");
+                false
+            }
+        }
     }
 }
 

--- a/src/app/file_handlers.rs
+++ b/src/app/file_handlers.rs
@@ -1,0 +1,95 @@
+//! File-open handler specs for the `[file_handlers]` config table and the
+//! File Explorer open path (#2283).
+//!
+//! A handler spec is a `kind:value` string chosen by the user per file
+//! extension. The grammar is prefix-namespaced by *handler kind* (not by
+//! `plexi:`) so the value space stays open-ended — new kinds (`mcp:`, `url:`,
+//! …) slot in without colliding with the app-id namespace:
+//!
+//!   `app:<id>`      — open in a Plexi app by its registry id
+//!   `os`            — hand to the OS default opener (`open` / `xdg-open`)
+//!   `cmd:<command>` — reserved; parsed now, executed in a follow-up
+//!
+//! `os` is the lone bare keyword (it is a singleton with no value), kept bare
+//! for ergonomics rather than forcing `os:default`.
+
+/// A parsed file-open handler. See the module docs for the grammar.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileHandler {
+    /// Open in a Plexi app by registry id.
+    App(String),
+    /// Hand to the OS default opener.
+    Os,
+    /// Run an external command with the path appended. Reserved — not yet
+    /// executed; callers fall back to [`FileHandler::Os`] behavior.
+    Cmd(String),
+}
+
+impl FileHandler {
+    /// Parse a `kind:value` handler spec. Returns `None` for an empty or
+    /// malformed spec (unknown kind, or `app:`/`cmd:` with no value) so the
+    /// caller can warn and fall through to the next resolution tier.
+    pub fn parse(spec: &str) -> Option<Self> {
+        let spec = spec.trim();
+        if spec == "os" {
+            return Some(FileHandler::Os);
+        }
+        if let Some(id) = spec.strip_prefix("app:") {
+            let id = id.trim();
+            return (!id.is_empty()).then(|| FileHandler::App(id.to_string()));
+        }
+        if let Some(cmd) = spec.strip_prefix("cmd:") {
+            let cmd = cmd.trim();
+            return (!cmd.is_empty()).then(|| FileHandler::Cmd(cmd.to_string()));
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_app_handler() {
+        assert_eq!(
+            FileHandler::parse("app:text-editor"),
+            Some(FileHandler::App("text-editor".to_string()))
+        );
+    }
+
+    #[test]
+    fn parses_os_keyword() {
+        assert_eq!(FileHandler::parse("os"), Some(FileHandler::Os));
+    }
+
+    #[test]
+    fn parses_cmd_handler() {
+        assert_eq!(
+            FileHandler::parse("cmd:code -w"),
+            Some(FileHandler::Cmd("code -w".to_string()))
+        );
+    }
+
+    #[test]
+    fn trims_surrounding_whitespace() {
+        assert_eq!(
+            FileHandler::parse("  app:text-editor  "),
+            Some(FileHandler::App("text-editor".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_kind() {
+        assert_eq!(FileHandler::parse("plexi:text-editor"), None);
+        assert_eq!(FileHandler::parse("text-editor"), None);
+        assert_eq!(FileHandler::parse(""), None);
+    }
+
+    #[test]
+    fn rejects_empty_value() {
+        assert_eq!(FileHandler::parse("app:"), None);
+        assert_eq!(FileHandler::parse("cmd:"), None);
+        assert_eq!(FileHandler::parse("app:   "), None);
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,6 +2,7 @@ pub mod account;
 pub mod app_trait;
 mod canvas_bindings;
 mod dispatch;
+pub mod file_handlers;
 mod focus;
 pub mod host_version;
 mod lifecycle;
@@ -1833,7 +1834,16 @@ impl eframe::App for PlexiApp {
                         });
 
                     let new_pane_id = self.host.next_pane_id();
-                    let _ = self.launch_app_by_id_with_layout(&type_id, layout, &args, None);
+                    if let Err(e) =
+                        self.launch_app_by_id_with_layout(&type_id, layout, &args, None)
+                    {
+                        // Fail loud: never swallow a launch failure or confirm
+                        // a spawn that did not happen (#2283).
+                        log::warn!(
+                            "SpawnApp: launch of '{type_id}' failed — {e}; not confirming AppSpawned"
+                        );
+                        continue;
+                    }
 
                     // Confirm back to the requesting app.
                     if let Some(req_pane_id) = requesting_pane_id {

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -263,7 +263,30 @@ pub struct LaunchSection {
     /// user immediate feedback that the app started. Omit to launch silently.
     #[serde(default)]
     pub startup_message: Option<String>,
+    /// The app's natural launch placement — the spatial disposition the host
+    /// uses when a caller does not specify one (#2283). Uses the host's layout-
+    /// hint vocabulary verbatim: `overlay` (default), `split_right`/`split_h`,
+    /// `split_below`/`split_v`, `split_left`, `split_above`, `tab`,
+    /// `new_window`. `None` = host default (`overlay`). Validated at query time
+    /// by [`AppRegistry::placement_for`]; an unrecognized value is ignored with
+    /// a warning so a typo cannot wedge a launch.
+    #[serde(default)]
+    pub placement: Option<String>,
 }
+
+/// The host layout-hint vocabulary an app's `[launch] placement` may declare.
+/// Kept in one place so the manifest validator and the launch path agree.
+pub const VALID_PLACEMENTS: &[&str] = &[
+    "overlay",
+    "split_h",
+    "split_right",
+    "split_v",
+    "split_below",
+    "split_left",
+    "split_above",
+    "tab",
+    "new_window",
+];
 
 impl AppCapabilities {
     /// Convert manifest-declared capabilities to runtime permissions.
@@ -535,6 +558,32 @@ impl AppRegistry {
         self.apps
             .get(app_id)
             .and_then(|a| a.launch.join_group.clone())
+    }
+
+    /// The app's natural launch placement (`[launch].placement`), validated
+    /// against [`VALID_PLACEMENTS`]. Returns `None` when unset, unknown, or the
+    /// app is not installed — callers then fall back to the host default
+    /// (`overlay`). An unrecognized value is logged so a manifest typo is
+    /// visible rather than silently dropped (#2283).
+    pub fn placement_for(&self, app_id: &str) -> Option<String> {
+        let placement = self.apps.get(app_id)?.launch.placement.clone()?;
+        if VALID_PLACEMENTS.contains(&placement.as_str()) {
+            Some(placement)
+        } else {
+            log::warn!(
+                "AppRegistry: app '{app_id}' declares unknown [launch] placement \
+                 '{placement}' — ignoring; valid: {VALID_PLACEMENTS:?}"
+            );
+            None
+        }
+    }
+
+    /// The registry id of the app that declares `[capabilities].file_types`
+    /// for this extension, if any. `ext` is matched lowercase, without a
+    /// leading dot. Backs resolution tier (b) of the File Explorer open path
+    /// (#2283).
+    pub fn handler_for_ext(&self, ext: &str) -> Option<&str> {
+        self.extension_map.get(&ext.to_lowercase()).map(|s| s.as_str())
     }
 
     /// Returns true when the app's manifest sets `[app] watch = true`.

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -86,3 +86,47 @@ fn wake_request_is_noop_on_host() {
     let panes_after: usize = h.app.windows.iter().map(|w| w.panes.len()).sum();
     assert_eq!(panes_after, panes_before, "wake must not touch panes");
 }
+
+/// #2283: a `[file_handlers]` entry routes a matching extension into the named
+/// Plexi app via the host open resolver (OpenInPane), rather than falling
+/// through to the OS opener. Proves resolution tier (a) + the launch path.
+#[test]
+fn file_handler_config_routes_extension_to_app() {
+    let ctx = egui::Context::default();
+    let ft = crate::platform::logging::new_frame_tick();
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, ft);
+
+    // Map .md -> the builtin text-editor.
+    let mut handlers = std::collections::HashMap::new();
+    handlers.insert("md".to_string(), "app:text-editor".to_string());
+    app.config.file_handlers = Some(handlers);
+
+    let panes_before: usize = app.windows.iter().map(|w| w.panes.len()).sum();
+
+    // sender_pane_id = 0 -> no pane -> workspace path check is bypassed
+    // (trusted host path), so a temp .md path opens cleanly.
+    let path = std::env::temp_dir()
+        .join("note.md")
+        .to_string_lossy()
+        .to_string();
+    app.dispatch_open_artifact(0, path, crate::app_protocol::ArtifactOpenMode::OpenInPane);
+
+    let panes_after: usize = app.windows.iter().map(|w| w.panes.len()).sum();
+    assert_eq!(
+        panes_after,
+        panes_before + 1,
+        "the md handler should open exactly one new in-Plexi pane"
+    );
+
+    let opened_text_editor = app.windows.iter().any(|w| {
+        w.panes.values().any(|p| {
+            p.as_app()
+                .map(|a| a.runtime.type_id() == "text-editor")
+                .unwrap_or(false)
+        })
+    });
+    assert!(
+        opened_text_editor,
+        "the file_handler-routed pane should be the text-editor app"
+    );
+}

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -130,3 +130,33 @@ fn file_handler_config_routes_extension_to_app() {
         "the file_handler-routed pane should be the text-editor app"
     );
 }
+
+/// The file browser must open at the context root when one is set, not the
+/// focused pane's CWD. Mirrors `resolve_new_pane_cwd`'s precedence
+/// (context.root → focused cwd → home) that every other new-pane path uses.
+#[test]
+fn file_browser_opens_at_context_root() {
+    let ctx = egui::Context::default();
+    let ft = crate::platform::logging::new_frame_tick();
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, ft);
+
+    let root = std::env::temp_dir().join("plexi-fb-root-test");
+    std::fs::create_dir_all(&root).expect("mkdir root");
+    app.set_context_root(root.clone(), None);
+
+    app.open_file_browser();
+
+    let fb_root = app.windows.iter().find_map(|w| {
+        w.panes.values().find_map(|p| {
+            p.as_app()
+                .filter(|a| a.runtime.type_id() == "file_browser")
+                .map(|a| a.workspace_root.clone())
+        })
+    });
+
+    assert_eq!(
+        fb_root.as_deref(),
+        Some(root.as_path()),
+        "file browser should open at the context root, not the focused pane CWD"
+    );
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -474,6 +474,16 @@ pub struct PlexiConfig {
     pub agents: Option<AgentsConfig>,
     pub cli: Option<CliConfig>,
     pub marketplace: Option<MarketplaceConfig>,
+    /// Per-extension file-open handlers (`[file_handlers]`). Keys are bare,
+    /// lowercase extensions (`md`, not `.md`); values are `kind:value` handler
+    /// specs resolved by [`crate::app::file_handlers::FileHandler`]:
+    ///   `app:<id>` — open in a Plexi app by registry id
+    ///   `os`       — hand to the OS default opener (`open` / `xdg-open`)
+    ///   `cmd:<command>` — reserved; falls back to OS open until wired
+    /// A user entry overrides any manifest-declared `file_types` association.
+    /// Unmapped extensions fall through to manifest associations, then builtin
+    /// media players, then the OS default.
+    pub file_handlers: Option<std::collections::HashMap<String, String>>,
 }
 
 /// CLI behavior configuration.

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -1,6 +1,10 @@
 mod helpers;
 mod icons;
 
+/// Re-exported so the host open resolver (`app::canvas_bindings`) can use the
+/// same media classification the File Explorer does (#2283).
+pub(crate) use helpers::MediaKind;
+
 use crate::app::app_trait::{App, AppCommand, AppRenderContext};
 use crate::ui::hints::{HintBar, HintGroup};
 use crate::ui::list::{self, ListRow};
@@ -15,7 +19,7 @@ use std::path::{Path, PathBuf};
 
 use helpers::{
     format_modified, format_size, is_text_preview_candidate, read_text_preview, sort_entries,
-    ColumnConfig, ColumnId, ColumnModel, DirStats, Entry, MediaKind, SortDirection, TextPreview,
+    ColumnConfig, ColumnId, ColumnModel, DirStats, Entry, SortDirection, TextPreview,
 };
 use icons::paint_entry_icon;
 
@@ -426,69 +430,28 @@ impl FileBrowserApp {
     }
 
     /// Open a file the user activated (Enter, double-click, search-Enter).
-    /// GUI↔Terminal media bridge (#79): recognised video/audio extensions
-    /// route to the in-app players (`video-player` / `audio-player`) so
-    /// the user stays inside the canvas. Everything else falls through
-    /// to the system default opener (`open` on macOS, `xdg-open` on
-    /// Linux). Failures to spawn the system opener are logged and
-    /// silently swallowed — they're not user-recoverable from the file
-    /// browser.
+    /// Hands the path to the host's single open resolver via `OpenArtifact`
+    /// (`OpenInPane`): the host consults `[file_handlers]`, manifest
+    /// `file_types`, builtin media players, and finally the OS default opener
+    /// (#2283). The File Explorer no longer routes by extension itself — that
+    /// logic lives in one place so terminal-driven and Explorer-driven opens
+    /// resolve identically.
     fn open_file(&mut self, path: &Path) {
-        let kind = MediaKind::for_path(path);
-        if let Some(app_id) = kind.player_app_id() {
-            log::info!(
-                "file_browser: routing {kind:?} file '{}' to in-app player '{app_id}'",
-                path.display()
-            );
-            self.pending_cmds.push(AppCommand::SpawnApp {
-                type_id: app_id.to_string(),
-                layout: None,
-                args: vec![path.to_string_lossy().to_string()],
-            });
-            return;
-        }
         #[cfg(test)]
         {
             self.opened_files.push(path.to_path_buf());
-            return;
         }
         #[cfg(not(test))]
-        match std::process::Command::new(Self::system_opener())
-            .arg(path)
-            .status()
         {
-            Ok(status) if status.success() => {
-                log::info!("file_browser: opened '{}'", path.display())
-            }
-            Ok(status) => log::error!(
-                "file_browser: system-open failed for '{}': {status}",
+            log::info!(
+                "file_browser: requesting host open-in-pane for '{}'",
                 path.display()
-            ),
-            Err(e) => log::error!(
-                "file_browser: system-open failed to spawn for '{}': {e}",
-                path.display()
-            ),
-        }
-    }
-
-    /// Platform-appropriate fallback opener. macOS / Linux only — Windows
-    /// callers fall through to a no-op since the media-bridge surface is
-    /// unix-first for v3.4 (mirrors `canvas_bindings::shell_open`).
-    #[cfg(not(test))]
-    fn system_opener() -> &'static str {
-        #[cfg(target_os = "macos")]
-        {
-            "open"
-        }
-        #[cfg(target_os = "linux")]
-        {
-            "xdg-open"
-        }
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-        {
-            // The Command will fail to spawn; the error log makes the
-            // platform gap visible without panicking.
-            "open"
+            );
+            self.pending_cmds.push(AppCommand::OpenArtifact {
+                sender_pane_id: 0, // dispatch.rs stamps the real pane_id
+                path: path.to_string_lossy().to_string(),
+                mode: crate::app_protocol::ArtifactOpenMode::OpenInPane,
+            });
         }
     }
 

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -865,22 +865,19 @@ impl PlexiApp {
             }
         }
 
-        let cwd = {
-            let ctx = &self.windows[self.active_window];
-            ctx.focused_pane
-                .and_then(|tile_id| ctx.get_focused_pane_cwd(tile_id))
-                .filter(|p| {
-                    if p == &PathBuf::from("/") {
-                        log::debug!(
-                            "open_file_browser: CWD is /, falling back to home_dir (GUI launch)"
-                        );
-                        false
-                    } else {
-                        true
-                    }
-                })
-                .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
-        };
+        // Resolve via the canonical new-pane resolver so the file browser
+        // honors the context root when set (context.root → focused-pane cwd →
+        // home), matching every other new-pane path. A GUI launch whose focused
+        // cwd is "/" still falls back to home.
+        let cwd = self
+            .resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
+            .filter(|p| p != &PathBuf::from("/"))
+            .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
+        log::info!(
+            "open_file_browser: cwd={} context_root={:?}",
+            cwd.display(),
+            self.router.active().root
+        );
 
         let app: Box<dyn App> = self
             .registry

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -941,6 +941,12 @@ impl PlexiApp {
             return Ok(());
         }
 
+        // When the caller does not specify a placement, fall back to the app's
+        // manifest-declared `[launch] placement` before the host default
+        // (`overlay`). One resolution point so every downstream hint inherits
+        // it (#2283). Builtins are not in the registry → None → `overlay`.
+        let layout = layout.or_else(|| self.registry.placement_for(id));
+
         let cwd_explicit = cwd_override.is_some();
         let cwd = cwd_override
             .or_else(|| {


### PR DESCRIPTION
Closes #2283

## Summary

- Unifies all file opens through the host's single `OpenArtifact`/`OpenInPane` resolver. File Explorer `open_file` now emits `OpenArtifact{OpenInPane}` instead of routing by extension itself (its bespoke `MediaKind` routing + system opener are removed).
- New `[file_handlers]` config table: bare-extension → `kind:value` spec (`app:<id>` | `os` | `cmd:<command>` reserved), parsed by `FileHandler` (src/app/file_handlers.rs, unit-tested).
- New `[launch] placement` manifest field — an app declares its natural launch mode (existing layout-hint vocabulary); resolved in `launch_app_by_id_with_layout` when the caller passes no layout.
- Resolver order (first match wins): user `[file_handlers]` → manifest `file_types` → builtin media players → **OS default (mandatory fallback)**. An `app:` handler that is unregistered or fails to launch falls through to the OS opener instead of vanishing.
- Fixes the swallowed `SpawnApp` launch (`let _ = ...`): logs on `Err` and skips the bogus `AppSpawned` confirmation.

**Fixes the reported bug:** Enter on a `.mp4` with no installed player previously did nothing (it dispatched `SpawnApp{video-player}`, an app that was never installed, and the failure was swallowed). It now falls through to the OS player.

## Done When

- Enter on a `.mp4` with no registered player opens it in the OS player + logs a warn — no silent failure.
- `md = "app:text-editor"` opens `.md` in the Plexi text-editor; `py = "os"` hands `.py` to the OS default.
- A manifest `[launch] placement = "split_right"` opens that app split-right.
- Unknown `app:` id falls back to OS open with a warning.
- `cargo test --bin plexi` green (1234 passed).