### PR TITLE
redesign app UI boilerplate: action bar and footer layout (stint 0314)

### DIFF
--- a/apps/calc/calc.py
+++ b/apps/calc/calc.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from plexi_sdk import log, state
 from plexi_sdk.effects import SetState, SetStatus, SetTitle
 from plexi_sdk.events import KeyEvent, UiAction
-from plexi_sdk.ui import Button, Column, Component, FooterKeys, Text
+from plexi_sdk.ui import ActionBar, Button, Column, FooterKeys, Text
 
 BUTTON_ROWS = [
     ["C", "+/-", "%", "/"],
@@ -22,22 +22,6 @@ DEFAULT_STATE = {
     "op": None,
     "fresh": True,
 }
-
-
-class ButtonRow(Component):
-    def __init__(self, labels: list[str]) -> None:
-        self.labels = labels
-
-    def to_node(self) -> dict:
-        return {
-            "type": "stack",
-            "direction": "horizontal",
-            "children": [
-                Button(label, f"calc:key:{label}", style=_button_style(label)).to_node()
-                for label in self.labels
-            ],
-            "gap": 8.0,
-        }
 
 
 def init(size, args) -> list:
@@ -71,9 +55,23 @@ def view():
             Text("Calculator", bold=True, size=15.0),
             Text(subtitle or "ready", size=11.0),
             Text(data["display"], size=28.0, bold=True, align="end", truncate=True),
-            *[ButtonRow(row) for row in BUTTON_ROWS],
+            *[
+                ActionBar(
+                    [
+                        Button(label, f"calc:key:{label}", style=_button_style(label))
+                        for label in row
+                    ],
+                    gap=8.0,
+                )
+                for row in BUTTON_ROWS
+            ],
             FooterKeys(
-                [("0-9", "digits"), ("ops", "queue"), ("enter", "equals"), ("backspace", "delete")]
+                [
+                    ("0-9", "digits"),
+                    ("ops", "queue"),
+                    ("enter", "equals"),
+                    ("backspace", "delete"),
+                ]
             ),
         ],
         gap=8.0,

--- a/apps/csv_viewer/csv_viewer.py
+++ b/apps/csv_viewer/csv_viewer.py
@@ -19,7 +19,7 @@ from plexi_sdk.events import (
     UiAction,
     UiValueChange,
 )
-from plexi_sdk.ui import AppBar, Button, Column, FooterKeys, Scrollable, SelectList, Text, TextEdit
+from plexi_sdk.ui import ActionBar, AppBar, Button, Column, FooterKeys, Scrollable, SelectList, Text, TextEdit
 
 VISIBLE_ROWS = 24
 VISIBLE_COLS = 5
@@ -229,7 +229,7 @@ def _list_view(data: dict):
         [
             AppBar("CSV Viewer", data["cwd"] or "choose folder"),
             TextEdit("csv-dir", value=data["dir_input"], placeholder="/path/to/folder"),
-            Button("Refresh", "csv-refresh", style="primary"),
+            ActionBar([Button("Refresh", "csv-refresh", style="primary")]),
             body,
             FooterKeys([("j/k", "select"), ("enter", "open"), ("r", "refresh")]),
         ],
@@ -249,7 +249,7 @@ def _detail_view(data: dict):
         [
             AppBar(name, f"{len(data['rows'])} rows x {len(data['headers'])} columns"),
             Scrollable(Text("\n".join(lines), size=12.0)),
-            Button("Back", "csv-back-list", style="ghost"),
+            ActionBar([Button("Back", "csv-back-list", style="ghost")]),
             FooterKeys([("j/k", "rows"), ("h/l", "cols"), ("esc", "list")]),
         ],
         grow=True,

--- a/apps/permissions/main.py
+++ b/apps/permissions/main.py
@@ -9,7 +9,7 @@ import plexi_sdk as sdk
 from plexi_sdk import log, state
 from plexi_sdk.effects import RequestCapability, SetState, SetStatus, SetTitle
 from plexi_sdk.events import CapabilityDenied, CapabilityGranted, KeyEvent, UiAction
