### PR TITLE
rebuild: todo app from scratch (stint 0299)

### DIFF
--- a/apps/todo/tests/test_todo_v3.py
+++ b/apps/todo/tests/test_todo_v3.py
@@ -11,49 +11,191 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import plexi_sdk as sdk  # noqa: E402
 from plexi_sdk import _v3_state  # noqa: E402
-from plexi_sdk.effects import PersistState  # noqa: E402
+from plexi_sdk.effects import PersistState, SetTitle  # noqa: E402
 from plexi_sdk.events import KeyEvent, UiAction, UiValueChange  # noqa: E402
 
 import todo  # noqa: E402
 
 
 def _set_state(values: dict) -> None:
-    raw = {key: b"" for key in values}
-    _v3_state._state = sdk.StateSnapshot(values, raw)
+    _v3_state._state = sdk.StateSnapshot(values, {})
     _v3_state._in_view = False
 
 
 def _state_effect(effects: list) -> dict:
-    effect = next(effect for effect in effects if isinstance(effect, PersistState))
-    return effect.data
+    return next(effect.data for effect in effects if isinstance(effect, PersistState))
 
 
-def test_add_toggle_and_delete_item_with_v3_effects() -> None:
+def test_init_persists_normalized_default_state() -> None:
+    _set_state({})
+
+    effects = todo.init((480, 320), [])
+
+    assert any(isinstance(effect, SetTitle) and effect.title == "Todo" for effect in effects)
+    assert _state_effect(effects) == todo.DEFAULT_STATE
+
+
+def test_add_toggle_with_space_enter_and_delete_item_with_v3_effects() -> None:
     _set_state(dict(todo.DEFAULT_STATE))
 
-    effects = todo.update(UiAction("todo-new"))
-    adding = _state_effect(effects)
+    adding = _state_effect(todo.update(KeyEvent("n")))
     assert adding["mode"] == "add"
 
     _set_state(adding)
-    effects = todo.update(UiValueChange("todo-draft", "Write tests"))
-    draft = _state_effect(effects)
+    draft = _state_effect(todo.update(UiValueChange(todo.DRAFT_ID, "Write tests")))
     assert draft["draft"] == "Write tests"
 
     _set_state(draft)
-    effects = todo.update(UiAction("todo-draft"))
-    added = _state_effect(effects)
+    added = _state_effect(todo.update(UiAction("todo-add")))
     assert added["items"] == [{"text": "Write tests", "done": False}]
     assert added["selected"] == 0
     assert added["mode"] == "list"
 
     _set_state(added)
-    effects = todo.update(KeyEvent("space"))
-    toggled = _state_effect(effects)
-    assert toggled["items"][0]["done"] is True
+    toggled_by_space = _state_effect(todo.update(KeyEvent("space")))
+    assert toggled_by_space["items"][0]["done"] is True
 
-    _set_state(toggled)
-    effects = todo.update(KeyEvent("d"))
-    deleted = _state_effect(effects)
+    _set_state(toggled_by_space)
+    toggled_by_enter = _state_effect(todo.update(KeyEvent("enter")))
+    assert toggled_by_enter["items"][0]["done"] is False
+
+    _set_state(toggled_by_enter)
+    deleted = _state_effect(todo.update(KeyEvent("d")))
     assert deleted["items"] == []
     assert deleted["selected"] == 0
