### PR TITLE
fix: prevent toolbar buttons from stealing keyboard focus

### DIFF
--- a/src/ui/button.rs
+++ b/src/ui/button.rs
@@ -53,13 +53,14 @@ pub(crate) fn toolbar_button(
     label: impl Into<egui::WidgetText>,
     hover_text: &str,
 ) -> egui::Response {
-    ui.add(
+    let resp = ui.add(
         egui::Button::new(label)
             .frame(false)
             .min_size(egui::vec2(style::BUTTON_H_MD - style::SPACE_SM, 0.0)),
-    )
-    .on_hover_cursor(egui::CursorIcon::PointingHand)
-    .on_hover_text(hover_text)
+    );
+    resp.surrender_focus();
+    resp.on_hover_cursor(egui::CursorIcon::PointingHand)
+        .on_hover_text(hover_text)
 }
 
 pub(crate) fn icon_button(


### PR DESCRIPTION
## Summary

- Toolbar buttons (`?` help, version/changelog, notification badge) are standard egui `Button` widgets that are focusable by default
- When a toolbar button holds keyboard focus, pressing Space or Enter activates it — even when the keypress is intended for an SDK app running in a pane
- This causes the keyboard shortcuts modal to pop up unexpectedly during gameplay (e.g. pressing Space to roll dice in Yahtzee)
- Calls `surrender_focus()` on every toolbar button each frame so they can never hold keyboard focus; mouse clicks still work normally

## Test plan

- [ ] Open any SDK app that uses Space or Enter (e.g. Yahtzee)
- [ ] Mash Space/Enter repeatedly during gameplay — keyboard shortcuts modal should never appear
- [ ] Click the `?` button with the mouse — shortcuts modal should still toggle normally
- [ ] Click the version label — changelog should still toggle normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)