### PR TITLE
feat(release): alpha/beta/stable prerelease flow and channel-aware update

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -18,11 +18,24 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Check tag is stable
+        id: gate
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "stable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stable=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping SDK publish for prerelease tag: $TAG"
+          fi
+
       - name: Install uv
+        if: steps.gate.outputs.stable == 'true'
         uses: astral-sh/setup-uv@v8.2.0
 
       - name: Check if SDK version already published
         id: check
+        if: steps.gate.outputs.stable == 'true'
         working-directory: sdk/python
         run: |
           VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,55 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Classify tag
+        id: classify
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "make_latest=true" >> "$GITHUB_OUTPUT"
+            echo "title=v${{ steps.version.outputs.version }}" >> "$GITHUB_OUTPUT"
+            PREV=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${TAG}$" | head -1)
+          elif [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-beta\.[0-9]+$ ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "make_latest=false" >> "$GITHUB_OUTPUT"
+            echo "title=${TAG} (beta)" >> "$GITHUB_OUTPUT"
+            PREV=$(git tag -l 'v*-beta.*' --sort=-v:refname | grep -v "^${TAG}$" | head -1)
+          elif [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "make_latest=false" >> "$GITHUB_OUTPUT"
+            echo "title=${TAG} (alpha)" >> "$GITHUB_OUTPUT"
+            PREV=$(git tag -l 'v*-alpha.*' --sort=-v:refname | grep -v "^${TAG}$" | head -1)
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "make_latest=false" >> "$GITHUB_OUTPUT"
+            echo "title=${TAG}" >> "$GITHUB_OUTPUT"
+            PREV=""
+          fi
+          if [[ -n "${PREV:-}" ]]; then
+            echo "notes_start_tag=$PREV" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "v${{ steps.version.outputs.version }}" \
+          ARGS=(
+            --title "${{ steps.classify.outputs.title }}"
             --generate-notes
+          )
+          if [[ "${{ steps.classify.outputs.prerelease }}" == "true" ]]; then
+            ARGS+=(--prerelease)
+          fi
+          ARGS+=(--latest=${{ steps.classify.outputs.make_latest }})
+          if [[ -n "${{ steps.classify.outputs.notes_start_tag }}" ]]; then
+            ARGS+=(--notes-start-tag "${{ steps.classify.outputs.notes_start_tag }}")
+          fi
+          gh release create "$GITHUB_REF_NAME" "${ARGS[@]}"

--- a/justfile
+++ b/justfile
@@ -318,6 +318,16 @@ promote to="" install="":
 release:
     bash scripts/release-tag.sh
 
+# Cut an alpha prerelease tag from the current version and push it.
+release-alpha:
+    bash scripts/release-version.sh --alpha
+    bash scripts/release-tag.sh
+
+# Cut a beta prerelease tag from the current version and push it.
+release-beta:
+    bash scripts/release-version.sh --beta
+    bash scripts/release-tag.sh
+
 # Remove a Plexi channel and its profile dir, app bundle, and CLI binary.
 # Defaults to removing all channels plus shell integration and completions.
 # Backlog folders inside profile dirs are archived to ~/plexi-backlog-archive/.

--- a/scripts/RELEASE_CHANNELS.md
+++ b/scripts/RELEASE_CHANNELS.md
@@ -104,15 +104,64 @@ running instance. Binary-local behavior, such as config paths, workspace paths,
 update/install behavior, and release gates, comes from whichever binary the
 shim executes.
 
-## Stable Release Flow
+## Public Release Lanes
 
-1. Finish release polish on `alpha`.
-2. Run tests.
-3. Run `just bump minor` for `0.1.0`.
-4. Install and test `rc-010`.
-5. Promote alpha to beta with `just promote beta`.
-6. Test beta.
-7. Promote beta to main with `just promote main`.
+Three lanes publish GitHub releases. Each is a tag push handled by
+`.github/workflows/release.yml`, which classifies the tag and marks prereleases.
 
-Do not use `plexi-beta update` to test unreleased alpha work. `plexi update`
-downloads the latest public GitHub release.
+| Lane | Tag scheme | GitHub release | Branch tagged from |
+|---|---|---|---|
+| Alpha | `vX.Y.Z-alpha.N` | prerelease | `alpha` |
+| Beta | `vX.Y.Z-beta.N` | prerelease | `alpha` |
+| Stable | `vX.Y.Z` | latest | `main` |
+
+The base `X.Y.Z` is the current `Cargo.toml` version. Prerelease tags do **not**
+bump `Cargo.toml` or touch the changelog — they pin a commit on `alpha` for
+testing the next version. The stable bump (`just bump`) sets the base version and
+regenerates the changelog.
+
+SemVer ordering: `vX.Y.Z-alpha.1 < alpha.2 < beta.1 < beta.2 < vX.Y.Z`.
+The Python SDK publishes only on stable tags; prerelease tags skip
+`publish-sdk.yml`.
+
+### Cutting a release
+
+```sh
+just release-alpha      # tag next vX.Y.Z-alpha.N from alpha, push
+just release-beta       # tag next vX.Y.Z-beta.N from alpha, push
+just bump minor         # bump base version + changelog on alpha
+just promote main       # fast-forward main
+just release            # tag vX.Y.Z at main HEAD, push
+```
+
+## Channel Update Policy
+
+A binary updates only to releases its channel accepts. The policy lives in
+`UpdateChannel::accepts` (`src/cli/release_resolver.rs`); the table below mirrors
+it.
+
+| Binary channel | Accepts |
+|---|---|
+| `plexi` (stable) | stable only |
+| `plexi-beta` | beta + stable |
+| `plexi-alpha`, `plexi-pr-*` | alpha + beta + stable |
+
+`plexi update` lists all releases (not just `/latest`), filters by the running
+binary's channel, picks the highest SemVer candidate newer than the current
+version, checks out that exact tag in `~/.plexi-src`, and rebuilds. The install
+target channel is always the running binary's channel — updating `plexi-alpha`
+to a stable tag still installs as `alpha`.
+
+Do not use `plexi-beta update` to test unreleased alpha work — beta never
+accepts alpha tags.
+
+## User Install by Channel
+
+```sh
+curl -fsSL https://plexiapp.com/install | sh                          # stable, prebuilt
+curl -fsSL https://plexiapp.com/install | sh -s -- --channel beta     # beta, source build
+curl -fsSL https://plexiapp.com/install | sh -s -- --channel alpha    # alpha, source build
+```
+
+Prerelease channels have no prebuilt assets, so they build from source and
+require Rust (https://rustup.rs) and Xcode command line tools.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -295,6 +295,14 @@ install_agents() {
 
 install_agents
 
+# Record the release tag that produced this install so the updater can compare
+# against prerelease tags of the same base version. Written by self-update and
+# user-install.sh when installing from a release tag; absent for source builds.
+if [[ -n "${PLEXI_INSTALL_TAG:-}" ]]; then
+  echo "$PLEXI_INSTALL_TAG" > "$profile_dir/installed_tag"
+  echo "Release tag: $PLEXI_INSTALL_TAG"
+fi
+
 echo "Installed $app_dest"
 echo "CLI: $bin_dest"
 echo "Config dir: $profile_dir/"

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -1,13 +1,47 @@
 #!/usr/bin/env bash
-# Push the version tag for the current Cargo.toml version.
-# Tags main HEAD if needed, then pushes the tag to trigger the GitHub Actions release workflow.
-# Run `just promote main` first to ensure main is up to date.
+# Push a version tag to trigger the GitHub Actions release workflow.
+#
+# Stable tags (vX.Y.Z) are pushed from the main worktree (run `just promote main`
+# first). Prerelease tags (vX.Y.Z-alpha.N / vX.Y.Z-beta.N) are pushed from alpha,
+# where they were cut by `scripts/release-version.sh --alpha|--beta`.
 set -euo pipefail
 
 REPO_ROOT=$(dirname "$(git rev-parse --git-common-dir)")
+ALPHA_TREE="$REPO_ROOT"
 MAIN_TREE="$REPO_ROOT/worktrees/main"
 
 die() { echo "error: $*" >&2; exit 1; }
+
+push_tag() {
+    local tree="$1" tag="$2"
+    remote_tag=$(git ls-remote --tags origin "refs/tags/$tag" | awk '{print $1}')
+    if [[ -n "$remote_tag" ]]; then
+        echo "Tag $tag already on remote — GitHub Actions release already triggered."
+    else
+        echo "Pushing tag $tag to origin..."
+        git -C "$tree" push origin "$tag"
+        echo "GitHub Actions release workflow triggered for $tag."
+    fi
+}
+
+# ── prerelease flow: newest alpha/beta tag on alpha ───────────────────────────
+
+base=$(grep '^version' "$ALPHA_TREE/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/' | sed 's/-.*//')
+pre_tag=$(git -C "$ALPHA_TREE" tag -l "v${base}-alpha.*" "v${base}-beta.*" --sort=-v:refname | head -1)
+
+if [[ -n "$pre_tag" ]]; then
+    tagged_commit=$(git -C "$ALPHA_TREE" rev-list -n 1 "$pre_tag")
+    head_commit=$(git -C "$ALPHA_TREE" rev-parse HEAD)
+    remote_tag=$(git ls-remote --tags origin "refs/tags/$pre_tag" | awk '{print $1}')
+    if [[ -z "$remote_tag" ]]; then
+        [[ "$tagged_commit" == "$head_commit" ]] \
+            || die "$pre_tag points at $tagged_commit, not alpha HEAD $head_commit — re-cut the prerelease"
+        push_tag "$ALPHA_TREE" "$pre_tag"
+        exit 0
+    fi
+fi
+
+# ── stable flow: vX.Y.Z from the main worktree ────────────────────────────────
 
 [[ $(git -C "$MAIN_TREE" rev-parse --abbrev-ref HEAD) == "main" ]] \
     || die "main worktree is not on 'main' branch"
@@ -31,11 +65,4 @@ else
     git -C "$MAIN_TREE" tag "v$version"
 fi
 
-remote_tag=$(git ls-remote --tags origin "refs/tags/v$version" | awk '{print $1}')
-if [[ -n "$remote_tag" ]]; then
-    echo "Tag v$version already on remote — GitHub Actions release already triggered."
-else
-    echo "Pushing tag v$version to origin..."
-    git -C "$MAIN_TREE" push origin "v$version"
-    echo "GitHub Actions release workflow triggered for v$version."
-fi
+push_tag "$MAIN_TREE" "v$version"

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 # Bump version, regenerate CHANGELOG via git-cliff, commit, and tag the release commit.
-# Usage: scripts/release-version.sh [patch|minor|major]
+# Usage: scripts/release-version.sh [patch|minor|major]           — stable bump
+#        scripts/release-version.sh --alpha                        — cut next alpha prerelease
+#        scripts/release-version.sh --beta                         — cut next beta prerelease
 # Default: patch
-# After this, run: just promote [beta|main]
+# After a stable bump, run: just promote [beta|main]
+# After a prerelease cut, run: bash scripts/release-tag.sh
 set -euo pipefail
 
 REPO_ROOT=$(dirname "$(git rev-parse --git-common-dir)")
@@ -12,16 +15,44 @@ die() { echo "error: $*" >&2; exit 1; }
 
 # ── validate args ─────────────────────────────────────────────────────────────
 
-bump="${1:-patch}"
-case "$bump" in
-    patch|minor|major) ;;
-    *) die "unknown bump type '$bump' — must be: patch | minor | major" ;;
+arg="${1:-patch}"
+prekind=""
+case "$arg" in
+    patch|minor|major) bump="$arg" ;;
+    --alpha) prekind="alpha" ;;
+    --beta) prekind="beta" ;;
+    *) die "unknown arg '$arg' — must be: patch | minor | major | --alpha | --beta" ;;
 esac
 
 # ── require clean state ───────────────────────────────────────────────────────
 
 git -C "$TREE" diff --quiet && git -C "$TREE" diff --cached --quiet \
     || die "alpha has uncommitted changes — commit first"