+
+
+def test_navigation_clamps_selection_with_j_k_and_arrows() -> None:
+    data = {
+        **todo.DEFAULT_STATE,
+        "items": [
+            {"text": "one", "done": False},
+            {"text": "two", "done": False},
+            {"text": "three", "done": False},
+        ],
+    }
+    _set_state(data)
+
+    selected = _state_effect(todo.update(KeyEvent("j")))
+    assert selected["selected"] == 1
+
+    _set_state(selected)
+    selected = _state_effect(todo.update(KeyEvent("ArrowDown")))
+    assert selected["selected"] == 2
+
+    _set_state(selected)
+    selected = _state_effect(todo.update(KeyEvent("j")))
+    assert selected["selected"] == 2
+
+    _set_state(selected)
+    selected = _state_effect(todo.update(KeyEvent("k")))
+    assert selected["selected"] == 1
+
+    _set_state(selected)
+    selected = _state_effect(todo.update(KeyEvent("ArrowUp")))
+    assert selected["selected"] == 0
+
+
+def test_delete_keeps_selection_on_next_available_item() -> None:
+    data = {
+        **todo.DEFAULT_STATE,
+        "items": [
+            {"text": "one", "done": False},
+            {"text": "two", "done": False},
+            {"text": "three", "done": False},
+        ],
+        "selected": 1,
+    }
+    _set_state(data)
+
+    deleted = _state_effect(todo.update(UiAction("todo-delete")))
+
+    assert deleted["items"] == [
+        {"text": "one", "done": False},
+        {"text": "three", "done": False},
+    ]
+    assert deleted["selected"] == 1
+
+
+def test_delete_alias_keys_still_remove_selected_item() -> None:
+    for key in ("x", "backspace", "delete"):
+        data = {
+            **todo.DEFAULT_STATE,
+            "items": [
+                {"text": "one", "done": False},
+                {"text": "two", "done": False},
+            ],
+            "selected": 0,
+        }
+        _set_state(data)
+
+        deleted = _state_effect(todo.update(KeyEvent(key)))
+
+        assert deleted["items"] == [{"text": "two", "done": False}]
+        assert deleted["selected"] == 0
+
+
+def test_add_mode_cancel_and_blank_submit_return_to_list() -> None:
+    data = {**todo.DEFAULT_STATE, "mode": "add", "draft": "  "}
+    _set_state(data)
+
+    submitted = _state_effect(todo.update(UiAction(todo.DRAFT_ID)))
+
+    assert submitted["items"] == []
+    assert submitted["mode"] == "list"
+    assert submitted["draft"] == ""
+
+    data = {**todo.DEFAULT_STATE, "mode": "add", "draft": "ignored"}
+    _set_state(data)
+    cancelled = _state_effect(todo.update(KeyEvent("escape")))
+
+    assert cancelled["mode"] == "list"
+    assert cancelled["draft"] == ""
+
+
+def test_list_view_uses_action_bar_and_footer_keys() -> None:
+    _set_state(
+        {
+            **todo.DEFAULT_STATE,
+            "items": [{"text": "Write tests", "done": False}],
+        }
+    )
+
+    node = todo.view().to_node()
+
+    assert node["type"] == "column"
+    app_bar, select_list, action_bar, footer = node["children"]
+    assert app_bar == {"type": "app_bar", "title": "Todo", "subtitle": "0/1 done"}
+    assert select_list["type"] == "select_list"
+    assert select_list["selected_idx"] == 0
+    assert action_bar["type"] == "stack"
+    assert action_bar["direction"] == "horizontal"
+    assert [button["label"] for button in action_bar["children"]] == [
+        "New",
+        "Toggle",
+        "Delete",
+    ]
+    assert footer["type"] == "pinned"
+    assert footer["edge"] == "bottom"
+    assert footer["child"]["type"] == "footer_keys"
+
+
+def test_add_view_uses_text_edit_action_bar_and_footer_keys() -> None:
+    _set_state({**todo.DEFAULT_STATE, "mode": "add", "draft": "Write docs"})
+
+    node = todo.view().to_node()
+
+    app_bar, text_edit, action_bar, footer = node["children"]
+    assert app_bar == {"type": "app_bar", "title": "Todo", "subtitle": "New item"}
+    assert text_edit == {
+        "type": "text_edit",
+        "node_id": todo.DRAFT_ID,
+        "placeholder": "What needs doing?",
+        "value": "Write docs",
+        "multiline": False,
+        "max_length": 0,
+    }
+    assert action_bar["type"] == "stack"
+    assert [button["label"] for button in action_bar["children"]] == ["Add", "Cancel"]
+    assert footer["type"] == "pinned"
+    assert footer["child"]["type"] == "footer_keys"

--- a/apps/todo/todo.py
+++ b/apps/todo/todo.py
@@ -1,104 +1,87 @@
 #!/usr/bin/env python3
