### PR TITLE
feat: CanvasRect border_color and border_width support (stint 0306)

### DIFF
--- a/apps/snake/snake.py
+++ b/apps/snake/snake.py
@@ -186,8 +186,8 @@ def _draw(data: dict) -> list:
     grid_h = ROWS * cell
     commands: list = [
         CanvasRect(0, 0, sdk.canvas_width, sdk.canvas_height, "#0d0d1a"),
-        CanvasRect(ox - 2, oy - 2, grid_w + 4, grid_h + 4, "#6c7086", radius=2.0),
-        CanvasRect(ox, oy, grid_w, grid_h, "#11111b"),
+        CanvasRect(ox, oy, grid_w, grid_h, "#11111b", radius=2.0,
+                   border_color="#6c7086", border_width=2.0),
     ]
     fx, fy = data["food"]
     commands.append(

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -435,11 +435,17 @@ class CanvasRect:
     height: float
     fill: str
     radius: float = 0.0
+    border_color: Optional[str] = None
+    border_width: float = 1.0
 
     def to_command(self) -> dict:
-        return {"type": "rect", "x": self.x, "y": self.y,
-                "w": self.width, "h": self.height,
-                "fill": self.fill, "radius": self.radius}
+        cmd = {"type": "rect", "x": self.x, "y": self.y,
+               "w": self.width, "h": self.height,
+               "fill": self.fill, "radius": self.radius}
+        if self.border_color is not None:
+            cmd["stroke"] = self.border_color
+            cmd["stroke_width"] = self.border_width
+        return cmd
 
 
 @dataclass
@@ -1237,15 +1243,9 @@ class Card(Component):
         return total + 2 * self.padding
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
-        ctx.rect(x, y, w, h, self.background or theme.surface, radius=self.radius)
         border_color = theme.highlight if self.border == "__theme__" else self.border
-        if border_color:
-            # Top + bottom + left + right 1px strokes. Drawn as four thin
-            # rects because `ctx.rect` doesn't support a separate stroke.
-            ctx.rect(x, y, w, 1.0, border_color)
-            ctx.rect(x, y + h - 1.0, w, 1.0, border_color)
-            ctx.rect(x, y, 1.0, h, border_color)
-            ctx.rect(x + w - 1.0, y, 1.0, h, border_color)
+        ctx.rect(x, y, w, h, self.background or theme.surface, radius=self.radius,
+                 stroke=border_color or None, stroke_width=1.0)
         inner_x = x + self.padding
         inner_y = y + self.padding
         inner_w = w - 2 * self.padding
@@ -1754,14 +1754,9 @@ class InfoTable(Component):
         return self.ROW_H * len(self.rows)
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
-        # Background + border
         background = self.background or theme.surface
         border = self.border or theme.highlight
-        ctx.rect(x, y, w, h, background, radius=self.radius)
-        ctx.rect(x, y, w, 1.0, border)
-        ctx.rect(x, y + h - 1.0, w, 1.0, border)
-        ctx.rect(x, y, 1.0, h, border)
-        ctx.rect(x + w - 1.0, y, 1.0, h, border)
+        ctx.rect(x, y, w, h, background, radius=self.radius, stroke=border, stroke_width=1.0)
 
         val_x = x + self.PAD_H + self.key_width + self.PAD_H
         val_w = w - self.PAD_H - self.key_width - self.PAD_H * 2

--- a/sdk/python/tests/test_v3_adapter.py
+++ b/sdk/python/tests/test_v3_adapter.py
@@ -141,6 +141,27 @@ def test_ui_tree_serializes_canvas_commands() -> None:
     ]
 
 
+def test_canvas_rect_border_serializes_stroke() -> None:
+    tree = _encode_uitree(
+        Canvas(
+            [
+                CanvasRect(0.0, 0.0, 10.0, 10.0, "#11111b",
+                           border_color="#6c7086", border_width=2.0),
+            ],
+        )
+    )
+    cmd = tree["nodes"][0]["data"]["commands"][0]
+    assert cmd["stroke"] == "#6c7086"
+    assert cmd["stroke_width"] == 2.0
+
+
+def test_canvas_rect_without_border_omits_stroke() -> None:
+    tree = _encode_uitree(Canvas([CanvasRect(0.0, 0.0, 10.0, 10.0, "#11111b")]))
+    cmd = tree["nodes"][0]["data"]["commands"][0]
+    assert "stroke" not in cmd
+    assert "stroke_width" not in cmd
+
+
 def test_effects_reject_unknown_dataclass() -> None:
     @dataclass
     class NotAnEffect:

--- a/src/process_app/render.rs
+++ b/src/process_app/render.rs
@@ -120,7 +120,7 @@ pub(crate) fn render_draw_commands(
                             rect,
                             *radius,
                             egui::Stroke::new(*stroke_width, stroke_color),
-                            egui::StrokeKind::Middle,
+                            egui::StrokeKind::Inside,
                         );
                     }
                 }


### PR DESCRIPTION
Stint task 0306 — no linked GitHub issue.

## Summary

- Add optional `border_color` (hex string) and `border_width` (f32) fields to `CanvasRect`; `to_command()` emits `stroke`/`stroke_width` keys when set
- Fix host `StrokeKind::Middle` → `StrokeKind::Inside` so the stroke renders within rect bounds
- Refactor `Card.render()` and `DetailTable.render()` to use `stroke=`/`stroke_width=` kwargs, eliminating the four-thin-rect border hack
- Update `snake.py` grid border to use the new border params instead of a separate backdrop rect

## Validation

Binary install required — canvas rendering change affects all apps using `CanvasRect` borders.
Install with `just pr-install <PR>` and run `plexi-pr-<PR> app launch apps/snake`.