### PR TITLE
fix(notes): preserve scroll position across pane zoom transitions

### DIFF
--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -515,6 +515,7 @@ impl App for TextEditorApp {
         let min_rows = ((ui.available_height() / row_height).floor() as usize).max(1);
 
         egui::ScrollArea::vertical()
+            .id_salt(egui::Id::new("text_editor_scroll").with(&self.path))
             .auto_shrink([false, false])
             .show(ui, |ui| {
                 // egui's caret is hidden (transparent, non-blinking) and


### PR DESCRIPTION
## Summary

- `ScrollArea::vertical()` in `TextEditorApp` had no explicit `id_salt`, so egui derived its scroll-state ID from the widget call tree position
- When a scratchpad pane is zoomed (Cmd+Enter), the tile layout hierarchy shifts, giving the `ScrollArea` a new derived ID — and losing the stored scroll offset
- Fix: add `.id_salt(egui::Id::new("text_editor_scroll").with(&self.path))` so the scroll position is keyed on the file path and survives zoom/unzoom

## Done When

- Opening a scratchpad, scrolling down, then pressing Cmd+Enter to zoom and Cmd+Enter again to unzoom preserves the scroll position