### PR TITLE
workspace env secrets: injection, resolver, migration (stint 0237)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -21,4 +21,4 @@ A PRM is the destination spec for a feature. It describes what to build and why.
 | `marketplace-hosted.md` | Hosted marketplace (Sprint S4) | see file |
 | `wasm-runtime.md` | WASM runtime architecture | see file |
 | `wasm-runtime-impl-plan.md` | WASM runtime build sequence (G1-G7, G11-G13) | see file |
-| `workspace-env-secrets.md` | Workspace env secret injection | 0161 |
+| `workspace-env-secrets.md` | Workspace env secret injection | 0237 |

--- a/docs/workspace-env-secrets.md
+++ b/docs/workspace-env-secrets.md
@@ -1,8 +1,8 @@
 # Workspace Environment Secrets PRM
 
-Status: product and architecture spec.
+Status: active.
 Parent: [`assistant-host-app.md`](assistant-host-app.md).
-Stint: [`0161`](../../.stint/tasks/0161-v2-workspace-env-secret-injection.md).
+Stint: `0237`.
 Last updated: 2026-06-11.
 
 This PRM replaces ad hoc shell-secret setup with a Plexi-owned, workspace-aware secret system that can inject selected credentials into terminal panes, `plexi run` commands, PGAP apps, and host integrations.
@@ -148,6 +148,11 @@ It returns:
 - missing names
 - source metadata: workspace, global, alias, or env fallback
 - diagnostic text suitable for UI and CLI
