### PR TITLE
marketplace: scan reviewed-native bypasses (stint 0320)

### DIFF
--- a/apps/github-issues/manifest.toml
+++ b/apps/github-issues/manifest.toml
@@ -14,8 +14,6 @@ allowed_hosts = ["api.github.com", "github.com"]
 
 [launch]
 
-# Uncomment to publish this app to the marketplace:
-# [marketplace]
-# visibility = "public"   # public | unlisted | private
-# price = "free"          # "free", or a price like "4.99"
-# publisher = "plexi"     # first-party Plexi app
+# Not a marketplace example: repo/token discovery shells out to `git` and `gh`.
+# Keep [marketplace] absent until those paths are replaced with host-mediated
+# APIs or the hosted review flow can label it as a reviewed native process.

--- a/src/app/marketplace.rs
+++ b/src/app/marketplace.rs
@@ -191,6 +191,11 @@ pub struct RegistryEntry {
     /// re-derived locally on install. Never claims more than the local check.
     #[serde(default)]
     pub trust_label: String,
+    /// Registry attestation that native/Python bypass patterns received human
+    /// review. Publisher submissions default false; the hosted review system
+    /// is the only writer that may set this true.
+    #[serde(default)]
+    pub reviewed_native: bool,
     #[serde(default)]
     pub visibility: Visibility,
     #[serde(default)]
@@ -240,6 +245,7 @@ impl RegistryEntry {
                 .collect(),
             tags,
             trust_label: trust_label.to_string(),
+            reviewed_native: false,
             visibility: marketplace.visibility,
             price: marketplace.price.clone(),
             checksum,
@@ -746,6 +752,7 @@ mod tests {
             capabilities: vec![],
             tags: vec![],
             trust_label: "Unreviewed Python process".to_string(),
+            reviewed_native: false,
             visibility: vis,
             price,
             checksum: "abc123".to_string(),
@@ -949,6 +956,36 @@ mod tests {
         assert!(!entry.price.is_free());
         assert_eq!(entry.checksum, "deadbeef");
         assert_eq!(entry.tags, vec!["productivity".to_string()]);
+        assert!(
+            !entry.reviewed_native,
+            "publisher-generated entries are not review attestations"
+        );
+    }
+
+    #[test]
+    fn registry_entry_reviewed_native_is_explicit_attestation() {
+        let reviewed: RegistryEntry = serde_json::from_str(
+            r#"{
+                "id": "reviewed",
+                "name": "Reviewed",
+                "version": "1.0.0",
+                "checksum": "abc123",
+                "reviewed_native": true
+            }"#,
+        )
+        .unwrap();
+        assert!(reviewed.reviewed_native);
+
+        let defaulted: RegistryEntry = serde_json::from_str(
+            r#"{
+                "id": "plain",
+                "name": "Plain",
+                "version": "1.0.0",
+                "checksum": "abc123"
+            }"#,
+        )
+        .unwrap();
+        assert!(!defaulted.reviewed_native);
     }
 
     #[test]

--- a/src/app/package.rs
+++ b/src/app/package.rs
@@ -124,6 +124,16 @@ pub enum PackageError {
         "unsupported runtime '{0}' in PACKAGE.toml — expected \"python\", \"native\", or \"wasm\""
     )]
     UnsupportedRuntime(String),
+    #[error(
+        "review required for {runtime} package: {category} bypass pattern in {path}:{line}: {snippet} — reviewed native apps are not sandboxed"
+    )]
+    BypassReviewRequired {
+        runtime: &'static str,
+        category: &'static str,
+        path: PathBuf,
+        line: usize,
+        snippet: String,
+    },
     #[error("file '{0}' listed in PACKAGE.toml is missing from the archive")]
     ListedFileMissing(String),
     #[error("file '{0}' present in the archive but not listed in PACKAGE.toml")]
