### PR TITLE
implement-stint: two-phase sub-agent pattern (stint 0186)

### DIFF
--- a/.agents/skills/implement-stint/SKILL.md
+++ b/.agents/skills/implement-stint/SKILL.md
@@ -244,10 +244,17 @@ Spawn **Sub-agent I** with the spec from Phase 3 and the worktree path. Sub-agen
 > - Write tests before implementation for host logic. New `AppRequest` or `HostEffect` behavior needs a `HostHarness` test first.
 > - Always run `cargo build` after edits.
 > - Run the narrower relevant test command: `cargo test --bin plexi <test_name>` (adjust filter as needed).
-- After tests pass, run a Codex review against alpha (maximum 2 runs; iterate on findings between runs):
+- After tests pass, run a Codex review against alpha (maximum 2 runs; iterate on findings between runs). Write output to a tmp file; only read it if findings are present:
 >   ```bash
+>   CODEX_OUT="/tmp/plexi-codex-review-$$.txt"
 >   codex review -c model_reasoning_effort=low --base alpha \
->     "Review this diff for correctness bugs, unsafe patterns, missed error handling, and clear simplification opportunities. Do not flag style or cosmetic issues. Reply with a concise bulleted findings list referencing file and line, or 'No issues found.' if clean."
+>     "Review this diff for correctness bugs, unsafe patterns, missed error handling, and clear simplification opportunities. Do not flag style or cosmetic issues. Reply with a concise bulleted findings list referencing file and line, or 'No issues found.' if clean." \
+>     > "$CODEX_OUT" 2>&1 || true
+>   if grep -qi "no issues found" "$CODEX_OUT"; then
+>     CODEX_VERDICT="clean"
+>   else
+>     CODEX_VERDICT=$(tail -80 "$CODEX_OUT")
+>   fi
 >   ```
 > - Stage all changes with `git add <files>`. Do NOT commit — the orchestrator commits.
 > - Return a summary in this format:

--- a/.agents/skills/implement-stint/SKILL.md
+++ b/.agents/skills/implement-stint/SKILL.md
@@ -189,55 +189,77 @@ If the implementation worktree already exists:
 - Keep setup reads short: `status --short --branch`, `diff --stat`, and targeted `rg` before full diffs or issue bodies.
 - Continue implementation in the existing worktree.
 
-## Phase 3 - Formulate
+## Phase 3 - Research (Sub-agent R)
 
-Read the task body first. If it links a GitHub issue, use the status/title/labels already fetched during setup. Fetch the issue body only if the task file is not enough to implement from.
+Spawn a **read-only** sub-agent. Its only job is to produce the implementation spec; it must not edit any file.
 
-Before editing code, produce a short implementation spec in context:
+**Prompt to Sub-agent R:**
 
-```text
-Task: <task-id> <title>
-Linked issue: #<n> or none
-Files to change:
-  - <path>: <what changes>
-Files not to touch:
-  - <path>: <why out of scope>
-Test that must pass:
-  - <command>
-Invariants:
-  - <from task, PRM, GOTCHAS.md, AGENTS.md>
-Logging plan:
-  - <new info/warn/error traces required by AGENTS.md>
-```
+> You are Sub-agent R for stint task `<task-id>`: `<title>`.
+> Worktree: `<worktree-path>`
+> Task body: `<paste full task body>`
+> Linked issue body (if any): `<paste or "none">`
+>
+> Your output is a structured implementation spec in exactly this format — nothing else:
+>
+> ```text
+> Task: <task-id> <title>
+> Linked issue: #<n> or none
+> Files to change:
+>   - <path>: <what changes>
+> Files not to touch:
+>   - <path>: <why out of scope>
+> Test that must pass:
+>   - <command>
+> Invariants:
+>   - <from task, CLAUDE.md, AGENTS.md>
+> Logging plan:
+>   - <new info/warn/error traces required by AGENTS.md>
+> ```
+>
+> Rules:
+> - Read `.agents/skills/implement-stint/SKILL.md` lines 1-50 for invariants.
+> - If the task or issue names exact files/functions, verify them with `rg`/`git ls-files` first.
+> - Short-circuit: if the task body already contains an explicit file+line implementation map, reformat it into the spec structure above without further discovery.
+> - For File Explorer work, read `src/ui/AGENTS.md` first.
+> - For app-framework, packaging, marketplace, MCPUI, WASM/WASI, or Bevy work, read `docs/app-framework-marketplace.md` first.
+> - For architectural choices, read `NORTH_STAR.md` and `GLOSSARY.md`.
+> - Do NOT edit any file. Return only the spec.
 
-If the task or linked issue names exact files/functions, verify them cheaply with `rg`/`git ls-files` before broad discovery. If they do not, do the narrowest search that identifies the owning code.
+Receive the spec from Sub-agent R. If it is missing any required field, ask Sub-agent R to fill the gap before proceeding to Phase 4.
 
-For File Explorer work, read `src/ui/AGENTS.md` first, then `.stint/sprints/s1.md`.
+## Phase 4 - Implement (Sub-agent I)
 
-For app-framework, packaging, marketplace, MCPUI, WASM/WASI, or Bevy work, read `docs/app-framework-marketplace.md` first.
+Spawn **Sub-agent I** with the spec from Phase 3 and the worktree path. Sub-agent I owns all edits, tests, and the Gemini review loop. It must NOT commit.
 
-For architectural choices, read `NORTH_STAR.md` and `GLOSSARY.md`.
+**Prompt to Sub-agent I:**
 
