### PR TITLE
fix(updater): skip sudo bin install in background build (#2339)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,7 +64,12 @@ if [[ ! -d "$bin_dir" || ! -w "$bin_dir" ]]; then
   bin_install_needs_sudo=true
 fi
 
-if $bin_install_needs_sudo; then
+# Non-interactive callers (background updater, CI) set PLEXI_SKIP_BIN_INSTALL=1
+# to skip the sudo credential check and /usr/local/bin write. The .app bundle
+# update is sufficient — the existing shim delegates to /Applications/Plexi.app.
+skip_bin_install="${PLEXI_SKIP_BIN_INSTALL:-0}"
+
+if [[ "$skip_bin_install" != "1" ]] && $bin_install_needs_sudo; then
   echo "CLI install needs admin access for $bin_dir"
   sudo -v
 fi
@@ -99,13 +104,14 @@ if [[ -n "$suffix" ]]; then
   mv "$app_dest/Contents/MacOS/plexi" "$app_dest/Contents/MacOS/plexi${suffix}"
 fi
 
-if [[ "$channel" == "main" ]]; then
-  # Main owns the bare `plexi` PATH command, but installs it as a contextual
-  # shim instead of a symlink. Inside a Plexi PTY, the shim delegates to the
-  # active channel binary from PLEXI_CHANNEL. Outside Plexi, it runs stable.
-  # Remove first so an old symlink is not followed when writing the script.
-  shim_tmp="$(mktemp)"
-  cat > "$shim_tmp" <<'EOF'
+if [[ "$skip_bin_install" != "1" ]]; then
+  if [[ "$channel" == "main" ]]; then
+    # Main owns the bare `plexi` PATH command, but installs it as a contextual
+    # shim instead of a symlink. Inside a Plexi PTY, the shim delegates to the
+    # active channel binary from PLEXI_CHANNEL. Outside Plexi, it runs stable.
+    # Remove first so an old symlink is not followed when writing the script.
+    shim_tmp="$(mktemp)"
+    cat > "$shim_tmp" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -125,24 +131,27 @@ fi
 
 exec "$stable_binary" "$@"
 EOF
-  if $bin_install_needs_sudo; then
-    [[ -d "$bin_dir" ]] || sudo mkdir -p "$bin_dir"
-    sudo rm -f "$bin_dest"
-    sudo install -m 0755 "$shim_tmp" "$bin_dest"
+    if $bin_install_needs_sudo; then
+      [[ -d "$bin_dir" ]] || sudo mkdir -p "$bin_dir"
+      sudo rm -f "$bin_dest"
+      sudo install -m 0755 "$shim_tmp" "$bin_dest"
+    else
+      [[ -d "$bin_dir" ]] || mkdir -p "$bin_dir"
+      rm -f "$bin_dest"
+      install -m 0755 "$shim_tmp" "$bin_dest"
+    fi
+    rm -f "$shim_tmp"
   else
-    [[ -d "$bin_dir" ]] || mkdir -p "$bin_dir"
-    rm -f "$bin_dest"
-    install -m 0755 "$shim_tmp" "$bin_dest"
+    if $bin_install_needs_sudo; then
+      [[ -d "$bin_dir" ]] || sudo mkdir -p "$bin_dir"
+      sudo ln -sf "$app_dest/Contents/MacOS/plexi${suffix}" "$bin_dest"
+    else
+      [[ -d "$bin_dir" ]] || mkdir -p "$bin_dir"
+      ln -sf "$app_dest/Contents/MacOS/plexi${suffix}" "$bin_dest"
+    fi
   fi
-  rm -f "$shim_tmp"
 else
-  if $bin_install_needs_sudo; then
-    [[ -d "$bin_dir" ]] || sudo mkdir -p "$bin_dir"
-    sudo ln -sf "$app_dest/Contents/MacOS/plexi${suffix}" "$bin_dest"
-  else
-    [[ -d "$bin_dir" ]] || mkdir -p "$bin_dir"
-    ln -sf "$app_dest/Contents/MacOS/plexi${suffix}" "$bin_dest"
-  fi
+  echo "Skipping bin install (PLEXI_SKIP_BIN_INSTALL=1 — shim unchanged at $bin_dest)"
 fi
 
 # Install shell completions for production and release-candidate channels.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -188,7 +188,7 @@ install_completions() {
   fi
 }
 
-if [[ "$channel" == "main" || "$channel" == "alpha" || "$channel" == "beta" || "$channel" == rc-* ]]; then
+if [[ "$skip_bin_install" != "1" ]] && [[ "$channel" == "main" || "$channel" == "alpha" || "$channel" == "beta" || "$channel" == rc-* ]]; then
   if [[ "$channel" == "main" ]]; then
     install_completions "$app_dest/Contents/MacOS/plexi"
   else

--- a/src/cli/updater.rs
+++ b/src/cli/updater.rs
@@ -182,14 +182,14 @@ fn background_build(tag: &str, profile_dir: &Path) -> Result<(), String> {
         return Err(format!("git checkout {tag} failed"));
     }
 
-    log::info!("background_build: running install.sh for {tag} channel={channel}");
+    log::info!("background_build: running install.sh for {tag} channel={channel} (PLEXI_SKIP_BIN_INSTALL=1 — non-TTY, shim unchanged)");
     let log_file = std::fs::File::create(&log_path)
         .map_err(|e| format!("create update log: {e}"))?;
     let log_err = log_file.try_clone()
         .map_err(|e| format!("clone log handle: {e}"))?;
 
     let install_cmd = format!(
-        "PLEXI_INSTALL_TAG='{}' bash '{}' '{}'",
+        "PLEXI_INSTALL_TAG='{}' PLEXI_SKIP_BIN_INSTALL=1 bash '{}' '{}'",
         tag,
         src_dir.join("scripts/install.sh").display(),
         channel,


### PR DESCRIPTION
Closes #2339

## Summary

- `background_build` in `updater.rs` now passes `PLEXI_SKIP_BIN_INSTALL=1` to `install.sh`, bypassing the `sudo -v` credential check that fatally exits the non-TTY background process before `cargo bundle` ever runs
- `install.sh` guards the `sudo -v` call and the entire `/usr/local/bin` write block behind that flag
- The shim at `/usr/local/bin/plexi` delegates unconditionally to `/Applications/Plexi.app` — once placed on first interactive install, it never needs updating; background builds only need to update the app bundle