### PR TITLE
fix: SDK versioning unification and min_sdk_version manifest gate (stint 0291)

### DIFF
--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -11,7 +11,8 @@ A future CPython-in-WASM compatibility runtime may provide a sandboxed Python
 app route. That work is deferred and is not the current SDK v3 execution path.
 """
 
-__version__ = "4.0.0"
+from ._version import __version__ as __version__
+
 SDK_ID = f"plexi-sdk-py/{__version__}"
 
 from ._v3_state import StateSnapshot, log, state

--- a/sdk/python/plexi_sdk/_constants.py
+++ b/sdk/python/plexi_sdk/_constants.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 from ._theme import _DEFAULTS as _TD
 
-# ── SDK version (single source of truth) ──────────────────────────────────────
-_SDK_VERSION = "0.5.0"
-
 # ── Font sizes (float, points) ────────────────────────────────────────────────
 TITLE      = 22.0
 HEADING    = 18.0

--- a/sdk/python/plexi_sdk/_v3_runtime.py
+++ b/sdk/python/plexi_sdk/_v3_runtime.py
@@ -148,6 +148,7 @@ class V3AppRuntime:
         _emit({
             "type": "ready",
             "sdk": sdk.SDK_ID,
+            "protocol_version": sdk.PROTOCOL_VERSION,
             "features_used": [],
         })
 

--- a/sdk/python/plexi_sdk/_version.py
+++ b/sdk/python/plexi_sdk/_version.py
@@ -1,0 +1,42 @@
+"""Single source of truth for the SDK version.
+
+The version lives in ``pyproject.toml`` (the ``[project].version`` field).
+At runtime it is read via ``importlib.metadata`` when the package is installed.
+When running from an uninstalled source checkout (no dist metadata), it is read
+directly from the sibling ``pyproject.toml``. Both paths return the same string;
+they never diverge because there is exactly one place the number is written.
+"""
+from __future__ import annotations
+
+import tomllib
+from importlib.metadata import PackageNotFoundError, version as _dist_version
+from pathlib import Path
+
+_DISTRIBUTION_NAME = "plexi-sdk"
+
+
+def _read_from_pyproject() -> str:
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    if not pyproject.is_file():
+        raise RuntimeError(
+            f"cannot resolve SDK version: {_DISTRIBUTION_NAME} is not installed and "
+            f"{pyproject} does not exist"
+        )
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    try:
+        return str(data["project"]["version"])
+    except KeyError as e:
+        raise RuntimeError(
+            f"cannot resolve SDK version: {pyproject} is missing [project].version"
+        ) from e
+
+
+def _resolve_version() -> str:
+    try:
+        return _dist_version(_DISTRIBUTION_NAME)
+    except PackageNotFoundError:
+        return _read_from_pyproject()
+
+
+__version__ = _resolve_version()

--- a/sdk/python/tests/test_version_unification.py
+++ b/sdk/python/tests/test_version_unification.py
@@ -1,0 +1,34 @@
+"""Guards against SDK version drift across files.
+
+There is one source of truth for the SDK version: ``[project].version`` in
+``pyproject.toml``. ``plexi_sdk.__version__`` and ``SDK_ID`` must derive from it.
+If anyone reintroduces a hardcoded version constant, these tests fail loudly.
+"""
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import plexi_sdk
+
+
+def _pyproject_version() -> str:
+    pyproject = Path(plexi_sdk.__file__).resolve().parent.parent / "pyproject.toml"
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    return str(data["project"]["version"])
+
+
+def test_dunder_version_matches_pyproject():
+    assert plexi_sdk.__version__ == _pyproject_version()
+
+
+def test_sdk_id_embeds_version():
+    assert plexi_sdk.SDK_ID == f"plexi-sdk-py/{plexi_sdk.__version__}"
+
+
+def test_no_stale_sdk_version_constant():
+    # _constants._SDK_VERSION was the old divergent source — it must stay gone.
+    from plexi_sdk import _constants
+
+    assert not hasattr(_constants, "_SDK_VERSION")

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -1,7 +1,8 @@
 version = 1
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
 name = "plexi-sdk"
-version = "3.0.0"
+version = "0.1.13"
 source = { editable = "." }

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -114,6 +114,13 @@ pub struct AppManifestApp {
     pub manifest_type: ManifestType,
     #[serde(default)]
     pub version: String,
+    /// Optional minimum SDK version this app requires, as a `major.minor.patch`
+    /// string (e.g. `"0.1.13"`). When set, the host compares it against the SDK
+    /// version reported in the ready handshake and rejects the app with a
+    /// user-visible fatal error if the running SDK is older. Absent → no gate;
+    /// the app launches on any SDK version (preserves every existing app).
+    #[serde(default)]
+    pub min_sdk_version: Option<String>,
     #[serde(default)]
     pub description: String,
     #[serde(default)]
@@ -713,6 +720,7 @@ impl AppRegistry {
         ) {
             Ok(mut app) => {
                 app.permissions.allowed_hosts = perms.allowed_hosts;
+                app.min_sdk_version = installed.manifest.min_sdk_version.clone();
                 app.manifest_min_width = installed.launch.min_width.unwrap_or(120.0);
                 app.manifest_min_height = installed.launch.min_height.unwrap_or(80.0);
                 app.compact_threshold = installed.launch.compact.unwrap_or(280.0);

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -742,6 +742,7 @@ impl PlexiApp {
                         ) {
                             Ok(mut process) => {
                                 process.permissions.allowed_hosts = perms.allowed_hosts;
+                                process.min_sdk_version = installed.manifest.min_sdk_version.clone();
                                 Some(process)
                             }
                             Err(e) => {
@@ -1415,6 +1416,7 @@ impl PlexiApp {
         ) {
             Ok(mut process) => {
                 process.permissions.allowed_hosts = perms.allowed_hosts;
+                process.min_sdk_version = installed.manifest.min_sdk_version.clone();
                 let group = installed.launch.join_group.clone();
                 let watch = installed.manifest.watch.unwrap_or(false);
                 log::info!(

--- a/src/process_app/host_bridge.rs
+++ b/src/process_app/host_bridge.rs
@@ -9,10 +9,12 @@ impl ProcessApp {
     /// that require UI-thread context (font metrics, clipboard, repaint).
     pub(crate) fn handle_control_command(&mut self, ui: &mut egui::Ui, cmd: ControlCommand) {
         match cmd {
-            ControlCommand::Ready { sdk, features_used } => {
-                self.sdk = Some(sdk);
-                self.features_used = features_used;
-                self.runtime.mark_ready();
+            ControlCommand::Ready {
+                sdk,
+                protocol_version,
+                features_used,
+            } => {
+                self.on_ready(sdk, protocol_version, features_used);
                 ui.ctx().request_repaint();
             }
             ControlCommand::FrameDone { frame_id: done_id } => {

--- a/src/process_app/mod.rs
+++ b/src/process_app/mod.rs
@@ -35,6 +35,67 @@ use runtime_state::{FrameDoneOutcome, PgapRuntime, RenderPoll};
 pub(crate) use scheduler::RENDER_IN_FLIGHT_TIMEOUT;
 pub(crate) use transport::StdinItem;
 
+/// Check a manifest `min_sdk_version` against the SDK version reported in the
+/// ready handshake. `reported_sdk` is the handshake `sdk` string, e.g.
+/// `"plexi-sdk-py/0.1.13"`; the version after the last `/` is parsed.
+///
+/// Pure and fully testable. Returns `Ok(())` when the running SDK satisfies the
+/// requirement, or `Err(message)` with a user-facing explanation when it does
+/// not (running SDK too old, or either version string is malformed — never a
+/// silent pass).
+fn check_sdk_gate(min: &str, reported_sdk: &str) -> Result<(), String> {
+    use crate::app::host_version::parse_version;
+
+    let Some(min_v) = parse_version(min) else {
+        return Err(format!(
+            "manifest [app].min_sdk_version = \"{min}\" is not a valid major.minor.patch version"
+        ));
+    };
+    let reported = reported_sdk.rsplit('/').next().unwrap_or("");
+    let Some(sdk_v) = parse_version(reported) else {
+        return Err(format!(
+            "could not parse SDK version from ready handshake (sdk = \"{reported_sdk}\"); \
+             this app requires SDK >= {min}"
+        ));
+    };
+    if sdk_v < min_v {
+        return Err(format!(
+            "this app requires Plexi SDK >= {min}, but the running SDK is {reported}. \
+             Update the Plexi SDK to run it."
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod sdk_gate_tests {
+    use super::check_sdk_gate;
+
+    #[test]
+    fn passes_when_sdk_at_or_above_min() {
+        assert!(check_sdk_gate("0.1.13", "plexi-sdk-py/0.1.13").is_ok());
+        assert!(check_sdk_gate("0.1.0", "plexi-sdk-py/0.1.13").is_ok());
+        assert!(check_sdk_gate("0.1.13", "plexi-sdk-py/0.2.0").is_ok());
+    }
+
+    #[test]
+    fn rejects_when_sdk_older_than_min() {
+        let err = check_sdk_gate("0.2.0", "plexi-sdk-py/0.1.13").unwrap_err();
+        assert!(err.contains(">= 0.2.0"), "message: {err}");
+        assert!(err.contains("0.1.13"), "message: {err}");
+    }
+
+    #[test]
+    fn rejects_malformed_min() {
+        assert!(check_sdk_gate("not-a-version", "plexi-sdk-py/0.1.13").is_err());
+    }
+
+    #[test]
+    fn rejects_unparseable_handshake_version() {
+        assert!(check_sdk_gate("0.1.0", "garbage").is_err());
+    }
+}
+
 fn channel_from_config_dir(config_dir: &Path) -> Option<String> {
     config_dir
         .file_name()
@@ -169,7 +230,12 @@ pub struct ProcessApp {
     pub(crate) pending_async_completions: usize,
     idle_render_poll_logged: bool,
     sdk: Option<String>,
+    /// Wire protocol version reported in the ready handshake (e.g. `"pgap/3"`).
+    protocol_version: Option<String>,
     features_used: Vec<String>,
+    /// Minimum SDK version this app requires (manifest `[app].min_sdk_version`).
+    /// `None` → no gate. Checked against the SDK version in the ready handshake.
+    pub(crate) min_sdk_version: Option<String>,
     /// workspace_root sent in Init — scopes all SecretGet calls.
     pub(crate) workspace_root: PathBuf,
     /// Directory containing the app's entry file — used to resolve relative
@@ -646,7 +712,9 @@ impl ProcessApp {
             pending_async_completions: 0,
             idle_render_poll_logged: false,
             sdk: None,
+            protocol_version: None,
             features_used: Vec::new(),
+            min_sdk_version: None,
             workspace_root,
             app_dir: bin_path
                 .parent()
@@ -819,7 +887,9 @@ impl ProcessApp {
             pending_async_completions: 0,
             idle_render_poll_logged: false,
             sdk: None,
+            protocol_version: None,
             features_used: Vec::new(),
+            min_sdk_version: None,
             workspace_root: std::env::temp_dir(),
             app_dir: std::env::temp_dir(),
             permissions,
@@ -1411,6 +1481,39 @@ impl ProcessApp {
         }
     }
 
+    /// Process the SDK ready handshake: record the reported SDK / protocol
+    /// versions, run the `min_sdk_version` gate, and mark the runtime ready
+    /// unless the gate rejected the app. Returns `true` if the app passed the
+    /// gate (or no gate was declared), `false` if it was rejected.
+    pub(crate) fn on_ready(
+        &mut self,
+        sdk: String,
+        protocol_version: String,
+        features_used: Vec<String>,
+    ) -> bool {
+        self.features_used = features_used;
+        self.protocol_version = if protocol_version.is_empty() {
+            None
+        } else {
+            Some(protocol_version)
+        };
+
+        if let Some(min) = self.min_sdk_version.clone() {
+            if let Err(message) = check_sdk_gate(&min, &sdk) {
+                self.sdk = Some(sdk);
+                self.record_fatal_error(
+                    message,
+                    String::from("SDK version gate failed at launch (manifest min_sdk_version)"),
+                );
+                return false;
+            }
+        }
+
+        self.sdk = Some(sdk);
+        self.runtime.mark_ready();
+        true
+    }
+
     fn set_scheduler_mode(&mut self, mode: &str, fps: Option<u32>) {
         match scheduler::AppSchedulerMode::from_wire(mode, fps) {
             Ok(parsed) => {
@@ -1621,10 +1724,12 @@ impl ProcessApp {
                     self.click_awaiting_frame = false;
                     self.lifecycle.on_frame_done();
                 }
-                DrawCommand::Control(ControlCommand::Ready { sdk, features_used }) => {
-                    self.sdk = Some(sdk);
-                    self.features_used = features_used;
-                    self.runtime.mark_ready();
+                DrawCommand::Control(ControlCommand::Ready {
+                    sdk,
+                    protocol_version,
+                    features_used,
+                }) => {
+                    self.on_ready(sdk, protocol_version, features_used);
                 }
                 DrawCommand::Control(ControlCommand::SetSchedulerMode { mode, fps }) => {
                     self.set_scheduler_mode(&mode, fps);

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -1544,6 +1544,11 @@ pub enum ControlCommand {
     Ready {
         #[serde(default)]
         sdk: String,
+        /// Wire protocol version the app was built against (e.g. `"pgap/3"`).
+        /// Lets the host know which protocol features the app may use. Empty
+        /// when an older SDK omits it.
+        #[serde(default)]
+        protocol_version: String,
         #[serde(default)]
         features_used: Vec<String>,
     },


### PR DESCRIPTION
Stint task 0291 — no linked GitHub issue.

## Summary

- Unify SDK version: `pyproject.toml` is now the single source; `__version__` reads from `importlib.metadata` (fallback: parses `pyproject.toml` directly for uninstalled source checkouts). Removes the conflicting `_constants._SDK_VERSION = "0.5.0"` constant.
- Add `protocol_version` field to `ControlCommand::Ready` and the Python ready handshake so the host knows which protocol features an app may use.
- Add `min_sdk_version` (optional) to `AppManifestApp`; host gate in `on_ready()` rejects apps with a user-visible fatal error when the installed SDK is older than required. Apps without the field launch unchanged.
- Add `check_sdk_gate()` with 4 unit tests (pass at/above min, reject older, reject malformed min, reject unparseable handshake).
- Add `test_version_unification.py` — fails loudly if anyone reintroduces a hardcoded version constant.

## Validation

Binary install required — host now reads `min_sdk_version` from manifest and gates app launch.
Install with `just pr-install <PR>` and verify: (1) existing apps launch normally (no `min_sdk_version` in manifest → no gate); (2) a test app with `min_sdk_version = "999.0.0"` shows a fatal error at launch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for app manifest limits on the minimum supported SDK version.
  * Included protocol version details in startup handshake messages.

* **Bug Fixes**
  * Prevented apps from launching when the running SDK is older than the manifest requires.
  * Kept version information consistent across the Python SDK package and startup metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->