### PR TITLE
Text editor overscroll padding (stint 0220)

### DIFF
--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -513,6 +513,7 @@ impl App for TextEditorApp {
         // to be taller than the viewport and triggering an unwanted scrollbar.
         let row_height = ui.fonts(|f| f.row_height(&font_id));
         let min_rows = ((ui.available_height() / row_height).floor() as usize).max(1);
+        const OVERSCROLL_ROWS: usize = 100;
 
         egui::ScrollArea::vertical()
             .id_salt(egui::Id::new("text_editor_scroll").with(&self.path))
@@ -528,7 +529,7 @@ impl App for TextEditorApp {
                             .id(te_id)
                             .font(font_id)
                             .desired_width(f32::INFINITY)
-                            .desired_rows(min_rows)
+                            .desired_rows(min_rows + OVERSCROLL_ROWS)
                             .margin(egui::vec2(4.0, 0.0))
                             .frame(false)
                             .show(ui)


### PR DESCRIPTION
## Summary

- Adds `OVERSCROLL_ROWS = 100` virtual padding rows below the text content in `TextEditorApp`
- Changes `desired_rows(min_rows)` to `desired_rows(min_rows + OVERSCROLL_ROWS)` so the cursor can sit near the top/middle of the viewport even on short documents
- No change to autosave, cursor painting, Down-key newline logic, or any other behavior

## Done When

- Short notes allow the cursor to be positioned near the top of the viewport without manually adding blank lines
- No spurious scrollbar appears on an empty note