### PR TITLE
fix: stats app UI broken after SDK v2→v3 migration (stint 0300)

### DIFF
--- a/apps/stats/stats.py
+++ b/apps/stats/stats.py
@@ -248,7 +248,7 @@ class Metrics:
             m.switches_today += 1
             label = _context_label(ev)
             offset = (local - day_start).total_seconds()
-            if 0 <= offset < 86400.0:
+            if 0 <= offset < 86400.0 and ev.get("reason") == "pane_switch":
                 b = min(WAVE_BUCKETS - 1, int(offset / bucket_secs))
                 wave_count[b] += 1
                 wave_ctx[b][label] = wave_ctx[b].get(label, 0.0) + max(secs, 1.0)

--- a/apps/stats/stats.py
+++ b/apps/stats/stats.py
@@ -357,12 +357,12 @@ def _build_dial(m: "Metrics", x: float, y: float, w: float, h: float) -> "list":
 
     # Baseline ring
     sw = max(2.5, math.tau * r0 / n * 1.6)
-    cmds.extend(_arc_lines(cx, cy, r0, 0, math.tau, dim(accent, 70), max(3.0, sw), steps=80))
+    cmds.extend(_arc_lines(cx, cy, r0, 0, math.tau, dim(accent, 70), max(3.0, sw), steps=240))
 
     # Waveform spokes
     for i in range(n):
         a = smooth[i]
-        if a <= 0:
+        if a < 0.5:
             continue
         color = m.wave[i][1]
         ang = clock_ang(i + 0.5)

--- a/apps/stats/stats.py
+++ b/apps/stats/stats.py
@@ -1,300 +1,586 @@
 #!/usr/bin/env python3
-"""Stats — SDK v3 activity summary from Plexi focus events."""
+"""Stats — an activity dashboard for your work.
 
+Reads Plexi focus events and renders a circular activity clock — a 24h dial
+whose amplitude is your pane-switch velocity through the day and whose colour
+is the context you were in, with today's focus total at the centre — plus stat
+tiles and a top-contexts list.
+
+Data notes (what is and isn't accurately measured):
+  * Every focus change is one `focus_changed` event with a microsecond
+    `timestamp` and an integer `duration_secs` (1-second resolution). Switch
+    counts and timing are exact — that is what drives the waveform amplitude.
+  * "Focus time" is the sum of focus dwell. Dwell can't see idle-at-keyboard,
+    so very long single-pane spans (e.g. a pane left focused overnight) are
+    treated as idle and clamped. Focus time is therefore approximate; switch
+    velocity is not.
+"""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+import json
+import math
+import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from plexi_sdk import state
-from plexi_sdk.effects import PersistState, SetStatus, SetTimer, SetTitle
-from plexi_sdk.events import FocusChanged, KeyEvent, TimerFired
-from plexi_sdk.ui import AppBar, Column, FooterKeys, SelectList, Text
+import plexi_sdk as sdk
+from plexi_sdk import dim, log, theme
+from plexi_sdk.effects import SetStatus, SetTimer, SetTitle
+from plexi_sdk.events import KeyEvent, TimerFired
+from plexi_sdk.ui import (
+    AppBar, Canvas, CanvasCircle, CanvasLine, CanvasRect, CanvasText,
+    Column, FooterKeys,
+    RADIUS_MD, SPACE_LG, SPACE_SM,
+    TEXT_CAPTION, TEXT_HEADING, TEXT_HINT,
+)
 
+HOME = str(Path.home())
 DAY_START_HOUR = 4
 IDLE_THRESHOLD_SECS = 15 * 60
 IDLE_CLAMP_SECS = 60
+WAVE_BUCKETS = 120
+
+RANK_COLORS = ["#f9e2af", "#bac2de", "#fab387"]
+CONTEXT_PALETTE = ["#89b4fa", "#a6e3a1", "#f9e2af", "#cba6f7", "#fab387", "#94e2d5"]
+TEXT_SOFT = "#a6adc8"
+
+TILES_H = 70.0
+ROW_H = 30.0
+DIAL_MIN_H = 180.0
+DIAL_MAX_R = 240.0
+TOP_CONTEXTS = 4
+CONTEXT_ROWS = TOP_CONTEXTS + 1
+OTHER_COLOR = "#585b70"
+
 REFRESH_TIMER_ID = 1
 REFRESH_MS = 60_000
