### PR TITLE
feat(host/events): expose app event subscriptions through MCP and CLI (#2288)

### DIFF
--- a/.stint/tasks/0214-cli-event-stream-subscriptions.md
+++ b/.stint/tasks/0214-cli-event-stream-subscriptions.md
@@ -1,0 +1,64 @@
+---
+id: "0214"
+title: "CLI event stream subscriptions for terminal agents"
+status: backlog
+estimate: "8h"
+blocked_by: []
+gh_issue:
+  - "2288"
+area:
+  - "cli/commands"
+  - "host/events"
+  - "sdk/pgap"
+  - "agents"
+tags:
+  - "v1"
+  - "assistant"
+  - "events"
+  - "agents"
+---
+
+Let third-party CLI agents subscribe to Plexi app event streams and receive
+brokered `PlexiEvent::AppEvent` deliveries as newline-delimited JSON.
+
+## Scope
+
+- Add `plexi events subscribe <app_id> <stream_name>` with payload, trigger,
+  resource, and all-stream options.
+- Keep the socket connection open for subscriptions and stream JSON lines to
+  stdout until interrupted.
+- Reuse `AppTimeline` subscriptions, broker grants, payload shaping, trigger
+  modes, and cleanup semantics. The socket path is transport only, not a second
+  event bus.
+- Derive the socket subscriber identity from the terminal pane / agent state;
+  never let the CLI spoof arbitrary subscriber identity.
+- Remove the subscription and queued deliveries when the client disconnects.
+- Add focused host/socket regression coverage for grant refusal, grant success,
+  payload shaping, event delivery, and disconnect cleanup.
+
+## Non-Scope
+
+- Do not build the host-level MCP server in this task.
+- Do not change per-app MCP server behavior.
+- Do not introduce a parallel event store, schema, or permission model.
+
+## Proposal
+
+Ship socket stream mode first, then expose it through a host-level MCP server
+later. The socket path gives Claude Code, Codex, Pi, and any future terminal
+agent immediate access through a subprocess/stdout contract while proving the
+lifecycle issues MCP also needs: identity, grants, delivery shaping, disconnect
+cleanup, and stable JSON.
+
+## References
+
+- GitHub issue #2288
+- `docs/prm/agent-platform.md`
+- `docs/prm/undo-and-app-events.md`
+- `src/app/mod.rs`
+- `src/cli/args.rs`
+- `src/cli/mod.rs`
+- `src/host/app_timeline.rs`
+- `src/protocol/commands.rs`
+- `src/protocol/events.rs`
+- `src/testing/harness_tests.rs`

--- a/.stint/tasks/0214-cli-event-stream-subscriptions.md
+++ b/.stint/tasks/0214-cli-event-stream-subscriptions.md
@@ -1,8 +1,9 @@
 ---
 id: "0214"
 title: "Host event subscriptions for third-party agents"
-status: backlog
+status: in-progress
 estimate: "12h"
+started_at: "2026-06-17T21:08:31Z"
 blocked_by: []
 gh_issue:
   - "2288"
@@ -17,6 +18,7 @@ tags:
   - "events"
   - "agents"
 ---
+
 
 Let third-party CLI agents subscribe to Plexi app event streams and receive
 brokered `PlexiEvent::AppEvent` deliveries through both CLI NDJSON and a

--- a/.stint/tasks/0214-cli-event-stream-subscriptions.md
+++ b/.stint/tasks/0214-cli-event-stream-subscriptions.md
@@ -1,8 +1,8 @@
 ---
 id: "0214"
-title: "CLI event stream subscriptions for terminal agents"
+title: "Host event subscriptions for third-party agents"
 status: backlog
-estimate: "8h"
+estimate: "12h"
 blocked_by: []
 gh_issue:
   - "2288"
@@ -19,36 +19,77 @@ tags:
 ---
 
 Let third-party CLI agents subscribe to Plexi app event streams and receive
-brokered `PlexiEvent::AppEvent` deliveries as newline-delimited JSON.
+brokered `PlexiEvent::AppEvent` deliveries through both CLI NDJSON and a
+host-level MCP server.
 
 ## Scope
 
-- Add `plexi events subscribe <app_id> <stream_name>` with payload, trigger,
-  resource, and all-stream options.
+- Add one host subscription service that owns subscriber identity, broker
+  checks, `AppTimeline` subscriptions, delivery draining, and disconnect
+  cleanup.
+- Add `plexi events subscribe <app_id> <stream_name>` as the universal
+  subprocess/stdout frontend, with payload, trigger, resource, and all-stream
+  options.
 - Keep the socket connection open for subscriptions and stream JSON lines to
   stdout until interrupted.
+- Add a host-level MCP server surface that exposes the same subscription
+  primitive to MCP-aware agents without requiring a wrapper subprocess.
 - Reuse `AppTimeline` subscriptions, broker grants, payload shaping, trigger
-  modes, and cleanup semantics. The socket path is transport only, not a second
-  event bus.
-- Derive the socket subscriber identity from the terminal pane / agent state;
+  modes, and cleanup semantics. CLI and MCP are transports only, not second
+  event buses.
+- Derive subscriber identity from the terminal pane / agent state;
   never let the CLI spoof arbitrary subscriber identity.
 - Remove the subscription and queued deliveries when the client disconnects.
-- Add focused host/socket regression coverage for grant refusal, grant success,
-  payload shaping, event delivery, and disconnect cleanup.
+- Add focused host, socket, and MCP regression coverage for grant refusal,
+  grant success, payload shaping, event delivery, and disconnect cleanup.
 
 ## Non-Scope
 
-- Do not build the host-level MCP server in this task.
 - Do not change per-app MCP server behavior.
 - Do not introduce a parallel event store, schema, or permission model.
 
 ## Proposal
 
-Ship socket stream mode first, then expose it through a host-level MCP server
-later. The socket path gives Claude Code, Codex, Pi, and any future terminal
-agent immediate access through a subprocess/stdout contract while proving the
-lifecycle issues MCP also needs: identity, grants, delivery shaping, disconnect
-cleanup, and stable JSON.
+Land the optimal infrastructure now: a shared host subscription core plus two
+thin transports. The CLI NDJSON stream is the lowest-common-denominator path
+for any agent that can read subprocess stdout; the host-level MCP server is the
+native path for agents that already speak MCP. Both must wrap the same core so
+Plexi has one event permission model, one delivery lifecycle, and one schema.
+
+## End-to-End Companion
+
+Build a tiny first-party PGAP proof app, `event-probe`, as the manual validation
+companion. It should declare one stream (`probe.tick`) and expose one visible
+button/action that emits a deterministic event:
+
+```json
+{
+  "event": "probe.tick",
+  "summary": "Probe tick 3",
+  "resource_id": "probe-session",
+  "revision_after": "tick-3",
+  "payload": { "count": 3 }
+}
+```
+
+Manual validation should exercise both agent-facing transports:
+
+- Open `event-probe` in Plexi and trigger one event from the UI.
+- From a terminal pane, run `plexi events subscribe event-probe probe.tick`
+  and confirm it prints the subscribed response plus the emitted event JSON.
+- Spawn a fresh Claude Code or Codex pane with the Plexi host MCP server
+  configured, then send a prompt equivalent to:
+
+```text
+Use the Plexi MCP server. Subscribe to the event-probe app's probe.tick event
+stream with full payload. Wait for the next event and report its count and
+summary. Do not read plexi.log or call the CLI event command directly.
+```
+
+The pass condition is that the external agent discovers the MCP tool/resource,
+subscribes through MCP, waits, and reports the next `probe.tick` event after the
+button is clicked. This proves the MCP adapter is actually wired, not just that
+the Rust host test can route an in-process delivery.
 
 ## References
 
@@ -62,3 +103,5 @@ cleanup, and stable JSON.
 - `src/protocol/commands.rs`
 - `src/protocol/events.rs`
 - `src/testing/harness_tests.rs`
+- `src/process_app/mcp_server.rs` for reference only; host-level MCP should not
+  be implemented by changing per-app MCP semantics.

--- a/GOTCHAS.md
+++ b/GOTCHAS.md
@@ -176,3 +176,15 @@ workspace-local apps) and in `app init` (to decide where to scaffold). In those 
 ## `just pr-install` must run from the feature worktree
 
 `scripts/install.sh` derives `REPO_ROOT` from `${BASH_SOURCE[0]}/..`. Running from the repo root resolves to alpha's working tree, so `rsync -a apps/dev/` syncs alpha's `apps/dev/` — missing any apps that only exist on the feature branch. Always `cd worktrees/feature/<branch> && just pr-install <N>`.
+
+---
+
+## CLI event subscriptions stream over a long-lived socket; deliveries poll the global timeline · host · events
+
+`plexi events subscribe` cannot use the normal one-shot request → response-file socket path (`send_to_socket`): it needs the connection held open while the host pushes many NDJSON lines over time. `handle_socket_connection` (`src/app/mod.rs`) intercepts control messages by their JSON `type` (`events_subscribe`/`events_list`) **before** `AppRequest` parsing, since those are not `AppRequest` variants. The grant check + identity resolution run on the UI thread (it owns the grant store) via a dedicated in-memory channel (`event_subscribe_rx`, drained in `drain_event_subscribe_channel`); the connection thread then streams deliveries by polling `app_timeline::global()` directly — the UI thread is never in the streaming hot loop. Disconnect is detected by a reader thread draining the (otherwise silent) input side: on EOF it flips a flag so an idle subscription with no events still tears down and `clear_subscriber` fires.
+
+**Subscriber identity is host-stamped, never client-supplied.** CLI = `pane:<PLEXI_PANE_ID>`; the host MCP server = `mcp:host` (via `HostSubscribeRequest::subscriber_override`, set by trusted transport code, not a tool arg). There is deliberately no CLI/MCP flag to set the subscriber id.
+
+## Two MCP servers share one HTTP/JSON-RPC envelope · host · mcp
+
+`src/mcp_http.rs` owns the `POST /mcp` framing, bearer auth, body-size guard, and response writer. Both the per-app bridge (`process_app::mcp_server`) and the host event server (`app::host_mcp`) call `read_json_rpc_request` / `write_http_response`. The host server is a singleton started in `PlexiApp::new`; its `(port, token)` is stored in a `OnceLock` (`host_mcp::discovery`) so `make_backend_settings` can inject `PLEXI_HOST_MCP_PORT`/`PLEXI_HOST_MCP_TOKEN` into every pane PTY. `start_host_mcp_server` also **returns** the `(port, token)` so tests (which start several servers) bind to the right one instead of reading the first-wins `OnceLock`.