+
+Host integrations that historically read process environment variables, such
+as the OpenRouter AI broker, must consult this resolver first when a workspace
+root is available. Process-env and legacy lowercase key names are compatibility
+fallbacks, not separate primary resolution systems.
 
 ## Migration
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -886,6 +886,7 @@ impl PlexiApp {
                             ws_id,
                             initial_cmd.as_deref(),
                             spec.ephemeral,
+                            cwd_override,
                         );
                         if spec.no_focus {
                             self.active_window = active;
@@ -896,7 +897,7 @@ impl PlexiApp {
                             spec.ephemeral
                         );
                         let original_focused = self.windows[active].focused_pane;
-                        self.new_tab(initial_cmd.as_deref(), spec.ephemeral);
+                        self.new_tab(initial_cmd.as_deref(), spec.ephemeral, cwd_override);
                         if spec.no_focus {
                             self.active_window = active;
                             self.restore_window_focused_pane(active, original_focused);
@@ -1636,7 +1637,14 @@ impl PlexiApp {
                         log::info!(
                             "pane_ipc: create_context window ctx_id={new_ctx_id} grid_x={new_x} cmd={cmd:?}"
                         );
-                        self.create_page_at(new_x, active_y, new_ctx_id, Some(cmd.as_str()), false);
+                        self.create_page_at(
+                            new_x,
+                            active_y,
+                            new_ctx_id,
+                            Some(cmd.as_str()),
+                            false,
+                            None,
+                        );
                         new_x += 1;
                     }
                 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3260,7 +3260,7 @@ impl eframe::App for PlexiApp {
                     self.step_focus_history_forward();
                 }
                 Action::NewTab => {
-                    self.new_tab(None, false);
+                    self.new_tab(None, false, None);
                     self.save_workspace();
                 }
                 Action::ToggleZoom => {

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -1723,7 +1723,7 @@ fn create_context_with_windows_adds_extra_pages() {
         .map(|x| x + 1)
         .unwrap_or(1);
     for cmd in &cmds {
-        app.create_page_at(new_x, active_y, ctx_id, Some(cmd.as_str()), false);
+        app.create_page_at(new_x, active_y, ctx_id, Some(cmd.as_str()), false, None);
         new_x += 1;
     }
 

--- a/src/host/shell.rs
+++ b/src/host/shell.rs
@@ -5,6 +5,9 @@ use std::process::Command;
 use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
+const TERMINAL_ENV_NAMES_VAR: &str = "PLEXI_TERMINAL_ENV_NAMES";
+const TERMINAL_ENV_VALUE_PREFIX: &str = "PLEXI_TERMINAL_ENV_VALUE_";
+
 pub fn detect_shell() -> String {
     if let Ok(shell) = std::env::var("SHELL") {
         if Path::new(&shell).exists() {
@@ -237,8 +240,20 @@ pub fn build_env(working_directory: Option<&Path>) -> HashMap<String, String> {
                         resolved.len(),
                         root.display()
                     );
+                    let mut names = Vec::new();
                     for (key, value) in resolved {
+                        if !is_shell_env_name(&key) {
+                            log::warn!(
+                                "shell::build_env: skipped invalid terminal env secret name {key}"
+                            );
+                            continue;
+                        }
+                        names.push(key.clone());
+                        env.insert(preserved_terminal_env_name(&key), value.to_string());
                         env.insert(key, value.to_string());
+                    }
+                    if !names.is_empty() {
+                        env.insert(TERMINAL_ENV_NAMES_VAR.into(), names.join(":"));
                     }
                 }
                 Err(e) => {
@@ -269,6 +284,21 @@ pub fn build_env(working_directory: Option<&Path>) -> HashMap<String, String> {
     }
 
     env
+}
+
+fn preserved_terminal_env_name(name: &str) -> String {
+    format!("{TERMINAL_ENV_VALUE_PREFIX}{name}")
+}
+
+fn is_shell_env_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
 }
 
 static CWD_CACHE: LazyLock<Mutex<HashMap<u32, (PathBuf, Instant)>>> =
@@ -373,6 +403,19 @@ __plexi_orig="${PLEXI_ORIG_ZDOTDIR:-$HOME}"
 [[ -f "$__plexi_orig/.zshrc" ]] && source "$__plexi_orig/.zshrc"
 unset __plexi_orig
 
+# Re-apply workspace terminal env after user startup files so workspace-scoped
+# secrets win over global exports in .zshrc/.zprofile.
+if [[ -n "${PLEXI_TERMINAL_ENV_NAMES:-}" ]]; then
+    for __plexi_env_name in ${(s.:.)PLEXI_TERMINAL_ENV_NAMES}; do
+        __plexi_value_var="PLEXI_TERMINAL_ENV_VALUE_${__plexi_env_name}"
+        if [[ -n "${(P)__plexi_value_var+x}" ]]; then
+            export "${__plexi_env_name}=${(P)__plexi_value_var}"
+            unset "$__plexi_value_var"
+        fi
+    done
+    unset PLEXI_TERMINAL_ENV_NAMES __plexi_env_name __plexi_value_var
+fi
+
 # Emit OSC 7 after each prompt so Plexi can track cwd for split inheritance
 __plexi_precmd() {
     printf '\e]7;file://%s%s\a' "$HOST" "$PWD"
@@ -471,5 +514,21 @@ mod tests {
     fn shell_join_special_chars_quoted() {
         let args = vec!["echo".to_string(), "$HOME".to_string()];
         assert_eq!(shell_join(&args), "echo '$HOME'");
+    }
+
+    #[test]
+    fn shell_env_name_validation_accepts_posix_names() {
+        assert!(is_shell_env_name("OPENROUTER_API_KEY"));
+        assert!(is_shell_env_name("_PLEXI_TEST"));
+        assert!(is_shell_env_name("A1"));
+    }
+
+    #[test]
+    fn shell_env_name_validation_rejects_unsafe_names() {
+        assert!(!is_shell_env_name(""));
+        assert!(!is_shell_env_name("1PASSWORD"));
+        assert!(!is_shell_env_name("BAD-NAME"));
+        assert!(!is_shell_env_name("BAD:NAME"));
+        assert!(!is_shell_env_name("BAD NAME"));
     }
 }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -2288,6 +2288,40 @@ mod tests {
         );
     }
 
+    #[test]
+    fn spawn_pane_new_window_uses_explicit_cwd() {
+        let mut h = HostHarness::new();
+        let _pane = h.add_test_pane();
+        let root = h.app.windows[0].tree.root.expect("root tile");
+        h.app.windows[0].focused_pane = Some(root);
+        let cwd = tempfile::tempdir().expect("cwd");
+        let cwd_path = cwd.path().to_path_buf();
+
+        h.inject_ipc(crate::app_protocol::AppRequest::SpawnPane {
+            type_id: "terminal".to_string(),
+            layout: Some("new_window".to_string()),
+            args: vec![],
+            pipe_id: None,
+            from_pane_id: None,
+            request_id: None,
+            response_file: None,
+            ephemeral: false,
+            cwd: Some(cwd_path.to_string_lossy().into_owned()),
+            no_focus: false,
+            path: None,
+            workspace_root: None,
+            target_context: None,
+            name: None,
+        });
+        h.run_frames(2);
+
+        let created = h.app.windows.last().expect("new window");
+        assert_eq!(
+            created.path, cwd_path,
+            "explicit SpawnPane cwd must become the new terminal window cwd"
+        );
+    }
+
     /// A second `new_window` spawn places the next window at grid_x=2, not grid_x=1.
     #[test]
     fn spawn_pane_new_window_stacks_right() {

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -10,7 +10,7 @@ use crate::host::pane::{Pane, TerminalPane};
 use crate::spatial::tiling::PaneId;
 use egui_term::BackendCommand;
 use egui_tiles::{Container, SimplificationOptions, Tile, TileId};
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 pub(crate) enum SwapResult {
     Swapped {
@@ -407,7 +407,12 @@ impl PlexiApp {
         ctx.navigate_to(new_tile);
     }
 
-    pub(crate) fn new_tab(&mut self, initial_cmd: Option<&str>, close_on_exit: bool) {
+    pub(crate) fn new_tab(
+        &mut self,
+        initial_cmd: Option<&str>,
+        close_on_exit: bool,
+        cwd_override: Option<PathBuf>,
+    ) {
         // Empty context (welcome screen): create the first pane as tree root.
         if self.windows[self.active_window].panes.is_empty() {
             let new_id = self.host.alloc_pane_id();
@@ -420,7 +425,7 @@ impl PlexiApp {
             let ctx_desc = self.context_description_for(ctx_id);
             let ctx_root = self.context_root_for(ctx_id);
             let ctx_depth = self.context_depth_for(ctx_id);
-            let cwd = self.cwd_for_welcome_tab();
+            let cwd = cwd_override.unwrap_or_else(|| self.cwd_for_welcome_tab());
             log::info!(
                 "new_tab (empty context): cwd={cwd:?} context_root={:?}",
                 self.router.active().root
@@ -469,7 +474,7 @@ impl PlexiApp {
 
         let new_id = self.host.alloc_pane_id();
 
-        let cwd = self.resolve_new_pane_cwd(None, Some(focused));
+        let cwd = cwd_override.or_else(|| self.resolve_new_pane_cwd(None, Some(focused)));
         log::info!(
             "new_tab: cwd={cwd:?} context_root={:?}",
             self.router.active().root

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -681,7 +681,7 @@ impl PlexiApp {
             Some(x) => x + 1,
             None => 1,
         };
-        self.create_page_at(new_x, active_y, ws_id, None, false);
+        self.create_page_at(new_x, active_y, ws_id, None, false, None);
     }
 
     /// Shared creation helper: create a single-pane window at `(grid_x, grid_y)` in
@@ -693,12 +693,15 @@ impl PlexiApp {
         context_id: u64,
         initial_cmd: Option<&str>,
         close_on_exit: bool,
+        cwd_override: Option<PathBuf>,
     ) {
         let old_window_id = self.windows[self.active_window].window_id;
         let old_focus = self.windows[self.active_window].focused_pane;
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-        let cwd = self
-            .resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
+        let cwd = cwd_override
+            .or_else(|| {
+                self.resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
+            })
             .filter(|p| p != &PathBuf::from("/"))
             .unwrap_or(home);
         log::info!("create_page_at({grid_x},{grid_y}): cwd={} context_id={context_id} initial_cmd={initial_cmd:?} close_on_exit={close_on_exit}", cwd.display());

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -223,7 +223,7 @@ fn dispatch_openrouter(
         .api_key_env
         .as_deref()
         .unwrap_or("OPENROUTER_API_KEY");
-    let api_key = match resolve_openrouter_api_key(api_key_env) {
+    let api_key = match resolve_openrouter_api_key(api_key_env, request.workspace_root.as_deref()) {
         Ok(k) => k,
         Err(msg) => {
             log::warn!("ai_broker[{}]: {msg} — denying ai.query", request.app_id);
@@ -246,17 +246,24 @@ fn dispatch_openrouter(
     )
 }
 
-fn resolve_openrouter_api_key(api_key_env: &str) -> Result<String, String> {
-    if let Ok(k) = std::env::var(api_key_env) {
-        if !k.is_empty() {
-            return Ok(k);
+fn resolve_openrouter_api_key(
+    api_key_env: &str,
+    workspace_root: Option<&std::path::Path>,
+) -> Result<String, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let store = crate::workspace::secrets::MacKeychain::new();
+        match resolve_openrouter_api_key_from_store(api_key_env, workspace_root, &store) {
+            Ok(Some(key)) => return Ok(key),
+            Ok(None) => {}
+            Err(msg) => return Err(msg),
         }
     }
 
-    if api_key_env == "OPENROUTER_API_KEY" {
-        if let Some(key) = read_global_openrouter_secret() {
-            log::info!("ai_broker: using global Plexi secret OPENROUTER_API_KEY");
-            return Ok(key);
+    if let Ok(k) = std::env::var(api_key_env) {
+        if !k.is_empty() {
+            log::info!("ai_broker: using process env {api_key_env}");
+            return Ok(k);
         }
     }
 
@@ -266,24 +273,89 @@ fn resolve_openrouter_api_key(api_key_env: &str) -> Result<String, String> {
 }
 
 #[cfg(target_os = "macos")]
-fn read_global_openrouter_secret() -> Option<String> {
-    use crate::workspace::secrets::{keychain_user_name, MacKeychain, SecretStore};
-    let store = MacKeychain::new();
-    for name in ["OPENROUTER_API_KEY", "openrouter-api-key"] {
-        let account = keychain_user_name(name);
-        if let Some(key) = store.get(&account) {
-            if !key.is_empty() {
-                log::info!("ai_broker: resolved OpenRouter key from {name}");
-                return Some(key.to_string());
+fn resolve_openrouter_api_key_from_store(
+    api_key_env: &str,
+    workspace_root: Option<&std::path::Path>,
+    store: &dyn crate::workspace::secrets::SecretStore,
+) -> Result<Option<String>, String> {
+    use crate::workspace::secrets::{
+        keychain_user_name, resolve_with_source, ResolveWithSourceOutcome, WorkspaceConfig,
+        WorkspaceSecrets,
+    };
+
+    if let Some(root) = workspace_root {
+        match (WorkspaceConfig::load(root), WorkspaceSecrets::load(root)) {
+            (Ok(Some(cfg)), Ok(Some(router))) => {
+                match resolve_with_source(&cfg.id, "host", api_key_env, &router, store) {
+                    ResolveWithSourceOutcome::Found(found) => {
+                        log::info!(
+                            "ai_broker: resolved {api_key_env} from workspace secrets source={:?}",
+                            found.source
+                        );
+                        return Ok(Some(found.value.to_string()));
+                    }
+                    ResolveWithSourceOutcome::PromptUser => {
+                        if router.route_for("host", api_key_env).is_some() || !router.fallback {
+                            return Err(format!(
+                                "api_key_missing: {api_key_env} missing from workspace secret policy"
+                            ));
+                        }
+                        log::info!(
+                            "ai_broker: workspace secret {api_key_env} missing; checking fallback sources"
+                        );
+                    }
+                    ResolveWithSourceOutcome::HardMissing { reason } => {
+                        log::warn!(
+                            "ai_broker: workspace secret {api_key_env} unavailable: {reason}"
+                        );
+                        return Err(format!(
+                            "api_key_missing: {api_key_env} blocked by workspace secret policy: {reason}"
+                        ));
+                    }
+                }
+            }
+            (Err(e), _) => {
+                log::warn!(
+                    "ai_broker: failed to load workspace.toml for secret resolution at {}: {e}",
+                    root.display()
+                );
+                return Err(format!(
+                    "api_key_missing: {api_key_env} blocked because workspace secret policy could not load: {e}"
+                ));
+            }
+            (_, Err(e)) => {
+                log::warn!(
+                    "ai_broker: failed to load secrets.toml for secret resolution at {}: {e}",
+                    root.display()
+                );
+                return Err(format!(
+                    "api_key_missing: {api_key_env} blocked because workspace secret policy could not load: {e}"
+                ));
+            }
+            _ => {
+                log::info!(
+                    "ai_broker: workspace secret context missing at {}; checking fallback sources",
+                    root.display()
+                );
             }
         }
     }
-    None
-}
 
-#[cfg(not(target_os = "macos"))]
-fn read_global_openrouter_secret() -> Option<String> {
-    None
+    if api_key_env == "OPENROUTER_API_KEY" {
+        for name in ["OPENROUTER_API_KEY", "openrouter-api-key"] {
+            let account = keychain_user_name(name);
+            if let Some(key) = store.get(&account) {
+                if !key.is_empty() {
+                    log::info!(
+                        "ai_broker: resolved OpenRouter key from global Plexi secret {name}"
+                    );
+                    return Ok(Some(key.to_string()));
+                }
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 /// Dispatch through the Ollama backend.
@@ -989,6 +1061,162 @@ mod tests {
                 .contains("api_key_missing"),
             "missing-key error must surface the api_key_missing tag"
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn openrouter_key_resolves_from_workspace_before_global_or_env() {
+        use crate::workspace::secrets::{InMemoryKeychain, SecretStore};
+
+        let env_name = "OPENROUTER_API_KEY";
+        let orig = std::env::var(env_name).ok();
+        unsafe { std::env::set_var(env_name, "sk-env") };
+
+        let ws_a = tempfile::tempdir().unwrap();
+        let ws_b = tempfile::tempdir().unwrap();
+        write_secret_workspace(ws_a.path(), "ws-a");
+        write_secret_workspace(ws_b.path(), "ws-b");
+
+        let store = InMemoryKeychain::new();
+        store
+            .set("plexi:ws-a:OPENROUTER_API_KEY", "sk-workspace-a")
+            .unwrap();
+        store
+            .set("plexi:ws-b:OPENROUTER_API_KEY", "sk-workspace-b")
+            .unwrap();
+        store
+            .set("plexi:user:OPENROUTER_API_KEY", "sk-global")
+            .unwrap();
+
+        let a = resolve_openrouter_api_key_from_store(env_name, Some(ws_a.path()), &store)
+            .expect("workspace A lookup")
+            .expect("workspace A key");
+        let b = resolve_openrouter_api_key_from_store(env_name, Some(ws_b.path()), &store)
+            .expect("workspace B lookup")
+            .expect("workspace B key");
+
+        if let Some(v) = orig {
+            unsafe { std::env::set_var(env_name, v) };
+        } else {
+            unsafe { std::env::remove_var(env_name) };
+        }
+
+        assert_eq!(a, "sk-workspace-a");
+        assert_eq!(b, "sk-workspace-b");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn openrouter_key_falls_back_to_legacy_global_secret() {
+        use crate::workspace::secrets::{InMemoryKeychain, SecretStore};
+
+        let store = InMemoryKeychain::new();
+        store
+            .set("plexi:user:openrouter-api-key", "sk-legacy")
+            .unwrap();
+
+        let resolved = resolve_openrouter_api_key_from_store("OPENROUTER_API_KEY", None, &store)
+            .expect("global lookup")
+            .expect("legacy global key");
+
+        assert_eq!(resolved, "sk-legacy");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn openrouter_key_honors_workspace_fallback_false() {
+        use crate::workspace::secrets::{InMemoryKeychain, SecretStore};
+
+        let env_name = "OPENROUTER_API_KEY";
+
+        let ws = tempfile::tempdir().unwrap();
+        let dir = ws.path().join(crate::config::workspace_channel_dir());
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("workspace.toml"), "id = \"ws-no-fallback\"\n").unwrap();
+        std::fs::write(dir.join("secrets.toml"), "fallback = false\n").unwrap();
+
+        let store = InMemoryKeychain::new();
+        store
+            .set("plexi:user:OPENROUTER_API_KEY", "sk-global")
+            .unwrap();
+
+        let store_err = resolve_openrouter_api_key_from_store(env_name, Some(ws.path()), &store)
+            .expect_err("fallback=false must block global keychain fallback");
+
+        assert!(store_err.contains("blocked by workspace secret policy"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn openrouter_key_does_not_bypass_missing_explicit_route() {
+        use crate::workspace::secrets::{InMemoryKeychain, SecretStore};
+
+        let ws = tempfile::tempdir().unwrap();
+        let dir = ws.path().join(crate::config::workspace_channel_dir());
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("workspace.toml"), "id = \"ws-route\"\n").unwrap();
+        std::fs::write(
+            dir.join("secrets.toml"),
+            "fallback = true\n\n[default]\nOPENROUTER_API_KEY = \"openrouter_team\"\n",
+        )
+        .unwrap();
+
+        let store = InMemoryKeychain::new();
+        store
+            .set("plexi:user:OPENROUTER_API_KEY", "sk-global")
+            .unwrap();
+
+        let err = resolve_openrouter_api_key_from_store(
+            "OPENROUTER_API_KEY",
+            Some(ws.path()),
+            &store,
+        )
+        .expect_err("missing explicit route must block global fallback");
+
+        assert!(err.contains("missing from workspace secret policy"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn openrouter_key_fails_closed_when_workspace_policy_is_invalid() {
+        use crate::workspace::secrets::{InMemoryKeychain, SecretStore};
+
+        let ws = tempfile::tempdir().unwrap();
+        let dir = ws.path().join(crate::config::workspace_channel_dir());
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("workspace.toml"), "id = \"ws-invalid\"\n").unwrap();
+        std::fs::write(dir.join("secrets.toml"), "[default]\nOPENROUTER_API_KEY = \"x\"\n")
+            .unwrap();
+
+        let store = InMemoryKeychain::new();
+        store
+            .set("plexi:user:OPENROUTER_API_KEY", "sk-global")
+            .unwrap();
+
+        let err = resolve_openrouter_api_key_from_store(
+            "OPENROUTER_API_KEY",
+            Some(ws.path()),
+            &store,
+        )
+        .expect_err("invalid workspace policy must block global fallback");
+
+        assert!(err.contains("workspace secret policy could not load"));
+    }
+
+    #[cfg(target_os = "macos")]
+    fn write_secret_workspace(root: &std::path::Path, workspace_id: &str) {
+        let dir = root.join(crate::config::workspace_channel_dir());
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("workspace.toml"),
+            format!("id = \"{workspace_id}\"\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("secrets.toml"),
+            "fallback = true\n\n[terminal.env]\ninject = [\"OPENROUTER_API_KEY\"]\n",
+        )
+        .unwrap();
     }
 
     #[test]

--- a/src/workspace/secrets.rs
+++ b/src/workspace/secrets.rs
@@ -890,6 +890,21 @@ mod tests {
         WorkspaceSecrets::parse(toml_src).expect("router parses")
     }
 
+    fn write_terminal_env_workspace(root: &Path, workspace_id: &str) {
+        let channel_dir = crate::config::workspace_channel_dir();
+        std::fs::create_dir_all(root.join(&channel_dir)).unwrap();
+        std::fs::write(
+            root.join(&channel_dir).join("workspace.toml"),
+            format!("id = \"{workspace_id}\"\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            root.join(&channel_dir).join("secrets.toml"),
+            "fallback = true\n\n[terminal.env]\ninject = [\"OPENROUTER_API_KEY\"]\n",
+        )
+        .unwrap();
+    }
+
     #[test]
     fn keychain_naming_uses_workspace_and_user_namespaces() {
         assert_eq!(
@@ -1059,6 +1074,34 @@ mod tests {
         assert_eq!(
             env.get("OPENAI_API_KEY").map(|v| v.as_str()),
             Some("sk-global")
+        );
+    }
+
+    #[test]
+    fn terminal_env_resolves_same_openrouter_name_per_workspace() {
+        let ws_a = tempfile::tempdir().unwrap();
+        let ws_b = tempfile::tempdir().unwrap();
+        write_terminal_env_workspace(ws_a.path(), "ws-a");
+        write_terminal_env_workspace(ws_b.path(), "ws-b");
+
+        let store = InMemoryKeychain::new();
+        store
+            .set("plexi:ws-a:OPENROUTER_API_KEY", "sk-openrouter-a")
+            .unwrap();
+        store
+            .set("plexi:ws-b:OPENROUTER_API_KEY", "sk-openrouter-b")
+            .unwrap();
+
+        let env_a = resolve_terminal_env(ws_a.path(), &store).expect("workspace A env");
+        let env_b = resolve_terminal_env(ws_b.path(), &store).expect("workspace B env");
+
+        assert_eq!(
+            env_a.get("OPENROUTER_API_KEY").map(|v| v.as_str()),
+            Some("sk-openrouter-a")
+        );
+        assert_eq!(
+            env_b.get("OPENROUTER_API_KEY").map(|v| v.as_str()),
+            Some("sk-openrouter-b")
         );
     }
 


### PR DESCRIPTION
Stint: 0237

## Summary

- Routes the OpenRouter AI broker through the workspace secret resolver before process-env fallback.
- Preserves canonical `OPENROUTER_API_KEY` lookup, legacy `openrouter-api-key` global fallback, and fail-closed workspace policy behavior.
- Adds resolver tests for workspace-specific OpenRouter terminal envs and AI broker policy edges.

## Done When

- Workspace defines canonical secret names injected into new PTY panes.
- Workspace and global values with the same canonical name resolve correctly.
- `plexi run`, PGAP apps, PTY env, and AI broker share the same resolver.
- OpenRouter uses `OPENROUTER_API_KEY` as canonical key, with migration from `openrouter-api-key`.
- Docs explain canonical names, workspace scope, global fallback, and injection allowlists.
- Tests cover two workspaces with different `OPENROUTER_API_KEY` producing different PTY environments.

## Validation

- `cargo test --bin plexi openrouter_key`
- `cargo test --bin plexi terminal_env_resolves_same_openrouter_name_per_workspace`
- `cargo test --bin plexi` (first run hit a reload coalescing flake; exact test passed on rerun; second full run passed: 1442 passed, 1 ignored)
- `cargo build`
- `git diff --check`
- `codex review --base alpha -c model_reasoning_effort=low` (findings addressed with regressions)
