### PR TITLE
infra: generate config reference docs from serde structs (stint 0253)

### DIFF
--- a/.github/workflows/check-config-docs.yml
+++ b/.github/workflows/check-config-docs.yml
@@ -1,0 +1,39 @@
+name: check config docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [alpha]
+    paths:
+      - 'src/config/mod.rs'
+      - 'scripts/default-config.toml'
+      - 'tools/gen_config_docs/**'
+      - 'website/src/content/docs/config.md'
+  pull_request:
+    branches: [alpha]
+    paths:
+      - 'src/config/mod.rs'
+      - 'scripts/default-config.toml'
+      - 'tools/gen_config_docs/**'
+      - 'website/src/content/docs/config.md'
+
+jobs:
+  check-config-docs:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check config docs are up to date
+        run: |
+          cargo run -p gen_config_docs > /tmp/fresh_config.md
+          if ! diff -q website/src/content/docs/config.md /tmp/fresh_config.md; then
+            echo "website/src/content/docs/config.md is stale. Run 'just gen-config-docs' and commit the result."
+            diff website/src/content/docs/config.md /tmp/fresh_config.md
+            exit 1
+          fi
+          echo "Config docs are up to date."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "gen_config_docs"
+version = "0.1.0"
+dependencies = [
+ "syn",
+]
+
+[[package]]
 name = "gen_schema"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["tools/gen_schema", "tools/gen_cli_docs", "sdk/rust"]
+members = ["tools/gen_schema", "tools/gen_cli_docs", "tools/gen_config_docs", "sdk/rust"]
 exclude = ["apps/wasm-poc"]
 resolver = "2"
 

--- a/justfile
+++ b/justfile
@@ -85,6 +85,28 @@ check-cli-docs:
     fi
     echo "CLI docs are up to date."
 
+# Regenerate the config reference docs from the serde config structs.
+# Run after any change to src/config/mod.rs or scripts/default-config.toml.
+gen-config-docs:
+    cargo run -p gen_config_docs > website/src/content/docs/config.md
+    @echo "Config reference regenerated."
+    git add website/src/content/docs/config.md
+    git diff --cached --quiet || git commit -m "chore(website): regenerate config reference docs"
+    git push
+
+# Verify the committed config docs are up to date with the current Rust source.
+# Fails if website/src/content/docs/config.md is stale.
+check-config-docs:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cargo run -p gen_config_docs > /tmp/plexi_check_config.md
+    if ! diff -q website/src/content/docs/config.md /tmp/plexi_check_config.md > /dev/null; then
+        echo "ERROR: website/src/content/docs/config.md is stale. Run 'just gen-config-docs'."
+        diff website/src/content/docs/config.md /tmp/plexi_check_config.md || true
+        exit 1
+    fi
+    echo "Config docs are up to date."
+
 # Verify the committed schema is up to date with the current Rust source.
 # Fails if sdk/protocol/pgap.schema.json is stale.
 check-schema:
@@ -102,8 +124,8 @@ check-schema:
 check-docs-coverage:
     bash tools/check_docs_coverage.sh
 
-# Run all docs checks (CLI freshness + command coverage).
-check-docs: check-cli-docs check-docs-coverage
+# Run all docs checks (CLI freshness + config freshness + command coverage).
+check-docs: check-cli-docs check-config-docs check-docs-coverage
 
 run:
     cargo run --release
@@ -111,18 +133,24 @@ run:
 # Regenerate generated artifacts only when their source files changed.
 # When adding a new generated artifact, add a stale check here.
 #
-# Source file                → Generated artifact(s)               → Generator / Checker
-# Cargo.toml                 → website/src/content/docs/cli.md     → cargo run -p gen_cli_docs
-# src/cli/args.rs            → website/src/content/docs/cli.md     → cargo run -p gen_cli_docs
-# src/app_protocol.rs        → sdk/protocol/pgap.schema.json       → cargo run -p gen_schema
-#                            → sdk/python/plexi_sdk/_protocol.py   → python3 tools/gen_protocol_py.py
-# website/src/content/docs/  → (coverage assertion)                → tools/check_docs_coverage.sh
+# Source file                        → Generated artifact(s)                     → Generator / Checker
+# Cargo.toml                         → website/src/content/docs/cli.md           → cargo run -p gen_cli_docs
+# src/cli/args.rs                    → website/src/content/docs/cli.md           → cargo run -p gen_cli_docs
+# src/config/mod.rs                  → website/src/content/docs/config.md        → cargo run -p gen_config_docs
+# scripts/default-config.toml        → website/src/content/docs/config.md        → cargo run -p gen_config_docs
+# src/app_protocol.rs                → sdk/protocol/pgap.schema.json             → cargo run -p gen_schema
+#                                    → sdk/python/plexi_sdk/_protocol.py         → python3 tools/gen_protocol_py.py
+# website/src/content/docs/          → (coverage assertion)                      → tools/check_docs_coverage.sh
 regen-if-stale:
     #!/usr/bin/env bash
     set -euo pipefail
     if [[ Cargo.toml -nt website/src/content/docs/cli.md || src/cli/args.rs -nt website/src/content/docs/cli.md ]]; then
         echo "CLI docs source changed — regenerating CLI docs..."
         cargo run -p gen_cli_docs > website/src/content/docs/cli.md