+
+# ── prerelease cut: tag only, no version bump, no changelog ───────────────────
+
+if [[ -n "$prekind" ]]; then
+    current=$(grep '^version' "$TREE/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
+    base=$(echo "$current" | sed 's/-.*//')
+    git -C "$TREE" fetch origin --tags --quiet 2>/dev/null || true
+    highest=$(git -C "$TREE" tag -l "v${base}-${prekind}.*" --sort=-v:refname | head -1)
+    if [[ -n "$highest" ]]; then
+        n=$(echo "$highest" | sed "s/.*-${prekind}\.//")
+        next=$((n + 1))
+    else
+        next=1
+    fi
+    tag="v${base}-${prekind}.${next}"
+    if git -C "$TREE" rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+        die "tag $tag already exists — refusing to reuse a release boundary"
+    fi
+    echo "Cutting $prekind prerelease: $tag (base $base)"
+    git -C "$TREE" tag "$tag"
+    echo ""
+    echo "$tag tagged locally on alpha."
+    echo "Next: bash scripts/release-tag.sh"
+    exit 0
+fi
 
 # ── require git-cliff ─────────────────────────────────────────────────────────
 

--- a/scripts/user-install.sh
+++ b/scripts/user-install.sh
@@ -71,11 +71,17 @@ if [[ "$CHANNEL" != "stable" ]]; then
         | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
     [[ -n "$TAGS" ]] || die "Could not list releases."
 
+    # SemVer: stable > beta > alpha for the same base version, but sort -V
+    # inverts this (prereleases sort above). Separate stable and prerelease tags,
+    # sort each group, then prefer stable over prerelease within the same base.
+    STABLE_TAGS=$(echo "$TAGS" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V -r)
+    PRE_TAGS=$(echo "$TAGS" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta)\.' | sort -V -r)
+    SORTED_TAGS=$(printf '%s\n%s' "$STABLE_TAGS" "$PRE_TAGS" | sed '/^$/d')
     TAG=""
     while IFS= read -r t; do
         [[ -n "$t" ]] || continue
         channel_accepts "$t" && { TAG="$t"; break; }
-    done <<< "$(echo "$TAGS" | sort -V -r)"
+    done <<< "$SORTED_TAGS"
     [[ -n "$TAG" ]] || die "No release found for channel '$CHANNEL'."
 
     info "Building Plexi $TAG from source (channel: $CHANNEL)..."
@@ -86,7 +92,7 @@ if [[ "$CHANNEL" != "stable" ]]; then
         git clone "https://github.com/$REPO.git" "$SRC"
     fi
     git -C "$SRC" checkout --force "$TAG"
-    bash "$SRC/scripts/install.sh" "$CHANNEL"
+    PLEXI_INSTALL_TAG="$TAG" bash "$SRC/scripts/install.sh" "$CHANNEL"
     ok "Plexi $TAG installed (channel: $CHANNEL). Run: plexi-$CHANNEL --version"
     exit 0
 fi

--- a/scripts/user-install.sh
+++ b/scripts/user-install.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 # Install Plexi from GitHub releases.
 # Usage: curl -fsSL https://plexiapp.com/install | sh
+#        curl -fsSL https://plexiapp.com/install | sh -s -- --channel beta
+#
+# --channel stable  (default) installs the latest stable release from a prebuilt zip.
+# --channel beta    installs the latest beta (or newer stable) prerelease by source build.
+# --channel alpha   installs the latest alpha/beta/stable prerelease by source build.
+#
+# Prerelease channels have no prebuilt assets, so they build from source.
+# Source builds require Rust (https://rustup.rs) and Xcode command line tools.
 set -euo pipefail
 
 REPO="ianjamesburke/PLEXI"
@@ -20,11 +28,68 @@ require() {
     command -v "$1" &>/dev/null || die "required tool not found: $1"
 }
 
+# ── parse args ────────────────────────────────────────────────────────────────
+
+CHANNEL="stable"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --channel) CHANNEL="${2:-}"; shift 2 ;;
+        --channel=*) CHANNEL="${1#--channel=}"; shift ;;
+        *) die "unknown argument: $1" ;;
+    esac
+done
+case "$CHANNEL" in
+    stable|beta|alpha) ;;
+    *) die "unknown channel '$CHANNEL' — must be: stable | beta | alpha" ;;
+esac
+
 # ── preflight ─────────────────────────────────────────────────────────────────
 
 [[ "$(uname)" == "Darwin" ]] || die "Plexi is macOS only."
 require curl
 require unzip
