### PR TITLE
chore: dependency audit and cleanup (stint 0271)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,7 +859,6 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde",
  "wasm-bindgen",
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ egui_term = { path = "deps/egui_term" }
 dirs = "6"
 fern = "0.7"
 log = "0.4"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = "0.4"
 schemars = { version = "1", features = ["derive"] }
-serde = { version = "1", features = ["derive", "rc"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 toml_edit = "0.22"


### PR DESCRIPTION
Stint task 0271 — dependency audit and cleanup.

## Summary

- Ran `cargo-machete`: zero unused top-level dependencies
- Removed unused `serde` feature from `chrono` (no `DateTime` fields are serialized anywhere in the codebase)
- Removed unused `rc` feature from `serde` (no `Rc<T>` types are serialized anywhere)
- Audited version duplicates in `Cargo.lock`: all 62 duplicates are transitive from external crates (wasmtime, eframe/winit, proc-macro-crate) and cannot be collapsed from our side

## Done When

- [ ] `cargo build` green
- [ ] `cargo test --bin plexi` green (pre-existing failure in `notes_picker_refuses_to_delete_open_text_editor_note` is on alpha too — unrelated)
- [ ] `Cargo.toml` feature flags reflect actual usage