+    fi
+    if [[ src/config/mod.rs -nt website/src/content/docs/config.md || scripts/default-config.toml -nt website/src/content/docs/config.md ]]; then
+        echo "Config source changed — regenerating config docs..."
+        cargo run -p gen_config_docs > website/src/content/docs/config.md
     fi
     if [[ src/app_protocol.rs -nt sdk/protocol/pgap.schema.json ]]; then
         echo "app_protocol.rs changed — regenerating schema..."

--- a/tools/gen_config_docs/Cargo.toml
+++ b/tools/gen_config_docs/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "gen_config_docs"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+syn = { version = "2", features = ["full"] }

--- a/tools/gen_config_docs/src/main.rs
+++ b/tools/gen_config_docs/src/main.rs
@@ -117,7 +117,9 @@ fn extract_doc(attrs: &[syn::Attribute]) -> String {
 fn simplify_type(ty: &Type) -> String {
     match ty {
         Type::Path(p) => {
-            let seg = p.path.segments.last().unwrap();
+            let Some(seg) = p.path.segments.last() else {
+                return "—".to_string();
+            };
             let name = seg.ident.to_string();
             if name == "Option" {
                 if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
@@ -155,8 +157,9 @@ fn extract_default(doc: &str) -> String {
         }
     }
     // "(default: X)"
-    if let Some(pos) = lower.find("(default: ") {
-        let after = &doc[pos + 10..];
+    const PAREN_DEFAULT: &str = "(default: ";
+    if let Some(pos) = lower.find(PAREN_DEFAULT) {
+        let after = &doc[pos + PAREN_DEFAULT.len()..];
         let val = cut_value(after);
         if !val.is_empty() {
             return val;

--- a/tools/gen_config_docs/src/main.rs
+++ b/tools/gen_config_docs/src/main.rs
@@ -1,0 +1,440 @@
+//! Generates website/src/content/docs/config.md from serde config structs.
+//! Usage: cargo run -p gen_config_docs > website/src/content/docs/config.md
+
+use std::collections::HashMap;
+use syn::{Fields, File, Item, ItemStruct, Type};
+
+struct FieldInfo {
+    name: String,
+    ty: String,
+    default: String,
+    doc: String,
+}
+
+struct StructInfo {
+    name: String,
+    fields: Vec<FieldInfo>,
+}
+
+fn main() {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let config_src = std::path::Path::new(manifest_dir).join("../../src/config/mod.rs");
+    let default_config =
+        std::path::Path::new(manifest_dir).join("../../scripts/default-config.toml");
+
+    let source = std::fs::read_to_string(&config_src)
+        .unwrap_or_else(|e| panic!("read {}: {e}", config_src.display()));
+    let default_toml = std::fs::read_to_string(&default_config)
+        .unwrap_or_else(|e| panic!("read {}: {e}", default_config.display()));
+
+    let file: File = syn::parse_str(&source).expect("parse src/config/mod.rs");
+
+    let structs: HashMap<String, StructInfo> = file
+        .items
+        .iter()
+        .filter_map(|item| {
+            if let Item::Struct(s) = item {
+                if derives_deserialize(s) {
+                    let info = extract_struct(s);
+                    Some((info.name.clone(), info))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    emit_doc(&structs, &default_toml);
+}
+
+fn derives_deserialize(s: &ItemStruct) -> bool {
+    s.attrs.iter().any(|attr| {
+        if attr.path().is_ident("derive") {
+            if let syn::Meta::List(list) = &attr.meta {
+                list.tokens.to_string().contains("Deserialize")
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    })
+}
+
+fn extract_struct(s: &ItemStruct) -> StructInfo {
+    let fields = if let Fields::Named(named) = &s.fields {
+        named
+            .named
+            .iter()
+            .map(|f| {
+                let name = f.ident.as_ref().unwrap().to_string();
+                let ty = simplify_type(&f.ty);
+                let doc = extract_doc(&f.attrs);
+                let default = extract_default(&doc);
+                FieldInfo {
+                    name,
+                    ty,
+                    default,
+                    doc,
+                }
+            })
+            .collect()
+    } else {
+        vec![]
+    };
+
+    StructInfo {
+        name: s.ident.to_string(),
+        fields,
+    }
+}
+
+fn extract_doc(attrs: &[syn::Attribute]) -> String {
+    attrs
+        .iter()
+        .filter_map(|attr| {
+            if attr.path().is_ident("doc") {
+                if let syn::Meta::NameValue(nv) = &attr.meta {
+                    if let syn::Expr::Lit(lit) = &nv.value {
+                        if let syn::Lit::Str(s) = &lit.lit {
+                            let v = s.value();
+                            let trimmed = v.trim().to_string();
+                            if !trimmed.is_empty() {
+                                return Some(trimmed);
+                            }
+                        }
+                    }
+                }
+            }
+            None
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn simplify_type(ty: &Type) -> String {
+    match ty {
+        Type::Path(p) => {
+            let seg = p.path.segments.last().unwrap();
+            let name = seg.ident.to_string();
+            if name == "Option" {
+                if let syn::PathArguments::AngleBracketed(args) = &seg.arguments {
+                    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                        return simplify_type(inner);
+                    }
+                }
+            }
+            match name.as_str() {
+                "bool" => "bool".to_string(),
+                "String" => "string".to_string(),
+                "f32" | "f64" => "float".to_string(),
+                "u32" | "u64" | "usize" => "integer".to_string(),
+                "HashMap" => "table".to_string(),
+                _ => name,
+            }
+        }
+        _ => "—".to_string(),
+    }
+}
+
+fn extract_default(doc: &str) -> String {
+    if doc.is_empty() {
+        return "—".to_string();
+    }
+    let lower = doc.to_lowercase();
+    let prefixes = ["default: ", "defaults to ", "; default ", ". default "];
+    for prefix in &prefixes {
+        if let Some(pos) = lower.find(prefix) {
+            let after = &doc[pos + prefix.len()..];
+            let val = cut_value(after);
+            if !val.is_empty() {
+                return val;
+            }
+        }
+    }
+    // "(default: X)"
+    if let Some(pos) = lower.find("(default: ") {
+        let after = &doc[pos + 10..];
+        let val = cut_value(after);
+        if !val.is_empty() {
+            return val;
+        }
+    }
+    "—".to_string()
+}
+
+fn cut_value(after: &str) -> String {
+    // Stop at the first sentence-ending or clause-starting punctuation.
+    let mut end = after.len();
+    for stop in [" (", " —"] {
+        if let Some(p) = after.find(stop) {
+            end = end.min(p);
+        }
+    }
+    for c in [';', ')', '\n'] {
+        if let Some(p) = after.find(c) {
+            end = end.min(p);
+        }
+    }
+    // Stop at '.' only when NOT a decimal point (digit follows).
+    let bytes = after.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        if i >= end {
+            break;
+        }
+        if b == b'.' && !matches!(bytes.get(i + 1), Some(b'0'..=b'9')) {
+            end = end.min(i);
+            break;
+        }
+    }
+    after[..end].trim().to_string()
+}
+
+fn emit_table(fields: &[FieldInfo]) {
+    println!("| Field | Type | Default | Description |");
+    println!("|---|---|---|---|");
+    for f in fields {
+        let doc = if f.doc.is_empty() { "—" } else { &f.doc };
+        println!("| `{}` | {} | {} | {} |", f.name, f.ty, f.default, doc);
+    }
+    println!();
+}
+
+fn emit_doc(structs: &HashMap<String, StructInfo>, default_toml: &str) {
+    // ── Frontmatter ─────────────────────────────────────────────────────────
+    print!(
+        r#"---
+title: Configuration
+description: Edit config.toml, choose a theme, wire AI models, and override shortcuts.
+order: 2
+---
+
+Plexi reads `config.toml` from the active channel profile. Alpha uses `~/.plexi-alpha/config.toml`, beta uses `~/.plexi-beta/config.toml`, main uses `~/.plexi/config.toml`, and PR builds use `~/.plexi-pr-<N>/config.toml`.
+
+Changes take effect on the next launch unless a command says otherwise.
+
+## Channel discipline
+
+Alpha config stays default. `just install` refreshes `~/.plexi-alpha/config.toml` from the built-in template, and PR builds seed from alpha. Do not use alpha for personal overrides you expect to keep.
+
+Beta config is the staging ground. `~/.plexi-beta/config.toml` is not reset by alpha installs, so it is the right place to test migrations, advanced settings, and personal config before promoting a release.
+
+PR builds are isolated. A PR build reads `~/.plexi-pr-<N>/config.toml`; use the `plexi-pr-<N>` binary when checking a PR-specific config behavior.
+
+## Commands
+
+```sh
+plexi config edit
+plexi config check
+plexi config reset
+```
+
+`config edit` opens the active channel config. `config check` validates known keys and TOML syntax. `config reset` backs up the current file to `config.toml.bak`, then writes the built-in default template.
+
+## Reference
+
+### Top-level (`config.toml`)
+
+"#
+    );
+
+    // Top-level scalar fields (skip subsection keys)
+    const SKIP_TOPLEVEL: &[&str] = &[
+        "theme",
+        "effects",
+        "log",
+        "notifications",
+        "ai",
+        "keybindings",
+        "agents",
+        "cli",
+        "marketplace",
+        "file_handlers",
+    ];
+    if let Some(s) = structs.get("PlexiConfig") {
+        let scalar: Vec<&FieldInfo> = s
+            .fields
+            .iter()
+            .filter(|f| !SKIP_TOPLEVEL.contains(&f.name.as_str()))
+            .collect();
+        emit_table_refs(&scalar);
+    }
+
+    // ── Theme ────────────────────────────────────────────────────────────────
+    print!(
+        r#"### Theme (`[theme]`)
+
+Pick a preset and optionally override individual colors. Individual color fields override preset values when both are set.
+
+Available presets: `catppuccin-mocha`, `catppuccin-latte`, `dracula`, `tokyo-night`, `tokyo-day`, `gruvbox-dark`, `gruvbox-light`, `nord`, `solarized-dark`, `solarized-light`, `matrix`, `bios`, `plexi-night`, `plexi-day`.
+
+"#
+    );
+    if let Some(s) = structs.get("ThemeConfig") {
+        emit_table(&s.fields);
+    }
+
+    // ── Effects ──────────────────────────────────────────────────────────────
+    println!("### Effects (`[effects]`)\n");
+    if let Some(s) = structs.get("EffectsConfig") {
+        emit_table(&s.fields);
+    }
+
+    // ── Log ──────────────────────────────────────────────────────────────────
+    print!(
+        r#"### Log (`[log]`)
+
+`level` accepts `error`, `warn`, `info`, or `debug`. Applies live on config save — no restart required.
+
+"#
+    );
+    if let Some(s) = structs.get("LogConfig") {
+        emit_table(&s.fields);
+    }
+
+    // ── Notifications ────────────────────────────────────────────────────────
+    print!(
+        r#"### Notifications (`[notifications]`)
+
+`interrupt_threshold` maps to named priority levels: `0` = LOW, `50` = NORMAL, `100` = HIGH, `200` = CRITICAL. Notifications below the threshold queue silently; at or above it, arrival opens the modal.
+
+"#
+    );
+    if let Some(s) = structs.get("NotificationsConfig") {
+        emit_table(&s.fields);
+    }
+
+    // ── AI ───────────────────────────────────────────────────────────────────
+    print!(
+        r#"### AI (`[ai]`)
+
+API keys are NOT stored in `config.toml`. Export `OPENROUTER_API_KEY` in your shell profile (`~/.zshrc`, `~/.zprofile`, etc.), or store it in the Plexi secret store:
+
+```sh
+plexi secret set openrouter-api-key --global
+```
+
+"#
+    );
+    if let Some(s) = structs.get("AiConfig") {
+        let scalar: Vec<&FieldInfo> = s
+            .fields
+            .iter()
+            .filter(|f| f.name != "openrouter" && f.name != "ollama")
+            .collect();
+        emit_table_refs(&scalar);
+    }
+
+    println!("#### OpenRouter (`[ai.openrouter]`)\n");
+    if let Some(s) = structs.get("OpenRouterBackendConfig") {
+        emit_table(&s.fields);
+    }
+
+    println!("#### Ollama (`[ai.ollama]`)\n");
+    if let Some(s) = structs.get("OllamaBackendConfig") {
+        emit_table(&s.fields);
+    }
+
+    // ── Agents ───────────────────────────────────────────────────────────────
+    print!(
+        r#"### Agents (`[agents]`)
+
+Command templates for dispatching coding agents. `{{cmd}}` is replaced with the prompt or slash command at dispatch time.
+
+"#
+    );
+    if let Some(s) = structs.get("AgentsConfig") {
+        emit_table(&s.fields);
+    }
+
+    // ── Keybindings ──────────────────────────────────────────────────────────
+    print!(
+        r#"### Keybindings (`[keybindings]`)
+
+Override only the shortcuts you want to change. Unknown or conflicting overrides log a warning at startup and keep the default binding.
+
+Modifier keys: `cmd` (alias: `command`), `shift`, `ctrl` (alias: `control`), `alt` (aliases: `opt`, `option`).
+
+Key names: `a`–`z`, `0`–`9`, `enter`, `escape`, `tab`, `space`, `backspace`, `delete`, `up`, `down`, `left`, `right`, `open_bracket`, `close_bracket`, `backslash`, `slash`, `comma`, `period`, `equals`, `minus`.
+
+Each value is a string like `"cmd+p"` or `"cmd+shift+w"`.
+
+"#
+    );
+    if let Some(s) = structs.get("KeybindingsConfig") {
+        println!("| Action | Description |");
+        println!("|---|---|");
+        for f in &s.fields {
+            let desc = if f.doc.is_empty() {
+                human_action_name(&f.name)
+            } else {
+                f.doc.clone()
+            };
+            println!("| `{}` | {} |", f.name, desc);
+        }
+        println!();
+    }
+
+    // ── CLI ──────────────────────────────────────────────────────────────────
+    println!("### CLI (`[cli]`)\n");
+    if let Some(s) = structs.get("CliConfig") {
+        emit_table(&s.fields);
+    }
+
+    // ── File handlers ────────────────────────────────────────────────────────
+    print!(
+        r#"### File handlers (`[file_handlers]`)
+
+Choose which app opens each file type from the File Explorer. Keys are bare lowercase extensions (e.g. `md`, not `.md`). Values are handler specs:
+
+| Value | Behavior |
+|---|---|
+| `app:<id>` | Open in a Plexi app by its registry id (e.g. `app:text-editor`) |
+| `os` | Hand to the OS default opener (`open` / `xdg-open`) |
+| `cmd:<command>` | Reserved; falls back to `os` until wired |
+
+A handler here overrides an app's own `file_types` association. Unmapped extensions fall through to manifest associations, then builtin media players, then the OS default.
+
+"#
+    );
+
+    // ── Marketplace ──────────────────────────────────────────────────────────
+    print!(
+        r#"### Marketplace (`[marketplace]`)
+
+All fields are optional. Omitting the section uses the official `plexiapp.com` registry and CDN. Override only to point at a private registry or to test publishing flows.
+
+"#
+    );
+    if let Some(s) = structs.get("MarketplaceConfig") {
+        emit_table(&s.fields);
+    }
+
+    // ── Default config.toml ──────────────────────────────────────────────────
+    println!("## Default config.toml\n");
+    println!(
+        "This is the built-in template Plexi writes when it creates or resets the active channel config.\n"
+    );
+    println!("```toml");
+    print!("{default_toml}");
+    if !default_toml.ends_with('\n') {
+        println!();
+    }
+    println!("```");
+}
+
+fn emit_table_refs(fields: &[&FieldInfo]) {
+    println!("| Field | Type | Default | Description |");
+    println!("|---|---|---|---|");
+    for f in fields {
+        let doc = if f.doc.is_empty() { "—" } else { &f.doc };
+        println!("| `{}` | {} | {} | {} |", f.name, f.ty, f.default, doc);
+    }
+    println!();
+}
+
+fn human_action_name(action: &str) -> String {
+    action.replace('_', " ")
+}

--- a/website/src/content/docs/config.md
+++ b/website/src/content/docs/config.md
@@ -26,107 +26,236 @@ plexi config reset
 
 `config edit` opens the active channel config. `config check` validates known keys and TOML syntax. `config reset` backs up the current file to `config.toml.bak`, then writes the built-in default template.
 
-## Theme
+## Reference
 
-Pick a preset and optionally override individual colors under `[theme]`:
+### Top-level (`config.toml`)
 
-```toml
-[theme]
-preset       = "catppuccin-mocha"
-accent       = "#89b4fa"
-terminal_bg  = "#292a44"
-text_primary = "#cdd6f4"
-```
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `config_version` | integer | — | — |
+| `font_size` | float | — | — |
+| `pane_gap` | float | 4.0 | Inter-pane gap width in pixels. Default: 4.0. Clamped to [0.0, 20.0]. |
+| `pane_title_font_size` | float | 11.0 | Pane title bar font size. Default: 11.0. Clamped to [6.0, 32.0]. |
+| `osc_pane_title` | bool | true | Apply OSC 0/1/2 title sequences from terminal processes as pane names. Defaults to true; set false to keep terminal pane names manual-only. |
+| `theme_preset` | string | — | — |
+| `confirm_quit` | bool | true | Set to false to quit immediately on Cmd+Q without triple-press confirmation (default: true). |
+| `confirm_close` | bool | true | Set to false to close panes immediately on Cmd+W without a confirmation dialog (default: true). |
+| `confirm_context_close` | bool | true | Set to false to close contexts immediately on Cmd+Shift+W without a confirmation dialog (default: true). |
+| `focus_history_depth` | integer | — | — |
 
-Available presets: `catppuccin-mocha`, `catppuccin-latte`, `dracula`, `tokyo-night`, `tokyo-day`, `gruvbox-dark`, `gruvbox-light`, `nord`, `solarized-dark`, `solarized-light`.
+### Theme (`[theme]`)
 
-Known color keys: `bg_darkest`, `bg_sidebar`, `bg_toolbar`, `terminal_bg`, `bg_hover`, `bg_sidebar_hover`, `bg_active`, `text_primary`, `text_dim`, `text_section`, `accent`, `border`, `foreground`, `background`, `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, `bright_black`, `bright_red`, `bright_green`, `bright_yellow`, `bright_blue`, `bright_magenta`, `bright_cyan`, `bright_white`, `bright_foreground`.
+Pick a preset and optionally override individual colors. Individual color fields override preset values when both are set.
 
-## AI
+Available presets: `catppuccin-mocha`, `catppuccin-latte`, `dracula`, `tokyo-night`, `tokyo-day`, `gruvbox-dark`, `gruvbox-light`, `nord`, `solarized-dark`, `solarized-light`, `matrix`, `bios`, `plexi-night`, `plexi-day`.
 
-OpenRouter is the default cloud backend. Store the key in the global Plexi secret store:
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `preset` | string | — | Theme preset name. Applied first; individual color fields override the preset. |
+| `bg_darkest` | string | — | — |
+| `bg_sidebar` | string | — | — |
+| `bg_toolbar` | string | — | — |
+| `terminal_bg` | string | — | — |
+| `bg_hover` | string | — | — |
+| `bg_sidebar_hover` | string | — | — |
+| `bg_active` | string | — | — |
+| `text_primary` | string | — | — |
+| `text_dim` | string | — | — |
+| `text_section` | string | — | — |
+| `accent` | string | — | — |
+| `border` | string | — | — |
+| `foreground` | string | — | — |
+| `background` | string | — | — |
+| `black` | string | — | — |
+| `red` | string | — | — |
+| `green` | string | — | — |
+| `yellow` | string | — | — |
+| `blue` | string | — | — |
+| `magenta` | string | — | — |
+| `cyan` | string | — | — |
+| `white` | string | — | — |
+| `bright_black` | string | — | — |
+| `bright_red` | string | — | — |
+| `bright_green` | string | — | — |
+| `bright_yellow` | string | — | — |
+| `bright_blue` | string | — | — |
+| `bright_magenta` | string | — | — |
+| `bright_cyan` | string | — | — |
+| `bright_white` | string | — | — |
+| `bright_foreground` | string | — | — |
+| `pip_working` | string | — | — |
+| `pip_idle` | string | — | — |
+| `pip_blocked` | string | — | — |
+| `pip_dim` | float | — | — |
+
+### Effects (`[effects]`)
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `crt` | bool | — | — |
+| `ghost` | bool | — | — |
+| `ghost_opacity` | float | 0.75 | Opacity for unfocused panes when ghost is enabled. Range 0.0–1.0; default 0.75. Setting this implies ghost = true unless `ghost = false` is explicit. |
+
+### Log (`[log]`)
+
+`level` accepts `error`, `warn`, `info`, or `debug`. Applies live on config save — no restart required.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `level` | string | — | — |
+| `retention_days` | integer | — | — |
+
+### Notifications (`[notifications]`)
+
+`interrupt_threshold` maps to named priority levels: `0` = LOW, `50` = NORMAL, `100` = HIGH, `200` = CRITICAL. Notifications below the threshold queue silently; at or above it, arrival opens the modal.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | bool | true | Master switch. If false, incoming notifications are silently dropped — apps still send them, but the modal never appears and the queue stays empty. Defaults to true. |
+| `focus_mode` | bool | false | Focus mode. When true, NO notification auto-surfaces regardless of priority. Everything queues silently; the user reviews via Cmd+Shift+A. Defaults to false. |
+| `interrupt_threshold` | integer | 100 | Minimum priority that may auto-open the modal. Notifications below this value queue silently (badge ticks, Cmd+Shift+A reveals them). At or above it, arrival auto-opens the modal. Defaults to 100 (`PRIORITY_HIGH`) — NORMAL and LOW are passive; HIGH and CRITICAL interrupt. Set to 0 to auto-open everything; set to 201 to match `focus_mode = true`. |
+
+### AI (`[ai]`)
+
+API keys are NOT stored in `config.toml`. Export `OPENROUTER_API_KEY` in your shell profile (`~/.zshrc`, `~/.zprofile`, etc.), or store it in the Plexi secret store:
 
 ```sh
 plexi secret set openrouter-api-key --global
 ```
 
-The broker also reads `OPENROUTER_API_KEY` from the host process environment:
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `backend` | string | — | Backend selection: `"openrouter"` (default) or `"ollama"`. |
+| `per_app_daily_usd` | float | $1.00 | Per-app daily spend cap in USD. Default $1.00. |
+| `global_daily_usd` | float | $10.00 | Global daily spend cap across all apps in USD. Default $10.00. |
 
-```sh
-export OPENROUTER_API_KEY=...
-```
+#### OpenRouter (`[ai.openrouter]`)
 
-Do not paste API keys into `config.toml`.
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `api_key_env` | string | `OPENROUTER_API_KEY` | Environment variable name for the API key. Default: `OPENROUTER_API_KEY`. |
+| `model_low` | string | — | Low-tier model. e.g. "qwen/qwen3.6-flash" |
+| `model_medium` | string | — | Medium-tier model. e.g. "xiaomi/mimo-v2.5-pro" |
+| `model_high` | string | — | High-tier model. e.g. "anthropic/claude-fable-5" |
 
-```toml
-[ai]
-backend = "openrouter"
+#### Ollama (`[ai.ollama]`)
 
-[ai.openrouter]
-api_key_env  = "OPENROUTER_API_KEY"
-model_low    = "qwen/qwen3.6-flash"
-model_medium = "xiaomi/mimo-v2.5-pro"
-model_high   = "anthropic/claude-fable-5"
-```
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `host` | string | `http://localhost:11434` | Ollama host URL. Default: `http://localhost:11434`. |
+| `model_low` | string | — | Low-tier model. e.g. "llama3.2:3b" |
+| `model_medium` | string | — | Medium-tier model. e.g. "llama3.3:70b" |
+| `model_high` | string | — | High-tier model. e.g. "qwq:32b" |
 
-Use Ollama for local models:
+### Agents (`[agents]`)
 
-```toml
-[ai]
-backend = "ollama"
+Command templates for dispatching coding agents. `{cmd}` is replaced with the prompt or slash command at dispatch time.
 
-[ai.ollama]
-host         = "http://localhost:11434"
-model_low    = "llama3.2:3b"
-model_medium = "llama3.3:70b"
-model_high   = "qwq:32b"
-```
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `low` | string | claude haiku with --dangerously-skip-permissions | Fast/cheap tasks. Default: claude haiku with --dangerously-skip-permissions. |
+| `medium` | string | claude sonnet with --dangerously-skip-permissions | Standard work. Default: claude sonnet with --dangerously-skip-permissions. |
+| `high` | string | claude with --dangerously-skip-permissions | Complex/autonomous tasks. Default: claude with --dangerously-skip-permissions. |
 
-Optional AI spend caps:
+### Keybindings (`[keybindings]`)
 
-```toml
-[ai]
-per_app_daily_usd = 1.00
-global_daily_usd  = 10.00
-```
+Override only the shortcuts you want to change. Unknown or conflicting overrides log a warning at startup and keep the default binding.
 
-## Keybindings
+Modifier keys: `cmd` (alias: `command`), `shift`, `ctrl` (alias: `control`), `alt` (aliases: `opt`, `option`).
 
-Add only the shortcuts you want to override:
+Key names: `a`–`z`, `0`–`9`, `enter`, `escape`, `tab`, `space`, `backspace`, `delete`, `up`, `down`, `left`, `right`, `open_bracket`, `close_bracket`, `backslash`, `slash`, `comma`, `period`, `equals`, `minus`.
 
-```toml
-[keybindings]
-toggle_command_palette = "cmd+p"
-open_config            = "cmd+comma"
-```
+Each value is a string like `"cmd+p"` or `"cmd+shift+w"`.
 
-Modifiers: `cmd`, `shift`, `ctrl`, `alt`. Aliases: `command`, `control`, `opt`, `option`.
+| Action | Description |
+|---|---|
+| `quit` | quit |
+| `close_pane` | close pane |
+| `toggle_command_palette` | toggle command palette |
+| `split_horizontal` | split horizontal |
+| `split_vertical` | split vertical |
+| `split_right` | split right |
+| `split_down` | split down |
+| `swap_pane_left` | swap pane left |
+| `swap_pane_down` | swap pane down |
+| `swap_pane_up` | swap pane up |
+| `swap_pane_right` | swap pane right |
+| `send_pane_left` | send pane left |
+| `send_pane_down` | send pane down |
+| `send_pane_up` | send pane up |
+| `send_pane_right` | send pane right |
+| `navigate_left` | navigate left |
+| `navigate_down` | navigate down |
+| `navigate_up` | navigate up |
+| `navigate_right` | navigate right |
+| `new_tab` | new tab |
+| `next_tab` | next tab |
+| `prev_tab` | prev tab |
+| `next_context` | next context |
+| `prev_context` | prev context |
+| `move_context_up` | move context up |
+| `move_context_down` | move context down |
+| `nav_back` | nav back |
+| `focus_history_forward` | focus history forward |
+| `toggle_sidebar` | toggle sidebar |
+| `toggle_zoom` | toggle zoom |
+| `toggle_shortcuts` | toggle shortcuts |
+| `rename_context` | rename context |
+| `rename_pane` | rename pane |
+| `new_context` | new context |
+| `new_page_right` | new page right |
+| `toggle_minimap` | toggle minimap |
+| `scroll_up` | scroll up |
+| `scroll_down` | scroll down |
+| `increase_font_size` | increase font size |
+| `decrease_font_size` | decrease font size |
+| `open_file_browser` | open file browser |
+| `open_quick_note` | open quick note |
+| `open_config` | open config |
+| `reload_config` | reload config |
+| `open_secrets_manager` | open secrets manager |
+| `open_assistant` | open assistant |
+| `force_reload_app` | force reload app |
+| `toggle_notification_modal` | toggle notification modal |
+| `open_scratchpad` | open scratchpad |
+| `push_to_subcontext` | push to subcontext |
+| `new_child_context` | new child context |
+| `set_context_root_from_cwd` | set context root from cwd |
+| `hide_pane` | hide pane |
+| `park_context` | park context |
+| `open_notes_picker` | open notes picker |
+| `close_context` | close context |
 
-Keys: `a-z`, `0-9`, `enter`, `escape`, `tab`, `space`, `backspace`, `delete`, `up`, `down`, `left`, `right`, `open_bracket`, `close_bracket`, `backslash`, `slash`, `comma`, `period`, `equals`, `minus`.
+### CLI (`[cli]`)
 
-Known actions: `quit`, `close_pane`, `toggle_command_palette`, `split_horizontal`, `split_vertical`, `split_right`, `split_down`, `swap_pane_left`, `swap_pane_down`, `swap_pane_up`, `swap_pane_right`, `send_pane_left`, `send_pane_down`, `send_pane_up`, `send_pane_right`, `navigate_left`, `navigate_down`, `navigate_up`, `navigate_right`, `new_tab`, `next_tab`, `prev_tab`, `next_context`, `prev_context`, `move_context_up`, `move_context_down`, `nav_back`, `focus_history_forward`, `toggle_sidebar`, `toggle_zoom`, `toggle_shortcuts`, `rename_context`, `rename_pane`, `new_context`, `new_page_right`, `toggle_minimap`, `scroll_up`, `scroll_down`, `increase_font_size`, `decrease_font_size`, `open_file_browser`, `open_quick_note`, `open_config`, `reload_config`, `open_secrets_manager`, `open_assistant`, `force_reload_app`, `toggle_notification_modal`, `open_scratchpad`, `push_to_subcontext`, `new_child_context`, `set_context_root_from_cwd`, `hide_pane`, `park_context`, `open_notes_picker`, `close_context`.
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `tips` | bool | `true` | Print contextual tips after CLI commands. Default: `true`. Set to `false` to suppress. |
 
-Unknown keys or conflicting overrides log a warning at startup and keep the default binding.
+### File handlers (`[file_handlers]`)
 
-## Notifications
+Choose which app opens each file type from the File Explorer. Keys are bare lowercase extensions (e.g. `md`, not `.md`). Values are handler specs:
 
-```toml
-[notifications]
-enabled = true
-focus_mode = false
-interrupt_threshold = 100
-```
+| Value | Behavior |
+|---|---|
+| `app:<id>` | Open in a Plexi app by its registry id (e.g. `app:text-editor`) |
+| `os` | Hand to the OS default opener (`open` / `xdg-open`) |
+| `cmd:<command>` | Reserved; falls back to `os` until wired |
 
-`interrupt_threshold` controls which app notifications open the modal immediately. `100` means high and critical notifications interrupt; normal and low notifications queue silently.
+A handler here overrides an app's own `file_types` association. Unmapped extensions fall through to manifest associations, then builtin media players, then the OS default.
 
-## CLI
+### Marketplace (`[marketplace]`)
 
-```toml
-[cli]
-tips = true
-```
+All fields are optional. Omitting the section uses the official `plexiapp.com` registry and CDN. Override only to point at a private registry or to test publishing flows.
 
-Set `tips = false` to hide contextual tips after CLI commands.
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `registry_url` | string | official `plexiapp | Override the catalog index URL. Default: official `plexiapp.com` index. |
+| `cdn_url` | string | official `plexiapp | Override the package CDN base. Default: official `plexiapp.com` CDN. |
+| `submit_url` | string | — | Publisher submission endpoint. Unset = publishing prepared locally but not uploaded (fails closed with a clear message). |
+| `payment_backend` | string | — | Payment backend selector. Unset / `"none"` = stub (paid installs fail closed). A real provider (e.g. `"stripe"`) slots into `crate::app::marketplace::payment_provider()` keyed on this value. |
+| `account_backend` | string | — | Account/auth backend selector. Unset / `"none"` = stub (login/signup fail closed). A real provider slots into `crate::app::account::account_provider()` keyed on this value. |
+| `account_email` | string | — | Default email pre-filled by `plexi account login`. Unset = prompt. |
 
 ## Default config.toml
 
@@ -151,7 +280,7 @@ osc_pane_title = true
 
 [theme]
 preset = "catppuccin-mocha"
-# Presets: catppuccin-mocha, catppuccin-latte, dracula, tokyo-night, tokyo-day, gruvbox-dark, gruvbox-light, nord, solarized-dark, solarized-light
+# Presets: catppuccin-mocha, catppuccin-latte, dracula, tokyo-night, tokyo-day, gruvbox-dark, gruvbox-light, nord, solarized-dark, solarized-light, matrix, bios, plexi-night, plexi-day
 # Uncomment to override individual colors:
 # accent       = "#89b4fa"
 # bg_darkest   = "#11111b"
@@ -200,6 +329,19 @@ high   = "claude --dangerously-skip-permissions '{cmd}'"
 
 [cli]
 tips = true
+
+# [file_handlers]
+# Choose which app opens each file type from the File Explorer (Enter / double-
+# click). Keys are bare, lowercase extensions; values are `kind:value` specs:
+#   "app:<id>"      open in a Plexi app by its registry id (e.g. text-editor)
+#   "os"            hand to the OS default opener (open / xdg-open)
+#   "cmd:<command>" reserved for a future release; falls back to "os" for now
+# A handler here overrides an app's own file_types association. Unmapped types
+# fall through to manifest associations, then builtin media players, then the OS.
+# md   = "app:text-editor"
+# txt  = "app:text-editor"
+# json = "app:text-editor"
+# py   = "os"
 
 # [marketplace]
 # Hosted app catalog + CDN. Defaults point at the official plexiapp.com registry,


### PR DESCRIPTION
## Summary

- Adds `tools/gen_config_docs` crate that parses `src/config/mod.rs` with `syn` and emits `website/src/content/docs/config.md` with a table per section (field, type, default, description)
- Replaces the hand-written config docs page with a generated one; defaults and descriptions are extracted directly from doc comments on struct fields
- Adds `just gen-config-docs` / `just check-config-docs` recipes, wires into `check-docs` and `regen-if-stale`, and adds `.github/workflows/check-config-docs.yml` CI freshness check

## Done When

- `cargo run -p gen_config_docs` produces a valid `config.md`
- `just check-config-docs` exits 0 when docs are fresh
- CI fails when `src/config/mod.rs` changes without regenerating the docs