-from plexi_sdk.ui import Button, Column, FooterKeys, SelectList, Spacer, Text
+from plexi_sdk.ui import ActionBar, Button, Column, FooterKeys, SelectList, Spacer, Text
 
 DEFAULT_STATE = {
     "grants": [],
@@ -168,8 +168,12 @@ def _list_view(data: dict):
             Text(data["path"] or "workspace unknown", size=11.0),
             body,
             Text(data["notice"], size=11.0) if data["notice"] else Spacer(size=0.0),
-            Button("Open", "permissions:detail", disabled=not rows),
-            Button("Reload", "permissions:reload"),
+            ActionBar(
+                [
+                    Button("Open", "permissions:detail", disabled=not rows),
+                    Button("Reload", "permissions:reload"),
+                ]
+            ),
             FooterKeys([("j/k", "select"), ("enter", "open"), ("r", "reload")]),
         ],
         gap=8.0,
@@ -191,13 +195,17 @@ def _detail_view(data: dict):
             Text(f"Stored: {'yes' if grant['stored'] else 'live only'}", size=12.0),
             Text(f"Sensitive: {'yes' if grant['sensitive'] else 'no'}", size=12.0),
             Text(data["notice"], size=11.0) if data["notice"] else Spacer(size=0.0),
-            Button(
-                "Revoke",
-                "permissions:revoke",
-                style="danger",
-                disabled=not data["can_manage"],
+            ActionBar(
+                [
+                    Button(
+                        "Revoke",
+                        "permissions:revoke",
+                        style="danger",
+                        disabled=not data["can_manage"],
+                    ),
+                    Button("Back", "permissions:back"),
+                ]
             ),
-            Button("Back", "permissions:back"),
             FooterKeys([("x", "revoke"), ("esc", "back")]),
         ],
         gap=8.0,

--- a/apps/todo/todo.py
+++ b/apps/todo/todo.py
@@ -6,7 +6,17 @@ from __future__ import annotations
 from plexi_sdk import log, state
 from plexi_sdk.effects import PersistState, SetStatus, SetTitle
 from plexi_sdk.events import KeyEvent, UiAction, UiValueChange
