### PR TITLE
fix(pane-ops): pane new --window uses caller context, not active context

### DIFF
--- a/.agents/skills/implement-stint/SKILL.md
+++ b/.agents/skills/implement-stint/SKILL.md
@@ -104,6 +104,15 @@ If that worktree is dirty, ahead, or this pane is resuming the task, enter resum
 
 ## Phase 1 - Pre-Flight
 
+**Before proposing any fix**, read the AGENTS.md for every directory the task touches. These files contain traps — patterns that look reasonable but are wrong for this codebase. Checking them first prevents pitching a solution the codebase explicitly prohibits.
+
+```bash
+# Example: task touches src/app/lifecycle.rs and src/pane_ops/workspace.rs
+cat AGENTS.md  # root — cross-cutting traps
+cat src/app/AGENTS.md 2>/dev/null || true
+cat src/pane_ops/AGENTS.md 2>/dev/null || true
+```
+
 Run from repo root:
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,8 @@ Non-obvious discoveries with no single owning directory. When you discover a tra
 - **Command handler data must be self-contained.** Any data a command handler needs must be in the command's own fields, never looked up from ambient state at dispatch time. By dispatch, that state may have been mutated or cleared by an earlier step in the same frame.
 - **`#[cfg(unix)]` removal — grep all sites.** When removing a `#[cfg(unix)]` block or executable-bit check, grep for `set_mode`, `PermissionsExt`, and `0o755` across all test functions in the same file before staging. The helper function is never the only site.
 - **Issue-referenced code may no longer exist.** When an issue names specific functions or code paths, grep for them in alpha before implementing. The function may have been removed or moved since the issue was filed.