-## Phase 4 - Implement
+> You are Sub-agent I for stint task `<task-id>`: `<title>`.
+> Worktree: `<worktree-path>`
+>
+> Implementation spec:
+> `<paste spec from Sub-agent R>`
+>
+> Rules:
+> - Write tests before implementation for host logic. New `AppRequest` or `HostEffect` behavior needs a `HostHarness` test first.
+> - Always run `cargo build` after edits.
+> - Run the narrower relevant test command: `cargo test --bin plexi <test_name>` (adjust filter as needed).
+> - After tests pass, run the `/code-review` skill (or equivalent Gemini diff review) on the staged diff. Maximum 2 review runs per validation attempt. Iterate on findings internally between runs.
+> - Stage all changes with `git add <files>`. Do NOT commit — the orchestrator commits.
+> - Return a summary in this format:
+>
+> ```text
+> Files changed: <list>
+> Test results: <N passed, M failed — command used>
+> Gemini verdict: clean | findings remaining: <list>
+> Staged: yes
+> ```
+>
+> If Gemini still has unresolved findings after 2 runs, include them in the `findings remaining` field — do not block; just report.
 
-Write tests before implementation for host logic. New `AppRequest` or `HostEffect` behavior needs a `HostHarness` test first.
+Receive the summary from Sub-agent I.
 
-Scope gate:
-
-- 3 files or fewer: implement inline.
-- More than 3 files or multiple subsystems: dispatch a subagent with the task body, linked issue body, implementation spec, worktree path, and the rule: stage changes but do not commit.
-
-Always run at least:
-
-```bash
-cargo build
-```
-
-Run the narrower relevant test command too, usually:
-
-```bash
-cargo test --bin plexi <test_name>
-```
+**Orchestrator diff review:** Run `git -C <worktree-path> diff --staged --stat` and spot-check the diff before committing. If Sub-agent I reported unresolved Gemini findings, surface them to the user and ask whether to proceed or iterate.
 
 Then run the `/testing` skill (`.agents/skills/testing/SKILL.md`) to produce the `**Test evidence:**` block — diff classification, harness tests, headless render screenshots for visual changes. Include the block in the Ship Log entry (or PR body when no issue is linked) during handoff.
 

--- a/.agents/skills/implement-stint/SKILL.md
+++ b/.agents/skills/implement-stint/SKILL.md
@@ -244,22 +244,26 @@ Spawn **Sub-agent I** with the spec from Phase 3 and the worktree path. Sub-agen
 > - Write tests before implementation for host logic. New `AppRequest` or `HostEffect` behavior needs a `HostHarness` test first.
 > - Always run `cargo build` after edits.
 > - Run the narrower relevant test command: `cargo test --bin plexi <test_name>` (adjust filter as needed).
-> - After tests pass, run the `/code-review` skill (or equivalent Gemini diff review) on the staged diff. Maximum 2 review runs per validation attempt. Iterate on findings internally between runs.
+- After tests pass, run a Codex review against alpha (maximum 2 runs; iterate on findings between runs):
+>   ```bash
+>   codex review -c model_reasoning_effort=low --base alpha \
+>     "Review this diff for correctness bugs, unsafe patterns, missed error handling, and clear simplification opportunities. Do not flag style or cosmetic issues. Reply with a concise bulleted findings list referencing file and line, or 'No issues found.' if clean."
+>   ```
 > - Stage all changes with `git add <files>`. Do NOT commit — the orchestrator commits.
 > - Return a summary in this format:
 >
 > ```text
 > Files changed: <list>
 > Test results: <N passed, M failed — command used>
-> Gemini verdict: clean | findings remaining: <list>
+> Codex verdict: clean | findings remaining: <list>
 > Staged: yes
 > ```
 >
-> If Gemini still has unresolved findings after 2 runs, include them in the `findings remaining` field — do not block; just report.
+> If Codex still has unresolved findings after 2 runs, include them in the `findings remaining` field — do not block; just report.
 
 Receive the summary from Sub-agent I.
 
-**Orchestrator diff review:** Run `git -C <worktree-path> diff --staged --stat` and spot-check the diff before committing. If Sub-agent I reported unresolved Gemini findings, surface them to the user and ask whether to proceed or iterate.
+**Orchestrator diff review:** Run `git -C <worktree-path> diff --staged --stat` and spot-check the diff before committing. If Sub-agent I reported unresolved Codex findings, surface them to the user and ask whether to proceed or iterate.
 
 Then run the `/testing` skill (`.agents/skills/testing/SKILL.md`) to produce the `**Test evidence:**` block — diff classification, harness tests, headless render screenshots for visual changes. Include the block in the Ship Log entry (or PR body when no issue is linked) during handoff.
 


### PR DESCRIPTION
No linked GitHub issue — see stint task 0186.

## Summary

- Replaces the inline Formulate phase with **Sub-agent R** (read-only research) that returns a structured impl spec
- Replaces the inline Implement phase with **Sub-agent I** (edits + cargo build/test + Gemini review loop, max 2 runs, stages but never commits)
- Orchestrator reviews the staged diff before committing; surfaces any unresolved Gemini findings to the user

## Done When

- `/implement-stint` Phase 3 spawns Sub-agent R and uses its output as the impl spec
- `/implement-stint` Phase 4 spawns Sub-agent I which handles edits + Gemini loop internally
- Orchestrator reviews diff and commits (never Sub-agent I)
- All existing implement-stint invariants preserved (claim commit, worktree base check, pane naming, etc.)