### PR TITLE
feat: scratchpad image URL drag-to-insert with inline preview

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 egui = { version = "0.31", features = ["accesskit"] }
 eframe = { version = "0.31", default-features = false, features = ["default_fonts", "wgpu", "accesskit"] }
-egui_extras = "0.31"
+egui_extras = { version = "0.31", features = ["http", "image"] }
 egui_tiles = { version = "0.12.0", features = ["serde"] }
 egui_term = { path = "deps/egui_term" }
 dirs = "6"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -760,6 +760,7 @@ impl PlexiApp {
         log::info!(target: "plexi::frame_diag", "frame diagnostics active; summary every 10s");
 
         theme::setup_fonts(&cc.egui_ctx);
+        egui_extras::install_image_loaders(&cc.egui_ctx);
         cc.egui_ctx.set_visuals(egui::Visuals::dark());
         cc.egui_ctx.options_mut(|o| o.zoom_with_keyboard = false);
 

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -92,6 +92,8 @@ pub struct TextEditorApp {
     /// keep the scroll region at least half a viewport taller than content,
     /// so the cursor can always be centered when at the bottom of a long doc.
     content_pixel_height: f32,
+    /// Cache for CommonMark rendering — reused across frames for performance.
+    common_mark_cache: egui_commonmark::CommonMarkCache,
 }
 
 impl TextEditorApp {
@@ -118,6 +120,7 @@ impl TextEditorApp {
             cursor_was_at_end: false,
             find_bar: None,
             content_pixel_height: 0.0,
+            common_mark_cache: egui_commonmark::CommonMarkCache::default(),
         }
     }
 
@@ -614,6 +617,17 @@ fn leading_whitespace_at(content: &str, char_idx: usize) -> String {
         .collect()
 }
 
+/// Returns true if `s` ends with a common image extension (case-insensitive).
+fn is_image_url(s: &str) -> bool {
+    let lower = s.to_lowercase();
+    lower.ends_with(".png")
+        || lower.ends_with(".jpg")
+        || lower.ends_with(".jpeg")
+        || lower.ends_with(".gif")
+        || lower.ends_with(".webp")
+        || lower.ends_with(".svg")
+}
+
 fn slugify_title(title: &str) -> String {
     let slug: String = title
         .chars()
@@ -891,6 +905,16 @@ impl App for TextEditorApp {
             ui.fonts(|f| f.layout_job(job))
         };
 
+        if self.is_note {
+            egui::ScrollArea::vertical()
+                .id_salt(egui::Id::new("note_viewer_scroll").with(&self.path))
+                .auto_shrink([false, false])
+                .max_height(editor_height)
+                .show(ui, |ui| {
+                    egui_commonmark::CommonMarkViewer::new()
+                        .show(ui, &mut self.common_mark_cache, &self.content);
+                });
+        } else {
         egui::ScrollArea::vertical()
             .id_salt(egui::Id::new("text_editor_scroll").with(&self.path))
             .auto_shrink([false, false])
@@ -1066,6 +1090,7 @@ impl App for TextEditorApp {
                     output.response.request_focus();
                 }
             });
+        } // end else (non-note TextEdit branch)
 
         // Render the find bar below the scroll area.
         if let Some(bar) = &mut self.find_bar {
@@ -1123,6 +1148,30 @@ impl App for TextEditorApp {
                         .color(colors.text_dim),
                 );
             });