+- **`create_page_at` takes an explicit `context_id`.** Never temporarily switch `active_window` or `router.active` to steer `create_page_at` into a context — pass `context_id: u64` directly. To get the caller-pane's context: `find_pane_in_any_window(from_pane_id)` → `self.windows[win_idx].context_id`.
+- **Don't switch global state to thread data through a function.** When a helper reads from `router.active()` or `active_window`, the fix is to add an explicit parameter — not to temporarily mutate global focus state before calling it. Global-state mutation as a calling convention is always a hack.
 
 ## Architecture
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -865,10 +865,13 @@ impl PlexiApp {
                     let layout_str = spec.layout.as_deref().unwrap_or("split_h");
                     let initial_cmd = super::cmd_from_args(&spec.args);
                     if layout_str == "new_window" {
-                        // Create a new spatial grid window to the right of the
-                        // current context row instead of splitting the active pane.
-                        let ws_id = self.router.active().context_id;
-                        let active_y = self.windows[self.active_window].grid_y;
+                        // Derive context from the calling pane's window; fall back to active.
+                        let target_win_idx = spec
+                            .from_pane_id
+                            .and_then(|fid| self.find_pane_in_any_window(fid).map(|(idx, _)| idx))
+                            .unwrap_or(self.active_window);
+                        let ws_id = self.windows[target_win_idx].context_id;
+                        let active_y = self.windows[target_win_idx].grid_y;
                         let max_x = self
                             .windows
                             .iter()
@@ -876,10 +879,11 @@ impl PlexiApp {
                             .map(|w| w.grid_x)
                             .max();
                         let new_x = max_x.map(|x| x + 1).unwrap_or(1);
-                        log::info!("pane_ipc: spawn_pane terminal layout=new_window grid=({new_x},{active_y}) initial_cmd={initial_cmd:?} ephemeral={}", spec.ephemeral);
+                        log::info!("pane_ipc: spawn_pane terminal layout=new_window context={ws_id} grid=({new_x},{active_y}) initial_cmd={initial_cmd:?} ephemeral={}", spec.ephemeral);
                         self.create_page_at(
                             new_x,
                             active_y,
+                            ws_id,
                             initial_cmd.as_deref(),
                             spec.ephemeral,
                         );
@@ -1604,15 +1608,12 @@ impl PlexiApp {
                     new_ctx_id = self.router.get(self.router.len() - 1).context_id;
                 }
                 if ctx_ok && !windows.is_empty() {
-                    // When no-focus, active context is still the parent — temporarily switch
-                    // to the new context so create_page_at places windows there, then restore.
-                    let need_restore = self.router.active().context_id != new_ctx_id;
-                    if need_restore {
-                        if let Some(idx) = self.router.position(|c| c.context_id == new_ctx_id) {
-                            self.switch_workspace(idx);
-                        }
-                    }
-                    let active_y = self.windows[self.active_window].grid_y;
+                    let active_y = self
+                        .windows
+                        .iter()
+                        .find(|w| w.context_id == new_ctx_id)
+                        .map(|w| w.grid_y)
+                        .unwrap_or_else(|| self.windows[self.active_window].grid_y);
                     let mut new_x = self
                         .windows
                         .iter()
@@ -1625,13 +1626,8 @@ impl PlexiApp {
                         log::info!(
                             "pane_ipc: create_context window ctx_id={new_ctx_id} grid_x={new_x} cmd={cmd:?}"
                         );
-                        self.create_page_at(new_x, active_y, Some(cmd.as_str()), false);
+                        self.create_page_at(new_x, active_y, new_ctx_id, Some(cmd.as_str()), false);
                         new_x += 1;
-                    }
-                    if need_restore {
-                        if let Some(idx) = self.router.position(|c| c.context_id == orig_ctx_id) {
-                            self.switch_workspace(idx);
-                        }
                     }
                 }
                 // Write JSON response for callers that passed a response_file path.

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -1723,7 +1723,7 @@ fn create_context_with_windows_adds_extra_pages() {
         .map(|x| x + 1)
         .unwrap_or(1);
     for cmd in &cmds {
-        app.create_page_at(new_x, active_y, Some(cmd.as_str()), false);
+        app.create_page_at(new_x, active_y, ctx_id, Some(cmd.as_str()), false);
         new_x += 1;
     }
 

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -160,3 +160,82 @@ fn file_browser_opens_at_context_root() {
         "file browser should open at the context root, not the focused pane CWD"
     );
 }
+
+/// When `plexi pane new --window` is called with a `from_pane_id` in a non-active
+/// context, the new window must land in that pane's context — not the active one.
+/// Regression for: `new_window` derived ws_id and grid_y from active_window instead
+/// of from the calling pane's window.
+#[test]
+fn spawn_pane_new_window_uses_caller_context_not_active() {
+    let ctx = egui::Context::default();
+    let ft = crate::platform::logging::new_frame_tick();
+    let (mut app, ipc_tx) = PlexiApp::new_for_test(ctx, ft);
+
+    // Context 1 (id=1) is created by new_for_test at grid_y=0.
+    // Add a pane to context 1's window so we have a valid from_pane_id.
+    let (tile_ctx1, pane_id_ctx1) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(tile_ctx1);
+
+    // Add context 2 at grid_y=1 and make it the active context.
+    let ctx2_id: u64 = 2;
+    app.router.push(crate::host::context::Context {
+        name: "Context 2".into(),
+        path: std::env::temp_dir(),
+        root: None,
+        description: None,
+        context_id: ctx2_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    app.windows.push(crate::host::context::Window {
+        name: "Context 2".into(),
+        path: std::env::temp_dir(),
+        tree: egui_tiles::Tree::empty("ctx2_tree"),
+        panes: std::collections::HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 0,
+        grid_y: 1,
+        window_id: 10,
+        context_id: ctx2_id,
+    });
+    app.active_window = 1;
+    app.router.set_active(1);
+
+    let windows_before = app.windows.len();
+
+    // Inject a spawn-pane IPC from context 1's pane (pane_id_ctx1) with layout=new_window.
+    let _ = ipc_tx.send(crate::app_protocol::AppRequest::SpawnPane {
+        type_id: "terminal".to_string(),
+        layout: Some("new_window".to_string()),
+        args: vec![],
+        pipe_id: None,
+        from_pane_id: Some(pane_id_ctx1),
+        request_id: None,
+        response_file: None,
+        ephemeral: false,
+        cwd: None,
+        no_focus: false,
+        path: None,
+        workspace_root: None,
+        target_context: None,
+        name: None,
+    });
+    app.drain_pane_cmd_channel();
+
+    // PTY creation may fail in some CI environments; guard before asserting.
+    if app.windows.len() == windows_before {
+        return; // terminal spawn failed; skip remainder
+    }
+
+    let new_win = app.windows.last().expect("new window must exist");
+    assert_eq!(
+        new_win.context_id, 1,
+        "new window must be in context 1 (caller's context), not context 2 (active)"
+    );
+    assert_eq!(
+        new_win.grid_y, 0,
+        "new window must be in row 0 (caller's grid row), not row 1 (active context's row)"
+    );
+}

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -681,15 +681,16 @@ impl PlexiApp {
             Some(x) => x + 1,
             None => 1,
         };
-        self.create_page_at(new_x, active_y, None, false);
+        self.create_page_at(new_x, active_y, ws_id, None, false);
     }
 
-    /// Shared creation helper: create a single-pane context at `(grid_x, grid_y)`
-    /// and make it the active context.
+    /// Shared creation helper: create a single-pane window at `(grid_x, grid_y)` in
+    /// `context_id` and make it the active window.
     pub(crate) fn create_page_at(
         &mut self,
         grid_x: u32,
         grid_y: u32,
+        context_id: u64,
         initial_cmd: Option<&str>,
         close_on_exit: bool,
     ) {
@@ -700,7 +701,7 @@ impl PlexiApp {
             .resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
             .filter(|p| p != &PathBuf::from("/"))
             .unwrap_or(home);
-        log::info!("create_page_at({grid_x},{grid_y}): cwd={} context_root={:?} initial_cmd={initial_cmd:?} close_on_exit={close_on_exit}", cwd.display(), self.router.active().root);
+        log::info!("create_page_at({grid_x},{grid_y}): cwd={} context_id={context_id} initial_cmd={initial_cmd:?} close_on_exit={close_on_exit}", cwd.display());
         let Some((tree, panes, root_tile)) =
             self.create_single_pane_tree(Some(cwd.clone()), initial_cmd, close_on_exit)
         else {
@@ -708,7 +709,7 @@ impl PlexiApp {
             return;
         };
         let name = String::new();
-        let ctx_id = self.router.active().context_id;
+        let ctx_id = context_id;
         let win_id = self.next_window_id;
         self.next_window_id += 1;
         self.push_focus_history(old_window_id, old_focus);


### PR DESCRIPTION
Stint: 0304 — no linked GitHub issue

## Summary

- `create_page_at` now accepts an explicit `context_id: u64` parameter instead of reading from `router.active()`, eliminating the need for callers to temporarily mutate global focus state
- `pane new --window` IPC path derives context and grid row from `from_pane_id`'s window via `find_pane_in_any_window`; falls back to active window when `from_pane_id` is absent or not found
- Removes the existing `switch_workspace` hack from the `create_context` IPC path which had the same root cause

## Done When

- `plexi pane new --window` from a non-focused context places the new window in the caller's context row
- Scripts using `PLEXI_PANE_ID` as implicit `--from` no longer need an explicit `--from` flag