### PR TITLE
fix: palette scroll position persists between opens (stint 0280)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -199,6 +199,9 @@ pub struct PlexiApp {
     /// time, cleared on close. Re-read on every open so edits hot-reload without
     /// a restart — same pattern as `palette_notes`.
     pub(crate) palette_commands: Vec<crate::cli::ResolvedUserCommand>,
+    /// Set to true on palette open; consumed on the first draw frame to reset
+    /// the scroll area back to the top before egui can apply the stale offset.
+    pub(crate) palette_scroll_reset: bool,
     /// TTL cache for the cwd-derived fallback workspace root passed to
     /// `PlexiBehavior` each frame (#2023). The fallback
     /// (`config::active_workspace_root()`) stat-walks the filesystem from the
@@ -1142,6 +1145,7 @@ impl PlexiApp {
                     palette_workspace_root: None,
                     palette_notes: Vec::new(),
                     palette_commands: Vec::new(),
+                    palette_scroll_reset: false,
                     workspace_root_fallback_cache: None,
                     context_visit_history: Vec::new(),
                     renaming_pane: None,
@@ -1387,6 +1391,7 @@ impl PlexiApp {
             palette_workspace_root: None,
             palette_notes: Vec::new(),
             palette_commands: Vec::new(),
+            palette_scroll_reset: false,
             workspace_root_fallback_cache: None,
             context_visit_history: Vec::new(),
             renaming_pane: None,
@@ -1608,6 +1613,7 @@ impl PlexiApp {
                 palette_workspace_root: None,
                 palette_notes: Vec::new(),
                 palette_commands: Vec::new(),
+                palette_scroll_reset: false,
                 workspace_root_fallback_cache: None,
                 context_visit_history: Vec::new(),
                 renaming_pane: None,
@@ -3354,6 +3360,7 @@ impl eframe::App for PlexiApp {
                         });
                         self.palette_query.clear();
                         self.palette_selected = 0;
+                        self.palette_scroll_reset = true;
                         // Resolve focused pane workspace once at open-time — not per draw-frame —
                         // to avoid filesystem traversal in the egui hot path.
                         let win = &self.windows[self.active_window];

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -945,14 +945,18 @@ impl PlexiApp {
                 let mut shown_commands_header = false;
                 let mut shown_run_header = false;
 
-                egui::ScrollArea::vertical()
+                let scroll_reset = std::mem::take(&mut self.palette_scroll_reset);
+                let mut scroll_area = egui::ScrollArea::vertical()
                     // animated(false): required by scroll_row_into_view — see src/ui/list.rs.
                     .animated(false)
                     .id_salt("palette_list")
                     .max_height(palette_max_list_h)
                     .min_scrolled_height(palette_max_list_h)
-                    .auto_shrink([false, false])
-                    .show(ui, |ui| {
+                    .auto_shrink([false, false]);
+                if scroll_reset {
+                    scroll_area = scroll_area.vertical_scroll_offset(0.0);
+                }
+                scroll_area.show(ui, |ui| {
                         // available_width — the scroll area reserves a
                         // scrollbar gutter; forcing the modal width would
                         // push rows back under the bar.


### PR DESCRIPTION
## Summary

- Palette scroll offset was persisting in egui memory between opens, while `palette_selected` reset to 0 — causing the selected item to be off-screen on reopen
- Added `palette_scroll_reset: bool` flag to `HostModel`, set on every palette open
- On the first draw frame after open, passes `.vertical_scroll_offset(0.0)` to the `ScrollArea` to snap back to top, then clears the flag so subsequent frames scroll freely

## Done When

- Reopening the palette always shows the list scrolled to the top
- First Cmd+J keypress after open moves selection down without a jarring jump