-"""Todo - SDK v3 persisted list."""
+"""Todo - persisted SDK v3 app."""
 
 from __future__ import annotations
 
 from plexi_sdk import log, state
 from plexi_sdk.effects import PersistState, SetStatus, SetTitle
 from plexi_sdk.events import KeyEvent, UiAction, UiValueChange
-from plexi_sdk.ui import (
-    ActionBar,
-    AppBar,
-    Button,
-    Column,
-    FooterKeys,
-    SelectList,
-    Spacer,
-    Text,
-    TextEdit,
-)
+from plexi_sdk.ui import ActionBar, AppBar, Button, Column, FooterKeys, SelectList, TextEdit
+
+MODE_LIST = "list"
+MODE_ADD = "add"
+
+DRAFT_ID = "todo-draft"
 
 DEFAULT_STATE = {
     "items": [],
     "selected": 0,
-    "mode": "list",
+    "mode": MODE_LIST,
     "draft": "",
 }
 
 
 def init(size, args) -> list:
-    data = _state()
-    effects: list = [SetTitle("Todo"), SetStatus(_status(data))]
-    if not state.get("items", None):
-        effects.append(PersistState({"items": data["items"]}))
-    log.info("todo: sdk v3 app initialized")
-    return effects
+    data = _read_state()
+    log.info(f"todo: initialized items={len(data['items'])} mode={data['mode']}")
+    return [SetTitle("Todo"), SetStatus(_status(data)), PersistState(data)]
 
 
 def update(event) -> list:
-    data = _state()
+    data = _read_state()
 
-    if isinstance(event, UiValueChange) and event.handler_id == "todo-draft":
+    if isinstance(event, UiValueChange) and event.handler_id == DRAFT_ID:
         data["draft"] = event.value
-        return _save(data)
+        return _persist(data, "draft")
 
     if isinstance(event, UiAction):
         if event.handler_id == "todo-new":
-            data["mode"] = "add"
-            data["draft"] = ""
-            return _save(data)
-        if event.handler_id == "todo-draft":
-            return _add(data)
+            return _start_add(data)
+        if event.handler_id in ("todo-add", DRAFT_ID):
+            return _add_item(data)
         if event.handler_id == "todo-cancel":
-            data["mode"] = "list"
-            data["draft"] = ""
-            return _save(data)
+            return _cancel_add(data)
         if event.handler_id == "todo-toggle":
-            return _toggle(data)
+            return _toggle_selected(data)
         if event.handler_id == "todo-delete":
-            return _delete(data)
+            return _delete_selected(data)
 
     if not isinstance(event, KeyEvent) or not event.pressed:
         return []
 
-    key = event.key
-    if data["mode"] == "add":
+    key = _key(event.key)
+    if data["mode"] == MODE_ADD:
         if key == "escape":
-            data["mode"] = "list"
-            data["draft"] = ""
-            return _save(data)
+            return _cancel_add(data)
+        if key == "enter":
+            return _add_item(data)
         return []
 
     if key in ("j", "down"):
-        data["selected"] = _clamp(data["selected"] + 1, len(data["items"]))
-    elif key in ("k", "up"):
-        data["selected"] = _clamp(data["selected"] - 1, len(data["items"]))
-    elif key in ("n", "a"):
-        data["mode"] = "add"
-        data["draft"] = ""
-    elif key in ("space", "enter", "return"):
-        return _toggle(data)
-    elif key in ("d", "x", "backspace", "delete"):
-        return _delete(data)
-    else:
-        return []
-    return _save(data)
+        return _move_selection(data, 1)
+    if key in ("k", "up"):
+        return _move_selection(data, -1)
+    if key in ("n", "a"):
+        return _start_add(data)
+    if key in ("space", "enter"):
+        return _toggle_selected(data)
+    if key in ("d", "x", "backspace", "delete"):
+        return _delete_selected(data)
+    return []
 
 
 def view():