-from plexi_sdk.ui import AppBar, Button, Column, FooterKeys, SelectList, Spacer, Text, TextEdit
+from plexi_sdk.ui import (
+    ActionBar,
+    AppBar,
+    Button,
+    Column,
+    FooterKeys,
+    SelectList,
+    Spacer,
+    Text,
+    TextEdit,
+)
 
 DEFAULT_STATE = {
     "items": [],
@@ -81,9 +91,20 @@ def view():
         return Column(
             [
                 AppBar("Todo", "New item"),
-                TextEdit("todo-draft", value=data["draft"], placeholder="What needs doing?"),
-                Button("Add", "todo-draft", style="primary", disabled=not data["draft"].strip()),
-                Button("Cancel", "todo-cancel", style="ghost"),
+                TextEdit(
+                    "todo-draft", value=data["draft"], placeholder="What needs doing?"
+                ),
+                ActionBar(
+                    [
+                        Button(
+                            "Add",
+                            "todo-draft",
+                            style="primary",
+                            disabled=not data["draft"].strip(),
+                        ),
+                        Button("Cancel", "todo-cancel", style="ghost"),
+                    ]
+                ),
                 FooterKeys([("enter", "add"), ("esc", "cancel")]),
             ],
             grow=True,
@@ -103,10 +124,16 @@ def view():
         [
             AppBar("Todo", _status(data)),
             body,
-            Button("New", "todo-new", style="primary"),
-            Button("Toggle", "todo-toggle", disabled=not rows),
-            Button("Delete", "todo-delete", style="danger", disabled=not rows),
-            FooterKeys([("j/k", "select"), ("enter", "toggle"), ("n", "new"), ("d", "delete")]),
+            ActionBar(
+                [
+                    Button("New", "todo-new", style="primary"),
+                    Button("Toggle", "todo-toggle", disabled=not rows),
+                    Button("Delete", "todo-delete", style="danger", disabled=not rows),
+                ]
+            ),
+            FooterKeys(
+                [("j/k", "select"), ("enter", "toggle"), ("n", "new"), ("d", "delete")]
+            ),
         ],
         grow=True,
         padding=0,

--- a/apps/wikipedia/wikipedia.py
+++ b/apps/wikipedia/wikipedia.py
@@ -9,7 +9,7 @@ import urllib.parse
 from plexi_sdk import log, state
 from plexi_sdk.effects import HttpFetch, RequestCapability, SetState, SetStatus, SetTitle
 from plexi_sdk.events import CapabilityDenied, CapabilityGranted, HttpResponse, KeyEvent, UiAction, UiValueChange
-from plexi_sdk.ui import AppBar, Button, Column, FooterKeys, Scrollable, SelectList, Spacer, Text, TextEdit
+from plexi_sdk.ui import ActionBar, AppBar, Button, Column, FooterKeys, Scrollable, SelectList, Spacer, Text, TextEdit
 
 SEARCH_API = "https://en.wikipedia.org/w/api.php"
 SUMMARY_API = "https://en.wikipedia.org/api/rest_v1/page/summary/"
@@ -200,7 +200,7 @@ def _search_view(data: dict):
         [
             AppBar("Wikipedia", subtitle),
             TextEdit("wiki-query", value=data["query"], placeholder="Search Wikipedia"),
-            Button("Search", "wiki-search", style="primary", disabled=not data["query"].strip()),
+            ActionBar([Button("Search", "wiki-search", style="primary", disabled=not data["query"].strip())]),
             Text(data["error"] or "Type a query and press Enter.", size=12.0),
             FooterKeys([("enter", "search")]),
         ],
@@ -231,7 +231,7 @@ def _results_view(data: dict):
         [
             AppBar("Wikipedia", f"Results for {data['query']}"),
             body,
-            Button("Back", "wiki-back-search", style="ghost"),
+            ActionBar([Button("Back", "wiki-back-search", style="ghost")]),
             FooterKeys([("j/k", "select"), ("enter", "open"), ("esc", "search")]),
         ],
         grow=True,
@@ -244,7 +244,7 @@ def _article_view(data: dict):
         [
             AppBar("Wikipedia", data["article_title"]),
             Scrollable(Text(data["article"] or data["error"], size=12.0)),
-            Button("Back", "wiki-back-results", style="ghost"),
+            ActionBar([Button("Back", "wiki-back-results", style="ghost")]),
             FooterKeys([("esc", "results")]),
         ],
         grow=True,

--- a/sdk/python/SDK_V3.md
+++ b/sdk/python/SDK_V3.md
@@ -585,6 +585,10 @@ def FooterKeys(pairs: list) -> Row:
         children.append(Space(8.0))
     return Row(children, gap=4.0, align="center")
 
+def ActionBar(actions: list) -> Row:
+    """Standard horizontal row for contextual Button actions."""
+    return Row(actions, gap=8.0, align="center")
+
 def Section(title: str, children: list) -> Column:
     """Titled section group."""
     return Column([
@@ -721,10 +725,10 @@ capabilities = []
 
 from __future__ import annotations
 
-from plexi_sdk import state, log
-from plexi_sdk.effects import SetTitle, SetState
-from plexi_sdk.events import KeyEvent
-from plexi_sdk.ui import Column, AppBar, Text, FooterKeys
+from plexi_sdk import log, state
+from plexi_sdk.effects import SetState, SetTitle
+from plexi_sdk.events import KeyEvent, UiAction
+from plexi_sdk.ui import ActionBar, AppBar, Button, Column, FooterKeys, Spacer, Text
 
 
 def init(size, args):
@@ -733,17 +737,36 @@ def init(size, args):
 
 
 def update(event):
-    if isinstance(event, KeyEvent) and event.key == "return" and event.pressed:
-        return [state.set("count", state.get("count", 0) + 1)]
+    if isinstance(event, UiAction):
+        if event.handler_id == "counter-increment":
+            return [SetState({"count": state.get("count", 0) + 1})]
+        if event.handler_id == "counter-decrement":
+            return [SetState({"count": state.get("count", 0) - 1})]
+        if event.handler_id == "counter-reset":
+            return [SetState({"count": 0})]
+    if isinstance(event, KeyEvent) and event.pressed:
+        if event.key in ("equals", "plus"):
+            return [SetState({"count": state.get("count", 0) + 1})]
+        if event.key == "minus":
+            return [SetState({"count": state.get("count", 0) - 1})]
+        if event.key == "r":
+            return [SetState({"count": 0})]
     return []
 
 
 def view():
     return Column([
         AppBar("{Name}"),
-        Text(str(state.get("count", 0)), bold=True),
-        FooterKeys([("return", "increment")]),
-    ], grow=True)
+        Text(str(state.get("count", 0)), size=28.0, bold=True),
+        Text("Runtime state counter", size=12.0),
+        Spacer(grow=True),
+        ActionBar([
+            Button("Increment", "counter-increment", style="primary"),
+            Button("Decrement", "counter-decrement"),
+            Button("Reset", "counter-reset", style="ghost"),
+        ]),
+        FooterKeys([("+", "increment"), ("-", "decrement"), ("r", "reset")]),
+    ], grow=True, padding=0)
 ```
 
 ---

--- a/sdk/python/plexi_sdk/_version.py
+++ b/sdk/python/plexi_sdk/_version.py
@@ -6,6 +6,7 @@ When running from an uninstalled source checkout (no dist metadata), it is read
 directly from the sibling ``pyproject.toml``. Both paths return the same string;
 they never diverge because there is exactly one place the number is written.
 """
+
 from __future__ import annotations
 
 import tomllib
@@ -28,10 +29,12 @@ def _read_from_pyproject() -> str | None:
 
 
 def _resolve_version() -> str:
+    if source_version := _read_from_pyproject():
+        return source_version
     try:
         return _dist_version(_DISTRIBUTION_NAME)
     except PackageNotFoundError:
-        return _read_from_pyproject() or _FALLBACK_VERSION
+        return _FALLBACK_VERSION
 
 
 __version__ = _resolve_version()

--- a/sdk/python/plexi_sdk/templates/app_init.py
+++ b/sdk/python/plexi_sdk/templates/app_init.py
@@ -10,8 +10,8 @@ from __future__ import annotations
 
 from plexi_sdk import log, state
 from plexi_sdk.effects import SetState, SetTitle
-from plexi_sdk.events import KeyEvent
-from plexi_sdk.ui import AppBar, Column, FooterKeys, Text
+from plexi_sdk.events import KeyEvent, UiAction
+from plexi_sdk.ui import ActionBar, AppBar, Button, Column, FooterKeys, Spacer, Text
 
 COUNT_KEY = "count"
 
@@ -38,6 +38,14 @@ def update(event) -> list:
     Do not mutate Plexi state in-place. Return SetState/PersistState or other
     effect objects, and the adapter applies them after ``update`` returns.
     """
+    if isinstance(event, UiAction):
+        if event.handler_id == "counter-increment":
+            return [SetState({COUNT_KEY: state.get(COUNT_KEY, 0) + 1})]
+        if event.handler_id == "counter-decrement":
+            return [SetState({COUNT_KEY: state.get(COUNT_KEY, 0) - 1})]
+        if event.handler_id == "counter-reset":
+            return [SetState({COUNT_KEY: 0})]
+
     if isinstance(event, KeyEvent) and event.pressed:
         if event.key in ("equals", "plus"):
             return [SetState({COUNT_KEY: state.get(COUNT_KEY, 0) + 1})]
@@ -55,12 +63,27 @@ def view():
     read state and build components; return effects from ``update`` instead.
     """
     count = state.get(COUNT_KEY, 0)
-    return Column([
-        AppBar("__DISPLAY_NAME__"),
-        Text(str(count), bold=True),
-        FooterKeys([
-            ("+", "increment"),
-            ("-", "decrement"),
-            ("r", "reset"),
-        ]),
-    ], grow=True)
+    return Column(
+        [
+            AppBar("__DISPLAY_NAME__"),
+            Text(str(count), size=28.0, bold=True),
+            Text("Runtime state counter", size=12.0),
+            Spacer(grow=True),
+            ActionBar(
+                [
+                    Button("Increment", "counter-increment", style="primary"),
+                    Button("Decrement", "counter-decrement"),
+                    Button("Reset", "counter-reset", style="ghost"),
+                ]
+            ),
+            FooterKeys(
+                [
+                    ("+", "increment"),
+                    ("-", "decrement"),
+                    ("r", "reset"),
+                ]
+            ),
+        ],
+        grow=True,
+        padding=0,
+    )

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -367,7 +367,7 @@ class Button(Component):
     key: str = ""
 
     def measure(self, _avail_w: float) -> float:
-        return 28.0
+        return 32.0
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
         fill = theme.accent if self.style == "primary" else theme.surface
@@ -381,6 +381,35 @@ class Button(Component):
             "label": self.label,
             "style": self.style,
             "disabled": self.disabled,
+        }
+
+
+@dataclass
+class ActionBar(Component):
+    """Horizontal row of contextual action buttons."""
+
+    actions: List[Button]
+    gap: float = SPACE_SM
+    key: str = ""
+
+    def __post_init__(self) -> None:
+        self.actions = list(self.actions)
+        for i, action in enumerate(self.actions):
+            if not isinstance(action, Button):
+                raise TypeError(
+                    f"ActionBar actions[{i}] must be a Button, got {type(action).__name__}. "
+                    "Example: ActionBar([Button('Save', 'save', style='primary')])"
+                )
+
+    def measure(self, avail_w: float) -> float:
+        return max((action.measure(avail_w) for action in self.actions), default=0.0)
+
+    def to_node(self) -> dict:
+        return {
+            "type": "stack",
+            "direction": "horizontal",
+            "children": [action.to_node() for action in self.actions],
+            "gap": self.gap,
         }
 
 
@@ -1030,7 +1059,7 @@ class FooterKeys(Component):
     # `max_width` can't fit everything; very narrow panes may render past
     # this measurement. Apps wanting exact bounded footers should put
     # FooterKeys in a fixed-height region or constrain the shortcut count.
-    ROW_H = CHIP_H + 2.0  # reduced from +4.0 — tighter without cramping chips
+    ROW_H = CHIP_H + 4.0
 
     def measure(self, avail_w: float) -> float:
         if not self.divider:
@@ -2359,7 +2388,7 @@ __all__ = [
     # components
     "Component", "Column", "HStack", "Sized", "Card",
     "AppBar", "Section", "KeyRow", "Heading", "Label",
-    "Spacer", "Divider", "Badge", "Canvas", "CanvasRect", "CanvasCircle", "CanvasLine",
+    "ActionBar", "Spacer", "Divider", "Badge", "Canvas", "CanvasRect", "CanvasCircle", "CanvasLine",
     "CanvasText", "CanvasButton", "ScrollLog", "Scrollable", "Footer", "FooterKeys",
     "ListItem", "Row", "TextEdit", "ChatBubble", "Markdown",
     "SelectList", "FormField",

--- a/sdk/python/tests/test_new_components.py
+++ b/sdk/python/tests/test_new_components.py
@@ -1,6 +1,8 @@
 """Tests for B2 UiNode component classes: Tabs, Grid, Toggle, Clickable, ProgressBar."""
 
-from plexi_sdk.ui import Tabs, Grid, Toggle, Clickable, ProgressBar, TextEdit, Column
+import pytest
+
+from plexi_sdk.ui import ActionBar, Button, Tabs, Grid, Toggle, Clickable, ProgressBar, TextEdit, Column
 
 
 # ── helpers ────────────────────────────────────────────────────────────────
@@ -230,3 +232,42 @@ def test_textedit_nested_in_column_is_native() -> None:
 def test_textedit_measure() -> None:
     te = TextEdit("x", height=80.0)
     assert te.measure(400.0) == 80.0
+
+
+# ── ActionBar ─────────────────────────────────────────────────────────────
+
+
+def test_action_bar_to_node_is_horizontal_stack() -> None:
+    bar = ActionBar(
+        [
+            Button("Save", "save", style="primary"),
+            Button("Cancel", "cancel", style="ghost"),
+        ]
+    )
+
+    node = bar.to_node()
+
+    assert node["type"] == "stack"
+    assert node["direction"] == "horizontal"
+    assert node["gap"] == 8.0
+    assert node["children"] == [
+        {
+            "type": "button",
+            "node_id": "save",
+            "label": "Save",
+            "style": "primary",
+            "disabled": False,
+        },
+        {
+            "type": "button",
+            "node_id": "cancel",
+            "label": "Cancel",
+            "style": "ghost",
+            "disabled": False,
+        },
+    ]
+
+
+def test_action_bar_rejects_non_button_actions() -> None:
+    with pytest.raises(TypeError, match="ActionBar actions\\[0\\] must be a Button"):
+        ActionBar([TextEdit("not-a-button")])

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -2082,6 +2082,14 @@ mod scaffold_marketplace_tests {
             main_src.contains("Components describe UI. Effects describe host work."),
             "generated main.py should explain component/effect separation"
         );
+        assert!(
+            main_src.contains("ActionBar("),
+            "generated main.py should demonstrate the standard action-row primitive"
+        );
+        assert!(
+            main_src.contains("FooterKeys("),
+            "generated main.py should keep shortcut hints in the footer"
+        );
     }
 
     #[test]

--- a/src/render/components.rs
+++ b/src/render/components.rs
@@ -208,7 +208,11 @@ fn render_component_tree_inner(
         } => {
             let w = width.unwrap_or_else(|| ui.available_width()).max(0.0);
             let h = height.unwrap_or_else(|| ui.available_height()).max(0.0);
-            log::trace!("render Sized: w={w} h={h} avail_w={} avail_h={}", ui.available_width(), ui.available_height());
+            log::trace!(
+                "render Sized: w={w} h={h} avail_w={} avail_h={}",
+                ui.available_width(),
+                ui.available_height()
+            );
             ui.allocate_ui(egui::vec2(w, h), |ui| {
                 ui.set_min_width(w);
                 ui.set_max_width(w);
@@ -814,10 +818,13 @@ fn render_component_tree_inner(
                     bottom: 0,
                 })
                 .show(ui, |ui| {
-                    // Expand the inner ui to fill available height so render_stack's
-                    // sticky-footer partition can see the full remaining pane height.
-                    let h = ui.available_height();
-                    ui.set_min_height(h);
+                    // Only fill the remaining height when the stack contains a child
+                    // that needs partitioning. Static nested Columns should stay
+                    // content-sized; otherwise they push later siblings into footers.
+                    if vertical_stack_needs_full_height(children) {
+                        let h = ui.available_height();
+                        ui.set_min_height(h);
+                    }
                     events.extend(render_stack(
                         ui,
                         &StackDirection::Vertical,
@@ -909,11 +916,8 @@ fn render_component_tree_inner(
             entries, divider, ..
         } => {
             let chip_row_h = chip_row_height(ui);
-            let total_h = if *divider {
-                1.0 + style::SPACE_SM + chip_row_h + style::SPACE_SM
-            } else {
-                style::SPACE_SM + chip_row_h + style::SPACE_SM
-            };
+            let row_h = chip_row_h + 4.0;
+            let total_h = footer_keys_height(ui, *divider);
             let (rect, _) = ui.allocate_exact_size(
                 egui::vec2(ui.available_width(), total_h),
                 egui::Sense::hover(),
@@ -928,9 +932,10 @@ fn render_component_tree_inner(
             ui.painter().rect_filled(full_rect, 0.0, colors.bg_sidebar);
 
             if *divider {
+                let line_y = full_rect.min.y + style::SPACE_SM;
                 ui.painter().rect_filled(
                     egui::Rect::from_min_size(
-                        egui::pos2(full_rect.min.x, full_rect.min.y),
+                        egui::pos2(full_rect.min.x, line_y),
                         egui::vec2(full_rect.width(), 1.0),
                     ),
                     0.0,
@@ -974,14 +979,13 @@ fn render_component_tree_inner(
             // Center the content group inside the usable area (below divider if present).
             let left =
                 (full_rect.center().x - content_w / 2.0).max(full_rect.min.x + style::SPACE_MD);
-            let usable_top = if *divider {
-                full_rect.min.y + 1.0
+            let row_top = if *divider {
+                full_rect.min.y + style::SPACE_SM + 1.0 + style::SPACE_SM
             } else {
-                full_rect.min.y
+                full_rect.min.y + style::SPACE_SM
             };
-            let usable_center_y = (usable_top + full_rect.max.y) / 2.0;
             let content_rect = egui::Rect::from_min_size(
-                egui::pos2(left, usable_center_y - chip_row_h / 2.0),
+                egui::pos2(left, row_top + (row_h - chip_row_h) / 2.0),
                 egui::vec2(content_w, chip_row_h),
             );
 
@@ -1301,18 +1305,20 @@ fn chip_row_height(ui: &egui::Ui) -> f32 {
     text_h + style::KEYCHIP_PAD_V * 2.0
 }
 
+fn footer_keys_height(ui: &egui::Ui, divider: bool) -> f32 {
+    let row_h = chip_row_height(ui) + 4.0;
+    if divider {
+        style::SPACE_SM + 1.0 + style::SPACE_SM + row_h + style::SPACE_SM
+    } else {
+        style::SPACE_SM + row_h + style::SPACE_SM
+    }
+}
+
 /// Returns the known fixed height of a node that can be bottom-pinned, or `None`
 /// if the height cannot be determined without rendering.
 fn bottom_pin_height(ui: &egui::Ui, node: &UiNode) -> Option<f32> {
     match node {
-        UiNode::FooterKeys { divider, .. } => {
-            let crh = chip_row_height(ui);
-            Some(if *divider {
-                1.0 + style::SPACE_SM + crh + style::SPACE_SM
-            } else {
-                style::SPACE_SM + crh + style::SPACE_SM
-            })
-        }
+        UiNode::FooterKeys { divider, .. } => Some(footer_keys_height(ui, *divider)),
         UiNode::Footer { .. } => {
             Some(style::SPACE_MD + 1.0 + style::SPACE_MD + style::TEXT_CAPTION + 5.0)
         }
@@ -1334,8 +1340,35 @@ fn vertical_grow_node(node: &UiNode) -> bool {
     }
 }
 
+fn vertical_stack_needs_full_height(children: &[UiNode]) -> bool {
+    children.iter().any(|child| {
+        vertical_grow_node(child)
+            || matches!(
+                child,
+                UiNode::Pinned {
+                    edge: PinnedEdge::Bottom,
+                    ..
+                } | UiNode::FooterKeys { .. }
+                    | UiNode::Footer { .. }
+            )
+    })
+}
+
 fn vertical_fixed_height(ui: &egui::Ui, node: &UiNode) -> Option<f32> {
     match node {
+        UiNode::Stack {
+            direction,
+            children,
+            padding,
+            ..
+        } if *direction == StackDirection::Horizontal => {
+            let mut max_h: f32 = 0.0;
+            for child in children {
+                let h = vertical_fixed_height(ui, child)?;
+                max_h = max_h.max(h);
+            }
+            Some(max_h + padding.top + padding.bottom)
+        }
         UiNode::AppBar { subtitle, .. } => {
             let band_h = if subtitle.is_empty() { 34.0 } else { 48.0 };
             Some(band_h + 1.0)
@@ -1687,7 +1720,11 @@ fn render_stack(
                     "render_components: render_stack vertical pinned body_h={body_h:.0} footer_h={total_pinned_h:.0}"
                 );
             } else {
-                log::trace!("render_stack: vertical no-pin {} children avail_h={}", children.len(), ui.available_height());
+                log::trace!(
+                    "render_stack: vertical no-pin {} children avail_h={}",
+                    children.len(),
+                    ui.available_height()
+                );
                 let child_refs: Vec<&UiNode> = children.iter().collect();
                 ui.vertical(|ui| {
                     events.extend(render_vertical_children(
@@ -2055,8 +2092,10 @@ mod render_component_tree_tests {
         ctx.begin_pass(egui::RawInput::default());
         egui::CentralPanel::default().show(&ctx, |ui| {
             let crh = chip_row_height(ui);
-            let expected_with_div = 1.0 + style::SPACE_SM + crh + style::SPACE_SM;
-            let expected_no_div = style::SPACE_SM + crh + style::SPACE_SM;
+            let row_h = crh + 4.0;
+            let expected_with_div =
+                style::SPACE_SM + 1.0 + style::SPACE_SM + row_h + style::SPACE_SM;
+            let expected_no_div = style::SPACE_SM + row_h + style::SPACE_SM;
 
             assert_eq!(bottom_pin_height(ui, &fk_with_div), Some(expected_with_div));
             assert_eq!(bottom_pin_height(ui, &fk_no_div), Some(expected_no_div));
@@ -2064,6 +2103,73 @@ mod render_component_tree_tests {
             assert_eq!(bottom_pin_height(ui, &label), None);
         });
         let _ = ctx.end_pass();
+    }
+
+    /// A horizontal stack of fixed-height buttons reserves one button row in vertical layout.
+    #[test]
+    fn horizontal_button_stack_has_fixed_height() {
+        use super::vertical_fixed_height;
+
+        let stack = UiNode::Stack {
+            direction: StackDirection::Horizontal,
+            children: vec![
+                UiNode::Button {
+                    node_id: "save".into(),
+                    label: "Save".into(),
+                    disabled: false,
+                    style: "primary".into(),
+                },
+                UiNode::Button {
+                    node_id: "cancel".into(),
+                    label: "Cancel".into(),
+                    disabled: false,
+                    style: "ghost".into(),
+                },
+            ],
+            gap: 8.0,
+            padding: crate::app_protocol::UiPadding {
+                top: 3.0,
+                bottom: 5.0,
+                ..Default::default()
+            },
+        };
+
+        let ctx = egui::Context::default();
+        ctx.begin_pass(egui::RawInput::default());
+        egui::CentralPanel::default().show(&ctx, |ui| {
+            assert_eq!(vertical_fixed_height(ui, &stack), Some(40.0));
+        });
+        let _ = ctx.end_pass();
+    }
+
+    /// Static nested Columns stay content-sized; pinned/grow stacks fill the available height.
+    #[test]
+    fn vertical_stack_fill_height_only_when_needed() {
+        use super::vertical_stack_needs_full_height;
+
+        let static_children = vec![UiNode::Text {
+            text: "body".into(),
+            size: 0.0,
+            color: String::new(),
+            bold: false,
+            monospace: false,
+        }];
+        assert!(!vertical_stack_needs_full_height(&static_children));
+
+        let grow_children = vec![UiNode::SelectList {
+            items: vec![],
+            selected_idx: 0,
+        }];
+        assert!(vertical_stack_needs_full_height(&grow_children));
+
+        let footer_children = vec![UiNode::Pinned {
+            edge: PinnedEdge::Bottom,
+            child: Box::new(UiNode::FooterKeys {
+                entries: vec![],
+                divider: true,
+            }),
+        }];
+        assert!(vertical_stack_needs_full_height(&footer_children));
     }
 
     /// `UiNode::TextEdit` PartialEq works.

--- a/website/src/content/docs/sdk.md
+++ b/website/src/content/docs/sdk.md
@@ -360,6 +360,10 @@ Clickable host-rendered button.
 ``on_click`` is the handler id delivered back as a ``UiAction`` event.
 Return state/effect changes from ``update(event)`` when that event arrives.
 
+### `ActionBar`
+
+Horizontal row of contextual action buttons.
+
 ### `Spacer`
 
 Fixed or flex gap. `grow=True` expands to consume remaining space.


### PR DESCRIPTION
Stint: 0314

## Summary

- Adds `ActionBar` to the Python SDK and updates the generated app scaffold to demonstrate `AppBar` + content + `ActionBar` + `FooterKeys`.
- Fixes `FooterKeys` bottom clipping by reserving the full footer band and accounting for fixed-height action rows in vertical layout.
- Migrates current raw button rows in core/sample apps to `ActionBar` where appropriate.

## Validation

- `env -u VIRTUAL_ENV PYTHONPATH=sdk/python uv run ruff check sdk/python/plexi_sdk/ui.py sdk/python/plexi_sdk/_version.py sdk/python/plexi_sdk/templates/app_init.py sdk/python/tests/test_new_components.py apps/todo/todo.py apps/calc/calc.py apps/permissions/main.py apps/csv_viewer/csv_viewer.py apps/wikipedia/wikipedia.py` - passed
- `env -u VIRTUAL_ENV PYTHONPATH=sdk/python uv run pytest sdk/python/tests -q` - 138 passed
- `env -u VIRTUAL_ENV PYTHONPATH=sdk/python uv run pytest apps/todo/tests/test_todo_v3.py apps/calc/tests/test_calc_v3.py apps/permissions/tests/test_permissions_v3.py apps/csv_viewer/tests/test_csv_viewer_v3.py apps/wikipedia/tests/test_wikipedia_v3.py -q` - 13 passed
- `cargo test --bin plexi render_component_tree_tests` - 20 passed
- `cargo test --bin plexi` - 1380 passed, 1 ignored
- `cargo build` - passed
- `rustfmt --check src/render/components.rs src/cli/app.rs` - passed
- `stint check` - ok
- `just scene /tmp/plexi-0314-todo-footer-scene.toml` - passed; screenshot: `/tmp/plexi-scenes/stint-0314-todo-footer.png`

## Notes

- Footer clipping was first reproduced by tightening the `bottom_pin_height_known_nodes` expectation; before the fix, the helper returned `Some(36.0)` for a divider footer where the full band needs `Some(48.0)`.
- `tests/scenes/footer-small-pane.toml` is currently stale because `apps/dev/ui-gallery` imports legacy `plexi_sdk.App`; the evidence scene uses `apps/todo`.
- `cargo fmt --check` is not clean repo-wide due unrelated existing formatting drift, so this PR checks touched Rust files directly.