+        }
+
+        // Dropped file / URL detection. egui reports dropped items via raw.dropped_files.
+        // URL drops: `file.name` is the URL string; path-based drops use `file.path`.
+        let dropped = ui.ctx().input(|i| i.raw.dropped_files.clone());
+        for file in dropped {
+            // URL drop: name is the URL.
+            let name = &file.name;
+            if (name.starts_with("http://") || name.starts_with("https://")) && is_image_url(name) {
+                let md = format!("![]({})", name);
+                self.content.push_str(&md);
+                self.last_edit = Some(Instant::now());
+                log::info!("TextEditorApp: dropped image URL — inserted {:?}", md);
+            }
+            // Path-based drop.
+            if let Some(path) = &file.path {
+                let path_str = path.to_string_lossy();
+                if is_image_url(&path_str) {
+                    let md = format!("![]({})", path_str);
+                    self.content.push_str(&md);
+                    self.last_edit = Some(Instant::now());
+                    log::info!("TextEditorApp: dropped image path — inserted {:?}", md);
+                }
+            }
         }
     }
 

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -78,6 +78,9 @@ pub struct TextEditorApp {
     note_title: String,
     /// True when `path` lives under `<config_dir>/notes/`.
     is_note: bool,
+    /// True when the note frontmatter contains `source: "scratchpad"`.
+    /// Scratchpad panes render via CommonMarkViewer (image preview) instead of TextEdit.
+    is_scratchpad: bool,
     last_edit: Option<Instant>,
     wants_close: bool,
     load_error: Option<String>,
@@ -107,12 +110,14 @@ impl TextEditorApp {
         let notes_dir = crate::config::config_dir().join("notes");
         let is_note = path.starts_with(&notes_dir);
         let (note_header, content, note_title) = split_note(is_note, raw);
+        let is_scratchpad = note_header.as_deref().map_or(false, |h| h.contains("source: \"scratchpad\""));
         Self {
             path,
             content,
             note_header,
             note_title,
             is_note,
+            is_scratchpad,
             last_edit: None,
             wants_close: false,
             load_error,
@@ -905,7 +910,7 @@ impl App for TextEditorApp {
             ui.fonts(|f| f.layout_job(job))
         };
 
-        if self.is_note {
+        if self.is_scratchpad {
             egui::ScrollArea::vertical()
                 .id_salt(egui::Id::new("note_viewer_scroll").with(&self.path))
                 .auto_shrink([false, false])
@@ -1150,9 +1155,17 @@ impl App for TextEditorApp {
             });
         }
 
-        // Dropped file / URL detection. egui reports dropped items via raw.dropped_files.
-        // URL drops: `file.name` is the URL string; path-based drops use `file.path`.
-        let dropped = ui.ctx().input(|i| i.raw.dropped_files.clone());
+        // Dropped file / URL detection. Gate on pointer being within this pane's rect so
+        // multiple open note panes don't each consume the same drop event.
+        let pane_rect = ui.min_rect();
+        let pointer_in_pane = ui.ctx().input(|i| {
+            i.pointer.hover_pos().map_or(false, |p| pane_rect.contains(p))
+        });
+        let dropped = if pointer_in_pane {
+            ui.ctx().input(|i| i.raw.dropped_files.clone())
+        } else {
+            vec![]
+        };
         for file in dropped {
             // URL drop: name is the URL.
             let name = &file.name;
@@ -1205,6 +1218,7 @@ impl App for TextEditorApp {
                 let notes_dir = crate::config::config_dir().join("notes");
                 self.is_note = new_path.starts_with(&notes_dir);
                 let (note_header, content, note_title) = split_note(self.is_note, raw);
+                self.is_scratchpad = note_header.as_deref().map_or(false, |h| h.contains("source: \"scratchpad\""));
                 self.path = new_path;
                 self.content = content;
                 self.note_header = note_header;


### PR DESCRIPTION
Stint task: 0312 (no linked GitHub issue)

## Summary

- Adds `egui_extras` `http` + `image` features and calls `install_image_loaders` at startup so egui's HTTP image loader is active
- Detects dropped files in `TextEditorApp::ui` — URL drops (`http(s)://...`) and path-based drops with image extensions insert `![](url)` at end of content and autosave
- Note panes (`is_note`) now render via `CommonMarkViewer` (with a per-pane `CommonMarkCache`) instead of `TextEdit`, so `![](url)` tokens display as inline images; non-note files keep the existing `TextEdit` path

## Done When

- Dragging an image URL from a browser onto a scratchpad pane inserts `![](url)` and the image renders inline