+
+# Mirror UpdateChannel::accepts from src/cli/release_resolver.rs.
+# stable: only vX.Y.Z   beta: beta + stable   alpha: alpha + beta + stable
+channel_accepts() {
+    local tag="$1"
+    case "$tag" in
+        *-alpha.*) [[ "$CHANNEL" == "alpha" ]] ;;
+        *-beta.*)  [[ "$CHANNEL" == "alpha" || "$CHANNEL" == "beta" ]] ;;
+        *)         true ;;
+    esac
+}
+
+# ── source-build path for prerelease channels ─────────────────────────────────
+
+if [[ "$CHANNEL" != "stable" ]]; then
+    require git
+    command -v cargo &>/dev/null || die "Rust is required for the $CHANNEL channel — install from https://rustup.rs"
+
+    info "Resolving latest $CHANNEL release..."
+    TAGS=$(curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=100" \
+        | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+    [[ -n "$TAGS" ]] || die "Could not list releases."
+
+    TAG=""
+    while IFS= read -r t; do
+        [[ -n "$t" ]] || continue
+        channel_accepts "$t" && { TAG="$t"; break; }
+    done <<< "$(echo "$TAGS" | sort -V -r)"
+    [[ -n "$TAG" ]] || die "No release found for channel '$CHANNEL'."
+
+    info "Building Plexi $TAG from source (channel: $CHANNEL)..."
+    SRC="$HOME/.plexi-src"
+    if [[ -d "$SRC/.git" ]]; then
+        git -C "$SRC" fetch origin --tags --force
+    else
+        git clone "https://github.com/$REPO.git" "$SRC"
+    fi
+    git -C "$SRC" checkout --force "$TAG"
+    bash "$SRC/scripts/install.sh" "$CHANNEL"
+    ok "Plexi $TAG installed (channel: $CHANNEL). Run: plexi-$CHANNEL --version"
+    exit 0
+fi
 
 # ── fetch version (needed for banner) ────────────────────────────────────────
 

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -512,9 +512,20 @@ pub fn run_self_update(from_gui: bool) -> Result<String, String> {
         "cli: self-update input channel={channel} update_channel={update_channel:?} install_target={channel}"
     );
 
-    let current_version = env!("CARGO_PKG_VERSION");
+    // Read the installed release tag if available (written by previous self-update),
+    // falling back to CARGO_PKG_VERSION for source builds.
+    let profile_dir = dirs::home_dir()
+        .unwrap_or_default()
+        .join(format!(".plexi{}", if suffix.is_empty() { String::new() } else { format!("-{channel}") }));
+    let current_version_raw = std::fs::read_to_string(profile_dir.join("installed_tag"))
+        .ok()
+        .and_then(|s| {
+            let t = s.trim().to_string();
+            release_resolver::ReleaseTag::parse(&t).map(|_| t)
+        })
+        .unwrap_or_else(|| format!("v{}", env!("CARGO_PKG_VERSION")));
     println!("Checking for updates...");
-    println!("Current: v{current_version}");
+    println!("Current: {current_version_raw}");
 
     let agent = ureq::AgentBuilder::new()
         .timeout_connect(std::time::Duration::from_secs(10))
@@ -523,11 +534,11 @@ pub fn run_self_update(from_gui: bool) -> Result<String, String> {
 
     let releases = release_resolver::fetch_releases(&agent)
         .map_err(|e| format!("error: {e}"))?;
-    let current_tag = release_resolver::ReleaseTag::parse(&format!("v{current_version}"))
-        .ok_or_else(|| format!("error: could not parse current version v{current_version}"))?;
+    let current_tag = release_resolver::ReleaseTag::parse(&current_version_raw)
+        .ok_or_else(|| format!("error: could not parse current version {current_version_raw}"))?;
     let selected = match release_resolver::resolve_best(&releases, update_channel, &current_tag) {
         Some(t) => t,
-        None => return Ok(format!("Already up to date (v{current_version}).")),
+        None => return Ok(format!("Already up to date ({current_version_raw}).")),
     };
     let tag_name = selected.raw.clone();
     let latest_version = tag_name.trim_start_matches('v').to_string();
@@ -563,7 +574,7 @@ pub fn run_self_update(from_gui: bool) -> Result<String, String> {
                git clone '{repo}' '{src}'\n\
              fi\n\
              git -C '{src}' checkout --force '{tag}'\n\
-             bash '{src}/scripts/install.sh' '{channel}'\n\
+             PLEXI_INSTALL_TAG='{tag}' bash '{src}/scripts/install.sh' '{channel}'\n\
              open '/Applications/{app_display_name}.app'\n",
             binary_name = binary_name,
             src = src_dir.display(),
@@ -628,6 +639,7 @@ pub fn run_self_update(from_gui: bool) -> Result<String, String> {
     let install = std::process::Command::new("bash")
         .arg(&install_script)
         .arg(&channel)
+        .env("PLEXI_INSTALL_TAG", &tag_name)
         .current_dir(&src_dir)
         .status()
         .map_err(|e| format!("error: failed to run install script: {e}"))?;

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -1,5 +1,6 @@
 use super::app::{is_bare_id, is_github_shorthand};
 use super::print_tip;
+use crate::cli::release_resolver;
 use std::io::{self, Write};
 
 pub fn install_cli(spec: &str) -> i32 {
@@ -496,44 +497,41 @@ pub fn run_self_update(from_gui: bool) -> Result<String, String> {
         log::info!("ui: one-click update triggered from changelog modal");
     }
 
-    if binary_name.contains("alpha") || binary_name.contains("pr-") {
-        return Err(
-            "Self-update is not available for dev builds.\nUpdate from source: git pull && just install"
-                .to_string(),
-        );
+    // Guard: when running inside a channel PTY, the binary name must match the
+    // PTY channel — otherwise a stray binary could update the wrong channel.
+    if let Ok(pty_channel) = std::env::var("PLEXI_CHANNEL") {
+        if !pty_channel.is_empty() && pty_channel != channel {
+            return Err(format!(
+                "error: PLEXI_CHANNEL={pty_channel} but this binary is '{binary_name}' (channel {channel}).\nRun the matching channel binary to self-update."
+            ));
+        }
     }
+
+    let update_channel = release_resolver::UpdateChannel::from_binary_name(binary_name);
+    log::info!(
+        "cli: self-update input channel={channel} update_channel={update_channel:?} install_target={channel}"
+    );
 
     let current_version = env!("CARGO_PKG_VERSION");
     println!("Checking for updates...");
     println!("Current: v{current_version}");
 
-    // Check latest release tag via GitHub API (no asset download needed).
     let agent = ureq::AgentBuilder::new()
         .timeout_connect(std::time::Duration::from_secs(10))
         .timeout(std::time::Duration::from_secs(30))
         .build();
 
-    let release_body = agent
-        .get("https://api.github.com/repos/ianjamesburke/PLEXI/releases/latest")
-        .set("User-Agent", "plexi-self-update")
-        .set("Accept", "application/vnd.github+json")
-        .call()
-        .map_err(|e| format!("error: failed to fetch release info: {e}"))?
-        .into_string()
-        .map_err(|e| format!("error: failed to read release response: {e}"))?;
-
-    let release: serde_json::Value = serde_json::from_str(&release_body)
-        .map_err(|e| format!("error: failed to parse release response: {e}"))?;
-
-    let tag_name = release["tag_name"]
-        .as_str()
-        .ok_or_else(|| "error: release has no tag_name".to_string())?
-        .to_string();
-
-    let latest_version = tag_name.trim_start_matches('v');
-    if latest_version == current_version {
-        return Ok(format!("Already up to date (v{current_version})."));
-    }
+    let releases = release_resolver::fetch_releases(&agent)
+        .map_err(|e| format!("error: {e}"))?;
+    let current_tag = release_resolver::ReleaseTag::parse(&format!("v{current_version}"))
+        .ok_or_else(|| format!("error: could not parse current version v{current_version}"))?;
+    let selected = match release_resolver::resolve_best(&releases, update_channel, &current_tag) {
+        Some(t) => t,
+        None => return Ok(format!("Already up to date (v{current_version}).")),
+    };
+    let tag_name = selected.raw.clone();
+    let latest_version = tag_name.trim_start_matches('v').to_string();
+    log::info!("cli: self-update selected tag={tag_name} install_target_channel={channel}");
     println!("Latest:  {tag_name}");
 
     // Build from the persistent source clone (~/.plexi-src) so the user's local
@@ -560,16 +558,16 @@ pub fn run_self_update(from_gui: bool) -> Result<String, String> {
              set -euo pipefail\n\
              while pgrep -x '{binary_name}' > /dev/null 2>&1; do sleep 0.3; done\n\
              if [[ -d '{src}/.git' ]]; then\n\
-               git -C '{src}' fetch origin\n\
-               git -C '{src}' checkout '{channel}' 2>/dev/null || git -C '{src}' checkout -b '{channel}' 'origin/{channel}'\n\
-               git -C '{src}' reset --hard 'origin/{channel}'\n\
+               git -C '{src}' fetch origin --tags --force\n\
              else\n\
-               git clone --branch '{channel}' '{repo}' '{src}'\n\
+               git clone '{repo}' '{src}'\n\
              fi\n\
+             git -C '{src}' checkout --force '{tag}'\n\
              bash '{src}/scripts/install.sh' '{channel}'\n\
              open '/Applications/{app_display_name}.app'\n",
             binary_name = binary_name,
             src = src_dir.display(),
+            tag = tag_name,
             channel = channel,
             repo = repo,
             app_display_name = app_display_name,
@@ -597,36 +595,33 @@ pub fn run_self_update(from_gui: bool) -> Result<String, String> {
         return Ok("Building update in background — Plexi will relaunch when ready.".to_string());
     }
 
-    // CLI path: update source and build inline.
+    // CLI path: update source and build inline. Check out the exact release
+    // tag (not the channel branch) so the build matches the resolved release.
     println!("Updating source...");
     if src_dir.join(".git").is_dir() {
         let fetch = std::process::Command::new("git")
-            .args(["-C", &src_dir.to_string_lossy(), "fetch", "origin"])
+            .args(["-C", &src_dir.to_string_lossy(), "fetch", "origin", "--tags", "--force"])
             .status()
             .map_err(|e| format!("error: git fetch failed: {e}"))?;
         if !fetch.success() {
             return Err("error: git fetch failed".to_string());
         }
-        // checkout may fail if branch doesn't exist locally yet; fall through to reset
-        let _ = std::process::Command::new("git")
-            .args(["-C", &src_dir.to_string_lossy(), "checkout", &channel])
-            .status();
-        let reset = std::process::Command::new("git")
-            .args(["-C", &src_dir.to_string_lossy(), "reset", "--hard", &format!("origin/{channel}")])
-            .status()
-            .map_err(|e| format!("error: git reset failed: {e}"))?;
-        if !reset.success() {
-            return Err("error: git reset failed".to_string());
-        }
     } else {
         println!("Cloning source to ~/.plexi-src...");
         let clone = std::process::Command::new("git")
-            .args(["clone", "--branch", &channel, repo, &src_dir.to_string_lossy()])
+            .args(["clone", repo, &src_dir.to_string_lossy()])
             .status()
             .map_err(|e| format!("error: git clone failed: {e}"))?;
         if !clone.success() {
             return Err("error: git clone failed".to_string());
         }
+    }
+    let checkout = std::process::Command::new("git")
+        .args(["-C", &src_dir.to_string_lossy(), "checkout", "--force", &tag_name])
+        .status()
+        .map_err(|e| format!("error: git checkout failed: {e}"))?;
+    if !checkout.success() {
+        return Err(format!("error: git checkout of tag {tag_name} failed"));
     }
 
     println!("Building v{latest_version} (this takes a few minutes)...");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -225,6 +225,7 @@ pub mod notify;
 pub mod open;
 pub mod pane;
 pub mod registry_watch;
+pub mod release_resolver;
 pub mod routine;
 pub mod run;
 pub mod updater;

--- a/src/cli/release_resolver.rs
+++ b/src/cli/release_resolver.rs
@@ -1,0 +1,344 @@
+//! Channel-aware release resolution via the GitHub releases API.
+
+use std::cmp::Ordering;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+const RELEASES_URL: &str = "https://api.github.com/repos/ianjamesburke/PLEXI/releases";
+
+/// A parsed release tag.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseTag {
+    pub major: u64,
+    pub minor: u64,
+    pub patch: u64,
+    pub pre: Option<Prerelease>,
+    pub raw: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Prerelease {
+    pub kind: PreKind,
+    pub num: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PreKind {
+    Alpha,
+    Beta,
+}
+
+/// Which releases a channel accepts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateChannel {
+    /// only plain vX.Y.Z
+    Stable,
+    /// beta + stable, never alpha
+    Beta,
+    /// alpha + beta + stable
+    Alpha,
+}
+
+impl ReleaseTag {
+    /// Parse `vX.Y.Z`, `vX.Y.Z-alpha.N`, `vX.Y.Z-beta.N`.
+    /// Returns `None` for malformed tags or unrecognized prerelease schemes
+    /// (e.g. old `-rc1` tags).
+    pub fn parse(tag: &str) -> Option<Self> {
+        let raw = tag.to_string();
+        let body = tag.strip_prefix('v').unwrap_or(tag);
+        let (version, pre_str) = match body.split_once('-') {
+            Some((v, p)) => (v, Some(p)),
+            None => (body, None),
+        };
+
+        let mut parts = version.split('.');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok()?;
+        let patch = parts.next()?.parse().ok()?;
+        if parts.next().is_some() {
+            return None;
+        }
+
+        let pre = match pre_str {
+            None => None,
+            Some(p) => {
+                let (kind_str, num_str) = p.split_once('.')?;
+                let kind = match kind_str {
+                    "alpha" => PreKind::Alpha,
+                    "beta" => PreKind::Beta,
+                    _ => return None,
+                };
+                let num = num_str.parse().ok()?;
+                Some(Prerelease { kind, num })
+            }
+        };
+
+        Some(ReleaseTag {
+            major,
+            minor,
+            patch,
+            pre,
+            raw,
+        })
+    }
+}
+
+impl Ord for ReleaseTag {
+    fn cmp(&self, other: &Self) -> Ordering {
+        (self.major, self.minor, self.patch)
+            .cmp(&(other.major, other.minor, other.patch))
+            .then_with(|| match (&self.pre, &other.pre) {
+                // A release with no prerelease is greater than any prerelease
+                // of the same base version (SemVer §11).
+                (None, None) => Ordering::Equal,
+                (None, Some(_)) => Ordering::Greater,
+                (Some(_), None) => Ordering::Less,
+                (Some(a), Some(b)) => a.kind.cmp(&b.kind).then(a.num.cmp(&b.num)),
+            })
+    }
+}
+
+impl PartialOrd for ReleaseTag {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl UpdateChannel {
+    /// `plexi` → Stable, `plexi-beta` → Beta, `plexi-alpha`/`plexi-pr-*` → Alpha.
+    /// Unknown channels default to Stable (the most conservative policy).
+    pub fn from_binary_name(name: &str) -> Self {
+        let suffix = match name.strip_prefix("plexi") {
+            Some(s) => s.strip_prefix('-').unwrap_or(""),
+            None => "",
+        };
+        if suffix.is_empty() {
+            UpdateChannel::Stable
+        } else if suffix == "beta" {
+            UpdateChannel::Beta
+        } else if suffix == "alpha" || suffix.starts_with("pr-") {
+            UpdateChannel::Alpha
+        } else {
+            UpdateChannel::Stable
+        }
+    }
+
+    /// Filtering logic per channel policy.
+    pub fn accepts(&self, tag: &ReleaseTag) -> bool {
+        match (self, &tag.pre) {
+            (_, None) => true, // every channel accepts stable releases
+            (UpdateChannel::Stable, Some(_)) => false,
+            (UpdateChannel::Beta, Some(p)) => p.kind == PreKind::Beta,
+            (UpdateChannel::Alpha, Some(_)) => true,
+        }
+    }
+}
+
+/// A GitHub release as returned by the releases list endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GithubRelease {
+    pub tag_name: String,
+    #[serde(default)]
+    pub prerelease: bool,
+    #[serde(default)]
+    pub draft: bool,
+}
+
+/// Pick the best update candidate for `channel` that is strictly newer than `current`.
+pub fn resolve_best(
+    releases: &[GithubRelease],
+    channel: UpdateChannel,
+    current: &ReleaseTag,
+) -> Option<ReleaseTag> {
+    releases
+        .iter()
+        .filter(|r| !r.draft)
+        .filter_map(|r| ReleaseTag::parse(&r.tag_name).map(|t| (r.prerelease, t)))
+        // GitHub's prerelease flag is authoritative: a release GitHub marks as a
+        // prerelease must never reach the Stable channel, even if the tag string
+        // parsed as a plain vX.Y.Z.
+        .filter(|(is_prerelease, t)| {
+            if *is_prerelease && t.pre.is_none() {
+                channel != UpdateChannel::Stable
+            } else {
+                channel.accepts(t)
+            }
+        })
+        .filter(|(_, t)| t > current)
+        .map(|(_, t)| t)
+        .max()
+}
+
+/// Fetch all releases from the GitHub releases list endpoint.
+pub fn fetch_releases(agent: &ureq::Agent) -> Result<Vec<GithubRelease>, String> {
+    let body = agent
+        .get(RELEASES_URL)
+        .set("User-Agent", "plexi-updater")
+        .set("Accept", "application/vnd.github+json")
+        .timeout(Duration::from_secs(30))
+        .call()
+        .map_err(|e| format!("failed to fetch releases: {e}"))?
+        .into_string()
+        .map_err(|e| format!("failed to read releases response: {e}"))?;
+    serde_json::from_str(&body).map_err(|e| format!("failed to parse releases response: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tag(s: &str) -> ReleaseTag {
+        ReleaseTag::parse(s).expect("valid tag")
+    }
+
+    #[test]
+    fn parse_stable() {
+        let t = tag("v0.1.12");
+        assert_eq!((t.major, t.minor, t.patch), (0, 1, 12));
+        assert!(t.pre.is_none());
+        assert_eq!(t.raw, "v0.1.12");
+    }
+
+    #[test]
+    fn parse_without_v_prefix() {
+        let t = tag("1.2.3");
+        assert_eq!((t.major, t.minor, t.patch), (1, 2, 3));
+    }
+
+    #[test]
+    fn parse_alpha() {
+        let t = tag("v0.1.12-alpha.3");
+        assert_eq!(t.pre, Some(Prerelease { kind: PreKind::Alpha, num: 3 }));
+    }
+
+    #[test]
+    fn parse_beta() {
+        let t = tag("v0.1.12-beta.1");
+        assert_eq!(t.pre, Some(Prerelease { kind: PreKind::Beta, num: 1 }));
+    }
+
+    #[test]
+    fn parse_malformed() {
+        assert!(ReleaseTag::parse("v1.2").is_none());
+        assert!(ReleaseTag::parse("v1.2.3.4").is_none());
+        assert!(ReleaseTag::parse("vfoo").is_none());
+        assert!(ReleaseTag::parse("v1.2.x").is_none());
+    }
+
+    #[test]
+    fn parse_old_rc_tag_rejected() {
+        assert!(ReleaseTag::parse("v3.5.0-rc1").is_none());
+        assert!(ReleaseTag::parse("v3.5.0-rc.1").is_none());
+    }
+
+    #[test]
+    fn ordering_cross_version() {
+        assert!(tag("v0.2.0") > tag("v0.1.99"));
+        assert!(tag("v1.0.0") > tag("v0.9.9"));
+        assert!(tag("v0.1.13") > tag("v0.1.12"));
+    }
+
+    #[test]
+    fn ordering_prerelease_below_release() {
+        assert!(tag("v0.1.12") > tag("v0.1.12-beta.1"));
+        assert!(tag("v0.1.12") > tag("v0.1.12-alpha.9"));
+    }
+
+    #[test]
+    fn ordering_same_base_prereleases() {
+        assert!(tag("v0.1.12-alpha.1") < tag("v0.1.12-alpha.2"));
+        assert!(tag("v0.1.12-alpha.2") < tag("v0.1.12-beta.1"));
+        assert!(tag("v0.1.12-beta.1") < tag("v0.1.12-beta.2"));
+        assert!(tag("v0.1.12-beta.2") < tag("v0.1.12"));
+    }
+
+    #[test]
+    fn channel_acceptance() {
+        let stable = tag("v0.1.12");
+        let beta = tag("v0.1.12-beta.1");
+        let alpha = tag("v0.1.12-alpha.1");
+
+        assert!(UpdateChannel::Stable.accepts(&stable));
+        assert!(!UpdateChannel::Stable.accepts(&beta));
+        assert!(!UpdateChannel::Stable.accepts(&alpha));
+
+        assert!(UpdateChannel::Beta.accepts(&stable));
+        assert!(UpdateChannel::Beta.accepts(&beta));
+        assert!(!UpdateChannel::Beta.accepts(&alpha));
+
+        assert!(UpdateChannel::Alpha.accepts(&stable));
+        assert!(UpdateChannel::Alpha.accepts(&beta));
+        assert!(UpdateChannel::Alpha.accepts(&alpha));
+    }
+
+    #[test]
+    fn from_binary_name() {
+        assert_eq!(UpdateChannel::from_binary_name("plexi"), UpdateChannel::Stable);
+        assert_eq!(UpdateChannel::from_binary_name("plexi-beta"), UpdateChannel::Beta);
+        assert_eq!(UpdateChannel::from_binary_name("plexi-alpha"), UpdateChannel::Alpha);
+        assert_eq!(UpdateChannel::from_binary_name("plexi-pr-123"), UpdateChannel::Alpha);
+        assert_eq!(UpdateChannel::from_binary_name("plexi-rc-010"), UpdateChannel::Stable);
+    }
+
+    fn rel(t: &str) -> GithubRelease {
+        GithubRelease { tag_name: t.to_string(), prerelease: false, draft: false }
+    }
+
+    #[test]
+    fn resolve_best_alpha_picks_newest_prerelease() {
+        let releases = vec![
+            rel("v0.1.12"),
+            rel("v0.1.13-alpha.1"),
+            rel("v0.1.13-alpha.2"),
+            rel("v0.1.13-beta.1"),
+        ];
+        let current = tag("v0.1.12");
+        let best = resolve_best(&releases, UpdateChannel::Alpha, &current).unwrap();
+        assert_eq!(best.raw, "v0.1.13-beta.1");
+    }
+
+    #[test]
+    fn resolve_best_stable_ignores_prereleases() {
+        let releases = vec![rel("v0.1.13-alpha.5"), rel("v0.1.13-beta.2")];
+        let current = tag("v0.1.12");
+        assert!(resolve_best(&releases, UpdateChannel::Stable, &current).is_none());
+    }
+
+    #[test]
+    fn resolve_best_skips_drafts() {
+        let mut draft = rel("v0.2.0");
+        draft.draft = true;
+        let releases = vec![draft, rel("v0.1.13")];
+        let current = tag("v0.1.12");
+        let best = resolve_best(&releases, UpdateChannel::Stable, &current).unwrap();
+        assert_eq!(best.raw, "v0.1.13");
+    }
+
+    #[test]
+    fn resolve_best_none_when_current_is_newest() {
+        let releases = vec![rel("v0.1.10"), rel("v0.1.11")];
+        let current = tag("v0.1.12");
+        assert!(resolve_best(&releases, UpdateChannel::Alpha, &current).is_none());
+    }
+
+    #[test]
+    fn resolve_best_github_prerelease_flag_excluded_from_stable() {
+        // A stable-looking tag GitHub flagged as prerelease must not reach stable.
+        let mut flagged = rel("v0.1.13");
+        flagged.prerelease = true;
+        let releases = vec![flagged];
+        let current = tag("v0.1.12");
+        assert!(resolve_best(&releases, UpdateChannel::Stable, &current).is_none());
+        // But alpha still accepts it.
+        assert!(resolve_best(&releases, UpdateChannel::Alpha, &current).is_some());
+    }
+
+    #[test]
+    fn resolve_best_beta_rejects_alpha_accepts_beta() {
+        let releases = vec![rel("v0.1.13-alpha.9"), rel("v0.1.13-beta.1")];
+        let current = tag("v0.1.12");
+        let best = resolve_best(&releases, UpdateChannel::Beta, &current).unwrap();
+        assert_eq!(best.raw, "v0.1.13-beta.1");
+    }
+}

--- a/src/cli/updater.rs
+++ b/src/cli/updater.rs
@@ -14,9 +14,9 @@ pub fn spawn_update_check(cache_dir: std::path::PathBuf, tx: mpsc::Sender<String
         .spawn(move || {
             let channel = detect_channel();
             let cache_path = cache_dir.join("update_cache.json");
+            let current_raw = installed_tag_or_cargo_version(&cache_dir);
             match cached_or_fetch(&cache_path, channel) {
                 Some(latest) => {
-                    let current_raw = format!("v{}", env!("CARGO_PKG_VERSION"));
                     let current = ReleaseTag::parse(&current_raw);
                     let latest_tag = ReleaseTag::parse(&latest);
                     let newer = match (&latest_tag, &current) {
@@ -38,6 +38,20 @@ pub fn spawn_update_check(cache_dir: std::path::PathBuf, tx: mpsc::Sender<String
             }
         })
         .ok();
+}
+
+/// Read the installed release tag from `<profile>/installed_tag`, falling back
+/// to `CARGO_PKG_VERSION` for source builds that don't write the tag file.
+fn installed_tag_or_cargo_version(cache_dir: &Path) -> String {
+    let tag_path = cache_dir.join("installed_tag");
+    if let Ok(tag) = std::fs::read_to_string(&tag_path) {
+        let trimmed = tag.trim().to_string();
+        if ReleaseTag::parse(&trimmed).is_some() {
+            log::info!("update check: using installed tag from {}", tag_path.display());
+            return trimmed;
+        }
+    }
+    format!("v{}", env!("CARGO_PKG_VERSION"))
 }
 
 fn detect_channel() -> UpdateChannel {

--- a/src/cli/updater.rs
+++ b/src/cli/updater.rs
@@ -4,113 +4,104 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
+use crate::cli::release_resolver::{self, ReleaseTag, UpdateChannel};
+
 const CHECK_INTERVAL: Duration = Duration::from_secs(86_400);
-const API_URL: &str = "https://api.github.com/repos/ianjamesburke/PLEXI/releases/latest";
 
 pub fn spawn_update_check(cache_dir: std::path::PathBuf, tx: mpsc::Sender<String>) {
     std::thread::Builder::new()
         .name("update-check".into())
         .spawn(move || {
+            let channel = detect_channel();
             let cache_path = cache_dir.join("update_cache.json");
-            match cached_or_fetch(&cache_path) {
+            match cached_or_fetch(&cache_path, channel) {
                 Some(latest) => {
-                    let current = env!("CARGO_PKG_VERSION");
-                    if semver_gt(&latest, current) {
+                    let current_raw = format!("v{}", env!("CARGO_PKG_VERSION"));
+                    let current = ReleaseTag::parse(&current_raw);
+                    let latest_tag = ReleaseTag::parse(&latest);
+                    let newer = match (&latest_tag, &current) {
+                        (Some(l), Some(c)) => l > c,
+                        _ => false,
+                    };
+                    if newer {
                         log::info!(
-                            "update check: newer release available: v{latest} (current v{current})"
+                            "update check: newer release available: {latest} (current {current_raw}, channel {channel:?})"
                         );
-                        let _ = tx.send(latest);
+                        let _ = tx.send(latest.trim_start_matches('v').to_string());
                     } else {
-                        log::info!("update check: already on latest or ahead (v{current})");
+                        log::info!(
+                            "update check: already on latest or ahead ({current_raw}, channel {channel:?})"
+                        );
                     }
                 }
-                None => log::warn!("update check: could not determine latest version"),
+                None => log::info!("update check: no newer release for channel {channel:?}"),
             }
         })
         .ok();
 }
 
-/// Returns true only when `a` is strictly newer than `b` by semver (M.m.p).
-/// Pre-release suffixes (e.g. `-alpha`, `-rc1`) are stripped before comparison.
-fn semver_gt(a: &str, b: &str) -> bool {
-    fn parse_component(s: &str) -> u64 {
-        let end = s.find(|c: char| !c.is_ascii_digit()).unwrap_or(s.len());
-        s[..end].parse().unwrap_or(0)
-    }
-    let parse = |s: &str| -> (u64, u64, u64) {
-        let mut parts = s.splitn(4, '.');
-        let major = parts.next().map(parse_component).unwrap_or(0);
-        let minor = parts.next().map(parse_component).unwrap_or(0);
-        let patch = parts.next().map(parse_component).unwrap_or(0);
-        (major, minor, patch)
-    };
-    parse(a) > parse(b)
+fn detect_channel() -> UpdateChannel {
+    let name = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .unwrap_or_else(|| "plexi".to_string());
+    UpdateChannel::from_binary_name(&name)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::semver_gt;
-
-    #[test]
-    fn test_semver_gt() {
-        assert!(semver_gt("3.4.114", "3.4.113"));
-        assert!(semver_gt("3.5.0", "3.4.113"));
-        assert!(semver_gt("4.0.0", "3.9.9"));
-        assert!(!semver_gt("3.4.113", "3.4.113")); // equal
-        assert!(!semver_gt("3.4.111", "3.4.113")); // behind
-        assert!(!semver_gt("3.4.112", "3.4.113")); // one behind
-                                                   // pre-release suffix stripping (#876)
-        assert!(!semver_gt("3.4.84", "3.4.84-alpha")); // equal after strip
-        assert!(semver_gt("3.4.85", "3.4.84-alpha")); // newer than pre-release
-        assert!(!semver_gt("3.4.84-alpha", "3.4.84")); // pre-release not newer than release
-        assert!(!semver_gt("3.5.0-rc1", "3.5.0")); // rc not newer than final
-    }
-}
-
-fn cached_or_fetch(cache_path: &Path) -> Option<String> {
+/// Returns the best candidate tag (e.g. `v0.1.13-beta.1`) for `channel`, or
+/// `None` when the cache is fresh and held no candidate or the fetch found none.
+fn cached_or_fetch(cache_path: &Path, channel: UpdateChannel) -> Option<String> {
     if let Ok(bytes) = std::fs::read(cache_path) {
         if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&bytes) {
             let checked_at = json["checked_at"].as_u64().unwrap_or(0);
+            let cached_channel = json["channel"].as_str().unwrap_or("");
             let now = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs();
-            if Duration::from_secs(now.saturating_sub(checked_at)) < CHECK_INTERVAL {
+            let fresh = Duration::from_secs(now.saturating_sub(checked_at)) < CHECK_INTERVAL;
+            if fresh && cached_channel == channel_key(channel) {
                 return json["latest"].as_str().map(|s| s.to_string());
             }
         }
     }
-    fetch_and_cache(cache_path)
+    fetch_and_cache(cache_path, channel)
 }
 
-fn fetch_and_cache(cache_path: &Path) -> Option<String> {
-    let response = ureq::AgentBuilder::new()
+fn channel_key(channel: UpdateChannel) -> &'static str {
+    match channel {
+        UpdateChannel::Stable => "stable",
+        UpdateChannel::Beta => "beta",
+        UpdateChannel::Alpha => "alpha",
+    }
+}
+
+fn fetch_and_cache(cache_path: &Path, channel: UpdateChannel) -> Option<String> {
+    let agent = ureq::AgentBuilder::new()
         .timeout(Duration::from_secs(5))
-        .build()
-        .get(API_URL)
-        .set("User-Agent", "plexi-updater")
-        .call()
-        .map_err(|e| log::warn!("update check: request failed: {e}"))
+        .build();
+    let releases = release_resolver::fetch_releases(&agent)
+        .map_err(|e| log::warn!("update check: {e}"))
         .ok()?;
-    let body = response
-        .into_string()
-        .map_err(|e| log::warn!("update check: response read failed: {e}"))
-        .ok()?;
-    let json: serde_json::Value = serde_json::from_str(&body)
-        .map_err(|e| log::warn!("update check: response parse failed: {e}"))
-        .ok()?;
-    let tag = json["tag_name"].as_str()?;
-    let version = tag.trim_start_matches('v').to_string();
+
+    let current = ReleaseTag::parse(&format!("v{}", env!("CARGO_PKG_VERSION")))?;
+    let best = release_resolver::resolve_best(&releases, channel, &current);
+
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs();
-    let cache = serde_json::json!({"checked_at": now, "latest": version});
+    let latest_raw = best.as_ref().map(|t| t.raw.clone());
+    let cache = serde_json::json!({
+        "checked_at": now,
+        "channel": channel_key(channel),
+        "latest": latest_raw,
+    });
     if let Err(e) = std::fs::write(cache_path, cache.to_string()) {
         log::warn!(
             "update check: failed to write cache to {}: {e}",
             cache_path.display()
         );
     }
-    Some(version)
+    latest_raw
 }


### PR DESCRIPTION
Stint task: 0303 (no linked GitHub issue)

## Summary

- Add shared release resolver (`src/cli/release_resolver.rs`) with proper SemVer prerelease ordering and channel-aware update candidate selection
- Enable `plexi update` for alpha and beta channels: alpha accepts all releases, beta accepts beta+stable, stable ignores prereleases
- Update GitHub release workflow to mark alpha/beta tags as prerelease (never latest) with same-lane release notes
- Gate SDK publishing to stable-only tags so alpha/beta app releases don't accidentally publish to PyPI
- Add release scripts for cutting prerelease tags (`just release-alpha`, `just release-beta`)
- Update `user-install.sh` with `--channel stable|beta|alpha` support
- Rewrite `RELEASE_CHANNELS.md` for the three-lane release model
- Add PLEXI_CHANNEL mismatch guard to prevent shim fallback from silently updating the wrong channel
- Self-update now checks out the exact release tag instead of resetting to branch HEAD

## Test evidence

- cargo test: 1365 passed, 0 failed (full bin suite)
- Conclusion: binary install required — release/update flow changes affect CLI self-update behavior and channel resolution
- PR install: required via `just pr-install <PR>` after merge validation

## Done When

- `plexi update` on stable ignores alpha/beta prereleases
- `plexi-beta update` can move to newer beta or stable releases
- `plexi-alpha update` can see alpha, beta, and stable releases
- GitHub alpha/beta releases are marked prerelease, never latest
- SDK publishing does not fire on prerelease tags
- `scripts/user-install.sh --channel alpha` works
- `RELEASE_CHANNELS.md` is canonical, no RC references in release flow