-    data = _state()
-    if data["mode"] == "add":
+    data = _read_state()
+    if data["mode"] == MODE_ADD:
         return Column(
             [
                 AppBar("Todo", "New item"),
-                TextEdit(
-                    "todo-draft", value=data["draft"], placeholder="What needs doing?"
-                ),
+                TextEdit(DRAFT_ID, value=data["draft"], placeholder="What needs doing?"),
                 ActionBar(
                     [
                         Button(
                             "Add",
-                            "todo-draft",
+                            "todo-add",
                             style="primary",
                             disabled=not data["draft"].strip(),
                         ),
@@ -111,19 +94,11 @@ def view():
             padding=0,
         )
 
-    rows = [
-        {
-            "name": item["text"],
-            "description": "done" if item["done"] else "open",
-            "leading": "[x]" if item["done"] else "[ ]",
-        }
-        for item in data["items"]
-    ]
-    body = SelectList(rows, selected_idx=data["selected"]) if rows else _empty()
+    rows = _rows(data["items"])
     return Column(
         [
             AppBar("Todo", _status(data)),
-            body,
+            SelectList(rows, selected_idx=data["selected"]),
             ActionBar(
                 [
                     Button("New", "todo-new", style="primary"),
@@ -132,7 +107,12 @@ def view():
                 ]
             ),
             FooterKeys(
-                [("j/k", "select"), ("enter", "toggle"), ("n", "new"), ("d", "delete")]
+                [
+                    ("j/k", "select"),
+                    (["space", "enter"], "toggle"),
+                    ("n", "new"),
+                    ("d", "delete"),
+                ]
             ),
         ],
         grow=True,
@@ -140,65 +120,94 @@ def view():
     )
 
 
-def _state() -> dict:
+def _read_state() -> dict:
     data = dict(DEFAULT_STATE)
-    for key, value in DEFAULT_STATE.items():
-        data[key] = state.get(key, value)
-    data["items"] = [_normalize_item(item) for item in list(data.get("items") or [])]
-    data["selected"] = _clamp(int(data.get("selected") or 0), len(data["items"]))
-    data["mode"] = "add" if data.get("mode") == "add" else "list"
+    for key, fallback in DEFAULT_STATE.items():
+        data[key] = state.get(key, fallback)
+
+    items = [_normalize_item(item) for item in data.get("items") or []]
+    data["items"] = [item for item in items if item["text"]]
+    data["selected"] = _clamp_index(data.get("selected"), len(data["items"]))
+    data["mode"] = MODE_ADD if data.get("mode") == MODE_ADD else MODE_LIST
     data["draft"] = str(data.get("draft") or "")
     return data
 
 
 def _normalize_item(item) -> dict:
     if isinstance(item, dict):
-        return {"text": str(item.get("text") or ""), "done": bool(item.get("done"))}
-    return {"text": str(item), "done": False}
+        text = str(item.get("text") or "").strip()
+        done = bool(item.get("done"))
+    else:
+        text = str(item).strip()
+        done = False
+    return {"text": text, "done": done}
 
 
-def _save(data: dict) -> list:
-    data["selected"] = _clamp(data["selected"], len(data["items"]))
-    log.info(f"todo: state mode={data['mode']} items={len(data['items'])}")
-    return [PersistState(data), SetStatus(_status(data))]
+def _rows(items: list[dict]) -> list[dict]:
+    return [
+        {
+            "name": item["text"],
+            "description": "done" if item["done"] else "open",
+            "leading": "[x]" if item["done"] else "[ ]",
+        }
+        for item in items
+    ]
 
 
-def _add(data: dict) -> list:
+def _start_add(data: dict) -> list:
+    data["mode"] = MODE_ADD
+    data["draft"] = ""
+    return _persist(data, "start_add")
+
+
+def _cancel_add(data: dict) -> list:
+    data["mode"] = MODE_LIST
+    data["draft"] = ""
+    return _persist(data, "cancel_add")
+
+
+def _add_item(data: dict) -> list:
     text = data["draft"].strip()
     if text:
         data["items"].append({"text": text, "done": False})
         data["selected"] = len(data["items"]) - 1
-    data["mode"] = "list"
+    data["mode"] = MODE_LIST
     data["draft"] = ""
-    return _save(data)
+    return _persist(data, "add")
 
 
-def _toggle(data: dict) -> list:
+def _move_selection(data: dict, delta: int) -> list:
     if not data["items"]:
         return []
-    item = dict(data["items"][data["selected"]])
+    data["selected"] = _clamp_index(data["selected"] + delta, len(data["items"]))
+    return _persist(data, "select")
+
+
+def _toggle_selected(data: dict) -> list:
+    selected = data["selected"]
+    if not data["items"] or selected >= len(data["items"]):
+        return []
+    item = dict(data["items"][selected])
     item["done"] = not item["done"]
-    data["items"][data["selected"]] = item
-    return _save(data)
+    data["items"][selected] = item
+    return _persist(data, "toggle")
 
 
-def _delete(data: dict) -> list:
-    if not data["items"]:
+def _delete_selected(data: dict) -> list:
+    selected = data["selected"]
+    if not data["items"] or selected >= len(data["items"]):
         return []
-    data["items"].pop(data["selected"])
-    return _save(data)
+    del data["items"][selected]
+    data["selected"] = _clamp_index(selected, len(data["items"]))
+    return _persist(data, "delete")
 
 
-def _empty():
-    return Column(
-        [
-            Spacer(size=24),
-            Text("No todo items", size=16.0, bold=True),
-            Text("Press n or click New.", size=12.0),
-        ],
-        grow=True,
-        padding=16,
+def _persist(data: dict, action: str) -> list:
+    data["selected"] = _clamp_index(data["selected"], len(data["items"]))
+    log.info(
+        f"todo: {action} items={len(data['items'])} selected={data['selected']} mode={data['mode']}"
     )
+    return [PersistState(data), SetStatus(_status(data))]
 
 
 def _status(data: dict) -> str:
@@ -207,7 +216,22 @@ def _status(data: dict) -> str:
     return f"{done}/{total} done"
 
 
-def _clamp(selected: int, total: int) -> int:
+def _clamp_index(value, total: int) -> int:
     if total <= 0:
         return 0
+    try:
+        selected = int(value)
+    except (TypeError, ValueError):
+        selected = 0
     return max(0, min(selected, total - 1))
+
+
+def _key(key: str) -> str:
+    normalized = str(key or "").lower()
+    return {
+        "arrowdown": "down",
+        "arrowup": "up",
+        "return": "enter",
+        "esc": "escape",
+        " ": "space",
+    }.get(normalized, normalized)


### PR DESCRIPTION
Stint: 0299
Linked GitHub issue: none

## Summary

- Rebuilt `apps/todo/todo.py` around SDK v3 module lifecycle, `PersistState`, normalized key handling, and current `ActionBar`/`FooterKeys` primitives.
- Preserved the existing `manifest.toml` and pruned unused todo imports.
- Expanded focused todo app coverage for add/list modes, j/k navigation, space/enter toggle, delete aliases, persistence effects, and rendered ActionBar/FooterKeys shape.

## Test evidence

- `uv run pytest apps/todo/tests/test_todo_v3.py -q` — 8 passed.
- `PYTHONPATH="$PWD/sdk/python" uv run pytest sdk/python/tests/test_new_components.py sdk/python/tests/test_v3_adapter.py -q` — 47 passed.
- `cargo build` — passed.
- `cargo test --bin plexi` — 1380 passed, 1 ignored.
- `stint check` — ok.
- `git diff --check` — ok.
- Headless app render via `target/debug/plexi app render apps/todo` — PNG/JSON passed for list at 640x420 and 360x260, empty at 360x260, add mode at 360x260. Screenshots: `/tmp/plexi-todo-640x420.png`, `/tmp/plexi-todo-360x260.png`, `/tmp/plexi-todo-empty-360x260.png`, `/tmp/plexi-todo-add-360x260.png`. Visual check: ActionBar and FooterKeys are visible and not clipped.
- Codex review against alpha — no actionable correctness issues after preserving delete-key aliases.

## Validation note

Visible app interaction changed. Binary install validation required: run `just pr-install <PR>` from this feature worktree and validate with the PR build.