### PR TITLE
refactor: separate heartbeat checkpoints from the public focus event log

### DIFF
--- a/apps/stats/stats.py
+++ b/apps/stats/stats.py
@@ -248,7 +248,7 @@ class Metrics:
             m.switches_today += 1
             label = _context_label(ev)
             offset = (local - day_start).total_seconds()
-            if 0 <= offset < 86400.0 and ev.get("reason") == "pane_switch":
+            if 0 <= offset < 86400.0 and ev.get("reason") in ("pane_switch", "crash_recovery"):
                 b = min(WAVE_BUCKETS - 1, int(offset / bucket_secs))
                 wave_count[b] += 1
                 wave_ctx[b][label] = wave_ctx[b].get(label, 0.0) + max(secs, 1.0)

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -7,6 +7,30 @@ use std::time::Duration;
 
 pub(crate) const FOCUS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(15 * 60);
 
+/// Format a Unix timestamp (seconds since epoch) as an ISO-8601 UTC string.
+/// Minimal implementation with no external dependencies.
+fn unix_secs_to_iso(secs: u64) -> String {
+    // Days since epoch → Gregorian date via the Zeller / proleptic algorithm.
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = (secs / 3600) % 24;
+    let days = secs / 86400;
+
+    // Algorithm: http://howardhinnant.github.io/date_algorithms.html (civil_from_days)
+    let z = days + 719_468;
+    let era = z / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let mo = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let y = if mo <= 2 { y + 1 } else { y };
+
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{m:02}:{s:02}Z")
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum FocusLogOutcome {
     Unchanged,
@@ -18,7 +42,6 @@ pub(crate) enum FocusLogOutcome {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum FocusSegmentReason {
     PaneSwitch,
-    Heartbeat,
     Shutdown,
 }
 
@@ -26,7 +49,6 @@ impl FocusSegmentReason {
     fn as_str(self) -> &'static str {
         match self {
             Self::PaneSwitch => "pane_switch",
-            Self::Heartbeat => "heartbeat",
             Self::Shutdown => "shutdown",
         }
     }
@@ -108,28 +130,33 @@ pub(crate) struct PendingRawWasmLaunch {
     pub launch_args: Vec<String>,
 }
 
+/// Pane metadata snapshot used for both journal checkpoints and event emission.
+pub(crate) struct PaneMetadata {
+    pub pane_id: u64,
+    pub context_name: String,
+    pub context_description: String,
+    pub context_root: Option<String>,
+    pub cwd: Option<String>,
+    pub pty_title: Option<String>,
+    pub pane_name: Option<String>,
+    pub app_type_id: Option<String>,
+}
+
 impl PlexiApp {
     /// Collect metadata for the pane at `tile_id` in the window identified by
-    /// stable `window_id` and emit a `FocusChanged` event. Called when the
-    /// focused pane changes and on shutdown.
-    pub(super) fn emit_focus_changed_for_tile(
+    /// stable `window_id`. Returns `None` if the window or tile is missing.
+    pub(super) fn collect_pane_metadata(
         &self,
         window_id: u64,
         tile_id: egui_tiles::TileId,
-        duration_secs: u64,
-        reason: FocusSegmentReason,
-    ) {
+    ) -> Option<PaneMetadata> {
         use egui_tiles::Tile;
-        let Some(win) = self.windows.iter().find(|w| w.window_id == window_id) else {
-            return;
-        };
+        let win = self.windows.iter().find(|w| w.window_id == window_id)?;
         let pane_id = match win.tree.tiles.get(tile_id) {
             Some(Tile::Pane(id)) => *id,
-            _ => return,
+            _ => return None,
         };
-        let Some(pane) = win.panes.get(&pane_id) else {
-            return;
-        };
+        let pane = win.panes.get(&pane_id)?;
         let context_name = self.context_name_for(win.context_id);
         let context_description = self.context_description_for(win.context_id);
         let context_root = self
@@ -150,11 +177,7 @@ impl PlexiApp {
             crate::host::pane::Pane::Portal(_) => (None, None, None, None),
         };
 
-        log::info!(
-            "focus_changed: pane_id={pane_id} reason={} context={context_name:?} context_root={context_root:?} duration_secs={duration_secs} pty_title={pty_title:?} pane_name={pane_name:?} app_type_id={app_type_id:?}",
-            reason.as_str()
-        );
-        crate::host::event_log::emit(crate::host::event_log::HostEvent::FocusChanged {
+        Some(PaneMetadata {
             pane_id,
             context_name,
             context_description,
@@ -163,10 +186,96 @@ impl PlexiApp {
             pty_title,
             pane_name,
             app_type_id,
+        })
+    }
+
+    /// Collect metadata and emit a `FocusChanged` event. Called when the
+    /// focused pane changes and on shutdown. Clears the focus journal on clean
+    /// transitions so crash-recovery only fires if the process was killed.
+    pub(super) fn emit_focus_changed_for_tile(
+        &self,
+        window_id: u64,
+        tile_id: egui_tiles::TileId,
+        duration_secs: u64,
+        reason: FocusSegmentReason,
+    ) {
+        let Some(meta) = self.collect_pane_metadata(window_id, tile_id) else {
+            return;
+        };
+
+        log::info!(
+            "focus_changed: pane_id={} reason={} context={:?} context_root={:?} duration_secs={duration_secs} pty_title={:?} pane_name={:?} app_type_id={:?}",
+            meta.pane_id,
+            reason.as_str(),
+            meta.context_name,
+            meta.context_root,
+            meta.pty_title,
+            meta.pane_name,
+            meta.app_type_id,
+        );
+        // On a clean close the journal is no longer needed — delete it so we
+        // don't emit a spurious crash_recovery on the next startup.
+        crate::app::focus_journal::clear_journal(&self.focus_journal_path);
+
+        crate::host::event_log::emit(crate::host::event_log::HostEvent::FocusChanged {
+            pane_id: meta.pane_id,
+            context_name: meta.context_name,
+            context_description: meta.context_description,
+            context_root: meta.context_root,
+            cwd: meta.cwd,
+            pty_title: meta.pty_title,
+            pane_name: meta.pane_name,
+            app_type_id: meta.app_type_id,
             reason: Some(reason.as_str().to_string()),
             duration_secs,
             timestamp: crate::host::event_log::now_timestamp(),
         });
+    }
+
+    /// Write (or overwrite) the focus journal checkpoint for the pane currently
+    /// in focus. The journal records the segment start time plus a `last_checkpoint_at`
+    /// so crash recovery can compute duration to now.
+    ///
+    /// `segment_start` is the `Instant` when this focus segment began. We convert
+    /// it to a wall-clock ISO timestamp by subtracting elapsed time from now.
+    pub(super) fn write_focus_journal_checkpoint(
+        &self,
+        window_id: u64,
+        tile_id: egui_tiles::TileId,
+        segment_start: std::time::Instant,
+    ) {
+        let Some(meta) = self.collect_pane_metadata(window_id, tile_id) else {
+            return;
+        };
+
+        // Convert Instant → wall clock by anchoring to SystemTime::now().
+        let elapsed_since_start = segment_start.elapsed();
+        let started_at_wall = std::time::SystemTime::now()
+            .checked_sub(elapsed_since_start)
+            .unwrap_or(std::time::SystemTime::now());
+
+        let to_iso = |t: std::time::SystemTime| -> String {
+            let secs = t
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            // Minimal ISO-8601 UTC formatter without external deps.
+            unix_secs_to_iso(secs)
+        };
+
+        let entry = crate::app::focus_journal::FocusJournalEntry {
+            pane_id: meta.pane_id,
+            context_name: meta.context_name,
+            context_description: meta.context_description,
+            context_root: meta.context_root,
+            cwd: meta.cwd,
+            pty_title: meta.pty_title,
+            pane_name: meta.pane_name,
+            app_type_id: meta.app_type_id,
+            started_at: to_iso(started_at_wall),
+            last_checkpoint_at: to_iso(std::time::SystemTime::now()),
+        };
+        crate::app::focus_journal::write_checkpoint(&self.focus_journal_path, &entry);
     }
 
     pub(crate) fn current_focus_target(&self) -> Option<(u64, egui_tiles::TileId)> {
@@ -199,6 +308,10 @@ impl PlexiApp {
             }
             self.last_logged_focus = current_focus;
             self.focus_started_at = current_focus.map(|_| now);
+            // Start a journal checkpoint for the new focus segment.
+            if let Some((window_id, tile_id)) = current_focus {
+                self.write_focus_journal_checkpoint(window_id, tile_id, now);
+            }
             return if had_previous_focus {
                 FocusLogOutcome::Transition
             } else {
@@ -221,13 +334,10 @@ impl PlexiApp {
             return FocusLogOutcome::Unchanged;
         }
 
-        self.emit_focus_changed_for_tile(
-            window_id,
-            tile_id,
-            elapsed.as_secs(),
-            FocusSegmentReason::Heartbeat,
-        );
-        self.focus_started_at = Some(now);
+        // Heartbeat: update the journal checkpoint only — do NOT emit to events.jsonl.
+        // Do NOT reset focus_started_at so the journal always records the full
+        // segment start; crash recovery can then compute the true total duration.
+        self.write_focus_journal_checkpoint(window_id, tile_id, started_at);
         FocusLogOutcome::Heartbeat
     }
 

--- a/src/app/focus_journal.rs
+++ b/src/app/focus_journal.rs
@@ -1,0 +1,299 @@
+//! Focus journal — single-file crash-recovery checkpoint for the current focus
+//! segment. Written on each heartbeat and on clean pane transitions; deleted on
+//! clean shutdown. If the file exists at startup it means Plexi crashed while
+//! a pane was focused; the host reads it, emits a `crash_recovery` event to
+//! `events.jsonl`, and deletes the file before normal operation begins.
+
+use std::path::Path;
+
+/// Snapshot of the currently focused pane written to the journal file.
+/// Serialised as a single JSON line; the file always contains exactly one line.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct FocusJournalEntry {
+    pub pane_id: u64,
+    pub context_name: String,
+    pub context_description: String,
+    pub context_root: Option<String>,
+    pub cwd: Option<String>,
+    pub pty_title: Option<String>,
+    pub pane_name: Option<String>,
+    pub app_type_id: Option<String>,
+    /// ISO-8601 timestamp when this focus segment started.
+    pub started_at: String,
+    /// ISO-8601 timestamp of the last checkpoint write.
+    pub last_checkpoint_at: String,
+}
+
+/// Write (overwrite) the journal file with the current checkpoint.
+/// Called on every heartbeat tick and on clean pane transitions.
+pub(crate) fn write_checkpoint(path: &Path, entry: &FocusJournalEntry) {
+    let json = match serde_json::to_string(entry) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!("focus_journal: failed to serialize checkpoint: {e}");
+            return;
+        }
+    };
+    let tmp = path.with_extension("jsonl.tmp");
+    if let Err(e) = std::fs::write(&tmp, format!("{json}\n")) {
+        log::warn!("focus_journal: failed to write tmp checkpoint {:?}: {e}", tmp);
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        log::warn!("focus_journal: failed to rename checkpoint {:?}: {e}", path);
+    }
+}
+
+/// Delete the journal file on clean close (pane_switch or shutdown).
+pub(crate) fn clear_journal(path: &Path) {
+    if path.exists() {
+        if let Err(e) = std::fs::remove_file(path) {
+            log::warn!("focus_journal: failed to delete journal {:?}: {e}", path);
+        }
+    }
+}
+
+/// On startup: if the journal file exists, read it, emit a `crash_recovery`
+/// event to `events.jsonl`, and delete the file.
+///
+/// The `crash_recovery` event uses the same `FocusChanged` schema so Stats can
+/// account for the time without special-casing.
+pub(crate) fn recover_from_focus_journal(path: &Path) {
+    let content = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+        Err(e) => {
+            log::warn!("focus_journal: failed to read journal {:?}: {e}", path);
+            return;
+        }
+    };
+
+    let line = content.trim();
+    if line.is_empty() {
+        log::warn!("focus_journal: empty journal file, deleting");
+        clear_journal(path);
+        return;
+    }
+
+    let entry: FocusJournalEntry = match serde_json::from_str(line) {
+        Ok(e) => e,
+        Err(e) => {
+            log::warn!("focus_journal: failed to parse journal entry: {e} — deleting");
+            clear_journal(path);
+            return;
+        }
+    };
+
+    // Compute duration from started_at to now.
+    let duration_secs = parse_iso_to_unix(&entry.started_at)
+        .map(|started_unix| {
+            let now_unix = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            now_unix.saturating_sub(started_unix)
+        })
+        .unwrap_or(0);
+
+    log::info!(
+        "focus_journal: crash_recovery — pane_id={} duration_secs={} context={:?}",
+        entry.pane_id,
+        duration_secs,
+        entry.context_name
+    );
+
+    crate::host::event_log::emit(crate::host::event_log::HostEvent::FocusChanged {
+        pane_id: entry.pane_id,
+        context_name: entry.context_name,
+        context_description: entry.context_description,
+        context_root: entry.context_root,
+        cwd: entry.cwd,
+        pty_title: entry.pty_title,
+        pane_name: entry.pane_name,
+        app_type_id: entry.app_type_id,
+        reason: Some("crash_recovery".to_string()),
+        duration_secs,
+        timestamp: crate::host::event_log::now_timestamp(),
+    });
+
+    clear_journal(path);
+}
+
+/// Parse an ISO-8601 timestamp string (RFC 3339 / UTC Z suffix) to a Unix
+/// seconds value. Returns `None` on parse failure.
+fn parse_iso_to_unix(ts: &str) -> Option<u64> {
+    // Expected format: "2024-01-15T12:34:56.789Z"
+    // We use a manual approach to avoid adding a chrono dependency just for
+    // this one conversion.
+    use std::time::{Duration, SystemTime};
+
+    // Try parsing with the `time` crate's OffsetDateTime if available;
+    // fall back to a simple manual parse.
+    //
+    // We use SystemTime::UNIX_EPOCH arithmetic directly from the parts so
+    // there is no external dependency beyond what's already in std.
+    let ts = ts.trim_end_matches('Z');
+    let (date_part, time_part) = ts.split_once('T')?;
+    let mut date_parts = date_part.split('-');
+    let year: u64 = date_parts.next()?.parse().ok()?;
+    let month: u64 = date_parts.next()?.parse().ok()?;
+    let day: u64 = date_parts.next()?.parse().ok()?;
+
+    let time_no_sub = time_part.split('.').next().unwrap_or(time_part);
+    let mut time_parts = time_no_sub.split(':');
+    let hour: u64 = time_parts.next()?.parse().ok()?;
+    let minute: u64 = time_parts.next()?.parse().ok()?;
+    let second: u64 = time_parts.next()?.parse().ok()?;
+
+    // Days since Unix epoch (1970-01-01) using the Gregorian calendar formula.
+    let days = days_since_epoch(year, month, day)?;
+    let unix = days * 86400 + hour * 3600 + minute * 60 + second;
+
+    // Sanity check: must be a plausible Plexi session timestamp (after 2020).
+    let min_plausible = 1_577_836_800u64; // 2020-01-01T00:00:00Z
+    if unix < min_plausible {
+        return None;
+    }
+
+    // Cross-check via SystemTime to catch overflow.
+    SystemTime::UNIX_EPOCH
+        .checked_add(Duration::from_secs(unix))
+        .map(|_| unix)
+}
+
+/// Number of days from the Unix epoch (1970-01-01) to the given Gregorian date.
+/// Returns None if the date is before 1970 or implausibly large.
+fn days_since_epoch(year: u64, month: u64, day: u64) -> Option<u64> {
+    if year < 1970 || month < 1 || month > 12 || day < 1 || day > 31 {
+        return None;
+    }
+    // Days in each month (non-leap year).
+    let days_in_month = [31u64, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let is_leap = |y: u64| (y % 4 == 0 && y % 100 != 0) || y % 400 == 0;
+
+    let mut total: u64 = 0;
+    for y in 1970..year {
+        total += if is_leap(y) { 366 } else { 365 };
+    }
+    for m in 1..month {
+        let idx = (m - 1) as usize;
+        total += days_in_month[idx];
+        if m == 2 && is_leap(year) {
+            total += 1;
+        }
+    }
+    total += day - 1;
+    Some(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn make_entry(started_at: &str) -> FocusJournalEntry {
+        FocusJournalEntry {
+            pane_id: 42,
+            context_name: "my-project".to_string(),
+            context_description: "".to_string(),
+            context_root: Some("/Users/test/project".to_string()),
+            cwd: Some("/Users/test/project".to_string()),
+            pty_title: Some("nvim".to_string()),
+            pane_name: None,
+            app_type_id: None,
+            started_at: started_at.to_string(),
+            last_checkpoint_at: started_at.to_string(),
+        }
+    }
+
+    #[test]
+    fn write_then_read_roundtrip() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("focus-journal.jsonl");
+
+        let entry = make_entry("2024-06-15T10:00:00Z");
+        write_checkpoint(&path, &entry);
+
+        assert!(path.exists());
+        let content = fs::read_to_string(&path).unwrap();
+        let parsed: FocusJournalEntry = serde_json::from_str(content.trim()).unwrap();
+        assert_eq!(parsed.pane_id, 42);
+        assert_eq!(parsed.context_name, "my-project");
+    }
+
+    #[test]
+    fn clear_deletes_file() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("focus-journal.jsonl");
+
+        let entry = make_entry("2024-06-15T10:00:00Z");
+        write_checkpoint(&path, &entry);
+        assert!(path.exists());
+
+        clear_journal(&path);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn clear_noop_when_missing() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("nonexistent.jsonl");
+        // Must not panic.
+        clear_journal(&path);
+    }
+
+    #[test]
+    fn parse_iso_to_unix_known_value() {
+        // 2024-01-15T12:00:00Z → known Unix value
+        let unix = parse_iso_to_unix("2024-01-15T12:00:00Z").unwrap();
+        // Verified: 2024-01-15 12:00:00 UTC = 1705320000
+        assert_eq!(unix, 1_705_320_000);
+    }
+
+    #[test]
+    fn parse_iso_subsecond() {
+        let unix = parse_iso_to_unix("2024-01-15T12:00:00.123Z").unwrap();
+        assert_eq!(unix, 1_705_320_000);
+    }
+
+    #[test]
+    fn parse_iso_rejects_pre_2020() {
+        assert!(parse_iso_to_unix("1969-12-31T23:59:59Z").is_none());
+    }
+
+    #[test]
+    fn recover_from_missing_journal_is_noop() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("focus-journal.jsonl");
+        // Just verifies no panic/error logged; we can't assert event emission
+        // without wiring up the global event log in tests.
+        recover_from_focus_journal(&path);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn recover_deletes_journal_after_reading() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("focus-journal.jsonl");
+
+        let entry = make_entry("2024-06-15T10:00:00Z");
+        write_checkpoint(&path, &entry);
+        assert!(path.exists());
+
+        // We can't assert the event was emitted (event_log global not initialised in
+        // unit tests), but we can verify the file is consumed.
+        recover_from_focus_journal(&path);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn recover_handles_corrupt_journal() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("focus-journal.jsonl");
+        fs::write(&path, "NOT_VALID_JSON\n").unwrap();
+
+        recover_from_focus_journal(&path);
+        assert!(!path.exists());
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4,6 +4,7 @@ mod canvas_bindings;
 mod dispatch;
 pub mod file_handlers;
 mod focus;
+pub(crate) mod focus_journal;
 pub mod host_mcp;
 pub mod host_version;
 pub(crate) mod launch_spec;
@@ -378,6 +379,10 @@ pub struct PlexiApp {
     pub(crate) last_logged_focus: Option<(u64, egui_tiles::TileId)>,
     /// When the current focus session started. Reset on each FocusChanged emit.
     pub(crate) focus_started_at: Option<std::time::Instant>,
+    /// Path to the focus journal file used for crash-recovery checkpoints.
+    /// Written on every heartbeat and on clean pane transitions; deleted on
+    /// clean shutdown. If present at startup → emit crash_recovery event.
+    pub(crate) focus_journal_path: std::path::PathBuf,
     /// Last observed system theme for auto-switching catppuccin variants (#1776).
     pub(crate) last_system_theme: Option<egui::Theme>,
     /// App commands held while a modal overlay owns keyboard input. Released and
@@ -835,6 +840,13 @@ impl PlexiApp {
             crate::host::event_log::init_global(global_path, workspace_path);
         }
 
+        // Check for an unclean shutdown from the previous session.
+        // If the focus journal has an unclosed segment, emit a crash_recovery event.
+        {
+            let journal_path = crate::config::config_dir().join("focus-journal.jsonl");
+            crate::app::focus_journal::recover_from_focus_journal(&journal_path);
+        }
+
         // Spawn background update check. Sends the latest version once if newer.
         let (update_tx, update_rx) = std::sync::mpsc::channel::<String>();
         crate::cli::updater::spawn_update_check(crate::config::config_dir(), update_tx);
@@ -1191,6 +1203,8 @@ impl PlexiApp {
                     pending_raw_wasm_launches: std::collections::VecDeque::new(),
                     last_logged_focus: None,
                     focus_started_at: None,
+                    focus_journal_path: crate::config::config_dir()
+                        .join("focus-journal.jsonl"),
                     last_system_theme: None,
                     overlay_held_cmds: Vec::new(),
                     agent_host: crate::agent::AgentHost::production(config.ai),
@@ -1432,6 +1446,7 @@ impl PlexiApp {
             pending_raw_wasm_launches: std::collections::VecDeque::new(),
             last_logged_focus: None,
             focus_started_at: None,
+            focus_journal_path: crate::config::config_dir().join("focus-journal.jsonl"),
             last_system_theme: None,
             overlay_held_cmds: Vec::new(),
             agent_host,
@@ -1649,6 +1664,7 @@ impl PlexiApp {
                 pending_raw_wasm_launches: std::collections::VecDeque::new(),
                 last_logged_focus: None,
                 focus_started_at: None,
+                focus_journal_path: crate::config::config_dir().join("focus-journal.jsonl"),
                 last_system_theme: None,
                 overlay_held_cmds: Vec::new(),
                 agent_host: crate::agent::AgentHost::inert(),

--- a/src/app/tests/focus_tests.rs
+++ b/src/app/tests/focus_tests.rs
@@ -167,18 +167,22 @@ fn focus_log_heartbeats_for_same_pane_after_threshold() {
 
     app.windows[0].focused_pane = Some(tile_a);
     app.last_logged_focus = Some((win_id, tile_a));
-    app.focus_started_at =
-        Some(std::time::Instant::now() - std::time::Duration::from_secs(15 * 60 + 1));
+    let original_start =
+        std::time::Instant::now() - std::time::Duration::from_secs(15 * 60 + 1);
+    app.focus_started_at = Some(original_start);
 
     let outcome = app.reconcile_focus_logging(std::time::Duration::from_secs(15 * 60));
 
     assert_eq!(outcome, FocusLogOutcome::Heartbeat);
     assert_eq!(app.last_logged_focus, Some((win_id, tile_a)));
-    assert!(
+    // Heartbeat no longer resets focus_started_at — the segment start is preserved
+    // so crash recovery can compute the full continuous duration from the
+    // original segment start to now (not just from the last heartbeat).
+    assert_eq!(
         app.focus_started_at
-            .expect("heartbeat should restart the focus segment")
-            .elapsed()
-            < std::time::Duration::from_secs(5)
+            .expect("focus_started_at must remain set after heartbeat"),
+        original_start,
+        "focus_started_at must not be reset on heartbeat so crash recovery duration is correct"
     );
 }
 


### PR DESCRIPTION
Stint task: 0301 (no linked GitHub issue)

## Summary

- Moves the 15-minute open-segment checkpoint out of `events.jsonl` into a separate `focus-journal.jsonl` write-ahead log
- Heartbeat path now writes/overwrites the journal instead of emitting a `FocusChanged` event — consumers never see heartbeat entries
- On startup, if the journal holds an unclosed segment (crash scenario), a single `reason: crash_recovery` event is emitted to `events.jsonl` and the journal is cleared
- Removes the `== "pane_switch"` wave-count filter from `apps/stats/stats.py` (now accepts `pane_switch` and `crash_recovery`)

## Validation

Binary install required — focus logging touches the startup path (crash recovery) and the heartbeat timer loop. Validate with `just pr-install` and confirm no heartbeat entries appear in `~/.plexi-pr-<N>/events.jsonl` after 15+ minutes of use.