### PR TITLE
fix: todo app space-to-toggle regression (stint 0281)

### DIFF
--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -2397,6 +2397,11 @@ impl App for ProcessApp {
                         if ch.is_control() {
                             continue;
                         }
+                        // Space comes through Event::Key as "Space" (→ SDK alias "space");
+                        // suppress the duplicate Text path to prevent double on_key calls.
+                        if ch == ' ' {
+                            continue;
+                        }
                         // Suppress j/k text events when a ListView is active
                         if self.render_session.list_view_intercepts_nav
                             && matches!(ch, 'j' | 'k' | 'J' | 'K')


### PR DESCRIPTION
## Summary

- Space key in todo (and snake) apps was double-firing: egui emits both `Event::Key { Space }` and `Event::Text(" ")` for a single press
- The prior fix (#2280) removed `Space` from `is_printable_key` so the Key path fires — but the Text path (`' '`) was never suppressed, causing two `on_key("space")` calls per press
- Double-toggle meant items toggled on then immediately off, appearing as "space does nothing"
- Fix: suppress `' '` in the `Event::Text` handler since space is already delivered canonically via the Key path as `"Space"` → SDK alias → `"space"`

## Done When

- Space toggles todo items (checked ↔ unchecked) with a single press
- No double-toggle on any item state