### PR TITLE
feat(text-editor): Tab indentation and auto-indent on newline

### DIFF
--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -447,6 +447,32 @@ mod tests {
     fn slugify_empty_falls_back_to_note() {
         assert_eq!(slugify_title("---"), "note");
     }
+
+    #[test]
+    fn leading_whitespace_at_first_line() {
+        let s = "    hello";
+        assert_eq!(leading_whitespace_at(s, 0), "    ");
+    }
+
+    #[test]
+    fn leading_whitespace_at_second_line() {
+        let s = "line1\n  indented";
+        // char index 6 = 'i' in "indented"
+        assert_eq!(leading_whitespace_at(s, 6), "  ");
+    }
+
+    #[test]
+    fn leading_whitespace_at_empty_line() {
+        let s = "a\n\nb";
+        assert_eq!(leading_whitespace_at(s, 2), "");
+    }
+
+    #[test]
+    fn leading_whitespace_at_mid_word() {
+        let s = "    hello world";
+        // char 8 = 'o' in "hello"; line start is col 0 with 4-space indent
+        assert_eq!(leading_whitespace_at(s, 8), "    ");
+    }
 }
 
 /// Split a note document into its raw frontmatter block (kept out of the
@@ -532,6 +558,21 @@ enum Durability {
 /// Convert a note title into a safe lowercase filename slug (no `.md` suffix).
 /// Non-alphanumeric characters become `-`; leading/trailing and consecutive
 /// dashes are collapsed; falls back to `"note"` for an all-symbol title.
+/// Returns the leading whitespace (spaces/tabs) of the line that contains
+/// the char at `char_idx`. Used for auto-indent on Enter.
+fn leading_whitespace_at(content: &str, char_idx: usize) -> String {
+    let byte_idx = content
+        .char_indices()
+        .nth(char_idx)
+        .map(|(b, _)| b)
+        .unwrap_or(content.len());
+    let line_start = content[..byte_idx].rfind('\n').map(|i| i + 1).unwrap_or(0);
+    content[line_start..]
+        .chars()
+        .take_while(|c| *c == ' ' || *c == '\t')
+        .collect()
+}
+
 fn slugify_title(title: &str) -> String {
     let slug: String = title
         .chars()
@@ -814,6 +855,55 @@ impl App for TextEditorApp {
             .auto_shrink([false, false])
             .max_height(editor_height)
             .show(ui, |ui| {
+                // Intercept Tab and Enter before TextEdit consumes them for
+                // focus traversal / bare newlines respectively.
+                if ui.ctx().memory(|m| m.has_focus(te_id)) && self.find_bar.is_none() {
+                    let cursor_idx = egui::TextEdit::load_state(ui.ctx(), te_id)
+                        .and_then(|s| s.cursor.char_range())
+                        .map(|r| r.primary.index);
+
+                    let tab_presses =
+                        ui.input_mut(|i| i.count_and_consume_key(egui::Modifiers::NONE, egui::Key::Tab));
+                    if tab_presses > 0 {
+                        if let Some(idx) = cursor_idx {
+                            let indent = "    ";
+                            for _ in 0..tab_presses {
+                                self.content.insert_str(idx, indent);
+                            }
+                            let new_idx = idx + indent.len() * tab_presses;
+                            let mut state =
+                                egui::TextEdit::load_state(ui.ctx(), te_id).unwrap_or_default();
+                            let c = egui::text::CCursor::new(new_idx);
+                            state.cursor.set_char_range(Some(egui::text::CCursorRange::one(c)));
+                            egui::TextEdit::store_state(ui.ctx(), te_id, state);
+                            self.last_edit = Some(Instant::now());
+                            log::info!("TextEditorApp: Tab — inserted {} spaces at {}", indent.len() * tab_presses, idx);
+                        }
+                    }
+
+                    let enter_presses = ui.input_mut(|i| {
+                        i.count_and_consume_key(egui::Modifiers::NONE, egui::Key::Enter)
+                    });
+                    if enter_presses > 0 {
+                        if let Some(idx) = cursor_idx {
+                            let leading = leading_whitespace_at(&self.content, idx);
+                            let insert = format!("\n{leading}");
+                            let insert_len = insert.len();
+                            for _ in 0..enter_presses {
+                                self.content.insert_str(idx, &insert);
+                            }
+                            let new_idx = idx + insert_len * enter_presses;
+                            let mut state =
+                                egui::TextEdit::load_state(ui.ctx(), te_id).unwrap_or_default();
+                            let c = egui::text::CCursor::new(new_idx);
+                            state.cursor.set_char_range(Some(egui::text::CCursorRange::one(c)));
+                            egui::TextEdit::store_state(ui.ctx(), te_id, state);
+                            self.last_edit = Some(Instant::now());
+                            log::info!("TextEditorApp: Enter — auto-indent {} chars at {}", leading.len(), idx);
+                        }
+                    }
+                }
+
                 // egui's caret is hidden (transparent, non-blinking) and
                 // draw_text_caret paints a glyph-height replacement on top.
                 let output = ui

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -449,6 +449,45 @@ mod tests {
     }
 
     #[test]
+    fn current_line_is_blank_pure_indent() {
+        assert!(current_line_is_blank("    ", 4));
+    }
+
+    #[test]
+    fn current_line_is_blank_with_content() {
+        assert!(!current_line_is_blank("    hello", 9));
+    }
+
+    #[test]
+    fn current_line_is_blank_mid_indent() {
+        // Cursor at char 2 of "    "; line still pure whitespace before cursor.
+        assert!(current_line_is_blank("    ", 2));
+    }
+
+    #[test]
+    fn spaces_before_cursor_pure_four_spaces() {
+        // "    " with cursor at end → 4 spaces → returns 4
+        assert_eq!(spaces_before_cursor("    ", 4), 4);
+    }
+
+    #[test]
+    fn spaces_before_cursor_two_spaces() {
+        assert_eq!(spaces_before_cursor("  ", 2), 2);
+    }
+
+    #[test]
+    fn spaces_before_cursor_mixed_line_returns_zero() {
+        // "foo   " — prefix has content, not pure indent, so no dedent
+        assert_eq!(spaces_before_cursor("foo   ", 6), 0);
+    }
+
+    #[test]
+    fn spaces_before_cursor_after_newline() {
+        // second line is "    " pure indent
+        assert_eq!(spaces_before_cursor("line\n    ", 9), 4);
+    }
+
+    #[test]
     fn leading_whitespace_at_first_line() {
         let s = "    hello";
         assert_eq!(leading_whitespace_at(s, 0), "    ");
@@ -566,6 +605,28 @@ fn char_to_byte(content: &str, char_idx: usize) -> usize {
         .nth(char_idx)
         .map(|(b, _)| b)
         .unwrap_or(content.len())
+}
+
+/// Returns true when every character on the current line before `char_idx`
+/// is a space or tab (i.e. the cursor is at the end of a blank-indent line).
+fn current_line_is_blank(content: &str, char_idx: usize) -> bool {
+    let byte_idx = char_to_byte(content, char_idx);
+    let line_start = content[..byte_idx].rfind('\n').map(|i| i + 1).unwrap_or(0);
+    content[line_start..byte_idx]
+        .chars()
+        .all(|c| c == ' ' || c == '\t')
+}
+
+/// Returns the number of leading spaces on the current line immediately before
+/// `char_idx`, capped at 4. Used for smart backspace dedent.
+fn spaces_before_cursor(content: &str, char_idx: usize) -> usize {
+    let byte_idx = char_to_byte(content, char_idx);
+    let line_start = content[..byte_idx].rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let before = &content[line_start..byte_idx];
+    // Count trailing spaces (the ones immediately preceding cursor on this line).
+    let spaces = before.chars().rev().take_while(|c| *c == ' ').count();
+    // Only dedent if those spaces are ALL that's on the line prefix (pure indent).
+    if before.chars().all(|c| c == ' ') { spaces.min(4) } else { 0 }
 }
 
 /// Returns the leading whitespace (spaces/tabs) of the line that contains
@@ -897,20 +958,73 @@ impl App for TextEditorApp {
                         if let Some(char_idx) = cursor_char {
                             let byte_idx = char_to_byte(&self.content, char_idx);
                             let leading = leading_whitespace_at(&self.content, char_idx);
-                            let insert = format!("\n{leading}");
-                            // Insert is ASCII (\n + spaces/tabs) so char count == byte count.
-                            let insert_chars = insert.chars().count();
-                            for _ in 0..enter_presses {
-                                self.content.insert_str(byte_idx, &insert);
+                            // If the cursor sits at the end of a line that is pure
+                            // whitespace (blank indented line), strip that indent and
+                            // produce a bare newline — "escape" from the indent level.
+                            let line_is_blank = current_line_is_blank(&self.content, char_idx);
+                            let (insert, stripped_chars) = if line_is_blank && !leading.is_empty() {
+                                let line_start_byte = byte_idx - leading.len();
+                                let strip_len = leading.len();
+                                self.content.drain(line_start_byte..byte_idx);
+                                log::info!("TextEditorApp: Enter on blank-indent line — stripped {} spaces", strip_len);
+                                // After stripping, byte_idx is no longer valid; recompute.
+                                let stripped_byte = line_start_byte;
+                                self.content.insert_str(stripped_byte, "\n");
+                                (String::new(), strip_len)
+                            } else {
+                                (format!("\n{leading}"), 0)
+                            };
+
+                            if stripped_chars > 0 {
+                                // Cursor is now right after the inserted '\n', at char_idx - stripped_chars + 1.
+                                let new_char_idx = char_idx.saturating_sub(stripped_chars) + 1;
+                                let mut state =
+                                    egui::TextEdit::load_state(ui.ctx(), te_id).unwrap_or_default();
+                                let c = egui::text::CCursor::new(new_char_idx);
+                                state.cursor.set_char_range(Some(egui::text::CCursorRange::one(c)));
+                                egui::TextEdit::store_state(ui.ctx(), te_id, state);
+                                // Only one press handled when stripping; remaining handled next frame.
+                            } else {
+                                // Insert is ASCII (\n + spaces/tabs) so char count == byte count.
+                                let insert_chars = insert.chars().count();
+                                for _ in 0..enter_presses {
+                                    self.content.insert_str(byte_idx, &insert);
+                                }
+                                let new_char_idx = char_idx + insert_chars * enter_presses;
+                                let mut state =
+                                    egui::TextEdit::load_state(ui.ctx(), te_id).unwrap_or_default();
+                                let c = egui::text::CCursor::new(new_char_idx);
+                                state.cursor.set_char_range(Some(egui::text::CCursorRange::one(c)));
+                                egui::TextEdit::store_state(ui.ctx(), te_id, state);
                             }
-                            let new_char_idx = char_idx + insert_chars * enter_presses;
-                            let mut state =
-                                egui::TextEdit::load_state(ui.ctx(), te_id).unwrap_or_default();
-                            let c = egui::text::CCursor::new(new_char_idx);
-                            state.cursor.set_char_range(Some(egui::text::CCursorRange::one(c)));
-                            egui::TextEdit::store_state(ui.ctx(), te_id, state);
                             self.last_edit = Some(Instant::now());
-                            log::info!("TextEditorApp: Enter — auto-indent {} chars at char {}", leading.len(), char_idx);
+                            log::info!("TextEditorApp: Enter — leading={:?} blank_line={} at char {}", leading, line_is_blank, char_idx);
+                        }
+                    }
+
+                    // Smart backspace: if the chars before cursor on the current line are
+                    // all spaces (1–4), delete them all in one keypress.
+                    let backspace_presses = ui.input_mut(|i| {
+                        i.count_and_consume_key(egui::Modifiers::NONE, egui::Key::Backspace)
+                    });
+                    if backspace_presses > 0 {
+                        if let Some(char_idx) = cursor_char {
+                            let spaces = spaces_before_cursor(&self.content, char_idx);
+                            if spaces > 1 {
+                                // Remove the indent block; remaining presses handled by TextEdit next frame.
+                                let byte_end = char_to_byte(&self.content, char_idx);
+                                let byte_start = byte_end - spaces;
+                                self.content.drain(byte_start..byte_end);
+                                let new_char_idx = char_idx - spaces;
+                                let mut state =
+                                    egui::TextEdit::load_state(ui.ctx(), te_id).unwrap_or_default();
+                                let c = egui::text::CCursor::new(new_char_idx);
+                                state.cursor.set_char_range(Some(egui::text::CCursorRange::one(c)));
+                                egui::TextEdit::store_state(ui.ctx(), te_id, state);
+                                self.last_edit = Some(Instant::now());
+                                log::info!("TextEditorApp: smart backspace — removed {} spaces at char {}", spaces, char_idx);
+                            }
+                            // spaces == 1 or 0: let TextEdit handle it normally (single char delete).
                         }
                     }
                 }

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -449,22 +449,6 @@ mod tests {
     }
 
     #[test]
-    fn current_line_is_blank_pure_indent() {
-        assert!(current_line_is_blank("    ", 4));
-    }
-
-    #[test]
-    fn current_line_is_blank_with_content() {
-        assert!(!current_line_is_blank("    hello", 9));
-    }
-
-    #[test]
-    fn current_line_is_blank_mid_indent() {
-        // Cursor at char 2 of "    "; line still pure whitespace before cursor.
-        assert!(current_line_is_blank("    ", 2));
-    }
-
-    #[test]
     fn spaces_before_cursor_pure_four_spaces() {
         // "    " with cursor at end → 4 spaces → returns 4
         assert_eq!(spaces_before_cursor("    ", 4), 4);
@@ -605,16 +589,6 @@ fn char_to_byte(content: &str, char_idx: usize) -> usize {
         .nth(char_idx)
         .map(|(b, _)| b)
         .unwrap_or(content.len())
-}
-
-/// Returns true when every character on the current line before `char_idx`
-/// is a space or tab (i.e. the cursor is at the end of a blank-indent line).
-fn current_line_is_blank(content: &str, char_idx: usize) -> bool {
-    let byte_idx = char_to_byte(content, char_idx);
-    let line_start = content[..byte_idx].rfind('\n').map(|i| i + 1).unwrap_or(0);
-    content[line_start..byte_idx]
-        .chars()
-        .all(|c| c == ' ' || c == '\t')
 }
 
 /// Returns the number of leading spaces on the current line immediately before
@@ -958,60 +932,35 @@ impl App for TextEditorApp {
                         if let Some(char_idx) = cursor_char {
                             let byte_idx = char_to_byte(&self.content, char_idx);
                             let leading = leading_whitespace_at(&self.content, char_idx);
-                            // If the cursor sits at the end of a line that is pure
-                            // whitespace (blank indented line), strip that indent and
-                            // produce a bare newline — "escape" from the indent level.
-                            let line_is_blank = current_line_is_blank(&self.content, char_idx);
-                            let (insert, stripped_chars) = if line_is_blank && !leading.is_empty() {
-                                let line_start_byte = byte_idx - leading.len();
-                                let strip_len = leading.len();
-                                self.content.drain(line_start_byte..byte_idx);
-                                log::info!("TextEditorApp: Enter on blank-indent line — stripped {} spaces", strip_len);
-                                // After stripping, byte_idx is no longer valid; recompute.
-                                let stripped_byte = line_start_byte;
-                                self.content.insert_str(stripped_byte, "\n");
-                                (String::new(), strip_len)
-                            } else {
-                                (format!("\n{leading}"), 0)
-                            };
-
-                            if stripped_chars > 0 {
-                                // Cursor is now right after the inserted '\n', at char_idx - stripped_chars + 1.
-                                let new_char_idx = char_idx.saturating_sub(stripped_chars) + 1;
-                                let mut state =
-                                    egui::TextEdit::load_state(ui.ctx(), te_id).unwrap_or_default();
-                                let c = egui::text::CCursor::new(new_char_idx);
-                                state.cursor.set_char_range(Some(egui::text::CCursorRange::one(c)));
-                                egui::TextEdit::store_state(ui.ctx(), te_id, state);
-                                // Only one press handled when stripping; remaining handled next frame.
-                            } else {
-                                // Insert is ASCII (\n + spaces/tabs) so char count == byte count.
-                                let insert_chars = insert.chars().count();
-                                for _ in 0..enter_presses {
-                                    self.content.insert_str(byte_idx, &insert);
-                                }
-                                let new_char_idx = char_idx + insert_chars * enter_presses;
-                                let mut state =
-                                    egui::TextEdit::load_state(ui.ctx(), te_id).unwrap_or_default();
-                                let c = egui::text::CCursor::new(new_char_idx);
-                                state.cursor.set_char_range(Some(egui::text::CCursorRange::one(c)));
-                                egui::TextEdit::store_state(ui.ctx(), te_id, state);
+                            // Always carry the current line's indent onto the new line.
+                            let insert = format!("\n{leading}");
+                            // insert is ASCII (\n + spaces/tabs) so char count == byte count.
+                            let insert_chars = insert.chars().count();
+                            for _ in 0..enter_presses {
+                                self.content.insert_str(byte_idx, &insert);
                             }
+                            let new_char_idx = char_idx + insert_chars * enter_presses;
+                            let mut state =
+                                egui::TextEdit::load_state(ui.ctx(), te_id).unwrap_or_default();
+                            let c = egui::text::CCursor::new(new_char_idx);
+                            state.cursor.set_char_range(Some(egui::text::CCursorRange::one(c)));
+                            egui::TextEdit::store_state(ui.ctx(), te_id, state);
                             self.last_edit = Some(Instant::now());
-                            log::info!("TextEditorApp: Enter — leading={:?} blank_line={} at char {}", leading, line_is_blank, char_idx);
+                            log::info!("TextEditorApp: Enter — leading={:?} at char {}", leading, char_idx);
                         }
                     }
 
-                    // Smart backspace: if the chars before cursor on the current line are
-                    // all spaces (1–4), delete them all in one keypress.
-                    let backspace_presses = ui.input_mut(|i| {
-                        i.count_and_consume_key(egui::Modifiers::NONE, egui::Key::Backspace)
-                    });
-                    if backspace_presses > 0 {
-                        if let Some(char_idx) = cursor_char {
-                            let spaces = spaces_before_cursor(&self.content, char_idx);
-                            if spaces > 1 {
-                                // Remove the indent block; remaining presses handled by TextEdit next frame.
+                    // Smart backspace: if the line prefix up to the cursor is pure spaces
+                    // (2–4), remove the whole block in one keypress. Only consume the key
+                    // when we handle it ourselves — if we consumed it unconditionally,
+                    // single-char deletes (spaces == 0 or 1) would be silently swallowed.
+                    if let Some(char_idx) = cursor_char {
+                        let spaces = spaces_before_cursor(&self.content, char_idx);
+                        if spaces > 1 {
+                            let backspace_presses = ui.input_mut(|i| {
+                                i.count_and_consume_key(egui::Modifiers::NONE, egui::Key::Backspace)
+                            });
+                            if backspace_presses > 0 {
                                 let byte_end = char_to_byte(&self.content, char_idx);
                                 let byte_start = byte_end - spaces;
                                 self.content.drain(byte_start..byte_end);
@@ -1024,8 +973,8 @@ impl App for TextEditorApp {
                                 self.last_edit = Some(Instant::now());
                                 log::info!("TextEditorApp: smart backspace — removed {} spaces at char {}", spaces, char_idx);
                             }
-                            // spaces == 1 or 0: let TextEdit handle it normally (single char delete).
                         }
+                        // spaces <= 1: don't consume — TextEdit handles the delete normally.
                     }
                 }
 

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -558,14 +558,20 @@ enum Durability {
 /// Convert a note title into a safe lowercase filename slug (no `.md` suffix).
 /// Non-alphanumeric characters become `-`; leading/trailing and consecutive
 /// dashes are collapsed; falls back to `"note"` for an all-symbol title.
-/// Returns the leading whitespace (spaces/tabs) of the line that contains
-/// the char at `char_idx`. Used for auto-indent on Enter.
-fn leading_whitespace_at(content: &str, char_idx: usize) -> String {
-    let byte_idx = content
+/// Converts a char index (as returned by `CCursor.index`) to a byte offset
+/// suitable for `String::insert_str`. Returns `content.len()` when out of range.
+fn char_to_byte(content: &str, char_idx: usize) -> usize {
+    content
         .char_indices()
         .nth(char_idx)
         .map(|(b, _)| b)
-        .unwrap_or(content.len());
+        .unwrap_or(content.len())
+}
+
+/// Returns the leading whitespace (spaces/tabs) of the line that contains
+/// the char at `char_idx`. Used for auto-indent on Enter.
+fn leading_whitespace_at(content: &str, char_idx: usize) -> String {
+    let byte_idx = char_to_byte(content, char_idx);
     let line_start = content[..byte_idx].rfind('\n').map(|i| i + 1).unwrap_or(0);
     content[line_start..]
         .chars()
@@ -858,26 +864,29 @@ impl App for TextEditorApp {
                 // Intercept Tab and Enter before TextEdit consumes them for
                 // focus traversal / bare newlines respectively.
                 if ui.ctx().memory(|m| m.has_focus(te_id)) && self.find_bar.is_none() {
-                    let cursor_idx = egui::TextEdit::load_state(ui.ctx(), te_id)
+                    // CCursor.index is a char index; String mutation needs byte offsets.
+                    let cursor_char = egui::TextEdit::load_state(ui.ctx(), te_id)
                         .and_then(|s| s.cursor.char_range())
                         .map(|r| r.primary.index);
 
                     let tab_presses =
                         ui.input_mut(|i| i.count_and_consume_key(egui::Modifiers::NONE, egui::Key::Tab));
                     if tab_presses > 0 {
-                        if let Some(idx) = cursor_idx {
+                        if let Some(char_idx) = cursor_char {
+                            let byte_idx = char_to_byte(&self.content, char_idx);
                             let indent = "    ";
                             for _ in 0..tab_presses {
-                                self.content.insert_str(idx, indent);
+                                self.content.insert_str(byte_idx, indent);
                             }
-                            let new_idx = idx + indent.len() * tab_presses;
+                            // Inserted text is ASCII so char count == byte count.
+                            let new_char_idx = char_idx + indent.len() * tab_presses;
                             let mut state =
                                 egui::TextEdit::load_state(ui.ctx(), te_id).unwrap_or_default();
-                            let c = egui::text::CCursor::new(new_idx);
+                            let c = egui::text::CCursor::new(new_char_idx);
                             state.cursor.set_char_range(Some(egui::text::CCursorRange::one(c)));
                             egui::TextEdit::store_state(ui.ctx(), te_id, state);
                             self.last_edit = Some(Instant::now());
-                            log::info!("TextEditorApp: Tab — inserted {} spaces at {}", indent.len() * tab_presses, idx);
+                            log::info!("TextEditorApp: Tab — inserted {} spaces at char {}", indent.len() * tab_presses, char_idx);
                         }
                     }
 
@@ -885,21 +894,23 @@ impl App for TextEditorApp {
                         i.count_and_consume_key(egui::Modifiers::NONE, egui::Key::Enter)
                     });
                     if enter_presses > 0 {
-                        if let Some(idx) = cursor_idx {
-                            let leading = leading_whitespace_at(&self.content, idx);
+                        if let Some(char_idx) = cursor_char {
+                            let byte_idx = char_to_byte(&self.content, char_idx);
+                            let leading = leading_whitespace_at(&self.content, char_idx);
                             let insert = format!("\n{leading}");
-                            let insert_len = insert.len();
+                            // Insert is ASCII (\n + spaces/tabs) so char count == byte count.
+                            let insert_chars = insert.chars().count();
                             for _ in 0..enter_presses {
-                                self.content.insert_str(idx, &insert);
+                                self.content.insert_str(byte_idx, &insert);
                             }
-                            let new_idx = idx + insert_len * enter_presses;
+                            let new_char_idx = char_idx + insert_chars * enter_presses;
                             let mut state =
                                 egui::TextEdit::load_state(ui.ctx(), te_id).unwrap_or_default();
-                            let c = egui::text::CCursor::new(new_idx);
+                            let c = egui::text::CCursor::new(new_char_idx);
                             state.cursor.set_char_range(Some(egui::text::CCursorRange::one(c)));
                             egui::TextEdit::store_state(ui.ctx(), te_id, state);
                             self.last_edit = Some(Instant::now());
-                            log::info!("TextEditorApp: Enter — auto-indent {} chars at {}", leading.len(), idx);
+                            log::info!("TextEditorApp: Enter — auto-indent {} chars at char {}", leading.len(), char_idx);
                         }
                     }
                 }


### PR DESCRIPTION
No linked GitHub issue — stint task 0302.

## Summary

- Intercepts `Tab` (no modifier) in the text editor before egui's focus traversal consumes it, inserting 4 spaces at the cursor position
- Intercepts `Enter` before egui's bare newline, detecting the current line's leading whitespace and prepending it to the new line
- Applies in both scratchpad and multi-file note panes (any `TextEditorApp` instance)

## Test Evidence

- `cargo test --bin plexi text_editor`: 26 passed (4 new unit tests for `leading_whitespace_at`)
- Conclusion: binary install required — Tab/Enter interception is egui input-state behavior only observable at runtime

## Validation

Install with `just pr-install <PR>` and open a note pane. Verify:
1. Tab inserts 4 spaces instead of moving focus
2. Enter on an indented line carries the leading whitespace to the new line
3. Enter on a non-indented line produces a plain newline