### PR TITLE
Periodic update re-check while app is running (stint 0305)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -349,6 +349,9 @@ pub struct PlexiApp {
     /// Channel receiver fed by the background update-check thread. Sends the
     /// latest version string exactly once if a newer release is available.
     update_rx: Option<std::sync::mpsc::Receiver<String>>,
+    /// Last time the host scheduled an update-check thread. Used to re-check
+    /// long-running sessions at the same interval as the updater cache.
+    last_update_check: std::time::Instant,
     /// Latest available version string, set after the background check resolves.
     /// `None` means either the check hasn't completed or we're already current.
     pub(crate) display_version: String,
@@ -851,6 +854,7 @@ impl PlexiApp {
         // Spawn background update check. Sends the latest version once if newer.
         let (update_tx, update_rx) = std::sync::mpsc::channel::<String>();
         crate::cli::updater::spawn_update_check(crate::config::config_dir(), update_tx);
+        let last_update_check = std::time::Instant::now();
 
         let (pane_ipc_tx, pane_ipc_rx) =
             std::sync::mpsc::channel::<crate::app_protocol::AppRequest>();
@@ -1194,6 +1198,7 @@ impl PlexiApp {
                     edge_pulse: None,
                     click_flash: None,
                     update_rx: Some(update_rx),
+                    last_update_check,
                     display_version: read_display_version(),
                     update_available: None,
                     update_quit_pending: false,
@@ -1438,6 +1443,7 @@ impl PlexiApp {
             edge_pulse: None,
             click_flash: None,
             update_rx: Some(update_rx),
+            last_update_check,
             display_version: read_display_version(),
             update_available: None,
             update_quit_pending: false,
@@ -1657,6 +1663,7 @@ impl PlexiApp {
                 cli_setup_check_result: None,
                 show_completions_banner: false,
                 update_rx: None,
+                last_update_check: std::time::Instant::now(),
                 display_version: read_display_version(),
                 update_available: None,
                 update_quit_pending: false,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1128,16 +1128,17 @@ mod tests {
 
     #[test]
     fn update_check_due_after_interval() {
-        let now = std::time::Instant::now();
-        let last = now - crate::cli::updater::CHECK_INTERVAL;
+        let last = std::time::Instant::now();
+        let now = last + crate::cli::updater::CHECK_INTERVAL;
 
         assert!(update_check_due(last, now));
     }
 
     #[test]
     fn update_check_not_due_before_interval() {
-        let now = std::time::Instant::now();
-        let last = now - crate::cli::updater::CHECK_INTERVAL + std::time::Duration::from_secs(1);
+        let last = std::time::Instant::now();
+        let now =
+            last + crate::cli::updater::CHECK_INTERVAL - std::time::Duration::from_secs(1);
 
         assert!(!update_check_due(last, now));
     }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -10,6 +10,10 @@ use std::collections::HashMap;
 const FLASH_DUR: f32 = 0.4;
 const FLASH_TAU: f32 = 0.10;
 
+fn update_check_due(last_update_check: std::time::Instant, now: std::time::Instant) -> bool {
+    now.saturating_duration_since(last_update_check) >= crate::cli::updater::CHECK_INTERVAL
+}
+
 impl PlexiApp {
     /// Cwd-derived fallback workspace root, used when the active context has no
     /// explicit `root`. `config::active_workspace_root()` stat-walks the
@@ -49,11 +53,22 @@ impl PlexiApp {
             }
         }
         if self.last_notify_poll.elapsed() >= std::time::Duration::from_secs(1) {
-            self.last_notify_poll = std::time::Instant::now();
+            let now = std::time::Instant::now();
+            self.last_notify_poll = now;
             self.drain_spawn_queue();
             self.tick_scheduler();
             self.tick_notification_timeouts();
             self.tick_terminal_activity();
+            if update_check_due(self.last_update_check, now) {
+                let config_dir = crate::config::config_dir();
+                if !crate::cli::updater::update_cache_fresh(&config_dir) {
+                    log::info!("update check: scheduling periodic re-check");
+                    let (update_tx, update_rx) = std::sync::mpsc::channel::<String>();
+                    crate::cli::updater::spawn_update_check(config_dir, update_tx);
+                    self.update_rx = Some(update_rx);
+                    self.last_update_check = now;
+                }
+            }
         }
         self.drain_pane_cmd_channel();
         if let Some(rx) = &self.update_rx {
@@ -1104,5 +1119,26 @@ impl PlexiApp {
                 ctx.memory_mut(|m| m.request_focus(egui::Id::new("capability_secret_input")));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::update_check_due;
+
+    #[test]
+    fn update_check_due_after_interval() {
+        let now = std::time::Instant::now();
+        let last = now - crate::cli::updater::CHECK_INTERVAL;
+
+        assert!(update_check_due(last, now));
+    }
+
+    #[test]
+    fn update_check_not_due_before_interval() {
+        let now = std::time::Instant::now();
+        let last = now - crate::cli::updater::CHECK_INTERVAL + std::time::Duration::from_secs(1);
+
+        assert!(!update_check_due(last, now));
     }
 }

--- a/src/cli/updater.rs
+++ b/src/cli/updater.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::cli::release_resolver::{self, ReleaseTag, UpdateChannel};
 
-const CHECK_INTERVAL: Duration = Duration::from_secs(86_400);
+pub(crate) const CHECK_INTERVAL: Duration = Duration::from_secs(86_400);
 
 /// Spawns a background thread that checks for updates, and if a newer version
 /// is found, builds and installs it silently. Only sends on `tx` when the new
@@ -51,6 +51,14 @@ pub fn spawn_update_check(cache_dir: std::path::PathBuf, tx: mpsc::Sender<String
         .ok();
 }
 
+pub(crate) fn update_cache_fresh(cache_dir: &Path) -> bool {
+    update_cache_fresh_for_channel(
+        &cache_dir.join("update_cache.json"),
+        detect_channel(),
+        unix_now_secs(),
+    )
+}
+
 /// Read the installed release tag from `<profile>/installed_tag`, falling back
 /// to `CARGO_PKG_VERSION` for source builds that don't write the tag file.
 fn installed_tag_or_cargo_version(cache_dir: &Path) -> String {
@@ -78,14 +86,7 @@ fn detect_channel() -> UpdateChannel {
 fn cached_or_fetch(cache_path: &Path, channel: UpdateChannel, current_raw: &str) -> Option<String> {
     if let Ok(bytes) = std::fs::read(cache_path) {
         if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&bytes) {
-            let checked_at = json["checked_at"].as_u64().unwrap_or(0);
-            let cached_channel = json["channel"].as_str().unwrap_or("");
-            let now = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs();
-            let fresh = Duration::from_secs(now.saturating_sub(checked_at)) < CHECK_INTERVAL;
-            if fresh && cached_channel == channel_key(channel) {
+            if cached_json_fresh_for_channel(&json, channel, unix_now_secs()) {
                 return json["latest"].as_str().map(|s| s.to_string());
             }
         }
@@ -93,11 +94,82 @@ fn cached_or_fetch(cache_path: &Path, channel: UpdateChannel, current_raw: &str)
     fetch_and_cache(cache_path, channel, current_raw)
 }
 
+fn update_cache_fresh_for_channel(cache_path: &Path, channel: UpdateChannel, now: u64) -> bool {
+    std::fs::read(cache_path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
+        .map_or(false, |json| {
+            cached_json_fresh_for_channel(&json, channel, now)
+        })
+}
+
+fn cached_json_fresh_for_channel(
+    json: &serde_json::Value,
+    channel: UpdateChannel,
+    now: u64,
+) -> bool {
+    let checked_at = json["checked_at"].as_u64().unwrap_or(0);
+    let cached_channel = json["channel"].as_str().unwrap_or("");
+    let fresh = Duration::from_secs(now.saturating_sub(checked_at)) < CHECK_INTERVAL;
+    fresh && cached_channel == channel_key(channel)
+}
+
+fn unix_now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
 fn channel_key(channel: UpdateChannel) -> &'static str {
     match channel {
         UpdateChannel::Stable => "stable",
         UpdateChannel::Beta => "beta",
         UpdateChannel::Alpha => "alpha",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_cache(dir: &Path, checked_at: u64, channel: &str) {
+        std::fs::create_dir_all(dir).expect("create temp cache dir");
+        let cache = serde_json::json!({
+            "checked_at": checked_at,
+            "channel": channel,
+            "latest": serde_json::Value::Null,
+        });
+        std::fs::write(dir.join("update_cache.json"), cache.to_string())
+            .expect("write update cache");
+    }
+
+    #[test]
+    fn update_check_cache_fresh_requires_matching_channel_and_interval() {
+        let dir =
+            std::env::temp_dir().join(format!("plexi-update-cache-test-{}", uuid::Uuid::new_v4()));
+        let now = CHECK_INTERVAL.as_secs() * 2;
+
+        write_cache(&dir, now - CHECK_INTERVAL.as_secs() + 1, "alpha");
+        assert!(update_cache_fresh_for_channel(
+            &dir.join("update_cache.json"),
+            UpdateChannel::Alpha,
+            now,
+        ));
+        assert!(!update_cache_fresh_for_channel(
+            &dir.join("update_cache.json"),
+            UpdateChannel::Beta,
+            now,
+        ));
+
+        write_cache(&dir, now - CHECK_INTERVAL.as_secs(), "alpha");
+        assert!(!update_cache_fresh_for_channel(
+            &dir.join("update_cache.json"),
+            UpdateChannel::Alpha,
+            now,
+        ));
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 }
 


### PR DESCRIPTION
PLACEHOLDER

## Validation attempt 1

- PR install: done — `plexi-pr-2342` / `Plexi PR2342.app`, v0.1.14.
- Install preflight: SDK Python tests passed — 64 passed.
- Validation finding: Codex flagged test-only `Instant` underflow risk; fixed in `17a80d0b`.
- cargo test: 3 passed, 0 failed — filter: `update_check` after fix.
- cargo test: 1377 passed, 0 failed, 1 ignored — full bin suite after fix.
- cargo build: passed after fix.
- PR reinstall: done after fix — `plexi-pr-2342` / `Plexi PR2342.app`, v0.1.14.
- AI review rerun: no correctness issues found.

## Validation attempt 1

- PR install: done — `plexi-pr-2342` / `Plexi PR2342.app`, v0.1.14.
- Install preflight: SDK Python tests passed — 64 passed.
- Validation finding: Codex flagged test-only `Instant` underflow risk; fixed in `17a80d0b`.
- cargo test: 3 passed, 0 failed — filter: `update_check` after fix.
- cargo test: 1377 passed, 0 failed, 1 ignored — full bin suite after fix.
- cargo build: passed after fix.
- PR reinstall: done after fix — `plexi-pr-2342` / `Plexi PR2342.app`, v0.1.14.
- AI review rerun: no correctness issues found.
