### PR TITLE
fix: remove global SDK import/install fallback from app CLI

### DIFF
--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1,85 +1,5 @@
 use std::io::{self, Write};
 
-pub(super) fn ensure_plexi_sdk() -> bool {
-    let check = std::process::Command::new("python3")
-        .args(["-c", "import plexi_sdk"])
-        .stderr(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
-        .status();
-
-    match check {
-        Ok(s) if s.success() => {
-            log::info!("ensure_plexi_sdk: already importable");
-            return true;
-        }
-        Err(e) => {
-            log::warn!("ensure_plexi_sdk: python3 not found: {e}");
-            eprintln!(
-                "warning: python3 not found — install plexi-sdk manually: pip install plexi-sdk"
-            );
-            return false;
-        }
-        Ok(_) => {}
-    }
-
-    log::info!("ensure_plexi_sdk: plexi_sdk not importable, attempting install");
-
-    // Try uv pip install first; suppress output so noisy venv warnings don't surface.
-    let uv_ok = std::process::Command::new("uv")
-        .args(["pip", "install", "plexi-sdk"])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
-
-    if uv_ok {
-        println!("Installed plexi-sdk (via uv).");
-        log::info!("ensure_plexi_sdk: installed via uv pip");
-        return true;
-    }
-
-    // Fallback: python3 -m pip to guarantee the same environment that python3 checked.
-    match std::process::Command::new("python3")
-        .args(["-m", "pip", "install", "plexi-sdk"])
-        .status()
-    {
-        Ok(s) if s.success() => {
-            println!("Installed plexi-sdk (via pip).");
-            log::info!("ensure_plexi_sdk: installed via python3 -m pip");
-            true
-        }
-        Ok(_) => {
-            eprintln!(
-                "warning: could not install plexi-sdk — install manually: pip install plexi-sdk"
-            );
-            log::warn!("ensure_plexi_sdk: python3 -m pip install failed");
-            false
-        }
-        Err(e) => {
-            eprintln!("warning: pip not available ({e}) — install manually: pip install plexi-sdk");
-            log::warn!("ensure_plexi_sdk: python3 -m pip not available: {e}");
-            false
-        }
-    }
-}
-
-/// Returns true if the app at `app_dir` has a Python entry point (entry ending in `.py`).
-pub(super) fn app_is_python(app_dir: &std::path::Path) -> bool {
-    let Ok(s) = std::fs::read_to_string(app_dir.join("manifest.toml")) else {
-        return false;
-    };
-    let Ok(manifest) = toml::from_str::<toml::Value>(&s) else {
-        return false;
-    };
-    let entry = manifest
-        .get("app")
-        .and_then(|a| a.get("entry"))
-        .and_then(|e| e.as_str())
-        .unwrap_or("");
-    entry.ends_with(".py")
-}
-
 /// Detect the channel config dir name from the running binary name.
 pub(super) fn app_init_config_dir() -> String {
     crate::config::config_dir()
@@ -195,7 +115,6 @@ pub fn app_init(
                 println!("  cargo build --release");
                 println!("  plexi app open {}", app_dir.display());
             } else {
-                ensure_plexi_sdk();
                 if open {
                     let path_str = app_dir.to_string_lossy().to_string();
                     log::info!("app_init: opening '{name}' split-right path={path_str} from_pane_id={from_pane_id:?}");
@@ -249,6 +168,7 @@ pub fn app_test_cli(path: &str, snapshot: bool) -> i32 {
 
     let mut cmd = std::process::Command::new("uv");
     cmd.args(["run", "pytest", "tests/"]).current_dir(app_dir);
+    cmd.env("PYTHONPATH", crate::config::build_pythonpath(None));
     if snapshot {
         cmd.env("PLEXI_UPDATE_SNAPSHOTS", "1");
     }
@@ -940,9 +860,6 @@ fn app_install_with_pin_inner(
         "Installed '{app_id}' v{app_version} from {}.",
         src.display()
     );
-    if app_is_python(&dest) {
-        ensure_plexi_sdk();
-    }
     println!("Run `plexi app open {app_id}` to launch it.");
     0
 }

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -1,4 +1,4 @@
-use super::app::{app_is_python, ensure_plexi_sdk, is_bare_id, is_github_shorthand};
+use super::app::{is_bare_id, is_github_shorthand};
 use super::print_tip;
 use std::io::{self, Write};
 
@@ -56,9 +56,6 @@ pub fn install_cli(spec: &str) -> i32 {
         Ok(outcome) => match outcome.status {
             crate::cli::install_host::InstallStatus::Installed(path) => {
                 println!("installed '{}' at {}", outcome.id, path.display());
-                if app_is_python(&path) {
-                    ensure_plexi_sdk();
-                }
                 print_tip(&format!(
                     "open your app with `plexi app open {}`.",
                     outcome.id

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -532,10 +532,6 @@ pub fn workspace_secret_delete(friendly: &str, global: bool) -> i32 {
 
 // ── plexi app subcommands ─────────────────────────────────────────────────────
 
-/// Returns true if `plexi_sdk` is importable in the current `python3` environment.
-/// If not, attempts installation via `uv pip install plexi-sdk`, falling back to
-/// `pip install plexi-sdk`. Prints a single line describing what happened.
-/// Returns false only if python3 is absent or all install attempts fail.
 #[cfg(test)]
 mod secret_set_tests {
     use super::{secret_list_scope, SecretListScope};


### PR DESCRIPTION
Stint task: 0290 (no linked GitHub issue)

## Summary

- Removes `ensure_plexi_sdk()` — a function that ran `python3 -c 'import plexi_sdk'` and fell back to `pip install` / `uv pip install`. This check targeted the global Python env, not the one Plexi injects at runtime.
- Removes dead `app_is_python()` helper that was only used to gate the removed check.
- Removes stale doc comment in `workspace.rs` that described the deleted function.
- SDK v3 is bundled in the profile dir and injected via `PYTHONPATH` at app launch — no global install is needed or meaningful.

## Done When

- `ensure_plexi_sdk` and `app_is_python` are gone from `src/cli/`
- `cargo build` and `cargo test --bin plexi` are green
- `plexi app init` and `plexi app install` no longer print SDK install messages