-TOP_CONTEXTS = 5
+
+_events: list[dict] = []
+_day_offset: int = 0
+_metrics: "Metrics | None" = None
 
 
-@dataclass
-class Metrics:
-    has_data: bool = False
-    active_secs: float = 0.0
-    switches_today: int = 0
-    contexts_today: int = 0
-    peak_hour_label: str = "-"
-    contexts: list[dict] = field(default_factory=list)
-    hourly_secs: list[float] = field(default_factory=lambda: [0.0] * 24)
-    idle_stats: dict = field(default_factory=dict)
+# ── Data layer ───────────────────────────────────────────────────────────────
+
+def _clean_text(value: object) -> "str | None":
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value or value in ("(none)", "Default"):
+        return None
+    return value
 
 
-def init(size, args) -> list:
-    effects: list = [
-        SetTitle("Stats"),
-        SetTimer(REFRESH_TIMER_ID, REFRESH_MS, repeat=True),
-    ]
-    missing = {}
-    if state.get("focus_events", None) is None:
-        missing["focus_events"] = []
-    if state.get("day_start_hour", None) is None:
-        missing["day_start_hour"] = DAY_START_HOUR
-    if missing:
-        effects.append(PersistState(missing))
-    return effects
+def _project_label(path: "str | None") -> str:
+    if not path:
+        return "No CWD"
+    if path == HOME:
+        return "~"
+    parts = Path(path).parts
+    if "GitHub" in parts:
+        idx = parts.index("GitHub")
+        if idx + 1 < len(parts):
+            return parts[idx + 1]
+    return Path(path).name or path
 
 
-def update(event) -> list:
-    if isinstance(event, FocusChanged):
-        focus_events = list(state.get("focus_events", []))
-        focus_events.append(_event_from_focus_changed(event))
-        return [
-            PersistState({"focus_events": focus_events[-5000:]}),
-            SetStatus(_summary_text(_compute_metrics(focus_events, _day_start_hour()))),
-        ]
-    if isinstance(event, TimerFired) and event.id == REFRESH_TIMER_ID:
-        return [SetStatus(_summary_text(_metrics_from_state()))]
-    if isinstance(event, KeyEvent) and event.pressed and event.key == "r":
-        return [SetStatus(_summary_text(_metrics_from_state()))]
-    return []
-
-
-def view():
-    metrics = _metrics_from_state()
-    if not metrics.has_data:
-        return Column([
-            AppBar("Stats", "no focus events"),
-            Text("No focus events yet.", size=16.0, bold=True),
-            Text("Stats will fill in as Plexi sends focus-change events.", size=12.0),
-            FooterKeys([("r", "refresh")]),
-        ], grow=True)
-
-    rows = [
-        {"name": ctx["label"], "description": _fmt_secs(ctx["secs"])}
-        for ctx in metrics.contexts
-    ]
-    return Column([
-        AppBar("Stats", _summary_text(metrics)),
-        Text(_activity_clock(metrics), size=14.0),
-        Text(_summary_tiles(metrics), size=12.0),
-        Text("Top contexts", size=12.0, bold=True),
-        SelectList(rows, selected_idx=0) if rows else Text("No contexts yet.", size=12.0),
-        FooterKeys([("r", "refresh")]),
-    ], grow=True)
-
-
-def _day_start_hour() -> int:
-    try:
-        return int(state.get("day_start_hour", DAY_START_HOUR))
-    except (TypeError, ValueError):
-        return DAY_START_HOUR
-
-
-def _metrics_from_state() -> Metrics:
-    return _compute_metrics(state.get("focus_events", []), _day_start_hour())
-
-
-def _event_from_focus_changed(event: FocusChanged) -> dict:
-    return {
-        "kind": "focus_changed",
-        "timestamp": event.timestamp,
-        "duration_secs": event.duration_secs,
-        "reason": event.reason,
-        "pane_id": event.pane_id,
-        "context_name": event.context_name,
-        "context_root": event.context_root,
-        "cwd": event.cwd,
-    }
-
-
-def _coerce_focus_events(events: list[dict]) -> list[dict]:
-    coerced = []
-    for event in events or []:
-        if event.get("kind", "focus_changed") != "focus_changed":
-            continue
-        try:
-            ts = datetime.fromisoformat(str(event.get("timestamp", "")))
-        except ValueError:
-            continue
-        if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=timezone.utc)
-        item = dict(event)
-        item["kind"] = "focus_changed"
-        item["_ts"] = ts
-        coerced.append(item)
-    coerced.sort(key=lambda e: e["_ts"])
-    return coerced
-
-
-def _normalize_focus_events(events: list[dict]) -> tuple[list[dict], dict]:
-    idle = False
-    normalized = []
-    stats = {
-        "raw_secs": 0,
-        "counted_secs": 0,
-        "clamped_secs": 0,
-        "skipped_secs": 0,
-        "counted_events": 0,
-        "clamped_events": 0,
-        "skipped_events": 0,
-    }
-
-    for event in events:
-        raw = int(_event_duration(event))
-        reason = event.get("reason") or ""
-        counted = raw
-        idle_state = "active"
-        if raw >= IDLE_THRESHOLD_SECS:
-            if idle:
-                counted = 0
-                idle_state = "skipped"
-            else:
-                counted = IDLE_CLAMP_SECS
-                idle_state = "clamped"
-            idle = True
-        elif idle and reason != "pane_switch":
-            counted = 0
-            idle_state = "skipped"
-        else:
-            idle = False
-
-        item = dict(event)
-        item["_raw_duration_secs"] = raw
-        item["duration_secs"] = counted
-        item["_idle_state"] = idle_state
-        normalized.append(item)
-
-        stats["raw_secs"] += raw
-        stats["counted_secs"] += counted
-        if idle_state == "clamped":
-            stats["clamped_secs"] += raw - counted
-            stats["clamped_events"] += 1
-            stats["counted_events"] += 1
-        elif idle_state == "skipped":
-            stats["skipped_secs"] += raw
-            stats["skipped_events"] += 1
-        else:
-            stats["counted_events"] += 1
-
-    return normalized, stats
-
-
-def _timeline_fractions(
-    timestamp: datetime,
-    counted_secs: float,
-    raw_secs: float,
-    idle_state: str,
-    start_window: datetime,
-) -> tuple[float, float, float, float]:
-    raw_start = max(0.0, (timestamp - timedelta(seconds=raw_secs) - start_window).total_seconds() / 86400.0)
-    raw_end = min(1.0, (timestamp - start_window).total_seconds() / 86400.0)
-    if idle_state == "clamped":
-        counted_start = raw_start
-        counted_end = min(raw_end, counted_start + counted_secs / 86400.0)
-    else:
-        counted_end = raw_end
-        counted_start = max(raw_start, counted_end - counted_secs / 86400.0)
-    return raw_start, raw_end, counted_start, counted_end
-
-
-def _compute_metrics(raw_events: list[dict], day_start_hour: int = DAY_START_HOUR) -> Metrics:
-    events, idle_stats = _normalize_focus_events(_coerce_focus_events(raw_events))
-    metrics = Metrics(has_data=bool(events), idle_stats=idle_stats)
-    if not events:
-        return metrics
-
-    now_local = datetime.now(timezone.utc).astimezone()
-    start = _day_start(now_local, day_start_hour)
-    end = start + timedelta(days=1)
-    by_context: dict[str, float] = {}
-
-    for event in events:
-        local = event["_ts"].astimezone()
-        if local < start or local >= end:
-            continue
-        metrics.switches_today += 1
-        secs = _event_duration(event)
-        if secs <= 0:
-            continue
-        metrics.active_secs += secs
-        metrics.hourly_secs[local.hour] += secs
-        label = _context_label(event)
-        by_context[label] = by_context.get(label, 0.0) + secs
-
-    metrics.contexts_today = len(by_context)
-    metrics.contexts = [
-        {"label": label, "secs": secs}
-        for label, secs in sorted(by_context.items(), key=lambda item: item[1], reverse=True)[:TOP_CONTEXTS]
-    ]
-    if any(metrics.hourly_secs):
-        peak = max(range(24), key=lambda hour: metrics.hourly_secs[hour])
-        metrics.peak_hour_label = _hour_label(peak)
-    return metrics
-
-
-def _event_duration(event: dict) -> float:
-    try:
-        return max(0.0, float(event.get("duration_secs", 0) or 0))
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def _day_start(local_dt: datetime, day_start_hour: int = DAY_START_HOUR) -> datetime:
-    start = local_dt.replace(hour=day_start_hour, minute=0, second=0, microsecond=0)
-    if local_dt.hour < day_start_hour:
-        start -= timedelta(days=1)
-    return start
-
-
-def _context_label(event: dict) -> str:
-    for key in ("context_name", "context_root", "cwd"):
-        value = event.get(key)
-        if isinstance(value, str) and value.strip() and value.strip() not in ("(none)", "Default"):
-            if key in ("context_root", "cwd"):
-                return Path(value).name or value
-            return value.strip()
+def _context_label(ev: dict) -> str:
+    name = _clean_text(ev.get("context_name"))
+    if name:
+        return name
+    root = _clean_text(ev.get("context_root"))
+    if root:
+        return _project_label(root)
+    cwd = _clean_text(ev.get("cwd"))
+    if cwd:
+        return _project_label(cwd)
     return "Untitled"
 
 
 def _fmt_secs(secs: float) -> str:
