### PR TITLE
feat: palette search matches renamed pane titles (stint 0279)

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -169,6 +169,19 @@ impl PlexiApp {
                             };
                             found = true;
                             break;
+                        } else if let Some(a) = pane.as_app_mut() {
+                            a.runtime.on_pane_renamed(name);
+                            a.name = if name.is_empty() {
+                                a.runtime.display_name()
+                            } else {
+                                name.clone()
+                            };
+                            log::info!(
+                                "pane_ipc: set_pane_title: app pane {pane_id} named {:?}",
+                                a.name
+                            );
+                            found = true;
+                            break;
                         }
                     }
                 }

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -1726,5 +1726,14 @@ mod tests {
         // Empty pane name falls back to the runtime display name.
         let (name, _) = pane_row_identity(&make_app("notes", ""), &[]);
         assert_eq!(name, "Test App");
+
+        // User-renamed app pane uses the assigned name in palette search.
+        let (name, chip) = pane_row_identity(&make_app("assistant", "chad"), &[]);
+        assert_eq!((name.as_str(), chip), ("chad", "app"));
+        let search = searchable_text(&[name.as_str(), "work"]);
+        assert!(
+            search.contains("chad"),
+            "renamed pane title must appear in palette search_text; got: {search:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fix `SetPaneTitle` IPC handler in `lifecycle.rs` to update app pane names (assistant, notes, etc.) — previously only terminal panes were handled, so `plexi pane name <title>` had no effect on app panes
- Renamed app pane titles now flow through `pane_row_identity` into palette `search_text`, making them findable by user-assigned name
- Add test asserting a renamed app pane's title appears in the palette search index

## Done When

- `plexi pane name "chad"` targeting an assistant pane updates the name visible in palette search
- Searching "chad" in the command palette surfaces the renamed assistant pane