--- a/apps/dev/event-probe/main.py
+++ b/apps/dev/event-probe/main.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Event Probe — POC companion for host event subscriptions (stint 0214).
+
+Declares one stream (``probe.tick``) and emits a deterministic event on a
+button press or the ``e`` key. Used to manually validate both agent-facing
+transports:
+
+  - CLI:  ``plexi events subscribe event-probe probe.tick`` (NDJSON stream)
+  - MCP:  the host event MCP server's ``subscribe_and_wait`` tool
+
+Each tick increments a counter and emits::
+
+    {"event": "probe.tick", "summary": "Probe tick N",
+     "resource_id": "probe-session", "revision_after": "tick-N",
+     "payload": {"count": N}}
+"""
+from plexi_sdk import App
+from plexi_sdk.ui import AppBar, ButtonRow, Column, FooterKeys, Label, Spacer
+
+STREAM = "probe.tick"
+RESOURCE = "probe-session"
+
+
+class EventProbe(App):
+    def on_init(self) -> None:
+        self.count: int = self.state.get("count", 0)
+        # Declare the stream before emitting on it — the host rejects events
+        # on undeclared streams.
+        self.emit.declare_event_streams([
+            {
+                "name": STREAM,
+                "schema": {
+                    "type": "object",
+                    "properties": {"count": {"type": "integer"}},
+                    "required": ["count"],
+                },
+                "description": "Fires once per probe tick with the running count.",
+            }
+        ])
+        self.emit.info(f"event-probe ready (count={self.count})")
+
+    def view(self):
+        return Column([
+            AppBar(title="Event Probe"),
+            Label(f"ticks emitted: {self.count}", bold=True),
+            Label(f"stream: {STREAM}  ·  resource: {RESOURCE}"),
+            Spacer(grow=True),
+            ButtonRow("emit", "Emit tick (e)"),
+            FooterKeys(shortcuts=[("e", "emit tick")]),
+        ])
+
+    def emit_tick(self) -> None:
+        self.count += 1
+        self.emit.emit_event(
+            event=STREAM,
+            actor="user",
+            summary=f"Probe tick {self.count}",
+            resource_id=RESOURCE,
+            resource_scope="document",
+            revision_after=f"tick-{self.count}",
+            payload={"count": self.count},
+            suggested_trigger="conversation",
+        )
+        self.emit.info(f"emitted {STREAM} count={self.count}")
+        self.state.save({"count": self.count})
+        self.emit.schedule_render()
+
+    def on_component_event(self, node_id: str, event_type: str, payload: dict) -> None:
+        if node_id == "emit" and event_type == "click":
+            self.emit_tick()
+
+    def on_key(self, key: str, mods: dict) -> None:
+        if key == "e":
+            self.emit_tick()
+
+
+EventProbe().run()

--- a/apps/dev/event-probe/manifest.toml
+++ b/apps/dev/event-probe/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "event-probe"
+type = "app"
+name = "Event Probe"
+entry = "main.py"
+version = "0.1.0"
+description = "POC: declares one event stream and emits ticks for subscription testing"
+watch = true
+
+[app.capabilities]
+capabilities = []
+
+[launch]

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -70,6 +70,11 @@ pub(crate) enum FocusLayer {
     /// so the modal renders in step 2 of `update()` with exclusive keyboard
     /// ownership — before `dispatch_app_key_events` can steal Escape.
     CapabilityModal,
+    /// Host event-subscription consent modal. Promoted when a CLI/MCP agent's
+    /// subscribe request hit the broker's `Ask` decision and is parked in
+    /// `pending_event_consents`, so the Allow/Always/Deny modal owns the
+    /// keyboard before `dispatch_app_key_events` can steal Enter/Escape.
+    EventConsent,
     /// Notes picker overlay: lists workspace notes sorted by mtime, opens selected in focused text-editor.
     NotesPicker,
     /// Notes inbox triage overlay: shows inbox notes one at a time for keep/trash/action.
@@ -271,6 +276,7 @@ impl PlexiApp {
                 | Some(FocusLayer::TextInput)
                 | Some(FocusLayer::ContextCloseConfirm)
                 | Some(FocusLayer::CapabilityModal)
+                | Some(FocusLayer::EventConsent)
                 | Some(FocusLayer::NotesPicker)
                 | Some(FocusLayer::NotesTriage)
         )
@@ -986,6 +992,23 @@ impl PlexiApp {
             log::info!("capability_modal: focus released — prompt queue drained");
             self.focus_stack
                 .retain(|l| *l != FocusLayer::CapabilityModal);
+        }
+    }
+
+    /// Promote/release the host event-consent modal layer to mirror
+    /// `pending_event_consents`. A parked CLI/MCP subscribe consent must own the
+    /// keyboard so Enter/Esc resolve it instead of leaking to the focused pane.
+    pub(crate) fn sync_event_consent_focus(&mut self) {
+        let should_own = !self.pending_event_consents.is_empty();
+        let has_layer = self.focus_stack.contains(&FocusLayer::EventConsent);
+        let is_top = matches!(self.focus_stack.last(), Some(FocusLayer::EventConsent));
+        if should_own && !is_top {
+            self.focus_stack.retain(|l| *l != FocusLayer::EventConsent);
+            log::info!("event_consent: focus captured — subscribe consent awaiting decision");
+            self.push_focus_layer(FocusLayer::EventConsent);
+        } else if !should_own && has_layer {
+            log::info!("event_consent: focus released — consent queue drained");
+            self.focus_stack.retain(|l| *l != FocusLayer::EventConsent);
         }
     }
 

--- a/src/app/host_mcp.rs
+++ b/src/app/host_mcp.rs
@@ -252,14 +252,18 @@ fn tool_subscribe_and_wait(
         .map_err(|_| "host not accepting subscriptions".to_string())?;
     egui_ctx.request_repaint();
 
-    let (subscriber_type, subscriber_id) = match reply_rx.recv_timeout(Duration::from_secs(5)) {
+    // A first-time MCP subscribe under default `Ask` posture blocks here until
+    // the user answers the host consent modal. Kept short enough that the
+    // consent wait plus the long-poll stay under common MCP client timeouts;
+    // once the user picks "Always" the grant persists and this is instant.
+    let (subscriber_type, subscriber_id) = match reply_rx.recv_timeout(Duration::from_secs(30)) {
         Ok(HostSubscribeReply::Ok {
             subscriber_type,
             subscriber_id,
             ..
         }) => (subscriber_type, subscriber_id),
         Ok(HostSubscribeReply::Err { message }) => return Err(message),
-        Err(_) => return Err("subscribe timed out".to_string()),
+        Err(_) => return Err("subscribe consent timed out".to_string()),
     };
 
     // Long-poll the global timeline for the next delivery.
@@ -368,8 +372,10 @@ mod tests {
         );
         std::thread::spawn(move || {
             while let Ok(req) = rx.recv() {
-                let reply = svc.handle_subscribe_request(&req);
-                let _ = req.reply.send(reply);
+                // Pre-granted in these tests, so classify answers immediately;
+                // an `Ask` would return a parked consent we have no UI to
+                // resolve, so it is dropped (the transport sees a closed reply).
+                let _ = svc.classify_subscribe_request(req);
             }
         });
         start_host_mcp_server(tx, egui::Context::default()).unwrap()

--- a/src/app/host_mcp.rs
+++ b/src/app/host_mcp.rs
@@ -1,0 +1,305 @@
+//! Host-level event-subscription MCP server — `stint 0214`.
+//!
+//! The native transport for MCP-aware agents (Claude Code, Codex). Unlike the
+//! per-app MCP bridge (`process_app::mcp_server`), this is a single host-wide
+//! server started once at boot. It exposes the same subscription primitive the
+//! `plexi events` CLI wraps, backed by the one host subscription core — CLI and
+//! MCP are transports, not separate event buses.
+//!
+//! Tools:
+//! - `list_event_streams` — discover the `(app, stream)` pairs running apps declare.
+//! - `subscribe_and_wait` — broker-checked subscribe, block for the next event,
+//!   return it, then drop the subscription. A long-poll, so an agent can "wait
+//!   for the next event and report it" in one tool call.
+//!
+//! Discovery: the bound port + bearer token are injected into every pane's PTY
+//! env as `PLEXI_HOST_MCP_PORT` / `PLEXI_HOST_MCP_TOKEN`, so an agent in a pane
+//! can configure this server without a wrapper subprocess.
+//!
+//! Identity: subscriptions are recorded under the host-stamped id `mcp:host`
+//! (set by this trusted transport, never from a tool argument), so an MCP client
+//! cannot spoof another subscriber.
+
+use crate::host::event_subscriptions::{HostSubscribeReply, HostSubscribeRequest};
+use crate::mcp_http::{read_json_rpc_request, write_http_response, RequestOutcome};
+use std::net::TcpListener;
+use std::sync::mpsc::Sender;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+/// The host-stamped subscriber identity for all MCP-routed subscriptions.
+const MCP_SUBSCRIBER_ID: &str = "mcp:host";
+/// Hard cap on `subscribe_and_wait` blocking, kept under common MCP client
+/// request timeouts. The client may request less via `timeout_secs`.
+const MAX_WAIT_SECS: u64 = 55;
+const DEFAULT_WAIT_SECS: u64 = 25;
+
+/// Process-wide discovery info for the singleton host MCP server: `(port,
+/// token)`. Set once when the server binds; read by the pane PTY env builder so
+/// every pane gets `PLEXI_HOST_MCP_PORT` / `PLEXI_HOST_MCP_TOKEN`.
+static DISCOVERY: OnceLock<(u16, String)> = OnceLock::new();
+
+/// The bound `(port, token)` once the server has started, else `None`.
+pub fn discovery() -> Option<&'static (u16, String)> {
+    DISCOVERY.get()
+}
+
+/// Start the host MCP server. `subscribe_tx` routes subscribe requests to the
+/// UI thread (which owns the grant store); `egui_ctx` is woken so the UI drains
+/// the subscribe channel promptly even while idle. Idempotent at the discovery
+/// level — the first successful bind wins.
+pub fn start_host_mcp_server(
+    subscribe_tx: Sender<HostSubscribeRequest>,
+    egui_ctx: egui::Context,
+) -> std::io::Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let port = listener.local_addr()?.port();
+    let token = uuid::Uuid::new_v4().to_string();
+    let _ = DISCOVERY.set((port, token.clone()));
+    let token_arc = std::sync::Arc::new(token.clone());
+
+    std::thread::Builder::new()
+        .name(format!("host-mcp-accept-{port}"))
+        .spawn(move || {
+            for stream in listener.incoming() {
+                match stream {
+                    Ok(stream) => {
+                        let token = std::sync::Arc::clone(&token_arc);
+                        let subscribe_tx = subscribe_tx.clone();
+                        let egui_ctx = egui_ctx.clone();
+                        std::thread::Builder::new()
+                            .name("host-mcp-conn".to_string())
+                            .spawn(move || {
+                                if let Err(e) =
+                                    handle_connection(stream, &token, &subscribe_tx, &egui_ctx)
+                                {
+                                    log::warn!("host_mcp: connection error: {e}");
+                                }
+                            })
+                            .ok();
+                    }
+                    Err(e) => {
+                        log::warn!("host_mcp: accept error: {e}");
+                        break;
+                    }
+                }
+            }
+        })
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
+    log::info!("host_mcp: started on 127.0.0.1:{port}");
+    Ok(())
+}
+
+fn tool_defs() -> serde_json::Value {
+    serde_json::json!([
+        {
+            "name": "list_event_streams",
+            "description": "List the event streams currently declared by running Plexi apps. Returns an array of {app_id, stream} pairs.",
+            "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false }
+        },
+        {
+            "name": "subscribe_and_wait",
+            "description": "Subscribe to a Plexi app's event stream and block until the next event arrives (or the timeout elapses), then return it. The subscription is dropped when the call returns.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "app_id": { "type": "string", "description": "App that publishes the stream, e.g. event-probe." },
+                    "stream": { "type": "string", "description": "Stream name, e.g. probe.tick. Omit with all=true to subscribe to every stream." },
+                    "all": { "type": "boolean", "description": "Subscribe to all of the app's declared streams." },
+                    "payload": { "type": "string", "enum": ["off", "summary", "full", "state_ref"], "description": "How much of the event to deliver (default full)." },
+                    "timeout_secs": { "type": "integer", "description": "Max seconds to wait for the next event (default 25, max 55)." }
+                },
+                "required": ["app_id"],
+                "additionalProperties": false
+            }
+        }
+    ])
+}
+
+fn handle_connection(
+    stream: std::net::TcpStream,
+    token: &str,
+    subscribe_tx: &Sender<HostSubscribeRequest>,
+    egui_ctx: &egui::Context,
+) -> std::io::Result<()> {
+    let peer = stream
+        .peer_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+    let mut write_stream = stream.try_clone()?;
+
+    let json = match read_json_rpc_request(&stream, token)? {
+        RequestOutcome::Json(v) => v,
+        RequestOutcome::Handled => return Ok(()),
+    };
+
+    let id = json.get("id").cloned().unwrap_or(serde_json::Value::Null);
+    let method_name = json.get("method").and_then(|m| m.as_str()).unwrap_or("");
+
+    let response_body = match method_name {
+        "initialize" => serde_json::json!({
+            "jsonrpc": "2.0", "id": id,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": "plexi-host-events", "version": "1.0.0" }
+            }
+        }),
+        "notifications/initialized" => serde_json::json!({
+            "jsonrpc": "2.0", "id": serde_json::Value::Null, "result": serde_json::Value::Null
+        }),
+        "tools/list" => serde_json::json!({
+            "jsonrpc": "2.0", "id": id, "result": { "tools": tool_defs() }
+        }),
+        "tools/call" => {
+            let params = json.get("params").cloned().unwrap_or_default();
+            let tool_name = params.get("name").and_then(|n| n.as_str()).unwrap_or("");
+            let arguments = params
+                .get("arguments")
+                .cloned()
+                .unwrap_or(serde_json::Value::Object(Default::default()));
+            log::info!("host_mcp: tool_call tool={tool_name} peer={peer}");
+            let result = match tool_name {
+                "list_event_streams" => tool_list_event_streams(),
+                "subscribe_and_wait" => {
+                    tool_subscribe_and_wait(&arguments, subscribe_tx, egui_ctx)
+                }
+                other => Err(format!("unknown tool: {other}")),
+            };
+            match result {
+                Ok(text) => serde_json::json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": { "content": [{ "type": "text", "text": text }], "isError": false }
+                }),
+                Err(msg) => serde_json::json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": { "content": [{ "type": "text", "text": msg }], "isError": true }
+                }),
+            }
+        }
+        other => serde_json::json!({
+            "jsonrpc": "2.0", "id": id,
+            "error": { "code": -32601, "message": format!("method not found: {other}") }
+        }),
+    };
+
+    let body_bytes = serde_json::to_vec(&response_body).unwrap_or_else(|_| b"{}".to_vec());
+    write_http_response(&mut write_stream, 200, &body_bytes)
+}
+
+/// `list_event_streams` — read declared streams from the global timeline.
+fn tool_list_event_streams() -> Result<String, String> {
+    let streams = crate::host::app_timeline::global()
+        .lock()
+        .unwrap()
+        .all_declared_streams();
+    let arr: Vec<serde_json::Value> = streams
+        .iter()
+        .map(|(a, s)| serde_json::json!({ "app_id": a, "stream": s }))
+        .collect();
+    serde_json::to_string(&serde_json::json!({ "streams": arr }))
+        .map_err(|e| format!("serialize failed: {e}"))
+}
+
+/// `subscribe_and_wait` — broker-checked subscribe, block for the next event,
+/// return it, then clear the subscription.
+fn tool_subscribe_and_wait(
+    args: &serde_json::Value,
+    subscribe_tx: &Sender<HostSubscribeRequest>,
+    egui_ctx: &egui::Context,
+) -> Result<String, String> {
+    let app_id = args
+        .get("app_id")
+        .and_then(|v| v.as_str())
+        .ok_or("missing required argument: app_id")?
+        .to_string();
+    let all = args.get("all").and_then(|v| v.as_bool()).unwrap_or(false);
+    let stream = args.get("stream").and_then(|v| v.as_str());
+    let event_names: Vec<String> = match (all, stream) {
+        (true, _) => vec![],
+        (false, Some(s)) => vec![s.to_string()],
+        (false, None) => {
+            return Err("provide a stream name or set all=true".to_string());
+        }
+    };
+    let payload_mode = match args.get("payload").and_then(|v| v.as_str()) {
+        Some("off") => crate::app_protocol::PayloadMode::Off,
+        Some("summary") => crate::app_protocol::PayloadMode::Summary,
+        Some("state_ref") => crate::app_protocol::PayloadMode::StateRef,
+        _ => crate::app_protocol::PayloadMode::Full,
+    };
+    let timeout_secs = args
+        .get("timeout_secs")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(DEFAULT_WAIT_SECS)
+        .clamp(1, MAX_WAIT_SECS);
+
+    // Route the broker-checked subscribe through the UI thread.
+    let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel::<HostSubscribeReply>(1);
+    let req = HostSubscribeRequest {
+        publisher_app_id: app_id.clone(),
+        event_names,
+        payload_mode,
+        trigger_mode: crate::app_protocol::TriggerMode::Conversation,
+        resource_id: None,
+        from_pane_id: None,
+        subscriber_override: Some(MCP_SUBSCRIBER_ID.to_string()),
+        reply: reply_tx,
+    };
+    subscribe_tx
+        .send(req)
+        .map_err(|_| "host not accepting subscriptions".to_string())?;
+    egui_ctx.request_repaint();
+
+    let (subscriber_type, subscriber_id) = match reply_rx.recv_timeout(Duration::from_secs(5)) {
+        Ok(HostSubscribeReply::Ok {
+            subscriber_type,
+            subscriber_id,
+            ..
+        }) => (subscriber_type, subscriber_id),
+        Ok(HostSubscribeReply::Err { message }) => return Err(message),
+        Err(_) => return Err("subscribe timed out".to_string()),
+    };
+
+    // Long-poll the global timeline for the next delivery.
+    let timeline = crate::host::app_timeline::global();
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    let mut first = None;
+    while Instant::now() < deadline {
+        let deliveries = timeline
+            .lock()
+            .unwrap()
+            .take_deliveries_for(subscriber_type, &subscriber_id);
+        if let Some(d) = deliveries.into_iter().next() {
+            first = Some(d);
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    // One-shot: drop the subscription and any extra queued deliveries.
+    timeline
+        .lock()
+        .unwrap()
+        .clear_subscriber(subscriber_type, &subscriber_id);
+
+    match first {
+        Some(d) => {
+            let out = serde_json::json!({
+                "app_id": d.app_id,
+                "event": d.event,
+                "event_id": d.event_id,
+                "resource_id": d.resource_id,
+                "summary": d.summary,
+                "payload": d.payload,
+                "state_ref": d.state_ref,
+                "created_at": d.created_at,
+            });
+            log::info!("host_mcp: subscribe_and_wait delivered event {} from {}", d.event, d.app_id);
+            serde_json::to_string(&out).map_err(|e| format!("serialize failed: {e}"))
+        }
+        None => Ok(format!(
+            "{{\"timeout\":true,\"message\":\"no event within {timeout_secs}s\"}}"
+        )),
+    }
+}

--- a/src/app/host_mcp.rs
+++ b/src/app/host_mcp.rs
@@ -51,7 +51,7 @@ pub fn discovery() -> Option<&'static (u16, String)> {
 pub fn start_host_mcp_server(
     subscribe_tx: Sender<HostSubscribeRequest>,
     egui_ctx: egui::Context,
-) -> std::io::Result<()> {
+) -> std::io::Result<(u16, String)> {
     let listener = TcpListener::bind("127.0.0.1:0")?;
     let port = listener.local_addr()?.port();
     let token = uuid::Uuid::new_v4().to_string();
@@ -88,7 +88,7 @@ pub fn start_host_mcp_server(
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
     log::info!("host_mcp: started on 127.0.0.1:{port}");
-    Ok(())
+    Ok((port, token))
 }
 
 fn tool_defs() -> serde_json::Value {
@@ -301,5 +301,169 @@ fn tool_subscribe_and_wait(
         None => Ok(format!(
             "{{\"timeout\":true,\"message\":\"no event within {timeout_secs}s\"}}"
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+
+    fn post(port: u16, token: Option<&str>, body: &[u8]) -> (u16, Vec<u8>) {
+        let mut stream = TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+        let auth = match token {
+            Some(t) => format!("Authorization: Bearer {t}\r\n"),
+            None => String::new(),
+        };
+        let req = format!(
+            "POST /mcp HTTP/1.1\r\nHost: localhost\r\n{auth}Content-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        stream.write_all(req.as_bytes()).unwrap();
+        stream.write_all(body).unwrap();
+        stream.flush().unwrap();
+        let mut resp = Vec::new();
+        let _ = stream.read_to_end(&mut resp);
+        let s = String::from_utf8_lossy(&resp);
+        let status = s
+            .lines()
+            .next()
+            .and_then(|l| l.split_whitespace().nth(1))
+            .and_then(|x| x.parse().ok())
+            .unwrap_or(0);
+        let start = s.find("\r\n\r\n").map(|i| i + 4).unwrap_or(resp.len());
+        (status, resp[start..].to_vec())
+    }
+
+    /// A test server whose subscribe channel is serviced by a granted service
+    /// bound to the global timeline (the production wiring, minus the UI loop).
+    fn start_test_server(grant_target: Option<&str>) -> (u16, String) {
+        use crate::broker::{
+            ActorScope, ActorType, Decision, GrantDuration, GrantRecord, GrantSource,
+            ResourceScope, TargetType,
+        };
+        let (tx, rx) = std::sync::mpsc::channel::<HostSubscribeRequest>();
+        let mut store = crate::broker::GrantStore::default();
+        if let Some(target) = grant_target {
+            store.record(GrantRecord {
+                actor_type: ActorType::Agent,
+                actor_id: MCP_SUBSCRIBER_ID.to_string(),
+                actor_scope: ActorScope::User,
+                workspace_root: None,
+                target_type: TargetType::AppEventStream,
+                target_id: target.to_string(),
+                resource_scope: ResourceScope::Global,
+                resource_id: None,
+                decision: Decision::Allow,
+                duration: GrantDuration::Session,
+                source: GrantSource::Session,
+                created_at: 0,
+                expires_at: None,
+            });
+        }
+        let svc = crate::host::event_subscriptions::HostSubscriptionService::new_for_test(
+            store,
+            crate::host::app_timeline::global(),
+        );
+        std::thread::spawn(move || {
+            while let Ok(req) = rx.recv() {
+                let reply = svc.handle_subscribe_request(&req);
+                let _ = req.reply.send(reply);
+            }
+        });
+        start_host_mcp_server(tx, egui::Context::default()).unwrap()
+    }
+
+    #[test]
+    fn no_auth_returns_401() {
+        let (port, _t) = start_test_server(None);
+        let (status, _) = post(port, None, br#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#);
+        assert_eq!(status, 401);
+    }
+
+    #[test]
+    fn tools_list_exposes_subscription_tools() {
+        let (port, token) = start_test_server(None);
+        let (status, body) = post(
+            port,
+            Some(&token),
+            br#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#,
+        );
+        assert_eq!(status, 200);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let names: Vec<&str> = json["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|t| t["name"].as_str())
+            .collect();
+        assert!(names.contains(&"list_event_streams"));
+        assert!(names.contains(&"subscribe_and_wait"));
+    }
+
+    /// End-to-end proof the MCP adapter is wired, not just that a host test can
+    /// route in-process: subscribe via the tool, emit on the timeline, and the
+    /// tool returns the event.
+    #[test]
+    fn subscribe_and_wait_delivers_emitted_event() {
+        use crate::app_protocol::{AppEventActor, EventStreamDecl};
+        use crate::host::app_timeline::EmittedEvent;
+        let app = "mcp-it-app";
+        let stream = "it.tick";
+        crate::host::app_timeline::global()
+            .lock()
+            .unwrap()
+            .declare_streams(
+                app,
+                vec![EventStreamDecl {
+                    name: stream.to_string(),
+                    schema: serde_json::json!({"type": "object"}),
+                    description: None,
+                }],
+            )
+            .unwrap();
+        let (port, token) = start_test_server(Some(&format!("{app}::{stream}")));
+
+        // Emit shortly after the tool call begins its long-poll.
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(300));
+            crate::host::app_timeline::global()
+                .lock()
+                .unwrap()
+                .record_event(
+                    app,
+                    1,
+                    EmittedEvent {
+                        event: stream.to_string(),
+                        actor: AppEventActor::User,
+                        actor_id: None,
+                        caused_by: None,
+                        summary: "it tick 1".to_string(),
+                        resource_id: "it-session".to_string(),
+                        resource_scope: Some("document".to_string()),
+                        revision_after: "tick-1".to_string(),
+                        payload: Some(serde_json::json!({"count": 1})),
+                        state_ref: None,
+                        revision_before: None,
+                        rollback_token: None,
+                        changed_resources: vec![],
+                        suggested_trigger: None,
+                    },
+                )
+                .unwrap();
+        });
+
+        let call = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{{"name":"subscribe_and_wait","arguments":{{"app_id":"{app}","stream":"{stream}","timeout_secs":5}}}}}}"#
+        );
+        let (status, body) = post(port, Some(&token), call.as_bytes());
+        assert_eq!(status, 200);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let text = json["result"]["content"][0]["text"].as_str().unwrap();
+        let event: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(event["event"], stream);
+        assert_eq!(event["summary"], "it tick 1");
+        assert_eq!(event["payload"]["count"], 1);
     }
 }

--- a/src/app/host_mcp.rs
+++ b/src/app/host_mcp.rs
@@ -16,6 +16,12 @@
 //! env as `PLEXI_HOST_MCP_PORT` / `PLEXI_HOST_MCP_TOKEN`, so an agent in a pane
 //! can configure this server without a wrapper subprocess.
 //!
+//! Persistence: the `(port, token)` is stored in `config_dir/host_mcp.json` and
+//! reused on every launch. This makes the server install-once — an agent runs
+//! `plexi events mcp-config` a single time, bakes the URL + bearer into a static
+//! MCP client config, and it keeps resolving across Plexi restarts instead of
+//! breaking when a fresh port/token is rolled each boot.
+//!
 //! Identity: subscriptions are recorded under the host-stamped id `mcp:host`
 //! (set by this trusted transport, never from a tool argument), so an MCP client
 //! cannot spoof another subscriber.
@@ -23,6 +29,7 @@
 use crate::host::event_subscriptions::{HostSubscribeReply, HostSubscribeRequest};
 use crate::mcp_http::{read_json_rpc_request, write_http_response, RequestOutcome};
 use std::net::TcpListener;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::Sender;
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
@@ -44,17 +51,97 @@ pub fn discovery() -> Option<&'static (u16, String)> {
     DISCOVERY.get()
 }
 
+/// The persisted host-MCP identity (`config_dir/host_mcp.json`). Survives
+/// restarts so a baked MCP client config keeps working — see the module docs.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct HostMcpIdentity {
+    port: u16,
+    token: String,
+}
+
+fn identity_path(config_dir: &Path) -> PathBuf {
+    config_dir.join("host_mcp.json")
+}
+
+/// Load the persisted `(port, token)` if the file exists and parses. A corrupt
+/// file is logged and ignored so the next launch re-rolls a fresh identity
+/// rather than failing to start the transport.
+fn load_identity(config_dir: &Path) -> Option<HostMcpIdentity> {
+    let path = identity_path(config_dir);
+    let bytes = std::fs::read(&path).ok()?;
+    match serde_json::from_slice::<HostMcpIdentity>(&bytes) {
+        Ok(id) => Some(id),
+        Err(e) => {
+            log::warn!("host_mcp: ignoring unparseable {}: {e}", path.display());
+            None
+        }
+    }
+}
+
+/// Atomically persist `(port, token)` with owner-only permissions — the file
+/// carries a bearer secret. Best-effort: a write failure only means the next
+/// launch re-rolls the identity, so it is logged rather than propagated.
+fn save_identity(config_dir: &Path, port: u16, token: &str) {
+    let path = identity_path(config_dir);
+    let tmp = path.with_extension("json.tmp");
+    let body = match serde_json::to_vec_pretty(&HostMcpIdentity {
+        port,
+        token: token.to_string(),
+    }) {
+        Ok(b) => b,
+        Err(e) => {
+            log::warn!("host_mcp: could not serialize identity: {e}");
+            return;
+        }
+    };
+    if let Err(e) = std::fs::write(&tmp, &body) {
+        log::warn!("host_mcp: could not write {}: {e}", tmp.display());
+        return;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600));
+    }
+    if let Err(e) = std::fs::rename(&tmp, &path) {
+        log::warn!("host_mcp: could not finalize {}: {e}", path.display());
+    }
+}
+
 /// Start the host MCP server. `subscribe_tx` routes subscribe requests to the
 /// UI thread (which owns the grant store); `egui_ctx` is woken so the UI drains
-/// the subscribe channel promptly even while idle. Idempotent at the discovery
-/// level — the first successful bind wins.
+/// the subscribe channel promptly even while idle. `config_dir` is the profile
+/// dir where the `(port, token)` identity is persisted across restarts.
+/// Idempotent at the discovery level — the first successful bind wins.
 pub fn start_host_mcp_server(
     subscribe_tx: Sender<HostSubscribeRequest>,
     egui_ctx: egui::Context,
+    config_dir: &Path,
 ) -> std::io::Result<(u16, String)> {
-    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let persisted = load_identity(config_dir);
+    // Reuse the persisted token so a baked `Authorization: Bearer` keeps
+    // authenticating; generate one only on first launch.
+    let token = persisted
+        .as_ref()
+        .map(|id| id.token.clone())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    // Reuse the persisted port so a static MCP URL keeps resolving. Fall back to
+    // an OS-assigned port if it is taken (e.g. another channel grabbed it while
+    // this instance was down) and re-persist whatever we actually bound.
+    let listener = match persisted.as_ref().map(|id| id.port) {
+        Some(p) => TcpListener::bind(("127.0.0.1", p)).or_else(|e| {
+            log::warn!(
+                "host_mcp: persisted port {p} unavailable ({e}); falling back to an ephemeral port"
+            );
+            TcpListener::bind("127.0.0.1:0")
+        })?,
+        None => TcpListener::bind("127.0.0.1:0")?,
+    };
     let port = listener.local_addr()?.port();
-    let token = uuid::Uuid::new_v4().to_string();
+
+    save_identity(config_dir, port, &token);
+
     let _ = DISCOVERY.set((port, token.clone()));
     let token_arc = std::sync::Arc::new(token.clone());
 
@@ -378,7 +465,34 @@ mod tests {
                 let _ = svc.classify_subscribe_request(req);
             }
         });
-        start_host_mcp_server(tx, egui::Context::default()).unwrap()
+        // Each test server gets an isolated profile dir so its persisted
+        // identity never collides with a sibling test's port/token.
+        let dir = tempfile::tempdir().unwrap();
+        start_host_mcp_server(tx, egui::Context::default(), dir.path()).unwrap()
+    }
+
+    #[test]
+    fn identity_round_trips_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        save_identity(dir.path(), 4242, "tok-abc");
+        let loaded = load_identity(dir.path()).expect("identity file written");
+        assert_eq!(loaded.port, 4242);
+        assert_eq!(loaded.token, "tok-abc");
+    }
+
+    #[test]
+    fn restart_reuses_persisted_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, _rx) = std::sync::mpsc::channel::<HostSubscribeRequest>();
+        let (port1, token1) =
+            start_host_mcp_server(tx.clone(), egui::Context::default(), dir.path()).unwrap();
+        // A second boot against the same profile dir must reuse the token so a
+        // baked `Authorization: Bearer` keeps authenticating across restarts.
+        let (_port2, token2) =
+            start_host_mcp_server(tx, egui::Context::default(), dir.path()).unwrap();
+        assert_eq!(token1, token2, "token must persist across restarts");
+        assert_eq!(load_identity(dir.path()).unwrap().token, token1);
+        assert!(port1 > 0);
     }
 
     #[test]

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -141,9 +141,10 @@ impl PlexiApp {
         }
         self.host_subscriptions.reload(&crate::config::config_dir());
         for req in requests {
-            let reply = self.host_subscriptions.handle_subscribe_request(&req);
-            if req.reply.send(reply).is_err() {
-                log::warn!("events: subscribe reply channel closed before delivery");
+            // `Allow`/`Deny`/undeclared answer the transport inline; `Ask`
+            // returns a parked consent we surface as a host modal next frame.
+            if let Some(consent) = self.host_subscriptions.classify_subscribe_request(req) {
+                self.pending_event_consents.push_back(consent);
             }
         }
     }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -121,6 +121,31 @@ impl PlexiApp {
         while let Ok(cmd) = self.pane_ipc_rx.try_recv() {
             self.handle_pane_ipc_request(cmd);
         }
+        self.drain_event_subscribe_channel();
+    }
+
+    /// Service CLI/MCP subscribe requests routed from socket connection threads.
+    /// The UI thread owns the grant store, so identity resolution + the broker
+    /// check happen here; the connection thread streams deliveries afterward.
+    /// Grants are reloaded from disk first so a just-granted permission applies
+    /// without a host restart.
+    fn drain_event_subscribe_channel(&mut self) {
+        // Pull all pending requests before touching the grant store so the
+        // reload happens at most once per frame regardless of request count.
+        let mut requests = Vec::new();
+        while let Ok(req) = self.event_subscribe_rx.try_recv() {
+            requests.push(req);
+        }
+        if requests.is_empty() {
+            return;
+        }
+        self.host_subscriptions.reload(&crate::config::config_dir());
+        for req in requests {
+            let reply = self.host_subscriptions.handle_subscribe_request(&req);
+            if req.reply.send(reply).is_err() {
+                log::warn!("events: subscribe reply channel closed before delivery");
+            }
+        }
     }
 
     /// Handle a single pane-IPC `AppRequest`. Shared by the socket drain above

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,6 +3,7 @@ pub mod app_trait;
 mod canvas_bindings;
 mod dispatch;
 mod focus;
+pub mod host_mcp;
 pub mod host_version;
 mod lifecycle;
 pub mod marketplace;
@@ -558,6 +559,7 @@ fn handle_events_subscribe(
         trigger_mode,
         resource_id,
         from_pane_id,
+        subscriber_override: None,
         reply: reply_tx,
     };
     if subscribe_tx.send(req).is_err() {
@@ -823,13 +825,20 @@ impl PlexiApp {
         let (event_subscribe_tx, event_subscribe_rx) = std::sync::mpsc::channel::<
             crate::host::event_subscriptions::HostSubscribeRequest,
         >();
-        spawn_socket_listener(pane_ipc_tx, event_subscribe_tx, cc.egui_ctx.clone());
+        spawn_socket_listener(
+            pane_ipc_tx,
+            event_subscribe_tx.clone(),
+            cc.egui_ctx.clone(),
+        );
         let host_subscriptions = crate::host::event_subscriptions::HostSubscriptionService::new(
             &crate::config::config_dir(),
             crate::config::active_workspace_root()
                 .unwrap_or_else(|| std::env::current_dir().unwrap_or_default()),
             crate::host::app_timeline::global(),
         );
+        if let Err(e) = host_mcp::start_host_mcp_server(event_subscribe_tx, cc.egui_ctx.clone()) {
+            log::warn!("host_mcp: failed to start event MCP server: {e}");
+        }
 
         // One-time migration: remove the legacy file-queue directory if it
         // still exists from a previous install. Notify commands now travel
@@ -1704,6 +1713,13 @@ impl PlexiApp {
             .to_string_lossy()
             .into_owned();
         env.insert("PLEXI_SOCKET".into(), socket);
+        // Host-level event MCP server discovery (stint 0214). Lets an MCP-aware
+        // agent in this pane configure the Plexi host MCP server without a
+        // wrapper subprocess.
+        if let Some((port, token)) = host_mcp::discovery() {
+            env.insert("PLEXI_HOST_MCP_PORT".into(), port.to_string());
+            env.insert("PLEXI_HOST_MCP_TOKEN".into(), token.clone());
+        }
         env.insert("PLEXI_CONTEXT_ID".into(), context_id.to_string());
         env.insert("PLEXI_CONTEXT_NAME".into(), context_name.to_string());
         env.insert(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -844,7 +844,11 @@ impl PlexiApp {
                 .unwrap_or_else(|| std::env::current_dir().unwrap_or_default()),
             crate::host::app_timeline::global(),
         );
-        if let Err(e) = host_mcp::start_host_mcp_server(event_subscribe_tx, cc.egui_ctx.clone()) {
+        if let Err(e) = host_mcp::start_host_mcp_server(
+            event_subscribe_tx,
+            cc.egui_ctx.clone(),
+            &crate::config::config_dir(),
+        ) {
             log::warn!("host_mcp: failed to start event MCP server: {e}");
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -366,6 +366,11 @@ pub struct PlexiApp {
     /// in `drain_event_subscribe_channel`.
     event_subscribe_rx:
         std::sync::mpsc::Receiver<crate::host::event_subscriptions::HostSubscribeRequest>,
+    /// Subscribe requests the broker answered with `Ask`, parked for an explicit
+    /// user decision. The front entry is surfaced as the host event-consent
+    /// modal; [`FocusLayer::EventConsent`] is promoted while this is non-empty.
+    pub(crate) pending_event_consents:
+        std::collections::VecDeque<crate::host::event_subscriptions::PendingEventConsent>,
     /// Last (window_id, tile_id) pair that was logged as a FocusChanged event.
     /// Uses stable window_id (u64) not a vector index so removals don't corrupt it.
     /// Compared at end of each frame to detect genuine focus transitions.
@@ -572,8 +577,11 @@ fn handle_events_subscribe(
     }
     egui_ctx.request_repaint();
 
+    // Generous wait: a first-time subscribe under the broker's default `Ask`
+    // posture blocks here until the user answers the host consent modal. A
+    // pre-granted subscribe replies near-instantly.
     let (subscriber_type, subscriber_id, subscription_id) =
-        match reply_rx.recv_timeout(Duration::from_secs(5)) {
+        match reply_rx.recv_timeout(Duration::from_secs(120)) {
             Ok(HostSubscribeReply::Ok {
                 subscription_id,
                 subscriber_type,
@@ -591,7 +599,7 @@ fn handle_events_subscribe(
                 let _ = writeln!(
                     write_half,
                     "{}",
-                    serde_json::json!({"type": "error", "message": "subscribe timed out"})
+                    serde_json::json!({"type": "error", "message": "subscribe consent timed out"})
                 );
                 return;
             }
@@ -1166,6 +1174,7 @@ impl PlexiApp {
                     pane_ipc_rx,
                     host_subscriptions,
                     event_subscribe_rx,
+                    pending_event_consents: std::collections::VecDeque::new(),
                     last_logged_focus: None,
                     focus_started_at: None,
                     last_system_theme: None,
@@ -1407,6 +1416,7 @@ impl PlexiApp {
             pane_ipc_rx,
             host_subscriptions,
             event_subscribe_rx,
+            pending_event_consents: std::collections::VecDeque::new(),
             last_logged_focus: None,
             focus_started_at: None,
             last_system_theme: None,
@@ -1624,6 +1634,7 @@ impl PlexiApp {
                 pane_ipc_rx,
                 host_subscriptions,
                 event_subscribe_rx,
+                pending_event_consents: std::collections::VecDeque::new(),
                 last_logged_focus: None,
                 focus_started_at: None,
                 last_system_theme: None,
@@ -1969,6 +1980,7 @@ impl eframe::App for PlexiApp {
                         self.context_close_confirm_handle_key(ctx)
                     }
                     Some(FocusLayer::CapabilityModal) => self.capability_modal_handle_key(ctx),
+                    Some(FocusLayer::EventConsent) => self.event_consent_handle_key(ctx),
                     Some(FocusLayer::NotesPicker) => {
                         self.notes_picker_handle_key(ctx);
                         crate::app::app_trait::KeyDisposition::Passthrough
@@ -2014,6 +2026,9 @@ impl eframe::App for PlexiApp {
                     Some(FocusLayer::CapabilityModal) => {
                         self.draw_capability_modal(ctx);
                     }
+                    Some(FocusLayer::EventConsent) => {
+                        self.draw_event_consent_modal(ctx);
+                    }
                     Some(FocusLayer::NotesPicker) => {
                         self.draw_notes_picker(ctx);
                     }
@@ -2035,6 +2050,7 @@ impl eframe::App for PlexiApp {
                 self.sync_cli_setup_prompt_focus();
                 self.sync_text_input_focus();
                 self.sync_capability_modal_focus();
+                self.sync_event_consent_focus();
                 disposition
             } // end else (non-preempted path)
         } else {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -356,6 +356,15 @@ pub struct PlexiApp {
     /// Receiver for AppRequests sent over the PLEXI_SOCKET Unix socket listener.
     /// Drained each frame in `drain_pane_cmd_channel`.
     pane_ipc_rx: std::sync::mpsc::Receiver<crate::app_protocol::AppRequest>,
+    /// Host-owned event subscription core shared by the CLI NDJSON transport and
+    /// the host MCP server. Resolves subscriber identity, runs the broker check,
+    /// and records subscriptions in the global timeline.
+    pub(crate) host_subscriptions: crate::host::event_subscriptions::HostSubscriptionService,
+    /// Receiver for CLI/MCP subscribe requests routed from socket connection
+    /// threads to the UI thread (which owns the grant store). Drained each frame
+    /// in `drain_event_subscribe_channel`.
+    event_subscribe_rx:
+        std::sync::mpsc::Receiver<crate::host::event_subscriptions::HostSubscribeRequest>,
     /// Last (window_id, tile_id) pair that was logged as a FocusChanged event.
     /// Uses stable window_id (u64) not a vector index so removals don't corrupt it.
     /// Compared at end of each frame to detect genuine focus transitions.
@@ -410,9 +419,11 @@ fn handle_socket_line(
 
 fn spawn_socket_listener(
     tx: std::sync::mpsc::Sender<crate::app_protocol::AppRequest>,
+    subscribe_tx: std::sync::mpsc::Sender<
+        crate::host::event_subscriptions::HostSubscribeRequest,
+    >,
     egui_ctx: egui::Context,
 ) {
-    use std::io::{BufRead, BufReader};
     use std::os::unix::net::UnixListener;
 
     let path = crate::config::config_dir().join("notify.sock");
@@ -435,20 +446,253 @@ fn spawn_socket_listener(
                 }
             };
             let tx = tx.clone();
+            let subscribe_tx = subscribe_tx.clone();
             let egui_ctx = egui_ctx.clone();
             std::thread::spawn(move || {
-                let reader = BufReader::new(stream);
-                for line in reader.lines() {
-                    let Ok(line) = line else { break };
-                    let line = line.trim().to_owned();
-                    if line.is_empty() {
-                        continue;
-                    }
-                    handle_socket_line(&line, &tx, &egui_ctx);
-                }
+                handle_socket_connection(stream, tx, subscribe_tx, egui_ctx);
             });
         }
     });
+}
+
+/// Per-connection handler. Most connections are one-shot `AppRequest` lines.
+/// Event-stream control messages (`events_subscribe`, `events_list`) are
+/// intercepted before `AppRequest` parsing because they keep the socket open
+/// and stream NDJSON back — a transport the normal request/response-file path
+/// does not support.
+fn handle_socket_connection(
+    stream: std::os::unix::net::UnixStream,
+    tx: std::sync::mpsc::Sender<crate::app_protocol::AppRequest>,
+    subscribe_tx: std::sync::mpsc::Sender<
+        crate::host::event_subscriptions::HostSubscribeRequest,
+    >,
+    egui_ctx: egui::Context,
+) {
+    use std::io::{BufRead, BufReader};
+    // A writable clone so a streaming handler can push NDJSON back while the
+    // BufReader owns the read side.
+    let write_half = match stream.try_clone() {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("pane_ipc: try_clone failed: {e}");
+            return;
+        }
+    };
+    let reader = BufReader::new(stream);
+    let mut lines = reader.lines();
+    let Some(Ok(first)) = lines.next() else {
+        return;
+    };
+    let first = first.trim().to_owned();
+    if first.is_empty() {
+        return;
+    }
+    // Intercept event-stream control messages. These share the `type`-tagged
+    // JSON shape but are not `AppRequest` variants, so anything else falls
+    // through to the normal one-shot path.
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(&first) {
+        match val.get("type").and_then(|t| t.as_str()) {
+            Some("events_subscribe") => {
+                handle_events_subscribe(write_half, lines, val, &subscribe_tx, &egui_ctx);
+                return;
+            }
+            Some("events_list") => {
+                handle_events_list(write_half, &val);
+                return;
+            }
+            _ => {}
+        }
+    }
+    // Normal path: first line plus any remaining lines as AppRequests.
+    handle_socket_line(&first, &tx, &egui_ctx);
+    for line in lines {
+        let Ok(line) = line else { break };
+        let line = line.trim().to_owned();
+        if line.is_empty() {
+            continue;
+        }
+        handle_socket_line(&line, &tx, &egui_ctx);
+    }
+}
+
+/// Stream one app's event deliveries to a CLI subscriber as NDJSON. Routes the
+/// subscribe round-trip through the UI thread (`subscribe_tx`) for identity +
+/// broker check, acks, then polls the global timeline and writes one JSON line
+/// per delivery until the client disconnects, then clears the subscription.
+fn handle_events_subscribe(
+    mut write_half: std::os::unix::net::UnixStream,
+    remaining: std::io::Lines<std::io::BufReader<std::os::unix::net::UnixStream>>,
+    val: serde_json::Value,
+    subscribe_tx: &std::sync::mpsc::Sender<
+        crate::host::event_subscriptions::HostSubscribeRequest,
+    >,
+    egui_ctx: &egui::Context,
+) {
+    use crate::host::event_subscriptions::{HostSubscribeReply, HostSubscribeRequest};
+    use std::io::Write;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    let app_id = val["app_id"].as_str().unwrap_or_default().to_string();
+    let event_names: Vec<String> = val["event_names"]
+        .as_array()
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    let payload_mode = serde_json::from_value(val["payload_mode"].clone())
+        .unwrap_or(crate::app_protocol::PayloadMode::Full);
+    let trigger_mode = serde_json::from_value(val["trigger_mode"].clone())
+        .unwrap_or(crate::app_protocol::TriggerMode::Conversation);
+    let resource_id = val["resource_id"].as_str().map(String::from);
+    let from_pane_id = val["from_pane_id"].as_u64();
+
+    let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel::<HostSubscribeReply>(1);
+    let req = HostSubscribeRequest {
+        publisher_app_id: app_id.clone(),
+        event_names,
+        payload_mode,
+        trigger_mode,
+        resource_id,
+        from_pane_id,
+        reply: reply_tx,
+    };
+    if subscribe_tx.send(req).is_err() {
+        let _ = writeln!(
+            write_half,
+            "{}",
+            serde_json::json!({"type": "error", "message": "host not accepting subscriptions"})
+        );
+        return;
+    }
+    egui_ctx.request_repaint();
+
+    let (subscriber_type, subscriber_id, subscription_id) =
+        match reply_rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(HostSubscribeReply::Ok {
+                subscription_id,
+                subscriber_type,
+                subscriber_id,
+            }) => (subscriber_type, subscriber_id, subscription_id),
+            Ok(HostSubscribeReply::Err { message }) => {
+                let _ = writeln!(
+                    write_half,
+                    "{}",
+                    serde_json::json!({"type": "error", "message": message})
+                );
+                return;
+            }
+            Err(_) => {
+                let _ = writeln!(
+                    write_half,
+                    "{}",
+                    serde_json::json!({"type": "error", "message": "subscribe timed out"})
+                );
+                return;
+            }
+        };
+
+    let ack = serde_json::json!({
+        "type": "subscribed",
+        "subscription_id": subscription_id,
+        "app_id": app_id,
+    });
+    if writeln!(write_half, "{ack}").is_err() {
+        return;
+    }
+    let _ = write_half.flush();
+    log::info!(
+        "events: streaming subscription {subscription_id} for {subscriber_type:?} '{subscriber_id}' -> '{app_id}'"
+    );
+
+    // Detect client disconnect: a reader thread drains the (otherwise silent)
+    // input side and flips the flag on EOF, so an idle subscription with no
+    // events still tears down promptly when the CLI exits.
+    let disconnected = Arc::new(AtomicBool::new(false));
+    {
+        let flag = Arc::clone(&disconnected);
+        std::thread::spawn(move || {
+            for _ in remaining {}
+            flag.store(true, Ordering::Relaxed);
+        });
+    }
+
+    let timeline = crate::host::app_timeline::global();
+    loop {
+        if disconnected.load(Ordering::Relaxed) {
+            break;
+        }
+        let deliveries = timeline
+            .lock()
+            .unwrap()
+            .take_deliveries_for(subscriber_type, &subscriber_id);
+        for d in deliveries {
+            let line = serde_json::json!({
+                "type": "event",
+                "subscription_id": d.subscription_id,
+                "app_id": d.app_id,
+                "event": d.event,
+                "event_id": d.event_id,
+                "resource_id": d.resource_id,
+                "trigger_mode": d.trigger_mode,
+                "summary": d.summary,
+                "payload": d.payload,
+                "state_ref": d.state_ref,
+                "created_at": d.created_at,
+            });
+            if writeln!(write_half, "{line}").is_err() {
+                disconnected.store(true, Ordering::Relaxed);
+                break;
+            }
+            let _ = write_half.flush();
+        }
+        if disconnected.load(Ordering::Relaxed) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+
+    let (subs, drops) = timeline
+        .lock()
+        .unwrap()
+        .clear_subscriber(subscriber_type, &subscriber_id);
+    log::info!(
+        "events: subscriber '{subscriber_id}' disconnected; cleared {subs} subscription(s), \
+         dropped {drops} queued delivery(ies)"
+    );
+}
+
+/// Answer `events_list`: write the declared `(app_id, stream)` pairs and close.
+/// Pure discovery — no grant check, no identity, no streaming.
+fn handle_events_list(mut write_half: std::os::unix::net::UnixStream, val: &serde_json::Value) {
+    use std::io::Write;
+    let json_mode = val["json"].as_bool().unwrap_or(false);
+    let streams = crate::host::app_timeline::global()
+        .lock()
+        .unwrap()
+        .all_declared_streams();
+    log::info!("events: list requested ({} stream(s) declared)", streams.len());
+    if json_mode {
+        let arr: Vec<serde_json::Value> = streams
+            .iter()
+            .map(|(a, s)| serde_json::json!({"app_id": a, "stream": s}))
+            .collect();
+        let _ = writeln!(
+            write_half,
+            "{}",
+            serde_json::json!({"type": "streams", "streams": arr})
+        );
+    } else if streams.is_empty() {
+        let _ = writeln!(write_half, "No event streams declared by running apps.");
+    } else {
+        for (app_id, stream) in &streams {
+            let _ = writeln!(write_half, "{app_id}  {stream}");
+        }
+    }
+    let _ = write_half.flush();
 }
 
 impl PlexiApp {
@@ -576,7 +820,16 @@ impl PlexiApp {
 
         let (pane_ipc_tx, pane_ipc_rx) =
             std::sync::mpsc::channel::<crate::app_protocol::AppRequest>();
-        spawn_socket_listener(pane_ipc_tx, cc.egui_ctx.clone());
+        let (event_subscribe_tx, event_subscribe_rx) = std::sync::mpsc::channel::<
+            crate::host::event_subscriptions::HostSubscribeRequest,
+        >();
+        spawn_socket_listener(pane_ipc_tx, event_subscribe_tx, cc.egui_ctx.clone());
+        let host_subscriptions = crate::host::event_subscriptions::HostSubscriptionService::new(
+            &crate::config::config_dir(),
+            crate::config::active_workspace_root()
+                .unwrap_or_else(|| std::env::current_dir().unwrap_or_default()),
+            crate::host::app_timeline::global(),
+        );
 
         // One-time migration: remove the legacy file-queue directory if it
         // still exists from a previous install. Notify commands now travel
@@ -902,6 +1155,8 @@ impl PlexiApp {
                     update_install_rx: None,
                     update_installing: false,
                     pane_ipc_rx,
+                    host_subscriptions,
+                    event_subscribe_rx,
                     last_logged_focus: None,
                     focus_started_at: None,
                     last_system_theme: None,
@@ -1141,6 +1396,8 @@ impl PlexiApp {
             update_install_rx: None,
             update_installing: false,
             pane_ipc_rx,
+            host_subscriptions,
+            event_subscribe_rx,
             last_logged_focus: None,
             focus_started_at: None,
             last_system_theme: None,
@@ -1211,6 +1468,14 @@ impl PlexiApp {
         let features = crate::features::FeatureFlags::from_config(&config);
         let (pane_ipc_tx, pane_ipc_rx) =
             std::sync::mpsc::channel::<crate::app_protocol::AppRequest>();
+        let (_event_subscribe_tx, event_subscribe_rx) = std::sync::mpsc::channel::<
+            crate::host::event_subscriptions::HostSubscribeRequest,
+        >();
+        let host_subscriptions = crate::host::event_subscriptions::HostSubscriptionService::new(
+            &crate::config::config_dir(),
+            std::env::current_dir().unwrap_or_default(),
+            crate::host::app_timeline::global(),
+        );
         (
             Self {
                 pty_event_rx: rx,
@@ -1348,6 +1613,8 @@ impl PlexiApp {
                 update_install_rx: None,
                 update_installing: false,
                 pane_ipc_rx,
+                host_subscriptions,
+                event_subscribe_rx,
                 last_logged_focus: None,
                 focus_started_at: None,
                 last_system_theme: None,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -93,6 +93,7 @@ impl PlexiApp {
         self.sync_cli_setup_prompt_focus();
         self.sync_text_input_focus();
         self.sync_capability_modal_focus();
+        self.sync_event_consent_focus();
 
         let _ = ctx; // ctx is unused in the preamble itself; parameter reserved for future use
     }

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -24,7 +24,7 @@ use crate::broker::{
     ActorScope, ActorType, Decision, GrantDuration, GrantRecord, GrantSource, GrantStore,
     PermissionRequest, ResourceScope, TargetType,
 };
-use crate::host::app_timeline::{AppTimeline, SubscriptionRecord};
+use crate::host::app_timeline::AppTimeline;
 use crate::plexi_ai::broker::{AiBroker, AiBrokerRequest};
 use crate::plexi_ai::turn_loop::TurnDelta;
 use crate::plexi_ai::CancelToken;
@@ -349,26 +349,18 @@ impl AssistantApp {
             log::info!("assistant: already subscribed to '{target}'");
             return;
         }
-        let subscription_id = format!("assistant-sub-{}", uuid::Uuid::new_v4());
-        self.timeline
-            .lock()
-            .unwrap()
-            .add_subscription(SubscriptionRecord {
-                subscription_id: subscription_id.clone(),
-                subscriber_type: ActorType::Agent,
-                subscriber_id: ASSISTANT_ACTOR_ID.to_string(),
-                app_id: app.to_string(),
-                event_names: if event == "*" {
-                    Vec::new()
-                } else {
-                    vec![event.to_string()]
-                },
-                payload_mode: PayloadMode::Full,
-                trigger_mode: TriggerMode::Conversation,
-                resource_id: None,
-                duration: GrantDuration::Session,
-                created_at: crate::host::event_log::now_timestamp(),
-            });
+        let event_names = if event == "*" { Vec::new() } else { vec![event.to_string()] };
+        let subscription_id = crate::host::event_subscriptions::record_subscription(
+            &self.timeline,
+            app,
+            ActorType::Agent,
+            ASSISTANT_ACTOR_ID,
+            event_names,
+            PayloadMode::Full,
+            TriggerMode::Conversation,
+            None,
+            GrantDuration::Session,
+        );
         log::info!("assistant: subscribed to '{target}' ({subscription_id})");
         self.live_subs.push((target, subscription_id));
     }
@@ -629,14 +621,16 @@ impl AssistantApp {
                     let _ = reply.send(ok(format!("already subscribed to {target}")));
                     return;
                 }
-                let req = PermissionRequest::new(
+                let event_names = if event == "*" { Vec::new() } else { vec![event.clone()] };
+                match crate::host::event_subscriptions::evaluate_subscription(
+                    &self.grant_store,
+                    None,
+                    &self.workspace_root,
+                    &app,
                     ActorType::Agent,
                     ASSISTANT_ACTOR_ID,
-                    TargetType::AppEventStream,
-                    &target,
-                    Some(&self.workspace_root),
-                );
-                match self.grant_store.evaluate(&req, None) {
+                    &event_names,
+                ) {
                     Decision::Allow => {
                         self.subscribe_stream(&app, &event);
                         self.audit
@@ -1944,6 +1938,38 @@ mod tests {
         assert_eq!(emit_move(&timeline, AppEventActor::User, None, None), 1);
         app.pump_turn_io();
         assert_eq!(event_rows(&app), 1, "one event row, not duplicates");
+    }
+
+    /// A granted assistant subscribe records a timeline `SubscriptionRecord`
+    /// stamped with the assistant's identity — the same shape the CLI/MCP
+    /// transports produce, now that all three share `record_subscription`.
+    #[test]
+    fn subscribe_stream_records_assistant_subscription_shape() {
+        let ws = tempfile::tempdir().unwrap();
+        let timeline = chess_timeline();
+        let mut app = test_app_with_timeline(ws.path(), timeline.clone());
+        app.subscribe_stream("chess", "move.played");
+
+        let guard = timeline.lock().unwrap();
+        let subs = guard.subscriptions();
+        assert_eq!(subs.len(), 1);
+        let record = &subs[0];
+        assert_eq!(record.subscriber_type, ActorType::Agent);
+        assert_eq!(record.subscriber_id, ASSISTANT_ACTOR_ID);
+        assert_eq!(record.app_id, "chess");
+        assert_eq!(record.event_names, vec!["move.played".to_string()]);
+
+        // `*` subscribes to all declared streams → empty event_names.
+        drop(guard);
+        app.subscribe_stream("chess", "*");
+        let guard = timeline.lock().unwrap();
+        let star = guard
+            .subscriptions()
+            .iter()
+            .find(|r| r.event_names.is_empty())
+            .expect("`*` subscribe must record an all-streams subscription");
+        assert_eq!(star.app_id, "chess");
+        assert_eq!(star.subscriber_id, ASSISTANT_ACTOR_ID);
     }
 
     #[test]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -122,6 +122,18 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: PaneCmd,
     },
+    /// Subscribe to a Plexi app's event streams and receive brokered deliveries.
+    ///
+    /// Apps declare named event streams (e.g. `probe.tick`) and emit events on them.
+    /// `plexi events subscribe <app_id> <stream>` opens a long-lived connection and
+    /// prints one JSON line per delivered event to stdout (NDJSON) until interrupted.
+    /// Subscriptions are brokered: the host stamps your identity from the pane you run
+    /// in and checks permission before any event is delivered.
+    #[command(next_help_heading = "Events")]
+    Events {
+        #[command(subcommand)]
+        cmd: EventsCmd,
+    },
     /// Send a notification to the Plexi UI.
     Notify {
         /// Notification title (required)
@@ -248,6 +260,43 @@ pub enum Commands {
     /// List run completions (hidden, used by shell completions)
     #[command(hide = true, name = "_complete-run")]
     CompleteRun,
+}
+
+#[derive(Subcommand)]
+pub enum EventsCmd {
+    /// Subscribe to an app's event stream and print delivered events as NDJSON.
+    ///
+    /// Opens a long-lived connection to the running Plexi instance and streams
+    /// one JSON object per line to stdout: first a `subscribed` acknowledgement,
+    /// then one line per delivered event. Runs until interrupted (Ctrl-C), at
+    /// which point the host drops the subscription and its queued deliveries.
+    ///
+    /// Example: plexi events subscribe event-probe probe.tick --payload full
+    Subscribe {
+        /// App id that publishes the stream (e.g. `event-probe`).
+        app_id: String,
+        /// Stream name to subscribe to (e.g. `probe.tick`). Omit with --all to
+        /// subscribe to every stream the app declares.
+        stream: Option<String>,
+        /// Subscribe to all of the app's declared streams instead of one.
+        #[arg(long, conflicts_with = "stream")]
+        all: bool,
+        /// How much of each event to deliver: off, summary, full, or state-ref.
+        #[arg(long, default_value = "full", value_parser = ["off", "summary", "full", "state-ref"])]
+        payload: String,
+        /// Trigger mode recorded on the subscription: never, conversation, ambient, or ask.
+        #[arg(long, default_value = "conversation", value_parser = ["never", "conversation", "ambient", "ask"])]
+        trigger: String,
+        /// Only deliver events for this resource id (document/game/pane). Omit for any.
+        #[arg(long)]
+        resource: Option<String>,
+    },
+    /// List event streams currently declared by running apps.
+    List {
+        /// Output as JSON instead of a human-readable table.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -297,6 +297,13 @@ pub enum EventsCmd {
         #[arg(long)]
         json: bool,
     },
+    /// Print the host event MCP server config for an MCP-aware agent.
+    ///
+    /// Emits a `mcpServers` JSON block pointing at this instance's host MCP
+    /// server (read from `PLEXI_HOST_MCP_PORT` / `PLEXI_HOST_MCP_TOKEN`), so a
+    /// Claude Code or Codex agent in this pane can subscribe to app events
+    /// natively over MCP.
+    McpConfig,
 }
 
 #[derive(Subcommand)]

--- a/src/cli/events.rs
+++ b/src/cli/events.rs
@@ -1,0 +1,141 @@
+//! `plexi events` — subscribe to app event streams from a terminal pane.
+//!
+//! The lowest-common-denominator agent transport: any process that can read
+//! subprocess stdout can subscribe. Both subcommands open the host socket,
+//! send one control line, and stream newline-delimited JSON back:
+//!
+//! - `subscribe` keeps the connection open and prints a `subscribed` ack line
+//!   followed by one line per delivered event, until interrupted.
+//! - `list` prints the apps' declared streams once and exits.
+//!
+//! Identity is host-stamped from `PLEXI_PANE_ID`; there is deliberately no flag
+//! to set the subscriber identity, so a CLI agent cannot spoof another.
+
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+
+/// Connect to the running host's command socket. Mirrors the connect/cleanup
+/// behaviour of `send_to_socket`, but returns the live stream so the caller can
+/// stream NDJSON responses back.
+fn connect_socket() -> Result<UnixStream, i32> {
+    let socket_path = match std::env::var("PLEXI_SOCKET") {
+        Ok(v) => v,
+        Err(_) => {
+            eprintln!("error: PLEXI_SOCKET is not set — run this inside a Plexi terminal pane");
+            return Err(1);
+        }
+    };
+    match UnixStream::connect(&socket_path) {
+        Ok(s) => Ok(s),
+        Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+            let _ = std::fs::remove_file(&socket_path);
+            eprintln!("error: Plexi is not responding (stale socket removed). Is Plexi running?");
+            Err(1)
+        }
+        Err(e) => {
+            eprintln!("error: could not connect to PLEXI_SOCKET {socket_path:?}: {e}");
+            Err(1)
+        }
+    }
+}
+
+fn from_pane_id() -> Option<u64> {
+    std::env::var("PLEXI_PANE_ID").ok()?.parse().ok()
+}
+
+/// Send one control line and stream every NDJSON line the host returns to
+/// stdout until the connection closes. Returns the process exit code.
+fn stream_control_line(payload: serde_json::Value) -> i32 {
+    let mut stream = match connect_socket() {
+        Ok(s) => s,
+        Err(code) => return code,
+    };
+    let line = format!("{payload}\n");
+    if let Err(e) = stream.write_all(line.as_bytes()) {
+        eprintln!("error: could not write to socket: {e}");
+        return 1;
+    }
+    let _ = stream.flush();
+    log::info!("events: sent control line type={}", payload["type"]);
+    let reader = BufReader::new(stream);
+    let stdout = std::io::stdout();
+    for line in reader.lines() {
+        match line {
+            Ok(line) => {
+                let mut out = stdout.lock();
+                if writeln!(out, "{line}").is_err() {
+                    return 0; // downstream consumer went away
+                }
+                let _ = out.flush();
+            }
+            Err(e) => {
+                eprintln!("error: reading event stream: {e}");
+                return 1;
+            }
+        }
+    }
+    0
+}
+
+/// `plexi events subscribe <app_id> <stream>` — stream deliveries as NDJSON.
+pub fn events_subscribe_cli(
+    app_id: &str,
+    stream: Option<&str>,
+    all: bool,
+    payload: &str,
+    trigger: &str,
+    resource: Option<&str>,
+) -> i32 {
+    let event_names: Vec<String> = match (all, stream) {
+        (true, _) => vec![],
+        (false, Some(s)) => vec![s.to_string()],
+        (false, None) => {
+            eprintln!(
+                "error: specify a stream name (e.g. `plexi events subscribe {app_id} probe.tick`) \
+                 or pass --all to subscribe to every stream"
+            );
+            return 2;
+        }
+    };
+    let payload_mode = payload_mode_json(payload);
+    let trigger_mode = trigger_mode_json(trigger);
+    let req = serde_json::json!({
+        "type": "events_subscribe",
+        "app_id": app_id,
+        "event_names": event_names,
+        "payload_mode": payload_mode,
+        "trigger_mode": trigger_mode,
+        "resource_id": resource,
+        "from_pane_id": from_pane_id(),
+    });
+    stream_control_line(req)
+}
+
+/// `plexi events list` — print declared streams once and exit.
+pub fn events_list_cli(json: bool) -> i32 {
+    let req = serde_json::json!({
+        "type": "events_list",
+        "json": json,
+    });
+    stream_control_line(req)
+}
+
+/// Map the CLI `--payload` value to the wire `PayloadMode` (snake_case serde).
+fn payload_mode_json(s: &str) -> &'static str {
+    match s {
+        "off" => "off",
+        "summary" => "summary",
+        "state-ref" => "state_ref",
+        _ => "full",
+    }
+}
+
+/// Map the CLI `--trigger` value to the wire `TriggerMode` (snake_case serde).
+fn trigger_mode_json(s: &str) -> &'static str {
+    match s {
+        "never" => "never",
+        "ambient" => "ambient",
+        "ask" => "ask",
+        _ => "conversation",
+    }
+}

--- a/src/cli/events.rs
+++ b/src/cli/events.rs
@@ -120,6 +120,42 @@ pub fn events_list_cli(json: bool) -> i32 {
     stream_control_line(req)
 }
 
+/// `plexi events mcp-config` — print the host MCP server config block.
+pub fn events_mcp_config_cli() -> i32 {
+    let port = std::env::var("PLEXI_HOST_MCP_PORT").ok();
+    let token = std::env::var("PLEXI_HOST_MCP_TOKEN").ok();
+    let (port, token) = match (port, token) {
+        (Some(p), Some(t)) if !p.is_empty() && !t.is_empty() => (p, t),
+        _ => {
+            eprintln!(
+                "error: PLEXI_HOST_MCP_PORT / PLEXI_HOST_MCP_TOKEN not set — run this inside a \
+                 Plexi terminal pane on a build with the host event MCP server"
+            );
+            return 1;
+        }
+    };
+    let config = serde_json::json!({
+        "mcpServers": {
+            "plexi-events": {
+                "type": "http",
+                "url": format!("http://127.0.0.1:{port}/mcp"),
+                "headers": { "Authorization": format!("Bearer {token}") }
+            }
+        }
+    });
+    match serde_json::to_string_pretty(&config) {
+        Ok(s) => {
+            println!("{s}");
+            log::info!("events: printed host MCP config for port {port}");
+            0
+        }
+        Err(e) => {
+            eprintln!("error: could not serialize MCP config: {e}");
+            1
+        }
+    }
+}
+
 /// Map the CLI `--payload` value to the wire `PayloadMode` (snake_case serde).
 fn payload_mode_json(s: &str) -> &'static str {
     match s {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -327,7 +327,7 @@ pub use context_cli::{
     context_push_cli, context_set_root_cli, context_zoom_cli, context_zoom_out_cli,
 };
 pub use demo::demo_cli;
-pub use events::{events_list_cli, events_subscribe_cli};
+pub use events::{events_list_cli, events_mcp_config_cli, events_subscribe_cli};
 pub use doctor::doctor_cli;
 pub use install::{
     install_cli, install_pack_cli, install_workspace_pack_cli, plexi_uninstall_cli,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -215,6 +215,7 @@ pub mod context_cli;
 pub mod demo;
 pub mod descriptor;
 pub mod doctor;
+pub mod events;
 pub mod install;
 pub mod install_host;
 pub mod list;
@@ -326,6 +327,7 @@ pub use context_cli::{
     context_push_cli, context_set_root_cli, context_zoom_cli, context_zoom_out_cli,
 };
 pub use demo::demo_cli;
+pub use events::{events_list_cli, events_subscribe_cli};
 pub use doctor::doctor_cli;
 pub use install::{
     install_cli, install_pack_cli, install_workspace_pack_cli, plexi_uninstall_cli,

--- a/src/host/event_subscriptions.rs
+++ b/src/host/event_subscriptions.rs
@@ -174,6 +174,18 @@ impl HostSubscriptionService {
         }
     }
 
+    /// Construct a service with an explicit grant store + timeline for tests,
+    /// bypassing disk loading.
+    #[cfg(test)]
+    pub fn new_for_test(grant_store: GrantStore, timeline: Arc<Mutex<AppTimeline>>) -> Self {
+        Self {
+            grant_store,
+            posture: None,
+            workspace_root: PathBuf::from("/tmp/ws"),
+            timeline,
+        }
+    }
+
     /// Reload grants + posture from disk. Call before evaluating a fresh
     /// subscription so newly-granted permissions take effect without a host
     /// restart.
@@ -288,13 +300,14 @@ impl HostSubscriptionService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::app_protocol::EventStreamDecl;
+    use crate::app_protocol::{AppEventActor, EventStreamDecl};
     use crate::broker::{ActorScope, Decision, GrantRecord, GrantSource, ResourceScope};
+    use crate::host::app_timeline::EmittedEvent;
 
-    fn allow_grant(target_id: &str) -> GrantRecord {
+    fn allow_grant(actor_id: &str, target_id: &str) -> GrantRecord {
         GrantRecord {
             actor_type: ActorType::Agent,
-            actor_id: "pane:7".to_string(),
+            actor_id: actor_id.to_string(),
             actor_scope: ActorScope::User,
             workspace_root: None,
             target_type: TargetType::AppEventStream,
@@ -352,7 +365,7 @@ mod tests {
     fn subscribe_succeeds_with_grant() {
         let timeline = timeline_with_stream();
         let mut store = GrantStore::default();
-        store.record(allow_grant("event-probe::probe.tick"));
+        store.record(allow_grant("pane:7", "event-probe::probe.tick"));
         let res = evaluate_and_record_subscription(
             &store,
             None,
@@ -370,5 +383,159 @@ mod tests {
         let sub_id = res.expect("grant present, subscription should record");
         assert!(sub_id.starts_with("sub-"));
         assert_eq!(timeline.lock().unwrap().subscriptions().len(), 1);
+    }
+
+    fn granted_service(timeline: Arc<Mutex<AppTimeline>>) -> HostSubscriptionService {
+        let mut store = GrantStore::default();
+        // Grant both the pane-derived (CLI) and override (MCP) identities.
+        store.record(allow_grant("pane:7", "event-probe::probe.tick"));
+        store.record(allow_grant("mcp:host", "event-probe::probe.tick"));
+        HostSubscriptionService::new_for_test(store, timeline)
+    }
+
+    fn subscribe_request(
+        event_names: Vec<String>,
+        payload_mode: PayloadMode,
+        override_id: Option<&str>,
+    ) -> (HostSubscribeRequest, std::sync::mpsc::Receiver<HostSubscribeReply>) {
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        let req = HostSubscribeRequest {
+            publisher_app_id: "event-probe".to_string(),
+            event_names,
+            payload_mode,
+            trigger_mode: TriggerMode::Conversation,
+            resource_id: None,
+            from_pane_id: Some(7),
+            subscriber_override: override_id.map(String::from),
+            reply: tx,
+        };
+        (req, rx)
+    }
+
+    fn probe_event(count: u64) -> EmittedEvent {
+        EmittedEvent {
+            event: "probe.tick".to_string(),
+            actor: AppEventActor::User,
+            actor_id: None,
+            caused_by: None,
+            summary: format!("Probe tick {count}"),
+            resource_id: "probe-session".to_string(),
+            resource_scope: Some("document".to_string()),
+            revision_after: format!("tick-{count}"),
+            payload: Some(serde_json::json!({ "count": count })),
+            state_ref: None,
+            revision_before: None,
+            rollback_token: None,
+            changed_resources: vec![],
+            suggested_trigger: Some(TriggerMode::Conversation),
+        }
+    }
+
+    /// `handle_subscribe_request` rejects a stream the app never declared,
+    /// before the broker is consulted.
+    #[test]
+    fn handle_request_rejects_undeclared_stream() {
+        let timeline = timeline_with_stream();
+        let svc = granted_service(Arc::clone(&timeline));
+        let (req, _rx) = subscribe_request(vec!["nope.stream".to_string()], PayloadMode::Full, None);
+        match svc.handle_subscribe_request(&req) {
+            HostSubscribeReply::Err { message } => assert!(message.contains("not declared")),
+            HostSubscribeReply::Ok { .. } => panic!("undeclared stream must be refused"),
+        }
+        assert!(timeline.lock().unwrap().subscriptions().is_empty());
+    }
+
+    /// A CLI subscriber (no override) is identified by its pane.
+    #[test]
+    fn handle_request_uses_pane_identity() {
+        let timeline = timeline_with_stream();
+        let svc = granted_service(Arc::clone(&timeline));
+        let (req, _rx) = subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
+        match svc.handle_subscribe_request(&req) {
+            HostSubscribeReply::Ok { subscriber_id, .. } => assert_eq!(subscriber_id, "pane:7"),
+            HostSubscribeReply::Err { message } => panic!("should subscribe: {message}"),
+        }
+    }
+
+    /// The MCP transport's host-stamped override identity is honoured.
+    #[test]
+    fn handle_request_honours_override_identity() {
+        let timeline = timeline_with_stream();
+        let svc = granted_service(Arc::clone(&timeline));
+        let (req, _rx) =
+            subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, Some("mcp:host"));
+        match svc.handle_subscribe_request(&req) {
+            HostSubscribeReply::Ok { subscriber_id, .. } => assert_eq!(subscriber_id, "mcp:host"),
+            HostSubscribeReply::Err { message } => panic!("should subscribe: {message}"),
+        }
+    }
+
+    /// End-to-end: subscribe (full payload) → emit → the delivery carries the
+    /// structured payload, then disconnect cleanup drops the subscription and
+    /// any queued deliveries.
+    #[test]
+    fn delivery_full_payload_then_disconnect_cleanup() {
+        let timeline = timeline_with_stream();
+        let svc = granted_service(Arc::clone(&timeline));
+        let (req, _rx) = subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
+        let (stype, sid) = match svc.handle_subscribe_request(&req) {
+            HostSubscribeReply::Ok {
+                subscriber_type,
+                subscriber_id,
+                ..
+            } => (subscriber_type, subscriber_id),
+            HostSubscribeReply::Err { message } => panic!("subscribe failed: {message}"),
+        };
+
+        timeline
+            .lock()
+            .unwrap()
+            .record_event("event-probe", 7, probe_event(3))
+            .expect("emit should record");
+
+        let deliveries = timeline.lock().unwrap().take_deliveries_for(stype, &sid);
+        assert_eq!(deliveries.len(), 1);
+        let d = &deliveries[0];
+        assert_eq!(d.event, "probe.tick");
+        assert_eq!(d.summary.as_deref(), Some("Probe tick 3"));
+        assert_eq!(d.payload, Some(serde_json::json!({ "count": 3 })));
+
+        // Disconnect: a second event re-queues, then clear_subscriber wipes it.
+        timeline
+            .lock()
+            .unwrap()
+            .record_event("event-probe", 7, probe_event(4))
+            .expect("emit should record");
+        assert_eq!(timeline.lock().unwrap().pending_delivery_count(), 1);
+        let (subs, drops) = timeline.lock().unwrap().clear_subscriber(stype, &sid);
+        assert_eq!(subs, 1);
+        assert_eq!(drops, 1);
+        assert!(timeline.lock().unwrap().subscriptions().is_empty());
+    }
+
+    /// `PayloadMode::Summary` delivers the summary but withholds the payload.
+    #[test]
+    fn delivery_summary_mode_withholds_payload() {
+        let timeline = timeline_with_stream();
+        let svc = granted_service(Arc::clone(&timeline));
+        let (req, _rx) =
+            subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Summary, None);
+        let (stype, sid) = match svc.handle_subscribe_request(&req) {
+            HostSubscribeReply::Ok {
+                subscriber_type,
+                subscriber_id,
+                ..
+            } => (subscriber_type, subscriber_id),
+            HostSubscribeReply::Err { message } => panic!("subscribe failed: {message}"),
+        };
+        timeline
+            .lock()
+            .unwrap()
+            .record_event("event-probe", 7, probe_event(1))
+            .expect("emit should record");
+        let deliveries = timeline.lock().unwrap().take_deliveries_for(stype, &sid);
+        assert_eq!(deliveries.len(), 1);
+        assert_eq!(deliveries[0].summary.as_deref(), Some("Probe tick 1"));
+        assert_eq!(deliveries[0].payload, None);
     }
 }

--- a/src/host/event_subscriptions.rs
+++ b/src/host/event_subscriptions.rs
@@ -121,6 +121,10 @@ pub struct HostSubscribeRequest {
     /// Pane id stamped by the host PTY env (`PLEXI_PANE_ID`), forwarded by the
     /// transport. Host-trusted: the CLI cannot pass a subscriber identity flag.
     pub from_pane_id: Option<u64>,
+    /// Transport-supplied subscriber id, used instead of the pane-derived one.
+    /// Set only by trusted host transport code (e.g. the host MCP server uses
+    /// `mcp:host`), never sourced from an untrusted client argument.
+    pub subscriber_override: Option<String>,
     pub reply: SyncSender<HostSubscribeReply>,
 }
 
@@ -225,7 +229,10 @@ impl HostSubscriptionService {
     /// broker check, and record the subscription. The single host entry point
     /// both transports' UI-thread handlers call.
     pub fn handle_subscribe_request(&self, req: &HostSubscribeRequest) -> HostSubscribeReply {
-        let (subscriber_type, subscriber_id) = Self::resolve_cli_subscriber(req.from_pane_id);
+        let (subscriber_type, subscriber_id) = match &req.subscriber_override {
+            Some(id) => (ActorType::Agent, id.clone()),
+            None => Self::resolve_cli_subscriber(req.from_pane_id),
+        };
         // Reject undeclared streams before involving the broker so the client
         // gets a precise error instead of a generic permission denial.
         let undeclared: Vec<&String> = req

--- a/src/host/event_subscriptions.rs
+++ b/src/host/event_subscriptions.rs
@@ -1,0 +1,367 @@
+//! Host-owned event subscription core — `docs/prm/undo-and-app-events.md`.
+//!
+//! One permission model, one delivery lifecycle, one schema. Both
+//! agent-facing transports — the CLI NDJSON stream (`plexi events
+//! subscribe`) and the host-level MCP server — wrap this module. They are
+//! transports only, never second event buses.
+//!
+//! - [`evaluate_and_record_subscription`] is the single broker-gated path
+//!   that turns a subscribe request into a [`SubscriptionRecord`]. Both the
+//!   per-app `ProcessApp` (with its per-app grant store) and the host-level
+//!   [`HostSubscriptionService`] (with the host grant store) call it, so the
+//!   `TargetType::AppEventStream` grant rules live in exactly one place.
+//! - [`HostSubscriptionService`] owns the host grant store + posture loaded
+//!   from the profile dir and the global timeline handle. It serves non-app
+//!   subscribers (CLI agents, host MCP clients) whose identity is derived
+//!   from trusted host state, never spoofed from CLI arguments.
+
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::SyncSender;
+use std::sync::{Arc, Mutex};
+
+use crate::app_protocol::{PayloadMode, TriggerMode};
+use crate::broker::{
+    ActorType, Decision, GrantDuration, GrantStore, PermissionPosture, PermissionRequest,
+    TargetType,
+};
+use crate::host::app_timeline::{AppTimeline, SubscriptionRecord};
+use crate::host::event_log;
+
+/// Evaluate broker grants for a subscription and, on a unanimous `Allow`,
+/// record it in `timeline`. One `TargetType::AppEventStream` evaluation per
+/// event name (`"<app_id>::<event>"`, or `"<app_id>::*"` for all streams);
+/// the strictest non-allow decision short-circuits and nothing is recorded.
+///
+/// This is the shared seam between the per-app and host subscription paths —
+/// keep the grant semantics here, not duplicated per caller.
+#[allow(clippy::too_many_arguments)]
+pub fn evaluate_and_record_subscription(
+    grant_store: &GrantStore,
+    posture: Option<&PermissionPosture>,
+    workspace_root: &Path,
+    timeline: &Arc<Mutex<AppTimeline>>,
+    publisher_app_id: &str,
+    subscriber_type: ActorType,
+    subscriber_id: &str,
+    event_names: Vec<String>,
+    payload_mode: PayloadMode,
+    trigger_mode: TriggerMode,
+    resource_id: Option<String>,
+    duration: GrantDuration,
+) -> Result<String, Decision> {
+    let targets: Vec<String> = if event_names.is_empty() {
+        vec![format!("{publisher_app_id}::*")]
+    } else {
+        event_names
+            .iter()
+            .map(|n| format!("{publisher_app_id}::{n}"))
+            .collect()
+    };
+    let mut strictest = Decision::Allow;
+    for target in &targets {
+        let req = PermissionRequest::new(
+            subscriber_type,
+            subscriber_id,
+            TargetType::AppEventStream,
+            target,
+            Some(workspace_root),
+        );
+        match grant_store.evaluate(&req, posture) {
+            Decision::Allow => {}
+            Decision::Deny => strictest = Decision::Deny,
+            Decision::Ask => {
+                if strictest != Decision::Deny {
+                    strictest = Decision::Ask;
+                }
+            }
+        }
+    }
+    if strictest != Decision::Allow {
+        log::info!(
+            "event_subscriptions: subscription to '{publisher_app_id}' events for \
+             {subscriber_type:?} '{subscriber_id}' blocked by broker ({})",
+            strictest.as_str()
+        );
+        return Err(strictest);
+    }
+    let subscription_id = format!("sub-{}", uuid::Uuid::new_v4());
+    let record = SubscriptionRecord {
+        subscription_id: subscription_id.clone(),
+        subscriber_type,
+        subscriber_id: subscriber_id.to_string(),
+        app_id: publisher_app_id.to_string(),
+        event_names,
+        payload_mode,
+        trigger_mode,
+        resource_id,
+        duration,
+        created_at: event_log::now_timestamp(),
+    };
+    log::info!(
+        "event_subscriptions: recorded subscription {subscription_id} for {subscriber_type:?} \
+         '{subscriber_id}' -> '{publisher_app_id}' (payload={payload_mode:?}, trigger={trigger_mode:?})"
+    );
+    timeline.lock().unwrap().add_subscription(record);
+    Ok(subscription_id)
+}
+
+/// An in-memory subscribe request handed from a transport's connection thread
+/// to the host UI thread. The UI thread owns the [`HostSubscriptionService`]
+/// (grant store + pane→identity trust), so identity resolution and the broker
+/// check happen there; the connection thread streams deliveries afterward by
+/// polling the global timeline directly. Not serialized — `reply` is a live
+/// channel.
+pub struct HostSubscribeRequest {
+    pub publisher_app_id: String,
+    /// Empty = subscribe to all of the app's declared streams.
+    pub event_names: Vec<String>,
+    pub payload_mode: PayloadMode,
+    pub trigger_mode: TriggerMode,
+    pub resource_id: Option<String>,
+    /// Pane id stamped by the host PTY env (`PLEXI_PANE_ID`), forwarded by the
+    /// transport. Host-trusted: the CLI cannot pass a subscriber identity flag.
+    pub from_pane_id: Option<u64>,
+    pub reply: SyncSender<HostSubscribeReply>,
+}
+
+/// The UI thread's answer to a [`HostSubscribeRequest`].
+pub enum HostSubscribeReply {
+    Ok {
+        subscription_id: String,
+        subscriber_type: ActorType,
+        subscriber_id: String,
+    },
+    Err {
+        message: String,
+    },
+}
+
+/// Host-level subscription service for non-app actors (CLI agents reading
+/// subprocess stdout, host MCP clients). Owns its own grant store + posture
+/// loaded from the profile dir and a clone of the global timeline handle.
+///
+/// Every transport routes through this so the host has one event permission
+/// model, one delivery queue, and one disconnect-cleanup path. The service
+/// stamps subscriber identity from host-trusted state; callers never pass an
+/// identity sourced from untrusted CLI arguments.
+pub struct HostSubscriptionService {
+    grant_store: GrantStore,
+    posture: Option<PermissionPosture>,
+    workspace_root: PathBuf,
+    timeline: Arc<Mutex<AppTimeline>>,
+}
+
+impl HostSubscriptionService {
+    /// Load the host grant store + posture from `config_dir` and bind the
+    /// service to `timeline` (the global timeline in production).
+    pub fn new(config_dir: &Path, workspace_root: PathBuf, timeline: Arc<Mutex<AppTimeline>>) -> Self {
+        let grant_store = GrantStore::load_or_default(config_dir);
+        let posture = PermissionPosture::load_from_config(config_dir);
+        log::info!(
+            "HostSubscriptionService: loaded {} grant record(s), posture={}",
+            grant_store.records().len(),
+            posture.is_some()
+        );
+        Self {
+            grant_store,
+            posture,
+            workspace_root,
+            timeline,
+        }
+    }
+
+    /// Reload grants + posture from disk. Call before evaluating a fresh
+    /// subscription so newly-granted permissions take effect without a host
+    /// restart.
+    pub fn reload(&mut self, config_dir: &Path) {
+        self.grant_store = GrantStore::load_or_default(config_dir);
+        self.posture = PermissionPosture::load_from_config(config_dir);
+    }
+
+    /// Subscribe a non-app actor to `publisher_app_id`'s streams. Broker-gated
+    /// exactly like the app path. Session-scoped: the subscription is dropped
+    /// when the transport disconnects (via [`Self::clear_subscriber`]).
+    #[allow(clippy::too_many_arguments)]
+    pub fn subscribe(
+        &self,
+        publisher_app_id: &str,
+        subscriber_type: ActorType,
+        subscriber_id: &str,
+        event_names: Vec<String>,
+        payload_mode: PayloadMode,
+        trigger_mode: TriggerMode,
+        resource_id: Option<String>,
+    ) -> Result<String, Decision> {
+        evaluate_and_record_subscription(
+            &self.grant_store,
+            self.posture.as_ref(),
+            &self.workspace_root,
+            &self.timeline,
+            publisher_app_id,
+            subscriber_type,
+            subscriber_id,
+            event_names,
+            payload_mode,
+            trigger_mode,
+            resource_id,
+            GrantDuration::Session,
+        )
+    }
+
+    /// Derive the trusted subscriber identity for a transport connection from
+    /// the host-stamped pane id. CLI/MCP agents are `Agent`-typed; the id is
+    /// namespaced by pane so it never collides with the assistant
+    /// (`agent:assistant`) or a `ProcessApp` (its `type_id`). A connection with
+    /// no pane context (rare) gets a stable anonymous id.
+    pub fn resolve_cli_subscriber(from_pane_id: Option<u64>) -> (ActorType, String) {
+        let id = match from_pane_id {
+            Some(p) => format!("pane:{p}"),
+            None => "cli:anon".to_string(),
+        };
+        (ActorType::Agent, id)
+    }
+
+    /// Resolve identity, validate the requested streams are declared, run the
+    /// broker check, and record the subscription. The single host entry point
+    /// both transports' UI-thread handlers call.
+    pub fn handle_subscribe_request(&self, req: &HostSubscribeRequest) -> HostSubscribeReply {
+        let (subscriber_type, subscriber_id) = Self::resolve_cli_subscriber(req.from_pane_id);
+        // Reject undeclared streams before involving the broker so the client
+        // gets a precise error instead of a generic permission denial.
+        let undeclared: Vec<&String> = req
+            .event_names
+            .iter()
+            .filter(|n| !self.stream_is_declared(&req.publisher_app_id, n))
+            .collect();
+        if !undeclared.is_empty() {
+            return HostSubscribeReply::Err {
+                message: format!(
+                    "app '{}' has not declared stream(s): {}",
+                    req.publisher_app_id,
+                    undeclared
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            };
+        }
+        match self.subscribe(
+            &req.publisher_app_id,
+            subscriber_type,
+            &subscriber_id,
+            req.event_names.clone(),
+            req.payload_mode,
+            req.trigger_mode,
+            req.resource_id.clone(),
+        ) {
+            Ok(subscription_id) => HostSubscribeReply::Ok {
+                subscription_id,
+                subscriber_type,
+                subscriber_id,
+            },
+            Err(decision) => HostSubscribeReply::Err {
+                message: format!("blocked by broker: {}", decision.as_str()),
+            },
+        }
+    }
+
+    /// Whether `app_id` has declared `stream_name`. Used to reject subscribe
+    /// requests for undeclared streams before they reach the broker.
+    pub fn stream_is_declared(&self, app_id: &str, stream_name: &str) -> bool {
+        self.timeline
+            .lock()
+            .unwrap()
+            .declared_streams(app_id)
+            .iter()
+            .any(|d| d.name == stream_name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_protocol::EventStreamDecl;
+    use crate::broker::{ActorScope, Decision, GrantRecord, GrantSource, ResourceScope};
+
+    fn allow_grant(target_id: &str) -> GrantRecord {
+        GrantRecord {
+            actor_type: ActorType::Agent,
+            actor_id: "pane:7".to_string(),
+            actor_scope: ActorScope::User,
+            workspace_root: None,
+            target_type: TargetType::AppEventStream,
+            target_id: target_id.to_string(),
+            resource_scope: ResourceScope::Global,
+            resource_id: None,
+            decision: Decision::Allow,
+            duration: GrantDuration::Session,
+            source: GrantSource::Session,
+            created_at: 0,
+            expires_at: None,
+        }
+    }
+
+    fn timeline_with_stream() -> Arc<Mutex<AppTimeline>> {
+        let mut t = AppTimeline::default();
+        t.declare_streams(
+            "event-probe",
+            vec![EventStreamDecl {
+                name: "probe.tick".to_string(),
+                schema: serde_json::json!({"type": "object"}),
+                description: None,
+            }],
+        )
+        .unwrap();
+        Arc::new(Mutex::new(t))
+    }
+
+    /// No grant on file → broker default is `Ask`, which is not `Allow`, so
+    /// the subscription is refused and nothing is recorded.
+    #[test]
+    fn subscribe_refused_without_grant() {
+        let timeline = timeline_with_stream();
+        let store = GrantStore::default();
+        let res = evaluate_and_record_subscription(
+            &store,
+            None,
+            Path::new("/tmp/ws"),
+            &timeline,
+            "event-probe",
+            ActorType::Agent,
+            "pane:7",
+            vec!["probe.tick".to_string()],
+            PayloadMode::Full,
+            TriggerMode::Conversation,
+            None,
+            GrantDuration::Session,
+        );
+        assert_eq!(res, Err(Decision::Ask));
+        assert!(timeline.lock().unwrap().subscriptions().is_empty());
+    }
+
+    /// An explicit allow grant for the stream → subscription recorded.
+    #[test]
+    fn subscribe_succeeds_with_grant() {
+        let timeline = timeline_with_stream();
+        let mut store = GrantStore::default();
+        store.record(allow_grant("event-probe::probe.tick"));
+        let res = evaluate_and_record_subscription(
+            &store,
+            None,
+            Path::new("/tmp/ws"),
+            &timeline,
+            "event-probe",
+            ActorType::Agent,
+            "pane:7",
+            vec!["probe.tick".to_string()],
+            PayloadMode::Full,
+            TriggerMode::Conversation,
+            None,
+            GrantDuration::Session,
+        );
+        let sub_id = res.expect("grant present, subscription should record");
+        assert!(sub_id.starts_with("sub-"));
+        assert_eq!(timeline.lock().unwrap().subscriptions().len(), 1);
+    }
+}

--- a/src/host/event_subscriptions.rs
+++ b/src/host/event_subscriptions.rs
@@ -21,8 +21,8 @@ use std::sync::{Arc, Mutex};
 
 use crate::app_protocol::{PayloadMode, TriggerMode};
 use crate::broker::{
-    ActorType, Decision, GrantDuration, GrantStore, PermissionPosture, PermissionRequest,
-    TargetType,
+    ActorScope, ActorType, Decision, GrantDuration, GrantRecord, GrantSource, GrantStore,
+    PermissionPosture, PermissionRequest, ResourceScope, TargetType,
 };
 use crate::host::app_timeline::{AppTimeline, SubscriptionRecord};
 use crate::host::event_log;
@@ -49,16 +49,63 @@ pub fn evaluate_and_record_subscription(
     resource_id: Option<String>,
     duration: GrantDuration,
 ) -> Result<String, Decision> {
-    let targets: Vec<String> = if event_names.is_empty() {
+    let decision = evaluate_subscription(
+        grant_store,
+        posture,
+        workspace_root,
+        publisher_app_id,
+        subscriber_type,
+        subscriber_id,
+        &event_names,
+    );
+    if decision != Decision::Allow {
+        log::info!(
+            "event_subscriptions: subscription to '{publisher_app_id}' events for \
+             {subscriber_type:?} '{subscriber_id}' blocked by broker ({})",
+            decision.as_str()
+        );
+        return Err(decision);
+    }
+    Ok(record_subscription(
+        timeline,
+        publisher_app_id,
+        subscriber_type,
+        subscriber_id,
+        event_names,
+        payload_mode,
+        trigger_mode,
+        resource_id,
+        duration,
+    ))
+}
+
+/// The broker target ids a subscription touches: one `"<app>::<event>"` per
+/// requested event, or a single `"<app>::*"` when subscribing to every stream.
+fn subscription_targets(publisher_app_id: &str, event_names: &[String]) -> Vec<String> {
+    if event_names.is_empty() {
         vec![format!("{publisher_app_id}::*")]
     } else {
         event_names
             .iter()
             .map(|n| format!("{publisher_app_id}::{n}"))
             .collect()
-    };
+    }
+}
+
+/// Run the broker over every target a subscription touches and return the
+/// strictest decision (`Deny` > `Ask` > `Allow`). Records nothing — callers
+/// decide what to do with the verdict (record on `Allow`, prompt on `Ask`).
+pub fn evaluate_subscription(
+    grant_store: &GrantStore,
+    posture: Option<&PermissionPosture>,
+    workspace_root: &Path,
+    publisher_app_id: &str,
+    subscriber_type: ActorType,
+    subscriber_id: &str,
+    event_names: &[String],
+) -> Decision {
     let mut strictest = Decision::Allow;
-    for target in &targets {
+    for target in &subscription_targets(publisher_app_id, event_names) {
         let req = PermissionRequest::new(
             subscriber_type,
             subscriber_id,
@@ -76,14 +123,24 @@ pub fn evaluate_and_record_subscription(
             }
         }
     }
-    if strictest != Decision::Allow {
-        log::info!(
-            "event_subscriptions: subscription to '{publisher_app_id}' events for \
-             {subscriber_type:?} '{subscriber_id}' blocked by broker ({})",
-            strictest.as_str()
-        );
-        return Err(strictest);
-    }
+    strictest
+}
+
+/// Add a subscription to `timeline` and return its id. Performs no broker check
+/// — the caller has already established consent (a unanimous `Allow` grant or an
+/// interactive user approval).
+#[allow(clippy::too_many_arguments)]
+pub fn record_subscription(
+    timeline: &Arc<Mutex<AppTimeline>>,
+    publisher_app_id: &str,
+    subscriber_type: ActorType,
+    subscriber_id: &str,
+    event_names: Vec<String>,
+    payload_mode: PayloadMode,
+    trigger_mode: TriggerMode,
+    resource_id: Option<String>,
+    duration: GrantDuration,
+) -> String {
     let subscription_id = format!("sub-{}", uuid::Uuid::new_v4());
     let record = SubscriptionRecord {
         subscription_id: subscription_id.clone(),
@@ -102,7 +159,7 @@ pub fn evaluate_and_record_subscription(
          '{subscriber_id}' -> '{publisher_app_id}' (payload={payload_mode:?}, trigger={trigger_mode:?})"
     );
     timeline.lock().unwrap().add_subscription(record);
-    Ok(subscription_id)
+    subscription_id
 }
 
 /// An in-memory subscribe request handed from a transport's connection thread
@@ -126,6 +183,48 @@ pub struct HostSubscribeRequest {
     /// `mcp:host`), never sourced from an untrusted client argument.
     pub subscriber_override: Option<String>,
     pub reply: SyncSender<HostSubscribeReply>,
+}
+
+/// A subscribe request the broker answered with `Ask`: it needs an explicit
+/// user decision before the subscription is recorded. The UI thread parks one
+/// of these (holding the transport's live `reply` channel) and surfaces a host
+/// consent modal; [`HostSubscriptionService::resolve_consent`] answers it.
+///
+/// Identity is already host-stamped here — the modal shows it, it is never
+/// taken from the user's click.
+pub struct PendingEventConsent {
+    pub subscriber_type: ActorType,
+    pub subscriber_id: String,
+    pub publisher_app_id: String,
+    /// Empty = all of the app's declared streams.
+    pub event_names: Vec<String>,
+    pub payload_mode: PayloadMode,
+    pub trigger_mode: TriggerMode,
+    pub resource_id: Option<String>,
+    reply: SyncSender<HostSubscribeReply>,
+}
+
+impl PendingEventConsent {
+    /// Human-readable target for the consent modal: `"<app> :: <events>"`.
+    pub fn target_label(&self) -> String {
+        let streams = if self.event_names.is_empty() {
+            "* (all streams)".to_string()
+        } else {
+            self.event_names.join(", ")
+        };
+        format!("{} :: {streams}", self.publisher_app_id)
+    }
+}
+
+/// The user's answer to a [`PendingEventConsent`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConsentChoice {
+    /// Record the subscription for this connection only; ask again next time.
+    AllowOnce,
+    /// Record a persistent `Allow` grant, then subscribe.
+    AllowAlways,
+    /// Refuse; the transport gets a permission-denied error.
+    Deny,
 }
 
 /// The UI thread's answer to a [`HostSubscribeRequest`].
@@ -194,36 +293,6 @@ impl HostSubscriptionService {
         self.posture = PermissionPosture::load_from_config(config_dir);
     }
 
-    /// Subscribe a non-app actor to `publisher_app_id`'s streams. Broker-gated
-    /// exactly like the app path. Session-scoped: the subscription is dropped
-    /// when the transport disconnects (via [`Self::clear_subscriber`]).
-    #[allow(clippy::too_many_arguments)]
-    pub fn subscribe(
-        &self,
-        publisher_app_id: &str,
-        subscriber_type: ActorType,
-        subscriber_id: &str,
-        event_names: Vec<String>,
-        payload_mode: PayloadMode,
-        trigger_mode: TriggerMode,
-        resource_id: Option<String>,
-    ) -> Result<String, Decision> {
-        evaluate_and_record_subscription(
-            &self.grant_store,
-            self.posture.as_ref(),
-            &self.workspace_root,
-            &self.timeline,
-            publisher_app_id,
-            subscriber_type,
-            subscriber_id,
-            event_names,
-            payload_mode,
-            trigger_mode,
-            resource_id,
-            GrantDuration::Session,
-        )
-    }
-
     /// Derive the trusted subscriber identity for a transport connection from
     /// the host-stamped pane id. CLI/MCP agents are `Agent`-typed; the id is
     /// namespaced by pane so it never collides with the assistant
@@ -237,51 +306,200 @@ impl HostSubscriptionService {
         (ActorType::Agent, id)
     }
 
-    /// Resolve identity, validate the requested streams are declared, run the
-    /// broker check, and record the subscription. The single host entry point
-    /// both transports' UI-thread handlers call.
-    pub fn handle_subscribe_request(&self, req: &HostSubscribeRequest) -> HostSubscribeReply {
+    /// Resolve host-stamped identity, validate the requested streams are
+    /// declared, and run the broker check. The single host entry point both
+    /// transports' UI-thread drain calls. Consumes the request so a deferred
+    /// `Ask` can move the live `reply` channel into the returned
+    /// [`PendingEventConsent`].
+    ///
+    /// - `Allow` → record the subscription and send `Ok` on `req.reply` now.
+    /// - `Deny` / undeclared stream → send `Err` on `req.reply` now.
+    /// - `Ask` → record nothing, send nothing; return `Some(consent)` for the
+    ///   caller to park and surface a consent modal. The reply fires later from
+    ///   [`Self::resolve_consent`].
+    ///
+    /// Returns `None` whenever the request was answered immediately.
+    pub fn classify_subscribe_request(
+        &self,
+        req: HostSubscribeRequest,
+    ) -> Option<PendingEventConsent> {
         let (subscriber_type, subscriber_id) = match &req.subscriber_override {
             Some(id) => (ActorType::Agent, id.clone()),
             None => Self::resolve_cli_subscriber(req.from_pane_id),
         };
         // Reject undeclared streams before involving the broker so the client
         // gets a precise error instead of a generic permission denial.
-        let undeclared: Vec<&String> = req
+        let undeclared: Vec<String> = req
             .event_names
             .iter()
             .filter(|n| !self.stream_is_declared(&req.publisher_app_id, n))
+            .cloned()
             .collect();
         if !undeclared.is_empty() {
-            return HostSubscribeReply::Err {
+            let _ = req.reply.send(HostSubscribeReply::Err {
                 message: format!(
                     "app '{}' has not declared stream(s): {}",
                     req.publisher_app_id,
-                    undeclared
-                        .iter()
-                        .map(|s| s.as_str())
-                        .collect::<Vec<_>>()
-                        .join(", ")
+                    undeclared.join(", ")
                 ),
-            };
+            });
+            return None;
         }
-        match self.subscribe(
+        let decision = evaluate_subscription(
+            &self.grant_store,
+            self.posture.as_ref(),
+            &self.workspace_root,
             &req.publisher_app_id,
             subscriber_type,
             &subscriber_id,
-            req.event_names.clone(),
-            req.payload_mode,
-            req.trigger_mode,
-            req.resource_id.clone(),
-        ) {
-            Ok(subscription_id) => HostSubscribeReply::Ok {
+            &req.event_names,
+        );
+        match decision {
+            Decision::Allow => {
+                let subscription_id = record_subscription(
+                    &self.timeline,
+                    &req.publisher_app_id,
+                    subscriber_type,
+                    &subscriber_id,
+                    req.event_names,
+                    req.payload_mode,
+                    req.trigger_mode,
+                    req.resource_id,
+                    GrantDuration::Session,
+                );
+                let _ = req.reply.send(HostSubscribeReply::Ok {
+                    subscription_id,
+                    subscriber_type,
+                    subscriber_id,
+                });
+                None
+            }
+            Decision::Deny => {
+                let _ = req.reply.send(HostSubscribeReply::Err {
+                    message: "blocked by broker: deny".to_string(),
+                });
+                None
+            }
+            Decision::Ask => {
+                log::info!(
+                    "event_subscriptions: subscription to '{}' for {subscriber_type:?} \
+                     '{subscriber_id}' awaiting user consent",
+                    req.publisher_app_id
+                );
+                Some(PendingEventConsent {
+                    subscriber_type,
+                    subscriber_id,
+                    publisher_app_id: req.publisher_app_id,
+                    event_names: req.event_names,
+                    payload_mode: req.payload_mode,
+                    trigger_mode: req.trigger_mode,
+                    resource_id: req.resource_id,
+                    reply: req.reply,
+                })
+            }
+        }
+    }
+
+    /// Answer a parked [`PendingEventConsent`] with the user's decision. On
+    /// `AllowAlways`, persist an `Allow` grant for every target so future
+    /// subscribes pass without prompting; on `AllowOnce`, record only the
+    /// session subscription. Fires the transport's reply either way. If the
+    /// transport already gave up (its `reply` receiver dropped), the freshly
+    /// recorded subscription is rolled back so no orphan accumulates deliveries.
+    pub fn resolve_consent(
+        &mut self,
+        consent: PendingEventConsent,
+        choice: ConsentChoice,
+        config_dir: &Path,
+    ) {
+        if choice == ConsentChoice::Deny {
+            log::info!(
+                "event_subscriptions: user denied subscription for {:?} '{}' -> '{}'",
+                consent.subscriber_type,
+                consent.subscriber_id,
+                consent.publisher_app_id
+            );
+            let _ = consent.reply.send(HostSubscribeReply::Err {
+                message: "subscription denied by user".to_string(),
+            });
+            return;
+        }
+
+        if choice == ConsentChoice::AllowAlways {
+            let created_at = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0);
+            for target in subscription_targets(&consent.publisher_app_id, &consent.event_names) {
+                self.grant_store.record(GrantRecord {
+                    actor_type: consent.subscriber_type,
+                    actor_id: consent.subscriber_id.clone(),
+                    actor_scope: ActorScope::User,
+                    workspace_root: None,
+                    target_type: TargetType::AppEventStream,
+                    target_id: target,
+                    resource_scope: ResourceScope::Global,
+                    resource_id: None,
+                    decision: Decision::Allow,
+                    duration: GrantDuration::Always,
+                    source: GrantSource::User,
+                    created_at,
+                    expires_at: None,
+                });
+            }
+            self.grant_store.save();
+            // Keep the in-memory store consistent with disk for later evals.
+            self.reload(config_dir);
+            log::info!(
+                "event_subscriptions: user granted ALWAYS to {:?} '{}' -> '{}'",
+                consent.subscriber_type,
+                consent.subscriber_id,
+                consent.publisher_app_id
+            );
+        }
+
+        let subscription_id = record_subscription(
+            &self.timeline,
+            &consent.publisher_app_id,
+            consent.subscriber_type,
+            &consent.subscriber_id,
+            consent.event_names.clone(),
+            consent.payload_mode,
+            consent.trigger_mode,
+            consent.resource_id.clone(),
+            GrantDuration::Session,
+        );
+        if consent
+            .reply
+            .send(HostSubscribeReply::Ok {
                 subscription_id,
-                subscriber_type,
-                subscriber_id,
-            },
-            Err(decision) => HostSubscribeReply::Err {
-                message: format!("blocked by broker: {}", decision.as_str()),
-            },
+                subscriber_type: consent.subscriber_type,
+                subscriber_id: consent.subscriber_id.clone(),
+            })
+            .is_err()
+        {
+            let (subs, drops) = self
+                .timeline
+                .lock()
+                .unwrap()
+                .clear_subscriber(consent.subscriber_type, &consent.subscriber_id);
+            log::warn!(
+                "event_subscriptions: consented subscriber '{}' already disconnected; \
+                 rolled back {subs} subscription(s), {drops} queued delivery(ies)",
+                consent.subscriber_id
+            );
+        } else {
+            log::info!(
+                "event_subscriptions: user allowed ({}) subscription for {:?} '{}' -> '{}'",
+                if choice == ConsentChoice::AllowAlways {
+                    "always"
+                } else {
+                    "once"
+                },
+                consent.subscriber_type,
+                consent.subscriber_id,
+                consent.publisher_app_id
+            );
         }
     }
 
@@ -431,14 +649,15 @@ mod tests {
         }
     }
 
-    /// `handle_subscribe_request` rejects a stream the app never declared,
+    /// `classify_subscribe_request` rejects a stream the app never declared,
     /// before the broker is consulted.
     #[test]
     fn handle_request_rejects_undeclared_stream() {
         let timeline = timeline_with_stream();
         let svc = granted_service(Arc::clone(&timeline));
-        let (req, _rx) = subscribe_request(vec!["nope.stream".to_string()], PayloadMode::Full, None);
-        match svc.handle_subscribe_request(&req) {
+        let (req, rx) = subscribe_request(vec!["nope.stream".to_string()], PayloadMode::Full, None);
+        assert!(svc.classify_subscribe_request(req).is_none());
+        match rx.recv().unwrap() {
             HostSubscribeReply::Err { message } => assert!(message.contains("not declared")),
             HostSubscribeReply::Ok { .. } => panic!("undeclared stream must be refused"),
         }
@@ -450,8 +669,9 @@ mod tests {
     fn handle_request_uses_pane_identity() {
         let timeline = timeline_with_stream();
         let svc = granted_service(Arc::clone(&timeline));
-        let (req, _rx) = subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
-        match svc.handle_subscribe_request(&req) {
+        let (req, rx) = subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
+        assert!(svc.classify_subscribe_request(req).is_none());
+        match rx.recv().unwrap() {
             HostSubscribeReply::Ok { subscriber_id, .. } => assert_eq!(subscriber_id, "pane:7"),
             HostSubscribeReply::Err { message } => panic!("should subscribe: {message}"),
         }
@@ -462,12 +682,85 @@ mod tests {
     fn handle_request_honours_override_identity() {
         let timeline = timeline_with_stream();
         let svc = granted_service(Arc::clone(&timeline));
-        let (req, _rx) =
+        let (req, rx) =
             subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, Some("mcp:host"));
-        match svc.handle_subscribe_request(&req) {
+        assert!(svc.classify_subscribe_request(req).is_none());
+        match rx.recv().unwrap() {
             HostSubscribeReply::Ok { subscriber_id, .. } => assert_eq!(subscriber_id, "mcp:host"),
             HostSubscribeReply::Err { message } => panic!("should subscribe: {message}"),
         }
+    }
+
+    /// Default `Ask` posture parks a consent instead of recording or erroring.
+    /// `AllowOnce` then records the subscription and replies `Ok` with the
+    /// host-stamped identity — no grant is persisted.
+    #[test]
+    fn consent_allow_once_records_session_subscription() {
+        let timeline = timeline_with_stream();
+        // No grant + no posture → broker default Ask.
+        let mut svc =
+            HostSubscriptionService::new_for_test(GrantStore::default(), Arc::clone(&timeline));
+        let (req, rx) = subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
+        let consent = svc
+            .classify_subscribe_request(req)
+            .expect("Ask must park a consent, not answer inline");
+        assert_eq!(consent.subscriber_id, "pane:7");
+        assert!(timeline.lock().unwrap().subscriptions().is_empty());
+
+        svc.resolve_consent(consent, ConsentChoice::AllowOnce, Path::new("/tmp/ws"));
+        match rx.recv().unwrap() {
+            HostSubscribeReply::Ok { subscriber_id, .. } => assert_eq!(subscriber_id, "pane:7"),
+            HostSubscribeReply::Err { message } => panic!("allow-once should subscribe: {message}"),
+        }
+        assert_eq!(timeline.lock().unwrap().subscriptions().len(), 1);
+    }
+
+    /// `Deny` answers the transport with a permission error and records nothing.
+    #[test]
+    fn consent_deny_refuses_and_records_nothing() {
+        let timeline = timeline_with_stream();
+        let mut svc =
+            HostSubscriptionService::new_for_test(GrantStore::default(), Arc::clone(&timeline));
+        let (req, rx) = subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
+        let consent = svc.classify_subscribe_request(req).expect("Ask must park a consent");
+        svc.resolve_consent(consent, ConsentChoice::Deny, Path::new("/tmp/ws"));
+        match rx.recv().unwrap() {
+            HostSubscribeReply::Err { message } => assert!(message.contains("denied by user")),
+            HostSubscribeReply::Ok { .. } => panic!("deny must refuse"),
+        }
+        assert!(timeline.lock().unwrap().subscriptions().is_empty());
+    }
+
+    /// `AllowAlways` persists an `Allow` grant: a fresh service over the same
+    /// profile dir subscribes without prompting (classify answers inline).
+    #[test]
+    fn consent_allow_always_persists_grant() {
+        let dir = tempfile::tempdir().unwrap();
+        let timeline = timeline_with_stream();
+        let mut svc = HostSubscriptionService::new(
+            dir.path(),
+            PathBuf::from("/tmp/ws"),
+            Arc::clone(&timeline),
+        );
+        let (req, rx) = subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
+        let consent = svc.classify_subscribe_request(req).expect("Ask must park a consent");
+        svc.resolve_consent(consent, ConsentChoice::AllowAlways, dir.path());
+        assert!(matches!(rx.recv().unwrap(), HostSubscribeReply::Ok { .. }));
+
+        // Fresh service over the same profile dir: the persisted grant makes the
+        // next subscribe pass inline (no parked consent).
+        let svc2 = HostSubscriptionService::new(
+            dir.path(),
+            PathBuf::from("/tmp/ws"),
+            Arc::clone(&timeline),
+        );
+        let (req2, rx2) =
+            subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
+        assert!(
+            svc2.classify_subscribe_request(req2).is_none(),
+            "persisted ALWAYS grant must answer inline, not re-prompt"
+        );
+        assert!(matches!(rx2.recv().unwrap(), HostSubscribeReply::Ok { .. }));
     }
 
     /// End-to-end: subscribe (full payload) → emit → the delivery carries the
@@ -477,8 +770,9 @@ mod tests {
     fn delivery_full_payload_then_disconnect_cleanup() {
         let timeline = timeline_with_stream();
         let svc = granted_service(Arc::clone(&timeline));
-        let (req, _rx) = subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
-        let (stype, sid) = match svc.handle_subscribe_request(&req) {
+        let (req, rx) = subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
+        assert!(svc.classify_subscribe_request(req).is_none());
+        let (stype, sid) = match rx.recv().unwrap() {
             HostSubscribeReply::Ok {
                 subscriber_type,
                 subscriber_id,
@@ -518,9 +812,10 @@ mod tests {
     fn delivery_summary_mode_withholds_payload() {
         let timeline = timeline_with_stream();
         let svc = granted_service(Arc::clone(&timeline));
-        let (req, _rx) =
+        let (req, rx) =
             subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Summary, None);
-        let (stype, sid) = match svc.handle_subscribe_request(&req) {
+        assert!(svc.classify_subscribe_request(req).is_none());
+        let (stype, sid) = match rx.recv().unwrap() {
             HostSubscribeReply::Ok {
                 subscriber_type,
                 subscriber_id,

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -10,6 +10,7 @@ pub mod context;
 pub mod context_state;
 pub mod effect;
 pub mod event_log;
+pub mod event_subscriptions;
 pub mod hot_reload;
 pub mod keys;
 pub mod launch_failed;

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,7 +217,8 @@ fn main() -> eframe::Result {
         .collect();
     use crate::cli::args::{
         AccountCmd, AgentCmd, AiCmd, AppCmd, Cli, Commands, ConfigCmd, ContextCmd, DescriptorCmd,
-        HookAction, LicenseCmd, NotesCmd, PaneCmd, PaneSlotCmd, RegistryCmd, RoutineCmd, SecretCmd,
+        EventsCmd, HookAction, LicenseCmd, NotesCmd, PaneCmd, PaneSlotCmd, RegistryCmd, RoutineCmd,
+        SecretCmd,
         UpdateCmd, WorkspaceCmd,
     };
     use clap::Parser;
@@ -878,6 +879,26 @@ fn main() -> eframe::Result {
                             }
                         }
                     }
+                    Commands::Events { cmd } => match cmd {
+                        EventsCmd::Subscribe {
+                            app_id,
+                            stream,
+                            all,
+                            payload,
+                            trigger,
+                            resource,
+                        } => std::process::exit(cli::events_subscribe_cli(
+                            &app_id,
+                            stream.as_deref(),
+                            all,
+                            &payload,
+                            &trigger,
+                            resource.as_deref(),
+                        )),
+                        EventsCmd::List { json } => {
+                            std::process::exit(cli::events_list_cli(json))
+                        }
+                    },
                     Commands::CompleteOpen { prefix } => {
                         std::process::exit(cli::complete_open_cli(&prefix));
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod config;
 mod features;
 mod file_browser;
 mod host;
+mod mcp_http;
 mod media;
 mod notes;
 mod overlays;
@@ -897,6 +898,9 @@ fn main() -> eframe::Result {
                         )),
                         EventsCmd::List { json } => {
                             std::process::exit(cli::events_list_cli(json))
+                        }
+                        EventsCmd::McpConfig => {
+                            std::process::exit(cli::events_mcp_config_cli())
                         }
                     },
                     Commands::CompleteOpen { prefix } => {

--- a/src/mcp_http.rs
+++ b/src/mcp_http.rs
@@ -1,0 +1,102 @@
+//! Shared minimal HTTP/1.1 JSON-RPC transport for Plexi's MCP servers.
+//!
+//! Both the per-app MCP bridge (`process_app::mcp_server`) and the host-level
+//! event MCP server (`app::host_mcp`) speak the same wire protocol: a single
+//! `POST /mcp` request carrying a JSON-RPC body, authenticated with
+//! `Authorization: Bearer <token>`. This module owns the request framing, auth
+//! check, body-size guard, and response writer so neither server duplicates it.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+
+/// Largest request body accepted, guarding against a crafted `Content-Length`.
+pub const MAX_BODY: usize = 10 * 1024 * 1024; // 10 MB
+
+/// Outcome of reading one request.
+pub enum RequestOutcome {
+    /// Authenticated `POST /mcp` with a parsed JSON-RPC body.
+    Json(serde_json::Value),
+    /// A non-200 HTTP response was already written; the caller should close.
+    Handled,
+}
+
+/// Read and authenticate one request on `stream`. On success returns the parsed
+/// JSON-RPC body. On any protocol or auth failure, writes the appropriate HTTP
+/// status to `stream` and returns [`RequestOutcome::Handled`].
+pub fn read_json_rpc_request(stream: &TcpStream, token: &str) -> std::io::Result<RequestOutcome> {
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut write_stream = stream.try_clone()?;
+
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line)? == 0 {
+        return Ok(RequestOutcome::Handled);
+    }
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or("");
+    let path = parts.next().unwrap_or("");
+    let is_post_mcp = method == "POST" && path == "/mcp";
+
+    let mut content_length: usize = 0;
+    let mut auth_ok = false;
+    let expected_auth = format!("bearer {}", token.to_lowercase());
+    loop {
+        let mut header = String::new();
+        if reader.read_line(&mut header)? == 0 {
+            return Ok(RequestOutcome::Handled);
+        }
+        let trimmed = header.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break; // blank line ends headers
+        }
+        let lower = trimmed.to_lowercase();
+        if let Some(rest) = lower.strip_prefix("content-length:") {
+            content_length = rest.trim().parse().unwrap_or(0);
+        }
+        if let Some(rest) = lower.strip_prefix("authorization:") {
+            auth_ok = rest.trim() == expected_auth;
+        }
+    }
+
+    if !auth_ok {
+        write_http_response(&mut write_stream, 401, b"{\"error\":\"unauthorized\"}")?;
+        return Ok(RequestOutcome::Handled);
+    }
+    if !is_post_mcp || content_length == 0 {
+        write_http_response(&mut write_stream, 405, b"{\"error\":\"method not allowed\"}")?;
+        return Ok(RequestOutcome::Handled);
+    }
+    if content_length > MAX_BODY {
+        write_http_response(&mut write_stream, 413, b"{\"error\":\"payload too large\"}")?;
+        return Ok(RequestOutcome::Handled);
+    }
+
+    let mut buf = vec![0u8; content_length];
+    reader.read_exact(&mut buf)?;
+    match serde_json::from_slice(&buf) {
+        Ok(v) => Ok(RequestOutcome::Json(v)),
+        Err(e) => {
+            log::warn!("mcp_http: invalid JSON body: {e}");
+            write_http_response(&mut write_stream, 400, b"{\"error\":\"invalid json\"}")?;
+            Ok(RequestOutcome::Handled)
+        }
+    }
+}
+
+/// Write a `Connection: close` HTTP/1.1 response with a JSON body.
+pub fn write_http_response(stream: &mut impl Write, status: u16, body: &[u8]) -> std::io::Result<()> {
+    let status_text = match status {
+        200 => "OK",
+        400 => "Bad Request",
+        401 => "Unauthorized",
+        405 => "Method Not Allowed",
+        413 => "Payload Too Large",
+        _ => "Error",
+    };
+    write!(
+        stream,
+        "HTTP/1.1 {status} {status_text}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    )?;
+    stream.write_all(body)?;
+    stream.flush()
+}

--- a/src/overlays/confirmations.rs
+++ b/src/overlays/confirmations.rs
@@ -344,6 +344,91 @@ impl PlexiApp {
         crate::app::app_trait::KeyDisposition::Consumed
     }
 
+    /// Host event-subscription consent modal. Surfaces the front parked
+    /// [`PendingEventConsent`](crate::host::event_subscriptions::PendingEventConsent):
+    /// a CLI/MCP agent's subscribe request the broker answered with `Ask`. The
+    /// subscriber identity shown is host-stamped — it is never taken from the
+    /// user's choice. Enter allows once, `A` allows always (persists a grant),
+    /// Esc/Deny refuses. Resolving the consent fires the transport's reply.
+    pub(crate) fn draw_event_consent_modal(&mut self, ctx: &egui::Context) {
+        use crate::host::event_subscriptions::ConsentChoice;
+        let (subscriber, target) = match self.pending_event_consents.front() {
+            Some(c) => (c.subscriber_id.clone(), c.target_label()),
+            None => return,
+        };
+        let colors = self.colors;
+        let actions = [
+            crate::ui::dialog::DialogAction::new(
+                "allow_once",
+                "Allow once",
+                crate::ui::button::ButtonKind::Primary,
+            )
+            .shortcut(crate::ui::dialog::DialogShortcut::new(
+                &["Enter"],
+                "allow once",
+                egui::Modifiers::NONE,
+                egui::Key::Enter,
+            )),
+            crate::ui::dialog::DialogAction::new(
+                "allow_always",
+                "Always",
+                crate::ui::button::ButtonKind::Secondary,
+            )
+            .shortcut(crate::ui::dialog::DialogShortcut::new(
+                &["A"],
+                "always",
+                egui::Modifiers::NONE,
+                egui::Key::A,
+            )),
+            crate::ui::dialog::DialogAction::new(
+                "deny",
+                "Deny",
+                crate::ui::button::ButtonKind::Danger,
+            )
+            .shortcut(crate::ui::dialog::DialogShortcut::new(
+                &["Esc"],
+                "deny",
+                egui::Modifiers::NONE,
+                egui::Key::Escape,
+            )),
+        ];
+        let response = crate::ui::dialog::ActionModal::new(
+            "event_consent_overlay",
+            "Event subscription request",
+            &actions,
+        )
+        .width(super::MODAL_WIDTH)
+        .show(ctx, &colors, |ui| {
+            crate::ui::typography::caption(ui, format!("{subscriber} wants to read:"), &colors);
+            crate::ui::typography::caption(ui, target, &colors);
+        });
+
+        let choice = if response.selected == Some("allow_once") {
+            Some(ConsentChoice::AllowOnce)
+        } else if response.selected == Some("allow_always") {
+            Some(ConsentChoice::AllowAlways)
+        } else if response.dismissed || response.selected == Some("deny") {
+            Some(ConsentChoice::Deny)
+        } else {
+            None
+        };
+
+        if let Some(choice) = choice {
+            if let Some(consent) = self.pending_event_consents.pop_front() {
+                let config_dir = crate::config::config_dir();
+                self.host_subscriptions
+                    .resolve_consent(consent, choice, &config_dir);
+            }
+        }
+    }
+
+    pub(crate) fn event_consent_handle_key(
+        &mut self,
+        _ctx: &egui::Context,
+    ) -> crate::app::app_trait::KeyDisposition {
+        crate::app::app_trait::KeyDisposition::Consumed
+    }
+
     fn draw_triple_tap_overlay(&self, ctx: &egui::Context, id: &str, count: u8, label: &str) {
         crate::ui::toast::ToastShell::bottom(id).show(ctx, &self.colors, |ui| {
             ui.horizontal(|ui| {

--- a/src/process_app/mcp_server.rs
+++ b/src/process_app/mcp_server.rs
@@ -18,8 +18,8 @@
 //! without a matching token are rejected with HTTP 401 before any body is read.
 
 use crate::app::registry::McpTool;
+use crate::mcp_http::{read_json_rpc_request, write_http_response, RequestOutcome};
 use std::collections::VecDeque;
-use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -130,82 +130,11 @@ fn handle_connection(
         .peer_addr()
         .map(|a| a.to_string())
         .unwrap_or_else(|_| "unknown".to_string());
-    let mut reader = BufReader::new(stream.try_clone()?);
-    let mut write_stream = stream;
+    let mut write_stream = stream.try_clone()?;
 
-    // Read HTTP request line (e.g. "POST /mcp HTTP/1.1")
-    let mut request_line = String::new();
-    if reader.read_line(&mut request_line)? == 0 {
-        return Ok(());
-    }
-
-    // Only handle POST /mcp (exact path match)
-    let mut req_parts = request_line.split_whitespace();
-    let method = req_parts.next().unwrap_or("").to_string();
-    let path = req_parts.next().unwrap_or("").to_string();
-    let is_post_mcp = method == "POST" && path == "/mcp";
-
-    // Read headers — collect Content-Length and Authorization.
-    let mut content_length: usize = 0;
-    let mut auth_ok = false;
-    let expected_auth = format!("bearer {}", token.to_lowercase());
-    loop {
-        let mut header = String::new();
-        match reader.read_line(&mut header)? {
-            0 => return Ok(()),
-            _ => {
-                let trimmed = header.trim_end_matches(|c| c == '\r' || c == '\n');
-                if trimmed.is_empty() {
-                    break; // blank line = end of headers
-                }
-                let lower = trimmed.to_lowercase();
-                if let Some(rest) = lower.strip_prefix("content-length:") {
-                    content_length = rest.trim().parse().unwrap_or(0);
-                }
-                if let Some(rest) = lower.strip_prefix("authorization:") {
-                    auth_ok = rest.trim() == expected_auth;
-                }
-            }
-        }
-    }
-
-    // Reject unauthenticated requests before reading the body.
-    if !auth_ok {
-        log::warn!("mcp_server: auth rejected peer={peer} method={method} path={path}");
-        write_http_response(&mut write_stream, 401, b"{\"error\":\"unauthorized\"}")?;
-        return Ok(());
-    }
-
-    if !is_post_mcp || content_length == 0 {
-        write_http_response(
-            &mut write_stream,
-            405,
-            b"{\"error\":\"method not allowed\"}",
-        )?;
-        return Ok(());
-    }
-
-    // Cap body size to prevent OOM from a crafted Content-Length header.
-    const MAX_BODY: usize = 10 * 1024 * 1024; // 10 MB
-    if content_length > MAX_BODY {
-        write_http_response(&mut write_stream, 413, b"{\"error\":\"payload too large\"}")?;
-        return Ok(());
-    }
-    // Read body (content_length bytes)
-    let mut buf = vec![0u8; content_length];
-    {
-        use std::io::Read;
-        reader.read_exact(&mut buf)?;
-    }
-    let body = buf;
-
-    let json: serde_json::Value = match serde_json::from_slice(&body) {
-        Ok(v) => v,
-        Err(e) => {
-            log::warn!("mcp_server: invalid JSON body: {e}");
-            write_http_response(&mut write_stream, 400, b"{\"error\":\"invalid json\"}")?;
-            return Ok(());
-        }
+    let json = match read_json_rpc_request(&stream, token)? {
+        RequestOutcome::Json(v) => v,
+        RequestOutcome::Handled => return Ok(()),
     };
 
     let id = json.get("id").cloned().unwrap_or(serde_json::Value::Null);
@@ -317,24 +246,6 @@ fn handle_connection(
     let body_bytes = serde_json::to_vec(&response_body).unwrap_or_else(|_| b"{}".to_vec());
     write_http_response(&mut write_stream, 200, &body_bytes)?;
     Ok(())
-}
-
-fn write_http_response(stream: &mut impl Write, status: u16, body: &[u8]) -> std::io::Result<()> {
-    let status_text = match status {
-        200 => "OK",
-        400 => "Bad Request",
-        401 => "Unauthorized",
-        405 => "Method Not Allowed",
-        413 => "Payload Too Large",
-        _ => "Error",
-    };
-    write!(
-        stream,
-        "HTTP/1.1 {status} {status_text}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-        body.len()
-    )?;
-    stream.write_all(body)?;
-    stream.flush()
 }
 
 fn generate_call_id() -> String {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -978,58 +978,22 @@ impl ProcessApp {
         resource_id: Option<String>,
         duration: crate::broker::GrantDuration,
     ) -> Result<String, crate::broker::Decision> {
-        use crate::broker::{Decision, PermissionRequest, TargetType};
-        let targets: Vec<String> = if event_names.is_empty() {
-            vec![format!("{publisher_app_id}::*")]
-        } else {
-            event_names
-                .iter()
-                .map(|n| format!("{publisher_app_id}::{n}"))
-                .collect()
-        };
-        let mut strictest = Decision::Allow;
-        for target in &targets {
-            let req = PermissionRequest::new(
-                subscriber_type,
-                subscriber_id,
-                TargetType::AppEventStream,
-                target,
-                Some(&self.workspace_root),
-            );
-            match self.grant_store.evaluate(&req, self.posture.as_ref()) {
-                Decision::Allow => {}
-                Decision::Deny => strictest = Decision::Deny,
-                Decision::Ask => {
-                    if strictest != Decision::Deny {
-                        strictest = Decision::Ask;
-                    }
-                }
-            }
-        }
-        if strictest != Decision::Allow {
-            log::info!(
-                "ProcessApp[{}]: subscription to '{publisher_app_id}' events for \
-                 {subscriber_type:?} '{subscriber_id}' blocked by broker ({})",
-                self.type_id,
-                strictest.as_str()
-            );
-            return Err(strictest);
-        }
-        let subscription_id = format!("sub-{}", uuid::Uuid::new_v4());
-        let record = crate::host::app_timeline::SubscriptionRecord {
-            subscription_id: subscription_id.clone(),
+        // Delegate to the shared host subscription core so the per-app and
+        // host-level (CLI/MCP) paths use one broker-gated implementation.
+        crate::host::event_subscriptions::evaluate_and_record_subscription(
+            &self.grant_store,
+            self.posture.as_ref(),
+            &self.workspace_root,
+            &self.app_timeline,
+            publisher_app_id,
             subscriber_type,
-            subscriber_id: subscriber_id.to_string(),
-            app_id: publisher_app_id.to_string(),
+            subscriber_id,
             event_names,
             payload_mode,
             trigger_mode,
             resource_id,
             duration,
-            created_at: event_log::now_timestamp(),
-        };
-        self.app_timeline.lock().unwrap().add_subscription(record);
-        Ok(subscription_id)
+        )
     }
 
     /// Request rollback of an undo checkpoint. Gated through the unified


### PR DESCRIPTION
Closes #2288

Implements stint 0214: third-party agents can subscribe to Plexi app event streams and receive brokered `PlexiEvent::AppEvent` deliveries through two transports over one host subscription core.

## Summary

- **Shared subscription core** (`src/host/event_subscriptions.rs`): one broker-gated `evaluate_and_record_subscription` (now reused by `ProcessApp`) plus `HostSubscriptionService`, which owns the host grant store + posture, resolves subscriber identity, and records subscriptions in the global timeline. Subscriber identity is host-stamped (`pane:<id>` for CLI, `mcp:host` for the host MCP server) — there is no client flag to spoof it.
- **CLI NDJSON transport** (`plexi events subscribe/list/mcp-config`): a new streaming socket primitive. `handle_socket_connection` intercepts `events_*` control messages before `AppRequest` parsing, routes the broker check through the UI thread, then streams one JSON line per delivery by polling the global timeline directly. A reader thread detects client disconnect (EOF) so idle subscriptions still clear.
- **Host-level MCP server** (`src/app/host_mcp.rs`): an always-on server exposing `list_event_streams` and a blocking `subscribe_and_wait` long-poll, backed by the same core. Port + token inject into every pane PTY as `PLEXI_HOST_MCP_PORT`/`PLEXI_HOST_MCP_TOKEN`; `plexi events mcp-config` prints the agent config block. The HTTP/JSON-RPC envelope is extracted into `src/mcp_http.rs` and shared with the per-app MCP bridge.
- **`event-probe` POC** (`apps/dev/event-probe/`): declares `probe.tick`, emits a deterministic counter event on button/key — the manual-validation companion for both transports.

## Test evidence (attempt 1)

- cargo test: **1235 passed, 0 failed** — filters: `event_subscriptions::` (grant refuse/allow, undeclared stream, pane vs MCP identity, full/summary payload shaping, delivery + disconnect cleanup), `host_mcp::` (auth, tools/list, wired `subscribe_and_wait` end-to-end proving the MCP adapter routes a real emitted event), `mcp_server::` (6 regression after the shared-envelope refactor), full bin suite.
- App render: `/tmp/event-probe.png` — shows title, "ticks emitted: 0", stream/resource labels, "Emit tick (e)" button.
- Conclusion: **binary install required** — live transport paths (PTY NDJSON streaming, host-MCP PTY env injection, an external MCP agent discovering the server) are only observable in the installed bundle.

## Manual validation

1. Open `event-probe` in Plexi, click **Emit tick**.
2. In a terminal pane: `plexi events subscribe event-probe probe.tick --payload full` → prints the `subscribed` ack then the emitted event JSON.
3. In an MCP-aware agent pane: `plexi events mcp-config` to configure, then ask it to subscribe to `event-probe`'s `probe.tick` via the Plexi MCP server, wait, and report the next event's count/summary after the button is clicked.

> Subscriptions are broker-gated: granting `AppEventStream` for the subscriber identity (`pane:<id>` / `mcp:host`) is part of the flow.