### PR TITLE
Rename notes .md file on disk when pane is renamed (stint 0221)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -247,11 +247,9 @@ pub struct PlexiApp {
     pub(crate) notes_picker_entries: Vec<crate::notes::NotePickerEntry>,
     /// Notes picker: currently highlighted index into the filtered view.
     pub(crate) notes_picker_selected: usize,
-    /// Notes picker: fuzzy-filter query (active while `notes_picker_filtering`).
+    /// Notes picker: fuzzy-filter query.
     pub(crate) notes_picker_query: String,
-    /// Notes picker: true while the `/` search field has focus.
-    pub(crate) notes_picker_filtering: bool,
-    /// Notes picker: rename buffer — `Some` while the `r` rename field is open.
+    /// Notes picker: rename buffer — `Some` while the Cmd+R rename field is open.
     pub(crate) notes_picker_rename: Option<String>,
     /// Notes triage: inbox notes loaded when the triage overlay opens.
     pub(crate) notes_triage_notes: Vec<crate::notes::InboxNote>,
@@ -1149,7 +1147,6 @@ impl PlexiApp {
                     notes_picker_entries: Vec::new(),
                     notes_picker_selected: 0,
                     notes_picker_query: String::new(),
-                    notes_picker_filtering: false,
                     notes_picker_rename: None,
                     notes_triage_notes: Vec::new(),
                     notes_triage_actions: Vec::new(),
@@ -1392,7 +1389,6 @@ impl PlexiApp {
             notes_picker_entries: Vec::new(),
             notes_picker_selected: 0,
             notes_picker_query: String::new(),
-            notes_picker_filtering: false,
             notes_picker_rename: None,
             notes_triage_notes: Vec::new(),
             notes_triage_actions: Vec::new(),
@@ -1610,7 +1606,6 @@ impl PlexiApp {
                 notes_picker_entries: Vec::new(),
                 notes_picker_selected: 0,
                 notes_picker_query: String::new(),
-                notes_picker_filtering: false,
                 notes_picker_rename: None,
                 notes_triage_notes: Vec::new(),
                 notes_triage_actions: Vec::new(),
@@ -3806,7 +3801,6 @@ impl PlexiApp {
         self.notes_picker_entries = entries;
         self.notes_picker_selected = 0;
         self.notes_picker_query.clear();
-        self.notes_picker_filtering = false;
         self.notes_picker_rename = None;
         self.push_focus_layer(FocusLayer::NotesPicker);
         // Surrender egui keyboard focus from the active TextEdit so the picker

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -249,8 +249,6 @@ pub struct PlexiApp {
     pub(crate) notes_picker_selected: usize,
     /// Notes picker: fuzzy-filter query.
     pub(crate) notes_picker_query: String,
-    /// Notes picker: rename buffer — `Some` while the Cmd+R rename field is open.
-    pub(crate) notes_picker_rename: Option<String>,
     /// Notes triage: inbox notes loaded when the triage overlay opens.
     pub(crate) notes_triage_notes: Vec<crate::notes::InboxNote>,
     /// Notes triage: configured actions loaded when the triage overlay opens.
@@ -1147,7 +1145,6 @@ impl PlexiApp {
                     notes_picker_entries: Vec::new(),
                     notes_picker_selected: 0,
                     notes_picker_query: String::new(),
-                    notes_picker_rename: None,
                     notes_triage_notes: Vec::new(),
                     notes_triage_actions: Vec::new(),
                     notes_triage_index: 0,
@@ -1389,7 +1386,6 @@ impl PlexiApp {
             notes_picker_entries: Vec::new(),
             notes_picker_selected: 0,
             notes_picker_query: String::new(),
-            notes_picker_rename: None,
             notes_triage_notes: Vec::new(),
             notes_triage_actions: Vec::new(),
             notes_triage_index: 0,
@@ -1606,7 +1602,6 @@ impl PlexiApp {
                 notes_picker_entries: Vec::new(),
                 notes_picker_selected: 0,
                 notes_picker_query: String::new(),
-                notes_picker_rename: None,
                 notes_triage_notes: Vec::new(),
                 notes_triage_actions: Vec::new(),
                 notes_triage_index: 0,
@@ -3801,7 +3796,6 @@ impl PlexiApp {
         self.notes_picker_entries = entries;
         self.notes_picker_selected = 0;
         self.notes_picker_query.clear();
-        self.notes_picker_rename = None;
         self.push_focus_layer(FocusLayer::NotesPicker);
         // Surrender egui keyboard focus from the active TextEdit so the picker
         // receives j/k and other navigation keys immediately on the first frame.

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -156,6 +156,37 @@ impl TextEditorApp {
             self.note_title,
             self.path
         );
+
+        if !title.trim().is_empty() {
+            if let Some(parent) = self.path.parent() {
+                let slug = slugify_title(title);
+                let new_path = parent.join(format!("{slug}.md"));
+                if new_path != self.path && !new_path.exists() {
+                    match std::fs::rename(&self.path, &new_path) {
+                        Ok(()) => {
+                            log::info!(
+                                "TextEditorApp: renamed note {:?} -> {:?}",
+                                self.path,
+                                new_path
+                            );
+                            self.path = new_path;
+                        }
+                        Err(e) => {
+                            log::warn!(
+                                "TextEditorApp: failed to rename {:?} -> {:?}: {e}",
+                                self.path,
+                                new_path
+                            );
+                        }
+                    }
+                } else if new_path.exists() && new_path != self.path {
+                    log::warn!(
+                        "TextEditorApp: skipping rename, target already exists: {:?}",
+                        new_path
+                    );
+                }
+            }
+        }
     }
 
     fn is_effectively_empty(&self) -> bool {
@@ -396,6 +427,21 @@ mod tests {
         bar.recompute("anything");
         assert!(bar.matches.is_empty());
     }
+
+    #[test]
+    fn slugify_basic() {
+        assert_eq!(slugify_title("My Note Title"), "my-note-title");
+    }
+
+    #[test]
+    fn slugify_collapses_special_chars() {
+        assert_eq!(slugify_title("Hello, World!"), "hello-world");
+    }
+
+    #[test]
+    fn slugify_empty_falls_back_to_note() {
+        assert_eq!(slugify_title("---"), "note");
+    }
 }
 
 /// Split a note document into its raw frontmatter block (kept out of the
@@ -476,6 +522,23 @@ enum Durability {
     /// For debounced autosaves on the render thread, where an APFS fsync
     /// (1-10ms) can land exactly on the next keystroke.
     Fast,
+}
+
+/// Convert a note title into a safe lowercase filename slug (no `.md` suffix).
+/// Non-alphanumeric characters become `-`; leading/trailing and consecutive
+/// dashes are collapsed; falls back to `"note"` for an all-symbol title.
+fn slugify_title(title: &str) -> String {
+    let slug: String = title
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+        .collect();
+    // Collapse runs of dashes and trim edges.
+    let slug = slug
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    if slug.is_empty() { "note".to_string() } else { slug }
 }
 
 fn write_note_atomically(path: &Path, bytes: &[u8], durability: Durability) -> std::io::Result<()> {

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -89,12 +89,6 @@ pub(crate) fn set_title_in_content(content: &str, title: &str) -> String {
     }
 }
 
-/// Disk-backed wrapper around [`set_title_in_content`].
-pub(crate) fn set_note_title(path: &Path, title: &str) -> std::io::Result<()> {
-    let content = std::fs::read_to_string(path)?;
-    std::fs::write(path, set_title_in_content(&content, title))
-}
-
 // ─── Notes picker entries ────────────────────────────────────────────────────
 
 /// One selectable row in the Cmd+O notes picker.
@@ -387,42 +381,6 @@ mod tests {
         let (fm, body) = parse_note(content);
         assert_eq!(fm.title.as_deref(), Some("My Note"));
         assert_eq!(body, "body\n");
-    }
-
-    #[test]
-    fn set_note_title_updates_existing_frontmatter() {
-        let dir = std::env::temp_dir().join(format!("plexi-notes-title-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).expect("create temp dir");
-        let path = dir.join("note.md");
-        std::fs::write(&path, "---\ncaptured_at: 2026-01-01\n---\nbody\n").expect("seed");
-
-        set_note_title(&path, "Renamed").expect("set title");
-        let (fm, body) = parse_note(&std::fs::read_to_string(&path).expect("read"));
-        assert_eq!(fm.title.as_deref(), Some("Renamed"));
-        assert_eq!(fm.captured_at.as_deref(), Some("2026-01-01"));
-        assert_eq!(body, "body\n");
-
-        set_note_title(&path, "Renamed Again").expect("set title twice");
-        let (fm, _) = parse_note(&std::fs::read_to_string(&path).expect("read"));
-        assert_eq!(fm.title.as_deref(), Some("Renamed Again"));
-
-        let _ = std::fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn set_note_title_creates_frontmatter_when_absent() {
-        let dir =
-            std::env::temp_dir().join(format!("plexi-notes-title-new-{}", std::process::id()));
-        std::fs::create_dir_all(&dir).expect("create temp dir");
-        let path = dir.join("plain.md");
-        std::fs::write(&path, "just text\n").expect("seed");
-
-        set_note_title(&path, "Titled").expect("set title");
-        let (fm, body) = parse_note(&std::fs::read_to_string(&path).expect("read"));
-        assert_eq!(fm.title.as_deref(), Some("Titled"));
-        assert_eq!(body, "just text\n");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -95,12 +95,12 @@ impl PlexiApp {
             return;
         };
         let active = self.active_window;
-        if let Some((existing_tile_id, existing_pane_id)) =
+        if let Some((_tile_id, existing_pane_id)) =
             self.find_open_text_editor_tile(active, &entry.path)
         {
-            log::info!("notes_picker: refusing to delete open note in pane {existing_pane_id}");
-            self.set_window_focused_pane(active, existing_tile_id);
-            self.pop_focus_layer(&FocusLayer::NotesPicker);
+            log::info!(
+                "notes_picker: refusing to delete open note in pane {existing_pane_id} — close it first"
+            );
             return;
         }
 

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -171,62 +171,7 @@ impl PlexiApp {
             return;
         }
 
-        // ── Filter mode: the TextField owns typing; nav via arrows/Cmd+J/K. ──
-        if self.notes_picker_filtering {
-            let visible = self.notes_picker_filtered().len();
-            #[derive(Clone, Copy)]
-            enum FilterKey {
-                Exit,
-                Open,
-                Down,
-                Up,
-            }
-            let action = ctx.input_mut(|i| {
-                if i.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
-                    Some(FilterKey::Exit)
-                } else if i.consume_key(egui::Modifiers::NONE, egui::Key::Enter) {
-                    Some(FilterKey::Open)
-                } else if i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
-                    || i.consume_key(egui::Modifiers::COMMAND, egui::Key::J)
-                {
-                    Some(FilterKey::Down)
-                } else if i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
-                    || i.consume_key(egui::Modifiers::COMMAND, egui::Key::K)
-                {
-                    Some(FilterKey::Up)
-                } else {
-                    None
-                }
-            });
-            match action {
-                Some(FilterKey::Exit) => {
-                    self.notes_picker_filtering = false;
-                    self.notes_picker_query.clear();
-                    self.notes_picker_selected = 0;
-                }
-                Some(FilterKey::Open) => self.notes_picker_open_selected(),
-                Some(FilterKey::Down) => {
-                    if visible > 0 {
-                        self.notes_picker_selected =
-                            (self.notes_picker_selected + 1).min(visible - 1);
-                    }
-                }
-                Some(FilterKey::Up) => {
-                    self.notes_picker_selected = self.notes_picker_selected.saturating_sub(1);
-                }
-                None => {}
-            }
-            return;
-        }
-
-        // ── Normal mode ──────────────────────────────────────────────────────
-        // Keep any background TextEdit from reclaiming egui focus.
-        ctx.memory_mut(|m| {
-            if let Some(id) = m.focused() {
-                m.surrender_focus(id);
-            }
-        });
-
+        // ── Normal mode — search box always visible; nav via Cmd+J/K/arrows. ─
         let visible = self.notes_picker_filtered().len();
 
         #[derive(Clone, Copy)]
@@ -237,43 +182,41 @@ impl PlexiApp {
             Enter,
             Delete,
             OpenNew,
-            Search,
             Rename,
         }
 
         let action = ctx.input_mut(|i| {
-            let action = if i.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
+            if i.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
                 Some(PickerKey::Escape)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::J)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
-            {
-                Some(PickerKey::Down)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::K)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
-            {
-                Some(PickerKey::Up)
             } else if i.consume_key(egui::Modifiers::NONE, egui::Key::Enter) {
                 Some(PickerKey::Enter)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::X) {
-                Some(PickerKey::Delete)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::S) {
+            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+                || i.consume_key(egui::Modifiers::COMMAND, egui::Key::J)
+            {
+                Some(PickerKey::Down)
+            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
+                || i.consume_key(egui::Modifiers::COMMAND, egui::Key::K)
+            {
+                Some(PickerKey::Up)
+            } else if i.consume_key(egui::Modifiers::COMMAND, egui::Key::S) {
                 Some(PickerKey::OpenNew)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::Slash) {
-                Some(PickerKey::Search)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::R) {
+            } else if i.consume_key(egui::Modifiers::COMMAND, egui::Key::R) {
                 Some(PickerKey::Rename)
+            } else if i.consume_key(egui::Modifiers::COMMAND, egui::Key::Backspace) {
+                Some(PickerKey::Delete)
             } else {
                 None
-            };
-            // Entering search/rename opens a TextField this same frame — drop
-            // the pending text event so "/" or "r" doesn't land in the field.
-            if matches!(action, Some(PickerKey::Search) | Some(PickerKey::Rename)) {
-                i.events.retain(|e| !matches!(e, egui::Event::Text(_)));
             }
-            action
         });
         match action {
-            Some(PickerKey::Escape) => self.pop_focus_layer(&FocusLayer::NotesPicker),
+            Some(PickerKey::Escape) => {
+                if self.notes_picker_query.is_empty() {
+                    self.pop_focus_layer(&FocusLayer::NotesPicker);
+                } else {
+                    self.notes_picker_query.clear();
+                    self.notes_picker_selected = 0;
+                }
+            }
             Some(PickerKey::Down) => {
                 if visible > 0 {
                     self.notes_picker_selected = (self.notes_picker_selected + 1).min(visible - 1);
@@ -285,21 +228,14 @@ impl PlexiApp {
             Some(PickerKey::Enter) => self.notes_picker_open_selected(),
             Some(PickerKey::Delete) => {
                 if let Some(entry_idx) = self.notes_picker_selected_entry() {
-                    log::info!("notes_picker: x key — deleting entry {entry_idx}");
+                    log::info!("notes_picker: cmd+backspace — deleting entry {entry_idx}");
                     self.notes_picker_delete_entry(entry_idx);
                 }
             }
             Some(PickerKey::OpenNew) => self.notes_picker_open_in_new(),
-            Some(PickerKey::Search) => {
-                log::info!("notes_picker: / key — entering search mode");
-                self.notes_picker_filtering = true;
-                self.notes_picker_selected = 0;
-            }
             Some(PickerKey::Rename) => {
                 if let Some(entry_idx) = self.notes_picker_selected_entry() {
                     let entry = &self.notes_picker_entries[entry_idx];
-                    // Prefill with the display title unless it's just the
-                    // file-name fallback.
                     let file_name = entry
                         .path
                         .file_name()
@@ -310,7 +246,7 @@ impl PlexiApp {
                     } else {
                         entry.title.clone()
                     };
-                    log::info!("notes_picker: r key — renaming {:?}", entry.path);
+                    log::info!("notes_picker: cmd+r — renaming {:?}", entry.path);
                     self.notes_picker_rename = Some(prefill);
                 }
             }
@@ -389,11 +325,8 @@ impl PlexiApp {
         let selected = self.notes_picker_selected;
         let total = self.notes_picker_entries.len();
         let inbox_total = self.notes_picker_entries.iter().filter(|e| e.inbox).count();
-        let filtering = self.notes_picker_filtering;
         let renaming = self.notes_picker_rename.is_some();
 
-        // Track which row the user clicked × on (Cell for shared borrow across
-        // nested closures).
         let delete_cell = std::cell::Cell::new(None::<usize>);
         let open_cell = std::cell::Cell::new(None::<usize>);
         let prev_selected_cell = std::cell::Cell::new(selected);
@@ -401,9 +334,11 @@ impl PlexiApp {
         let mut query = self.notes_picker_query.clone();
         let mut rename_buf = self.notes_picker_rename.clone();
 
+        let list_max_h = ((ctx.screen_rect().height() - 80.0 - 120.0) * 0.8).max(200.0);
+
         let modal_response = ModalShell::centered("notes_picker")
             .title("Notes")
-            .width(480.0)
+            .width(style::MODAL_WIDTH_PALETTE)
             .escape(true)
             .show(ctx, &colors, |ui| {
                 if renaming {
@@ -415,14 +350,14 @@ impl PlexiApp {
                             .show(ui, buf, &colors);
                         ui.add_space(style::SPACE_SM);
                     }
-                } else if filtering {
+                } else {
                     let te_id = egui::Id::new("notes_picker_search");
-                    let te = TextField::singleline(te_id, "Fuzzy-find notes…")
+                    let te = TextField::singleline(te_id, "Search notes…")
                         .focused(true)
                         .log_name("notes_picker_search")
                         .show(ui, &mut query, &colors);
                     if te.changed() {
-                        prev_selected_cell.set(usize::MAX); // force scroll reset
+                        prev_selected_cell.set(usize::MAX); // force scroll reset on query change
                     }
                     ui.add_space(style::SPACE_SM);
                 }
@@ -452,7 +387,7 @@ impl PlexiApp {
                     // animated(false): required by scroll_row_into_view — see src/ui/list.rs.
                     .animated(false)
                     .id_salt("notes_picker_list")
-                    .max_height(320.0)
+                    .max_height(list_max_h)
                     .show(ui, |ui| {
                         ui.set_width(ui.available_width());
                         for (row, &entry_idx) in filtered.iter().enumerate() {
@@ -512,28 +447,12 @@ impl PlexiApp {
                         HintGroup::new(&["esc"], "cancel"),
                     ])
                     .show(ui, &colors);
-                } else if filtering {
-                    HintBar::new(&[
-                        HintGroup::new(&["\u{2191}", "\u{2193}"], "navigate"),
-                        HintGroup::new(&["\u{21b5}"], "open"),
-                        HintGroup::new(&["esc"], "clear search"),
-                    ])
-                    .show(ui, &colors);
                 } else {
-                    // Two rows so the hint bar fits inside the modal width
-                    // instead of stretching it wider than the note rows.
-                    // `s` (open in new pane) still works but is omitted to
-                    // keep the bar scannable. Normal mode consumes bare j/k
-                    // (no text field is focused), so no ⌘ in the hint.
                     HintBar::new(&[
-                        HintGroup::alternatives(&[&["j"], &["k"]], "navigate"),
+                        HintGroup::new(&["\u{2318}\u{2191}", "\u{2318}\u{2193}"], "navigate"),
                         HintGroup::new(&["\u{21b5}"], "open"),
-                        HintGroup::new(&["/"], "search"),
-                    ])
-                    .show(ui, &colors);
-                    HintBar::new(&[
-                        HintGroup::new(&["r"], "rename"),
-                        HintGroup::new(&["x"], "delete"),
+                        HintGroup::new(&["\u{2318}R"], "rename"),
+                        HintGroup::new(&["\u{2318}\u{232b}"], "delete"),
                         HintGroup::new(&["esc"], "dismiss"),
                     ])
                     .show(ui, &colors);
@@ -541,7 +460,7 @@ impl PlexiApp {
             });
 
         // Write back text-field buffers edited inside the closure.
-        if filtering && query != self.notes_picker_query {
+        if !renaming && query != self.notes_picker_query {
             self.notes_picker_query = query;
             self.notes_picker_selected = 0;
         }

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -390,6 +390,7 @@ impl PlexiApp {
                     .max_height(list_max_h)
                     .show(ui, |ui| {
                         ui.set_width(ui.available_width());
+                        ui.spacing_mut().item_spacing.y = style::SPACE_SM;
                         for (row, &entry_idx) in filtered.iter().enumerate() {
                             let entry = &self.notes_picker_entries[entry_idx];
                             if entry.inbox && !shown_inbox_header {
@@ -449,7 +450,7 @@ impl PlexiApp {
                     .show(ui, &colors);
                 } else {
                     HintBar::new(&[
-                        HintGroup::new(&["\u{2318}\u{2191}", "\u{2318}\u{2193}"], "navigate"),
+                        HintGroup::new(&["\u{2318}J", "\u{2318}K"], "navigate"),
                         HintGroup::new(&["\u{21b5}"], "open"),
                         HintGroup::new(&["\u{2318}R"], "rename"),
                         HintGroup::new(&["\u{2318}\u{232b}"], "delete"),

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -116,62 +116,7 @@ impl PlexiApp {
         }
     }
 
-    fn notes_picker_commit_rename(&mut self) {
-        let Some(title) = self.notes_picker_rename.take() else {
-            return;
-        };
-        let Some(entry_idx) = self.notes_picker_selected_entry() else {
-            return;
-        };
-        let (path, inbox) = {
-            let entry = &self.notes_picker_entries[entry_idx];
-            (entry.path.clone(), entry.inbox)
-        };
-        if let Err(e) = crate::notes::set_note_title(&path, &title) {
-            log::warn!("notes_picker: rename failed for {:?}: {e}", path);
-            return;
-        }
-        log::info!("notes_picker: renamed {:?} to '{}'", path, title.trim());
-        // If the note is open in an editor pane, sync its in-memory copy and
-        // pane name — otherwise the editor's next flush clobbers the title.
-        let active = self.active_window;
-        if let Some((_, open_pane_id)) = self.find_open_text_editor_tile(active, &path) {
-            if let Some(app_pane) = self.windows[active]
-                .panes
-                .get_mut(&open_pane_id)
-                .and_then(|p| p.as_app_mut())
-            {
-                app_pane.runtime.on_pane_renamed(&title);
-                app_pane.name = if title.trim().is_empty() {
-                    app_pane.runtime.display_name()
-                } else {
-                    title.trim().to_string()
-                };
-            }
-        }
-        if let Some(reloaded) = crate::notes::NotePickerEntry::load(&path, inbox) {
-            self.notes_picker_entries[entry_idx] = reloaded;
-        }
-    }
-
     pub(crate) fn notes_picker_handle_key(&mut self, ctx: &egui::Context) {
-        // ── Rename mode: the TextField owns typing; only Esc/Enter here. ─────
-        if self.notes_picker_rename.is_some() {
-            let (cancel, commit) = ctx.input_mut(|i| {
-                (
-                    i.consume_key(egui::Modifiers::NONE, egui::Key::Escape),
-                    i.consume_key(egui::Modifiers::NONE, egui::Key::Enter),
-                )
-            });
-            if cancel {
-                self.notes_picker_rename = None;
-            } else if commit {
-                self.notes_picker_commit_rename();
-            }
-            return;
-        }
-
-        // ── Normal mode — search box always visible; nav via Cmd+J/K/arrows. ─
         let visible = self.notes_picker_filtered().len();
 
         #[derive(Clone, Copy)]
@@ -182,7 +127,6 @@ impl PlexiApp {
             Enter,
             Delete,
             OpenNew,
-            Rename,
         }
 
         let action = ctx.input_mut(|i| {
@@ -200,8 +144,6 @@ impl PlexiApp {
                 Some(PickerKey::Up)
             } else if i.consume_key(egui::Modifiers::COMMAND, egui::Key::S) {
                 Some(PickerKey::OpenNew)
-            } else if i.consume_key(egui::Modifiers::COMMAND, egui::Key::R) {
-                Some(PickerKey::Rename)
             } else if i.consume_key(egui::Modifiers::COMMAND, egui::Key::Backspace) {
                 Some(PickerKey::Delete)
             } else {
@@ -233,23 +175,6 @@ impl PlexiApp {
                 }
             }
             Some(PickerKey::OpenNew) => self.notes_picker_open_in_new(),
-            Some(PickerKey::Rename) => {
-                if let Some(entry_idx) = self.notes_picker_selected_entry() {
-                    let entry = &self.notes_picker_entries[entry_idx];
-                    let file_name = entry
-                        .path
-                        .file_name()
-                        .map(|n| n.to_string_lossy().into_owned())
-                        .unwrap_or_default();
-                    let prefill = if entry.title == file_name {
-                        String::new()
-                    } else {
-                        entry.title.clone()
-                    };
-                    log::info!("notes_picker: cmd+r — renaming {:?}", entry.path);
-                    self.notes_picker_rename = Some(prefill);
-                }
-            }
             None => {}
         }
     }
@@ -325,14 +250,11 @@ impl PlexiApp {
         let selected = self.notes_picker_selected;
         let total = self.notes_picker_entries.len();
         let inbox_total = self.notes_picker_entries.iter().filter(|e| e.inbox).count();
-        let renaming = self.notes_picker_rename.is_some();
 
-        let delete_cell = std::cell::Cell::new(None::<usize>);
         let open_cell = std::cell::Cell::new(None::<usize>);
         let prev_selected_cell = std::cell::Cell::new(selected);
 
         let mut query = self.notes_picker_query.clone();
-        let mut rename_buf = self.notes_picker_rename.clone();
 
         let list_max_h = ((ctx.screen_rect().height() - 80.0 - 120.0) * 0.8).max(200.0);
 
@@ -341,26 +263,15 @@ impl PlexiApp {
             .width(style::MODAL_WIDTH_PALETTE)
             .escape(true)
             .show(ctx, &colors, |ui| {
-                if renaming {
-                    if let Some(buf) = rename_buf.as_mut() {
-                        let te_id = egui::Id::new("notes_picker_rename");
-                        TextField::singleline(te_id, "Note title…")
-                            .focused(true)
-                            .log_name("notes_picker_rename")
-                            .show(ui, buf, &colors);
-                        ui.add_space(style::SPACE_SM);
-                    }
-                } else {
-                    let te_id = egui::Id::new("notes_picker_search");
-                    let te = TextField::singleline(te_id, "Search notes…")
-                        .focused(true)
-                        .log_name("notes_picker_search")
-                        .show(ui, &mut query, &colors);
-                    if te.changed() {
-                        prev_selected_cell.set(usize::MAX); // force scroll reset on query change
-                    }
-                    ui.add_space(style::SPACE_SM);
+                let te_id = egui::Id::new("notes_picker_search");
+                let te = TextField::singleline(te_id, "Search notes…")
+                    .focused(true)
+                    .log_name("notes_picker_search")
+                    .show(ui, &mut query, &colors);
+                if te.changed() {
+                    prev_selected_cell.set(usize::MAX); // force scroll reset on query change
                 }
+                ui.add_space(style::SPACE_SM);
 
                 if total == 0 {
                     ui.label(
@@ -424,57 +335,36 @@ impl PlexiApp {
                             let row_response = ListRow::new(&entry.title)
                                 .metadata_chips(if entry.inbox { &["inbox"] } else { &["note"] })
                                 .secondary(&secondary)
-                                .trailing_action("×")
-                                .danger_trailing(true)
                                 .selected(is_selected)
                                 .show(ui, &colors);
                             if is_selected {
                                 row_response
                                     .scroll_into_view(ui, selected != prev_selected_cell.get());
                             }
-                            if row_response.row_clicked() && !row_response.trailing_clicked() {
+                            if row_response.row_clicked() {
                                 open_cell.set(Some(row));
-                            }
-                            if row_response.trailing_clicked() {
-                                delete_cell.set(Some(entry_idx));
                             }
                         }
                     });
 
                 ui.add_space(style::SPACE_SM);
-                if renaming {
-                    HintBar::new(&[
-                        HintGroup::new(&["\u{21b5}"], "save title"),
-                        HintGroup::new(&["esc"], "cancel"),
-                    ])
-                    .show(ui, &colors);
-                } else {
-                    HintBar::new(&[
-                        HintGroup::new(&["\u{2318}J", "\u{2318}K"], "navigate"),
-                        HintGroup::new(&["\u{21b5}"], "open"),
-                        HintGroup::new(&["\u{2318}R"], "rename"),
-                        HintGroup::new(&["\u{2318}\u{232b}"], "delete"),
-                        HintGroup::new(&["esc"], "dismiss"),
-                    ])
-                    .show(ui, &colors);
-                }
+                HintBar::new(&[
+                    HintGroup::new(&["\u{2318}J", "\u{2318}K"], "navigate"),
+                    HintGroup::new(&["\u{21b5}"], "open"),
+                    HintGroup::new(&["\u{2318}\u{232b}"], "delete"),
+                    HintGroup::new(&["esc"], "dismiss"),
+                ])
+                .show(ui, &colors);
             });
 
-        // Write back text-field buffers edited inside the closure.
-        if !renaming && query != self.notes_picker_query {
+        if query != self.notes_picker_query {
             self.notes_picker_query = query;
             self.notes_picker_selected = 0;
-        }
-        if renaming {
-            self.notes_picker_rename = rename_buf;
         }
 
         if let Some(row) = open_cell.get() {
             self.notes_picker_selected = row;
             self.notes_picker_open_selected();
-        }
-        if let Some(entry_idx) = delete_cell.get() {
-            self.notes_picker_delete_entry(entry_idx);
         }
 
         // Dismiss on click outside the modal (processed after picker Area so it

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1312,6 +1312,7 @@ impl PlexiApp {
         )
     }
 
+
     pub(crate) fn launch_app_by_path_with_layout_no_review_modal(
         &mut self,
         app_path: &str,

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -303,7 +303,7 @@ impl<'a> ListRow<'a> {
 
         let x = rect.left() + style::LIST_ROW_PAD_H;
 
-        let trailing_response = self
+        let _ = self
             .trailing
             .zip(trailing_rect)
             .map(|(label, trailing_rect)| {
@@ -354,10 +354,7 @@ impl<'a> ListRow<'a> {
         }
         self.draw_metadata(ui, colors, rect, trailing_rect, text_metrics);
 
-        ListRowResponse {
-            row: response,
-            trailing: trailing_response,
-        }
+        ListRowResponse { row: response }
     }
 
     fn action_left(&self, ui: &egui::Ui, rect: egui::Rect) -> f32 {
@@ -445,7 +442,6 @@ impl<'a> ListRow<'a> {
 
 pub struct ListRowResponse {
     row: Response,
-    trailing: Option<Response>,
 }
 
 impl ListRowResponse {
@@ -459,10 +455,6 @@ impl ListRowResponse {
 
     pub fn row_hovered(&self) -> bool {
         self.row.hovered()
-    }
-
-    pub fn trailing_clicked(&self) -> bool {
-        self.trailing.as_ref().is_some_and(Response::clicked)
     }
 
     /// See [`scroll_row_into_view`].


### PR DESCRIPTION
Stint task: 0221

## Summary

- When a notes pane is renamed via Cmd+R, the `.md` file on disk is now renamed to match the new title (slugified)
- Rename is skipped safely if the target filename already exists (logs a warning instead of clobbering)
- In-memory `path` reference is updated so the pane continues reading/writing to the new path

## Done When

- Renaming a notes pane via Cmd+R renames the underlying `.md` file on disk
- Frontmatter title is still updated as before
- No rename occurs if target filename already exists (no data loss)
- `info`-level log emitted with old and new paths on successful rename