-    hours = int(secs) // 3600
-    minutes = (int(secs) % 3600) // 60
-    if hours:
-        return f"{hours}h {minutes:02d}m"
-    return f"{minutes}m"
+    h = int(secs) // 3600
+    m = (int(secs) % 3600) // 60
+    if h > 0:
+        return f"{h}h {m:02d}m"
+    return f"{m}m"
 
 
-def _hour_label(hour: int) -> str:
-    ampm = "AM" if hour < 12 else "PM"
-    h12 = hour % 12 or 12
-    nxt = (hour + 1) % 12 or 12
-    return f"{h12}-{nxt} {ampm}"
+def _event_duration(ev: dict) -> float:
+    try:
+        return max(0.0, float(ev.get("duration_secs", 0) or 0))
+    except (TypeError, ValueError):
+        return 0.0
 
 
-def _summary_text(metrics: Metrics) -> str:
-    return (
-        f"{_fmt_secs(metrics.active_secs)} active, "
-        f"{metrics.switches_today} switches, "
-        f"{metrics.contexts_today} contexts"
+def _day_start(local_dt: datetime) -> datetime:
+    start = local_dt.replace(hour=DAY_START_HOUR, minute=0, second=0, microsecond=0)
+    if local_dt.hour < DAY_START_HOUR:
+        start -= timedelta(days=1)
+    return start
+
+
+def _logical_date(local_dt: datetime):
+    return (local_dt - timedelta(hours=DAY_START_HOUR)).date()
+
+
+def _resolve_events_path() -> "Path | None":
+    override = os.environ.get("PLEXI_STATS_EVENTS", "")
+    if override:
+        p = Path(override).expanduser()
+        if p.exists():
+            return p
+    sock = os.environ.get("PLEXI_SOCKET", "")
+    if sock:
+        p = Path(sock).parent / "events.jsonl"
+        if p.exists():
+            return p
+    candidates = sorted(Path.home().glob(".plexi*/events.jsonl"),
+                        key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[0] if candidates else None
+
+
+def _parse_focus_events(path: Path) -> "list[dict]":
+    events = []
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if ev.get("kind") != "focus_changed":
+                    continue
+                try:
+                    ts = datetime.fromisoformat(ev.get("timestamp", ""))
+                except ValueError:
+                    continue
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                ev["_ts"] = ts
+                events.append(ev)
+    except OSError:
+        pass
+    return events
+
+
+def _counted_duration(ev: dict, idle_stream: "list[bool]") -> float:
+    raw = _event_duration(ev)
+    reason = ev.get("reason") or ""
+    if reason == "pane_switch" and raw < IDLE_THRESHOLD_SECS:
+        idle_stream[0] = False
+        return raw
+    if raw >= IDLE_THRESHOLD_SECS:
+        if idle_stream[0]:
+            return 0.0
+        idle_stream[0] = True
+        return float(IDLE_CLAMP_SECS)
+    if idle_stream[0] and reason != "pane_switch":
+        return 0.0
+    return raw
+
+
+def _read_events() -> None:
+    global _events
+    path = _resolve_events_path()
+    _events = _parse_focus_events(path) if path else []
+    _events.sort(key=lambda e: e["_ts"])
+
+
+# ── Metrics ──────────────────────────────────────────────────────────────────
+
+class Metrics:
+    def __init__(self) -> None:
+        self.has_data = False
+        self.active_secs = 0.0
+        self.lifetime_secs = 0.0
+        self.streak_days = 0
+        self.switches_today = 0
+        self.contexts_today = 0
+        self.active_days = 0
+        self.avg_daily_secs = 0.0
+        self.peak_hour_label = "—"
+        self.contexts: "list[dict]" = []
+        self.other_secs = 0.0
+        self.other_count = 0
+        self.wave: "list[tuple[int, str]]" = [(0, TEXT_SOFT)] * WAVE_BUCKETS
+        self.wave_peak = 1
+        self.now_frac = 0.0
+        self.is_today = True
+        self.selected_date = None
+        self.day_offset = 0
+
+    @classmethod
+    def compute(cls, events: "list[dict]", day_offset: int = 0) -> "Metrics":
+        m = cls()
+        m.day_offset = max(0, day_offset)
+        if not events:
+            return m
+        m.has_data = True
+
+        now = datetime.now(timezone.utc)
+        now_local = now.astimezone()
+        day_start = _day_start(now_local) - timedelta(days=m.day_offset)
+        day_end = day_start + timedelta(days=1)
+        m.is_today = m.day_offset == 0
+        m.selected_date = _logical_date(day_start + timedelta(hours=DAY_START_HOUR))
+        midnight = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+        m.now_frac = min(1.0, max(0.0, (now_local - midnight).total_seconds() / 86400.0))
+        bucket_secs = 86400.0 / WAVE_BUCKETS
+
+        idle = [False]
+        by_ctx: "dict[str, float]" = {}
+        active_dates: "set" = set()
+        hourly = [0.0] * 24
+        wave_count = [0] * WAVE_BUCKETS
+        wave_ctx: "list[dict[str, float]]" = [dict() for _ in range(WAVE_BUCKETS)]
+
+        for ev in events:
+            secs = _counted_duration(ev, idle)
+            m.lifetime_secs += secs
+            local = ev["_ts"].astimezone()
+            if secs > 0:
+                active_dates.add(_logical_date(local))
+            if local < day_start or local >= day_end:
+                continue
+            m.switches_today += 1
+            label = _context_label(ev)
+            offset = (local - day_start).total_seconds()
+            if 0 <= offset < 86400.0:
+                b = min(WAVE_BUCKETS - 1, int(offset / bucket_secs))
+                wave_count[b] += 1
+                wave_ctx[b][label] = wave_ctx[b].get(label, 0.0) + max(secs, 1.0)
+            if secs > 0:
+                m.active_secs += secs
+                hourly[local.hour] += secs
+                by_ctx[label] = by_ctx.get(label, 0.0) + secs
+
+        m.active_days = len(active_dates)
+        m.avg_daily_secs = m.lifetime_secs / max(1, m.active_days)
+        m.contexts_today = len(by_ctx)
+
+        ranked = sorted(by_ctx.items(), key=lambda kv: kv[1], reverse=True)
+        ctx_color = {name: CONTEXT_PALETTE[i % len(CONTEXT_PALETTE)]
+                     for i, (name, _) in enumerate(ranked)}
+        m.contexts = [{"label": name, "secs": secs, "color": ctx_color[name]}
+                      for name, secs in ranked[:TOP_CONTEXTS]]
+        rest = ranked[TOP_CONTEXTS:]
+        m.other_count = len(rest)
+        m.other_secs = sum(secs for _, secs in rest)
+
+        m.wave_peak = max(wave_count) or 1
+        wave = []
+        for b in range(WAVE_BUCKETS):
+            if wave_ctx[b]:
+                dom = max(wave_ctx[b].items(), key=lambda kv: kv[1])[0]
+                color = ctx_color.get(dom, TEXT_SOFT)
+            else:
+                color = TEXT_SOFT
+            wave.append((wave_count[b], color))
+        m.wave = wave
+
+        today = _logical_date(now_local)
+        d = today if today in active_dates else today - timedelta(days=1)
+        while d in active_dates:
+            m.streak_days += 1
+            d -= timedelta(days=1)
+
+        if any(hourly):
+            peak = max(range(24), key=lambda h: hourly[h])
+            ampm = "AM" if peak < 12 else "PM"
+            h12 = peak % 12 or 12
+            nxt = (peak + 1) % 12 or 12
+            m.peak_hour_label = f"{h12}–{nxt} {ampm}"
+        return m
+
+
+# ── Canvas drawing helpers ────────────────────────────────────────────────────
+
+def _arc_lines(cx: float, cy: float, r: float,
+               start_a: float, end_a: float,
+               color: str, width: float,
+               steps: int = 48) -> "list[CanvasLine]":
+    """Approximate an arc with line segments (v3 has no native arc_ring)."""
+    cmds = []
+    span = end_a - start_a
+    if abs(span) < 1e-6:
+        return cmds
+    actual_steps = max(4, min(steps, int(abs(span) / math.tau * 120)))
+    da = span / actual_steps
+    for i in range(actual_steps):
+        a0 = start_a + i * da
+        a1 = a0 + da
+        cmds.append(CanvasLine(
+            cx + math.cos(a0) * r, cy + math.sin(a0) * r,
+            cx + math.cos(a1) * r, cy + math.sin(a1) * r,
+            color, width,
+        ))
+    return cmds
+
+
+def _momentum(m: "Metrics") -> "tuple[str, str]":
+    if m.active_days <= 1 or m.avg_daily_secs <= 0:
+        return "building your baseline", TEXT_SOFT
+    pct = (m.active_secs / m.avg_daily_secs - 1.0) * 100.0
+    if pct >= 10:
+        return f"+{pct:.0f}% vs a typical day", theme.success
+    if pct <= -10:
+        return f"{pct:.0f}% vs a typical day", theme.warning
+    return "on pace with a typical day", TEXT_SOFT
+
+
+def _build_dial(m: "Metrics", x: float, y: float, w: float, h: float) -> "list":
+    accent = theme.accent
+    cap_h = 30.0
+    ch = h - cap_h
+    cx = x + w / 2
+    cy = y + ch / 2
+    outer = max(48.0, min(w / 2, ch / 2, DIAL_MAX_R) - 22.0)
+    amp = outer * 0.42
+    r0 = outer - amp
+    base = math.pi / 2
+    n = len(m.wave)
+    bucket_secs = 86400.0 / n
+
+    def clock_ang(i: float) -> float:
+        clock_secs = (DAY_START_HOUR * 3600 + i * bucket_secs) % 86400.0
+        return -base + clock_secs / 86400.0 * math.tau
+
+    counts = [c for c, _ in m.wave]
+    smooth = [(counts[(i - 1) % n] + counts[i] + counts[(i + 1) % n]) / 3.0
+              for i in range(n)]
+    peak = max(smooth) or 1.0
+
+    cmds: list = []
+
+    # Baseline ring
+    sw = max(2.5, math.tau * r0 / n * 1.6)
+    cmds.extend(_arc_lines(cx, cy, r0, 0, math.tau, dim(accent, 70), max(3.0, sw), steps=80))
+
+    # Waveform spokes
+    for i in range(n):
+        a = smooth[i]
+        if a <= 0:
+            continue
+        color = m.wave[i][1]
+        ang = clock_ang(i + 0.5)
+        rr = r0 + amp * (min(1.0, a / peak) ** 0.6)
+        cmds.append(CanvasLine(
+            cx + math.cos(ang) * r0, cy + math.sin(ang) * r0,
+            cx + math.cos(ang) * rr, cy + math.sin(ang) * rr,
+            color, sw,
+        ))
+
+    # Inner progress ring
+    pr = r0 - 7.0
+    frac = min(1.0, m.active_secs / m.avg_daily_secs) if m.avg_daily_secs > 0 else 0.0
+    cmds.extend(_arc_lines(cx, cy, pr, 0, math.tau, dim(accent, 40), 3.0))
+    if frac > 0:
+        cmds.extend(_arc_lines(cx, cy, pr, -base, -base + math.tau * frac, accent, 3.0))
+
+    # "Now" needle (today only)
+    if m.is_today:
+        nang = -base + m.now_frac * math.tau
+        cmds.append(CanvasLine(
+            cx + math.cos(nang) * (pr - 2.0), cy + math.sin(nang) * (pr - 2.0),
+            cx + math.cos(nang) * (outer + 4.0), cy + math.sin(nang) * (outer + 4.0),
+            theme.fg, 2.5,
+        ))
+        cmds.append(CanvasCircle(
+            cx + math.cos(nang) * (outer + 4.0),
+            cy + math.sin(nang) * (outer + 4.0),
+            3.5, theme.fg,
+        ))
+
+    # Quarter-day tick labels
+    lr = outer + 12.0
+    for tfrac, lbl in ((0.0, "12a"), (0.25, "6a"), (0.5, "12p"), (0.75, "6p")):
+        ang = -base + tfrac * math.tau
+        cmds.append(CanvasText(
+            cx + lr * math.cos(ang), cy + lr * math.sin(ang),
+            lbl, TEXT_HINT, TEXT_SOFT, False, "center_center",
+        ))
+
+    # Hub text
+    num_size = max(22.0, min(r0 * 0.52, 40.0))
+    cmds.append(CanvasText(cx, cy - num_size * 0.26,
+                           _fmt_secs(m.active_secs), num_size, theme.fg, True, "center_center"))
+    cmds.append(CanvasText(cx, cy + num_size * 0.62,
+                           "focused today" if m.is_today else "focused",
+                           TEXT_HINT, TEXT_SOFT, False, "center_center"))
+
+    # Caption
+    ry = y + ch + 12.0
+    mom_text, mom_color = _momentum(m)
+    cmds.append(CanvasText(cx, ry, mom_text, TEXT_CAPTION, mom_color, True, "center_center"))
+
+    return cmds
+
+
+def _build_tile(x: float, y: float, w: float, h: float,
+                value: str, label: str, color: str) -> "list":
+    cmds: list = [CanvasRect(x, y, w, h, theme.surface, RADIUS_MD)]
+    cxx = x + w / 2
+    cmds.append(CanvasText(cxx, y + h * 0.34, value, TEXT_HEADING, theme.fg, True, "center_center"))
+    uw = w * 0.34
+    cmds.append(CanvasRect(cxx - uw / 2, y + h * 0.56, uw, 2.0, color, 1.0))
+    cmds.append(CanvasText(cxx, y + h * 0.74, label.upper(), TEXT_HINT, TEXT_SOFT, True, "center_center"))
+    return cmds
+
+
+def _build_tiles(m: "Metrics", x: float, y: float, w: float, h: float) -> "list":
+    gap = SPACE_SM
+    tw = (w - gap * 3) / 4
+    tiles = [
+        (_fmt_secs(m.active_secs) if m.streak_days == 0 else f"{m.streak_days}d", "Streak", theme.warning),
+        (str(m.contexts_today), "Contexts", theme.success),
+        (str(m.switches_today), "Switches", theme.accent),
+        (m.peak_hour_label, "Peak Hour", theme.red),
+    ]
+    # Rebuild streak tile correctly
+    tiles[0] = (f"{m.streak_days}d", "Streak", theme.warning)
+    cmds: list = []
+    for i, (val, lbl, color) in enumerate(tiles):
+        cmds.extend(_build_tile(x + i * (tw + gap), y, tw, h, val, lbl, color))
+    return cmds
+
+
+def _build_contexts(m: "Metrics", x: float, y: float, w: float) -> "list":
+    cmds: list = [CanvasText(x, y, "TOP CONTEXTS", TEXT_HINT, TEXT_SOFT, True, "left_top")]
+    name_w = w * 0.46
+    time_w = 56.0
+    bar_x = x + name_w
+    bar_w = w - name_w - time_w
+    bar_h = 13.0
+
+    rows = list(m.contexts)
+    if m.other_secs > 0 or m.other_count > 0:
+        rows.append({"label": f"Other ({m.other_count})", "secs": m.other_secs,
+                     "color": OTHER_COLOR, "other": True})
+    top = max((r["secs"] for r in rows), default=0.0)
+
+    for i in range(CONTEXT_ROWS):
+        ry = y + SPACE_LG + i * ROW_H
+        if i >= len(rows):
+            continue
+        c = rows[i]
+        is_other = c.get("other", False)
+        cyy = ry + bar_h / 2
+        rank_color = RANK_COLORS[i] if i < 3 and not is_other else TEXT_SOFT
+        marker = "·" if is_other else f"{i + 1}"
+        cmds.append(CanvasText(x, cyy, marker, TEXT_CAPTION, rank_color, True, "left_center"))
+        cmds.append(CanvasText(x + SPACE_LG, cyy, c["label"], TEXT_CAPTION,
+                               TEXT_SOFT if is_other else theme.fg, True, "left_center"))
+        cmds.append(CanvasRect(bar_x, ry, bar_w, bar_h, theme.surface, bar_h / 2))
+        frac = c["secs"] / top if top else 0.0
+        if frac > 0:
+            fw = max(bar_h, bar_w * frac)
+            cmds.append(CanvasRect(bar_x, ry, fw, bar_h, c["color"], bar_h / 2))
+        cmds.append(CanvasText(x + w, cyy, _fmt_secs(c["secs"]),
+                               TEXT_CAPTION, TEXT_SOFT, False, "right_center"))
+    return cmds
+
+
+def _build_canvas_commands(m: "Metrics") -> "list":
+    w = sdk.canvas_width or sdk.pane_width or 640.0
+    h = sdk.canvas_height or sdk.pane_height or 360.0
+    cmds: list = [CanvasRect(0, 0, w, h, theme.bg)]
+
+    if not m.has_data:
+        cmds.append(CanvasText(w / 2, h / 2, "No focus events yet",
+                               TEXT_HEADING, TEXT_SOFT, False, "center_center"))
+        return cmds
+
+    pad = SPACE_LG
+    inner_w = w - 2 * pad
+    contexts_h = SPACE_LG + CONTEXT_ROWS * ROW_H
+    bottom = h - SPACE_LG
+    cur = SPACE_SM
+    dial_h = max(DIAL_MIN_H, bottom - cur - TILES_H - contexts_h - 2 * SPACE_LG)
+
+    cmds.extend(_build_dial(m, pad, cur, inner_w, dial_h))
+    cur += dial_h + SPACE_LG
+    cmds.extend(_build_tiles(m, pad, cur, inner_w, TILES_H))
+    cur += TILES_H + SPACE_LG
+    cmds.extend(_build_contexts(m, pad, cur, inner_w))
+    return cmds
+
+
+def _subtitle(m: "Metrics") -> str:
+    if not m.has_data or m.selected_date is None:
+        return "no data"
+    d = m.selected_date
+    label = f"{d:%A, %B} {d.day}"
+    if m.day_offset == 1:
+        return f"{label} · yesterday"
+    if m.day_offset > 1:
+        return f"{label} · {m.day_offset} days ago"
+    return label
+
+
+def _recompute() -> None:
+    global _metrics
+    _metrics = Metrics.compute(_events, _day_offset)
+
+
+# ── SDK v3 entry points ───────────────────────────────────────────────────────
+
+def init(size, args) -> list:  # noqa: ARG001
+    _read_events()
+    _recompute()
+    m = _metrics if _metrics is not None else Metrics()
+    log.info(
+        f"stats: loaded data={m.has_data} "
+        f"active_today={int(m.active_secs)}s switches={m.switches_today} "
+        f"contexts={m.contexts_today} lifetime={int(m.lifetime_secs)}s"
     )
+    effects: list = [
+        SetTitle("Stats"),
+        SetTimer(REFRESH_TIMER_ID, REFRESH_MS, repeat=True),
+    ]
+    if m.has_data:
+        effects.append(SetStatus(_fmt_secs(m.active_secs) + " active"))
+    return effects
 
 
-def _summary_tiles(metrics: Metrics) -> str:
-    return (
-        f"Peak {metrics.peak_hour_label}  |  "
-        f"Idle clamped {_fmt_secs(metrics.idle_stats.get('clamped_secs', 0))}  |  "
-        f"Skipped {_fmt_secs(metrics.idle_stats.get('skipped_secs', 0))}"
-    )
+def update(event) -> list:
+    global _day_offset
+
+    if isinstance(event, TimerFired) and event.id == REFRESH_TIMER_ID:
+        _read_events()
+        _recompute()
+        m = _metrics if _metrics is not None else Metrics()
+        log.info("stats: timer refresh complete")
+        return [SetStatus(_fmt_secs(m.active_secs) + " active")] if m.has_data else []
+
+    if isinstance(event, KeyEvent) and event.pressed:
+        if event.key == "left":
+            _day_offset += 1
+            _recompute()
+        elif event.key == "right" and _day_offset > 0:
+            _day_offset -= 1
+            _recompute()
+        elif event.key == "t" and _day_offset != 0:
+            _day_offset = 0
+            _recompute()
+        elif event.key == "r":
+            _read_events()
+            _recompute()
+            log.info("stats: manual refresh from disk")
+        else:
+            return []
+        log.info(f"stats: day_offset={_day_offset}")
+        return []
+
+    return []
 
 
-def _activity_clock(metrics: Metrics) -> str:
-    max_hour = max(metrics.hourly_secs) or 1.0
-    blocks = " .:-=+*#%@"
-    chars = []
-    for value in metrics.hourly_secs:
-        idx = round((value / max_hour) * (len(blocks) - 1)) if value else 0
-        chars.append(blocks[idx])
-    return "24h activity " + "".join(chars)
+def view():
+    m = _metrics if _metrics is not None else Metrics()
+    return Column([
+        AppBar(title="Stats", subtitle=_subtitle(m)),
+        Canvas(_build_canvas_commands(m), grow=True),
+        FooterKeys([("←/→", "day"), ("t", "today"), ("r", "refresh"), ("esc", "close")]),
+    ], padding=0, gap=0)


### PR DESCRIPTION
Stint task: 0300 (no linked GitHub issue)

## Summary

- Restores disk-based event reading via `_resolve_events_path()` + `_parse_focus_events()` — the v3 rewrite broke this by relying on `FocusChanged` events that are never delivered to background apps
- Rebuilds the full canvas dashboard (24h dial waveform, 4 stat tiles, context bar chart) using v3 typed canvas commands (`CanvasLine`, `CanvasRect`, `CanvasCircle`, `CanvasText`)
- Restores day navigation (←/→/t) and 60s refresh timer

## Done When

- Stats app renders with real focus data (not "No focus events yet")
- 24h dial, streak/contexts/switches/peak-hour tiles, and context rows all visible
- Day navigation (←/→) and today shortcut (t) work
- Manual refresh (r) re-reads events.jsonl from disk