@@ -245,24 +255,22 @@ pub enum TrustLabel {
     NativeUnreviewed,
     /// A Python app from outside the core pack.
     PythonUnreviewed,
-    /// A Python app that has passed marketplace review.
-    PythonReviewed,
+    /// A Python/native app that has passed marketplace review.
+    ReviewedNative,
     /// A WASM component from outside the core pack.
-    WasmComponent,
+    SandboxedWasm,
 }
 
 impl TrustLabel {
     /// Honest display string. Never claims sandboxing — none exists in v1.
     pub fn display_str(self) -> &'static str {
         match self {
-            Self::FirstPartyCore => "First-party core — ships with Plexi",
+            Self::FirstPartyCore => "First-party core — bundled with Plexi",
             Self::PythonUnreviewed => {
                 "Unreviewed Python process — runs with your full user permissions"
             }
-            Self::PythonReviewed => {
-                "Reviewed native process — manifest reviewed; not sandboxed"
-            }
-            Self::WasmComponent => "WASM component — sandboxed; host imports are capability-gated",
+            Self::ReviewedNative => "Reviewed native process — human-reviewed; not sandboxed",
+            Self::SandboxedWasm => "Sandboxed WASM — scoped host imports are capability-gated",
             Self::NativeUnreviewed => {
                 "Unreviewed native process — runs with your full user permissions"
             }
@@ -280,20 +288,30 @@ impl TrustLabel {
 /// attacker-controlled and must not be used here. For local installs pass
 /// `false`; marketplace installs will pass `true` based on server attestation
 /// when that flow ships.
-pub fn trust_label(report: &PackageReport, core_ids: &[&str], marketplace_reviewed: bool) -> TrustLabel {
+pub fn trust_label(
+    report: &PackageReport,
+    core_ids: &[&str],
+    marketplace_reviewed: bool,
+) -> TrustLabel {
     if core_ids.contains(&report.id.as_str()) {
         TrustLabel::FirstPartyCore
     } else {
         match report.runtime {
             PackageRuntime::Python => {
                 if marketplace_reviewed {
-                    TrustLabel::PythonReviewed
+                    TrustLabel::ReviewedNative
                 } else {
                     TrustLabel::PythonUnreviewed
                 }
             }
-            PackageRuntime::Wasm => TrustLabel::WasmComponent,
-            PackageRuntime::Native => TrustLabel::NativeUnreviewed,
+            PackageRuntime::Wasm => TrustLabel::SandboxedWasm,
+            PackageRuntime::Native => {
+                if marketplace_reviewed {
+                    TrustLabel::ReviewedNative
+                } else {
+                    TrustLabel::NativeUnreviewed
+                }
+            }
         }
     }
 }
@@ -305,7 +323,7 @@ pub fn trust_label(report: &PackageReport, core_ids: &[&str], marketplace_review
 /// previous extraction) is ignored by the file walk — it is regenerated at
 /// build time and verified at package-validate time.
 pub fn validate_dir(app_dir: &Path) -> Result<PackageReport, PackageError> {
-    let report = validate_dir_inner(app_dir)?;
+    let report = validate_dir_inner(app_dir, NativeBypassReview::Block)?;
     log::info!(
         "package: validate_dir ok id={} version={} runtime={} files={} bytes={} dir={}",
         report.id,
@@ -318,7 +336,16 @@ pub fn validate_dir(app_dir: &Path) -> Result<PackageReport, PackageError> {
     Ok(report)
 }
 
-fn validate_dir_inner(app_dir: &Path) -> Result<PackageReport, PackageError> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NativeBypassReview {
+    Block,
+    Reviewed,
+}
+
+fn validate_dir_inner(
+    app_dir: &Path,
+    native_bypass_review: NativeBypassReview,
+) -> Result<PackageReport, PackageError> {
     if !app_dir.is_dir() {
         return Err(PackageError::NotADirectory(app_dir.to_path_buf()));
     }
@@ -350,6 +377,8 @@ fn validate_dir_inner(app_dir: &Path) -> Result<PackageReport, PackageError> {
     )?;
 
     let files = collect_files(app_dir)?;
+    let runtime = PackageRuntime::from_manifest(manifest.app.manifest_type, &entry);
+    scan_native_bypass_patterns(app_dir, &files, runtime, native_bypass_review)?;
     let total_size = files.iter().map(|(_, size)| size).sum();
 
     let (requires_plexi_min, requires_plexi_max) = manifest
@@ -361,7 +390,7 @@ fn validate_dir_inner(app_dir: &Path) -> Result<PackageReport, PackageError> {
         id: manifest.app.id,
         name: manifest.app.name,
         version: manifest.app.version,
-        runtime: PackageRuntime::from_manifest(manifest.app.manifest_type, &entry),
+        runtime,
         entry,
         capabilities,
         wasm_required_capabilities,
@@ -440,6 +469,142 @@ fn parse_wasm_capabilities(
         }
     }
     Ok(strings.to_vec())
+}
+
+fn scan_native_bypass_patterns(
+    root: &Path,
+    files: &[(PathBuf, u64)],
+    runtime: PackageRuntime,
+    native_bypass_review: NativeBypassReview,
+) -> Result<(), PackageError> {
+    if runtime == PackageRuntime::Wasm {
+        return Ok(());
+    }
+
+    for (rel, _) in files {
+        if !should_scan_bypass_file(rel) {
+            continue;
+        }
+        let path = root.join(rel);
+        let raw = fs::read_to_string(&path).map_err(|e| io_err("read", &path, e))?;
+        for (idx, line) in raw.lines().enumerate() {
+            if let Some((category, snippet)) = detect_native_bypass_line(line) {
+                if native_bypass_review == NativeBypassReview::Reviewed {
+                    log::info!(
+                        "package: reviewed native bypass accepted runtime={} category={} path={} line={}",
+                        runtime.as_str(),
+                        category,
+                        rel.display(),
+                        idx + 1
+                    );
+                    continue;
+                }
+                return Err(PackageError::BypassReviewRequired {
+                    runtime: runtime.as_str(),
+                    category,
+                    path: rel.to_path_buf(),
+                    line: idx + 1,
+                    snippet,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn should_scan_bypass_file(rel: &Path) -> bool {
+    if rel.components().any(|component| {
+        matches!(
+            component,
+            Component::Normal(name) if name == "tests" || name == "test"
+        )
+    }) {
+        return false;
+    }
+    if rel
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("test_"))
+    {
+        return false;
+    }
+
+    matches!(
+        rel.extension().and_then(|ext| ext.to_str()),
+        Some("py" | "pyw" | "sh" | "bash" | "zsh")
+    )
+}
+
+fn detect_native_bypass_line(line: &str) -> Option<(&'static str, String)> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+    let lower = trimmed.to_ascii_lowercase();
+
+    let category = if contains_host_routing_pattern(trimmed) {
+        "host routing"
+    } else if contains_subprocess_pattern(&lower) {
+        "subprocess"
+    } else if contains_direct_socket_pattern(&lower) {
+        "direct socket"
+    } else if contains_path_traversal_pattern(&lower) {
+        "path traversal"
+    } else {
+        return None;
+    };
+
+    Some((category, snippet_for_error(trimmed)))
+}
+
+fn contains_host_routing_pattern(line: &str) -> bool {
+    line.contains("PLEXI_SOCKET") || line.contains("notify.sock")
+}
+
+fn contains_subprocess_pattern(lower: &str) -> bool {
+    lower.starts_with("import subprocess")
+        || lower.starts_with("from subprocess import")
+        || lower.contains(" subprocess.")
+        || lower.contains("subprocess.")
+        || lower.contains("asyncio.create_subprocess")
+        || lower.contains("os.system(")
+        || lower.contains("os.popen(")
+        || lower.contains("os.spawn")
+        || lower.contains("os.exec")
+        || lower.contains("pty.spawn(")
+}
+
+fn contains_direct_socket_pattern(lower: &str) -> bool {
+    lower.starts_with("import socket")
+        || lower.starts_with("from socket import")
+        || lower.contains(" socket.")
+        || lower.contains("socket.")
+        || lower.contains("asyncio.open_connection(")
+        || lower.contains("socketserver")
+        || lower.contains("af_unix")
+}
+
+fn contains_path_traversal_pattern(lower: &str) -> bool {
+    lower.contains("../")
+        || lower.contains("..\\")
+        || lower.contains("os.pardir")
+        || lower.contains(".parent.parent")
+        || lower.contains("path(\"..\")")
+        || lower.contains("path('..')")
+        || lower.contains("joinpath(\"..\")")
+        || lower.contains("joinpath('..')")
+        || lower.contains("join(\"..\")")
+        || lower.contains("join('..')")
+}
+
+fn snippet_for_error(line: &str) -> String {
+    const MAX: usize = 96;
+    let mut snippet: String = line.chars().take(MAX).collect();
+    if line.chars().count() > MAX {
+        snippet.push_str("...");
+    }
+    snippet
 }
 
 /// Returns true for root-level dev artifacts generated by scaffold/check flows
@@ -747,7 +912,18 @@ fn unique_temp_dir() -> Result<TempDirGuard, PackageError> {
 ///    capability strings)
 /// 5. `PACKAGE.toml` id/version/runtime agree with `manifest.toml`
 pub fn validate_package(file: &Path) -> Result<PackageReport, PackageError> {
-    let result = validate_package_inner(file);
+    validate_package_with_review(file, NativeBypassReview::Block)
+}
+
+pub fn validate_package_reviewed_native(file: &Path) -> Result<PackageReport, PackageError> {
+    validate_package_with_review(file, NativeBypassReview::Reviewed)
+}
+
+fn validate_package_with_review(
+    file: &Path,
+    native_bypass_review: NativeBypassReview,
+) -> Result<PackageReport, PackageError> {
+    let result = validate_package_inner(file, native_bypass_review);
     match &result {
         Ok(report) => log::info!(
             "package: validate_package ok id={} version={} files={} file={}",
@@ -764,7 +940,10 @@ pub fn validate_package(file: &Path) -> Result<PackageReport, PackageError> {
     result
 }
 
-fn validate_package_inner(file: &Path) -> Result<PackageReport, PackageError> {
+fn validate_package_inner(
+    file: &Path,
+    native_bypass_review: NativeBypassReview,
+) -> Result<PackageReport, PackageError> {
     if file.extension().and_then(|e| e.to_str()) != Some(PACKAGE_EXTENSION) {
         return Err(PackageError::WrongExtension(file.to_path_buf()));
     }
@@ -830,7 +1009,7 @@ fn validate_package_inner(file: &Path) -> Result<PackageReport, PackageError> {
     }
 
     // The extracted tree must itself be a valid app dir.
-    let report = validate_dir_inner(&root)?;
+    let report = validate_dir_inner(&root, native_bypass_review)?;
 
     // PACKAGE.toml identity must agree with manifest.toml.
     if descriptor.package.id != report.id {
@@ -927,6 +1106,26 @@ mod tests {
         builder.into_inner().unwrap().finish().unwrap();
     }
 
+    fn rewrite_entry_with_descriptor(pkg: &Path, rel: &str, bytes: &[u8], out: &Path) {
+        let mut entries = read_entries(pkg);
+        entries.insert(rel.to_string(), bytes.to_vec());
+
+        let descriptor_raw = String::from_utf8(entries.get(PACKAGE_TOML).unwrap().clone()).unwrap();
+        let mut descriptor: PackageToml = toml::from_str(&descriptor_raw).unwrap();
+        let file = descriptor
+            .files
+            .iter_mut()
+            .find(|file| file.path == rel)
+            .expect("test package must list edited file");
+        file.size = bytes.len() as u64;
+        file.sha256 = hex_string(&Sha256::digest(bytes));
+        entries.insert(
+            PACKAGE_TOML.to_string(),
+            toml::to_string_pretty(&descriptor).unwrap().into_bytes(),
+        );
+        write_entries(out, &entries);
+    }
+
     /// Build a valid package for a fresh app dir; returns (workdir, pkg path).
     fn build_valid_package(id: &str) -> (TempDir, PathBuf) {
         let work = TempDir::new().unwrap();
@@ -1014,7 +1213,10 @@ mod tests {
         std::os::unix::fs::symlink("/usr/bin/python3", venv_bin.join("python3")).unwrap();
 
         let report = validate_dir(&app_dir).expect("generated .venv must be ignored");
-        assert_eq!(report.file_count, 2, "only manifest and entry are package content");
+        assert_eq!(
+            report.file_count, 2,
+            "only manifest and entry are package content"
+        );
 
         let pkg = build_package(&app_dir, Some(&work.path().join("venv.plexipkg")))
             .expect("package build should ignore generated .venv");
@@ -1076,6 +1278,125 @@ mod tests {
         }
         // Build must refuse too.
         assert!(build_package(&app_dir, Some(&work.path().join("x.plexipkg"))).is_err());
+    }
+
+    #[test]
+    fn reviewed_native_subprocess_pattern_requires_review_in_package() {
+        let (work, pkg) = build_valid_package("pkg-subprocess-bypass");
+        let reviewed_native = work.path().join("review-required.plexipkg");
+        rewrite_entry_with_descriptor(
+            &pkg,
+            "main.py",
+            b"import subprocess\nsubprocess.run(['git', 'status'])\n",
+            &reviewed_native,
+        );
+
+        let err = validate_package(&reviewed_native).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                PackageError::BypassReviewRequired {
+                    category: "subprocess",
+                    ref path,
+                    line: 1,
+                    ..
+                } if path.ends_with("main.py")
+            ),
+            "expected subprocess review-required error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn reviewed_native_attestation_allows_bypass_package_validation() {
+        let (work, pkg) = build_valid_package("pkg-reviewed-bypass");
+        let reviewed_native = work.path().join("reviewed.plexipkg");
+        rewrite_entry_with_descriptor(
+            &pkg,
+            "main.py",
+            b"import subprocess\nsubprocess.run(['gh', 'auth', 'token'])\n",
+            &reviewed_native,
+        );
+
+        let report = validate_package_reviewed_native(&reviewed_native)
+            .expect("marketplace-reviewed package may pass scanner");
+        assert_eq!(report.id, "pkg-reviewed-bypass");
+    }
+
+    #[test]
+    fn reviewed_native_socket_pattern_requires_review_in_dir() {
+        let work = TempDir::new().unwrap();
+        let app_dir = work.path().join("app");
+        fs::create_dir(&app_dir).unwrap();
+        write_app(&app_dir, "pkg-socket-bypass", "\"net.http\"");
+        fs::write(
+            app_dir.join("main.py"),
+            "import socket\nsock = socket.socket()\n",
+        )
+        .unwrap();
+
+        let err = validate_dir(&app_dir).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                PackageError::BypassReviewRequired {
+                    category: "direct socket",
+                    ref path,
+                    line: 1,
+                    ..
+                } if path.ends_with("main.py")
+            ),
+            "expected socket review-required error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn reviewed_native_host_socket_pattern_requires_review_in_dir() {
+        let work = TempDir::new().unwrap();
+        let app_dir = work.path().join("app");
+        fs::create_dir(&app_dir).unwrap();
+        write_app(&app_dir, "pkg-host-routing-bypass", "\"panes.read\"");
+        fs::write(
+            app_dir.join("main.py"),
+            "import os\nhost_socket = os.environ.get('PLEXI_SOCKET')\n",
+        )
+        .unwrap();
+
+        let err = validate_dir(&app_dir).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                PackageError::BypassReviewRequired {
+                    category: "host routing",
+                    ref path,
+                    line: 2,
+                    ..
+                } if path.ends_with("main.py")
+            ),
+            "expected host-routing review-required error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn reviewed_native_path_traversal_pattern_requires_review_in_dir() {
+        let work = TempDir::new().unwrap();
+        let app_dir = work.path().join("app");
+        fs::create_dir(&app_dir).unwrap();
+        write_app(&app_dir, "pkg-path-bypass", "\"fs.read\"");
+        fs::write(app_dir.join("main.py"), "open('../secrets.txt').read()\n").unwrap();
+
+        let err = validate_dir(&app_dir).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                PackageError::BypassReviewRequired {
+                    category: "path traversal",
+                    ref path,
+                    line: 1,
+                    ..
+                } if path.ends_with("main.py")
+            ),
+            "expected path-traversal review-required error, got: {err}"
+        );
     }
 
     #[test]
@@ -1182,14 +1503,17 @@ mod tests {
         );
         assert_eq!(
             TrustLabel::FirstPartyCore.display_str(),
-            "First-party core — ships with Plexi"
+            "First-party core — bundled with Plexi"
         );
     }
 
     #[test]
     fn trust_label_python_entry_is_python_unreviewed() {
         let r = report("third-party", PackageRuntime::Python);
-        assert_eq!(trust_label(&r, &["welcome"], false), TrustLabel::PythonUnreviewed);
+        assert_eq!(
+            trust_label(&r, &["welcome"], false),
+            TrustLabel::PythonUnreviewed
+        );
         assert_eq!(
             TrustLabel::PythonUnreviewed.display_str(),
             "Unreviewed Python process — runs with your full user permissions"
@@ -1199,10 +1523,13 @@ mod tests {
     #[test]
     fn trust_label_marketplace_reviewed_python_is_python_reviewed() {
         let r = report("marketplace-app", PackageRuntime::Python);
-        assert_eq!(trust_label(&r, &["welcome"], true), TrustLabel::PythonReviewed);
         assert_eq!(
-            TrustLabel::PythonReviewed.display_str(),
-            "Reviewed native process — manifest reviewed; not sandboxed"
+            trust_label(&r, &["welcome"], true),
+            TrustLabel::ReviewedNative
+        );
+        assert_eq!(
+            TrustLabel::ReviewedNative.display_str(),
+            "Reviewed native process — human-reviewed; not sandboxed"
         );
     }
 
@@ -1227,12 +1554,18 @@ mod tests {
     }
 
     #[test]
+    fn trust_label_marketplace_reviewed_native_is_reviewed_native() {
+        let r = report("third-party-bin", PackageRuntime::Native);
+        assert_eq!(trust_label(&r, &[], true), TrustLabel::ReviewedNative);
+    }
+
+    #[test]
     fn trust_label_wasm_entry_is_component() {
         let r = report("third-party-wasm", PackageRuntime::Wasm);
-        assert_eq!(trust_label(&r, &[], false), TrustLabel::WasmComponent);
+        assert_eq!(trust_label(&r, &[], false), TrustLabel::SandboxedWasm);
         assert_eq!(
-            TrustLabel::WasmComponent.display_str(),
-            "WASM component — sandboxed; host imports are capability-gated"
+            TrustLabel::SandboxedWasm.display_str(),
+            "Sandboxed WASM — scoped host imports are capability-gated"
         );
     }
 
@@ -1251,8 +1584,8 @@ mod tests {
         // With marketplace attestation: reviewed.
         assert_eq!(
             trust_label(&report, &[], true),
-            TrustLabel::PythonReviewed,
-            "marketplace_reviewed=true must yield PythonReviewed"
+            TrustLabel::ReviewedNative,
+            "marketplace_reviewed=true must yield ReviewedNative"
         );
     }
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -563,10 +563,13 @@ pub fn host_version_gate(report: &crate::app::package::PackageReport) -> Option<
 }
 
 /// Resolve the trust label for a report against the bundled core pack ids.
-fn trust_label_for(report: &crate::app::package::PackageReport) -> crate::app::package::TrustLabel {
+fn trust_label_for(
+    report: &crate::app::package::PackageReport,
+    marketplace_reviewed: bool,
+) -> crate::app::package::TrustLabel {
     let core_ids = crate::cli::install_host::core_pack_ids();
     let core_refs: Vec<&str> = core_ids.iter().map(String::as_str).collect();
-    crate::app::package::trust_label(report, &core_refs, false)
+    crate::app::package::trust_label(report, &core_refs, marketplace_reviewed)
 }
 
 /// The install confirmation gate. Returns `Ok(true)` to proceed,
@@ -674,9 +677,10 @@ fn prompt_wasm_optional_grants(
 fn run_install_gate(
     report: &crate::app::package::PackageReport,
     assume_yes: bool,
+    marketplace_reviewed: bool,
 ) -> Result<InstallGateDecision, i32> {
     use std::io::IsTerminal;
-    let label = trust_label_for(report);
+    let label = trust_label_for(report, marketplace_reviewed);
     print_trust_sheet(report, label);
     // Host-version compatibility: a too-old host (or malformed requirement)
     // aborts before the confirm prompt; a too-new host only warns.
@@ -732,7 +736,7 @@ pub fn app_inspect_cli(path: &str) -> i32 {
     };
     match report {
         Ok(report) => {
-            print_trust_sheet(&report, trust_label_for(&report));
+            print_trust_sheet(&report, trust_label_for(&report, false));
             0
         }
         Err(e) => {
@@ -783,7 +787,7 @@ fn app_install_with_pin_inner(
     match crate::app::package::validate_dir(&src) {
         Ok(report) => {
             if confirm == InstallConfirm::Interactive {
-                match run_install_gate(&report, assume_yes) {
+                match run_install_gate(&report, assume_yes, false) {
                     Ok(decision) => {
                         gate_decision = decision;
                     }
@@ -1006,6 +1010,25 @@ pub fn app_install_package(
     confirm: InstallConfirm,
     assume_yes: bool,
 ) -> i32 {
+    app_install_package_inner(file, pin, confirm, assume_yes, false)
+}
+
+pub fn app_install_marketplace_package(
+    file: &str,
+    pin: Option<&str>,
+    confirm: InstallConfirm,
+    assume_yes: bool,
+) -> i32 {
+    app_install_package_inner(file, pin, confirm, assume_yes, true)
+}
+
+fn app_install_package_inner(
+    file: &str,
+    pin: Option<&str>,
+    confirm: InstallConfirm,
+    assume_yes: bool,
+    marketplace_reviewed: bool,
+) -> i32 {
     log::info!("app_install:cli: package file={file} pin={pin:?} confirm={confirm:?}");
     let pkg_path = match std::path::Path::new(file).canonicalize() {
         Ok(p) => p,
@@ -1015,7 +1038,11 @@ pub fn app_install_package(
         }
     };
 
-    let report = match crate::app::package::validate_package(&pkg_path) {
+    let report = match if marketplace_reviewed {
+        crate::app::package::validate_package_reviewed_native(&pkg_path)
+    } else {
+        crate::app::package::validate_package(&pkg_path)
+    } {
         Ok(r) => r,
         Err(e) => {
             eprintln!("error: package validation failed — refusing install: {e}");
@@ -1024,7 +1051,7 @@ pub fn app_install_package(
     };
 
     let gate_decision = if confirm == InstallConfirm::Interactive {
-        match run_install_gate(&report, assume_yes) {
+        match run_install_gate(&report, assume_yes, marketplace_reviewed) {
             Ok(decision) => Some(decision),
             Err(code) => return code,
         }
@@ -1717,7 +1744,7 @@ mod install_confirm_tests {
         r.wasm_required_capabilities = vec!["state:read-write".to_string()];
         r.wasm_optional_capabilities = vec!["ai.query".to_string()];
 
-        let lines = trust_sheet_lines(&r, TrustLabel::WasmComponent);
+        let lines = trust_sheet_lines(&r, TrustLabel::SandboxedWasm);
         assert!(lines
             .iter()
             .any(|line| line == "wasm required capabilities:"));
@@ -1726,6 +1753,37 @@ mod install_confirm_tests {
             .iter()
             .any(|line| line == "wasm optional capabilities:"));
         assert!(lines.iter().any(|line| line.contains("ai.query")));
+    }
+
+    #[test]
+    fn trust_sheet_uses_honest_runtime_labels() {
+        let mut r = report();
+        let reviewed_lines = trust_sheet_lines(&r, TrustLabel::ReviewedNative);
+        assert!(reviewed_lines.iter().any(|line| {
+            line == "runtime:      python — Reviewed native process — human-reviewed; not sandboxed"
+        }));
+
+        r.runtime = PackageRuntime::Wasm;
+        r.entry = "app.wasm".to_string();
+        let wasm_lines = trust_sheet_lines(&r, TrustLabel::SandboxedWasm);
+        assert!(wasm_lines.iter().any(|line| {
+            line == "runtime:      wasm — Sandboxed WASM — scoped host imports are capability-gated"
+        }));
+
+        let core_lines = trust_sheet_lines(&report(), TrustLabel::FirstPartyCore);
+        assert!(core_lines
+            .iter()
+            .any(|line| line == "runtime:      python — First-party core — bundled with Plexi"));
+    }
+
+    #[test]
+    fn marketplace_reviewed_helper_uses_reviewed_native_label() {
+        let r = report();
+        assert_eq!(
+            super::trust_label_for(&r, false),
+            TrustLabel::PythonUnreviewed
+        );
+        assert_eq!(super::trust_label_for(&r, true), TrustLabel::ReviewedNative);
     }
 
     #[test]

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -13,9 +13,20 @@ pub fn install_cli(spec: &str) -> i32 {
         // source); a paid app with no license is blocked; an unknown id or an
         // unreachable registry is a hard error. There is no legacy fallback.
         match crate::cli::marketplace::plan_install(&source_str) {
-            InstallPlan::Package(pkg) => {
+            InstallPlan::Package {
+                path,
+                reviewed_native,
+            } => {
+                if reviewed_native {
+                    return crate::cli::app::app_install_marketplace_package(
+                        &path.to_string_lossy(),
+                        None,
+                        crate::cli::InstallConfirm::Interactive,
+                        false,
+                    );
+                }
                 return crate::cli::app::app_install_package(
-                    &pkg.to_string_lossy(),
+                    &path.to_string_lossy(),
                     None,
                     crate::cli::InstallConfirm::Interactive,
                     false,

--- a/src/cli/marketplace.rs
+++ b/src/cli/marketplace.rs
@@ -94,7 +94,10 @@ fn print_entry_table(entries: &[&RegistryEntry]) {
 pub enum InstallPlan {
     /// Catalog app, free or licensed, artifact downloaded + checksum-verified.
     /// Install this `.plexipkg` directly.
-    Package(PathBuf),
+    Package {
+        path: PathBuf,
+        reviewed_native: bool,
+    },
     /// Catalog app that resolves to a source spec (e.g. `github:owner/repo`).
     /// Install via the existing source-clone path.
     Source(String),
@@ -161,7 +164,12 @@ pub fn plan_install(app_id: &str) -> InstallPlan {
             uuid::Uuid::new_v4()
         ));
         match cli.download_package(&entry, &dest) {
-            Ok(path) => return InstallPlan::Package(path),
+            Ok(path) => {
+                return InstallPlan::Package {
+                    path,
+                    reviewed_native: entry.reviewed_native,
+                }
+            }
             Err(e) => {
                 eprintln!(
                     "error: could not download '{}' from the marketplace: {e}",


### PR DESCRIPTION
Stint: 0320
Linked GitHub issue: none

Summary:
- Add fail-closed native/Python package bypass scanning for subprocess, direct socket, inherited host-routing, and path traversal signatures.
- Add explicit reviewed_native catalog attestation so only human-reviewed marketplace packages bypass the scanner and receive the Reviewed native process trust label.
- Update trust labels to distinguish Reviewed native process, Sandboxed WASM, and First-party core; keep github-issues out of marketplace examples while it shells out.

Test evidence:
- cargo test: 28 passed, 0 failed — filter: package::tests
- cargo test: 12 passed, 0 failed — filter: marketplace::tests
- cargo test: 11 passed, 0 failed — filter: install_confirm_tests::
- cargo test: 1395 passed, 0 failed, 1 ignored — full bin suite via cargo test --bin plexi
- cargo build: passed
- stint check: passed
- package audit: target/debug/plexi app package apps/github-issues --out /tmp/github-issues-0320.plexipkg failed as expected on subprocess import
- Codex review: no discrete correctness issues found after fixes
- Conclusion: install skippable — host logic and CLI/package trust behavior covered by focused and full Rust tests; no UI or installed-bundle-only behavior changed.

Docs generation: not run; no generated docs or help text changed.