### PR TITLE
feat: add AI onboarding guide (stint 0324)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ curl -fsSL https://plexiapp.com/install | sh
 
 Downloads the latest release, installs to `/Applications`, sets up the `plexi` CLI, and wires ZSH integration. Restart your terminal when done.
 
+First run:
+
+```bash
+plexi ai onboard
+```
+
+This guides AI setup with local Ollama, a user-owned OpenRouter key, or a skip-for-now path, then points you at the next app install command.
+
 To install a pre-release channel, pass `--channel`:
 
 ```bash

--- a/src/cli/ai.rs
+++ b/src/cli/ai.rs
@@ -394,6 +394,61 @@ fn print_report(hw: &HardwareReport, integrations: &IntegrationReport, rec: &Mod
     println!("  {dim}{}{reset}", rec.note);
 }
 
+fn format_onboarding_guide(integrations: &IntegrationReport, rec: &ModelRecommendation) -> String {
+    let mut out = String::new();
+    out.push_str("plexi ai onboard -- first-run setup\n\n");
+    out.push_str("1. Pick an AI path\n");
+
+    if integrations.ollama_running && !integrations.ollama_models.is_empty() {
+        out.push_str("   Local AI is ready. Ollama is running with models installed.\n");
+        out.push_str("   Next: run `plexi ai doctor` to verify the full report.\n");
+    } else if integrations.openrouter_configured {
+        out.push_str("   Cloud AI is ready. OpenRouter is configured.\n");
+        out.push_str("   Next: run `plexi ai doctor` to verify the full report.\n");
+    } else if integrations.ollama_running {
+        let model = ollama_setup_model(rec);
+        out.push_str("   Ollama is running, but no models are installed yet.\n");
+        out.push_str(&format!(
+            "   Next: run `ollama pull {model}`, then `plexi ai setup`.\n"
+        ));
+    } else if integrations.ollama_installed {
+        out.push_str("   Ollama is installed but not running.\n");
+        out.push_str("   Next: run `ollama serve` in a Plexi pane, then `plexi ai setup`.\n");
+    } else if rec.tier == "cloud-recommended" {
+        out.push_str("   This machine is best suited for cloud AI.\n");
+        out.push_str("   Next: run `plexi secret set OPENROUTER_API_KEY --global`.\n");
+    } else {
+        let model = ollama_setup_model(rec);
+        out.push_str("   This machine can run local AI.\n");
+        out.push_str(&format!(
+            "   Next: install Ollama, then run `plexi ai setup` to pull {model}.\n"
+        ));
+        out.push_str("   Cloud option: run `plexi secret set OPENROUTER_API_KEY --global`.\n");
+    }
+
+    out.push_str("\n2. Skip AI for now\n");
+    out.push_str("   You can use non-AI apps immediately. Come back with `plexi ai onboard`.\n");
+
+    out.push_str("\n3. Install an app\n");
+    out.push_str("   Try the built-in starter pack: `plexi app install --pack core`.\n");
+    out.push_str("   Install a reviewed app: `plexi app install <id>`.\n");
+    out.push_str("   Install from GitHub: `plexi app install github:owner/repo`.\n");
+
+    out.push_str("\nUseful checks\n");
+    out.push_str("   `plexi ai doctor` shows hardware, Ollama, and OpenRouter status.\n");
+    out.push_str("   `plexi app list` shows installed apps.\n");
+
+    out
+}
+
+fn ollama_setup_model(rec: &ModelRecommendation) -> &'static str {
+    rec.models
+        .iter()
+        .copied()
+        .find(|model| !model.starts_with("openrouter/") && !model.contains('/'))
+        .unwrap_or("llama3.2:3b")
+}
+
 // ── Setup wizard ─────────────────────────────────────────────────────────────
 
 /// Write or update the `[ai]` + `[ai.ollama]` section in config.toml.
@@ -662,6 +717,29 @@ pub fn ai_setup_cli() -> i32 {
 
 // ── Entry point ───────────────────────────────────────────────────────────────
 
+pub fn ai_onboard_cli() -> i32 {
+    log::info!("cli:ai:onboard: starting first-run guide");
+
+    let hw = detect_hardware();
+    let integrations = check_integrations();
+    let recommendation = recommend_models(&hw);
+
+    log::info!(
+        "cli:ai:onboard: tier={} ollama_installed={} ollama_running={} models={} openrouter={}",
+        recommendation.tier,
+        integrations.ollama_installed,
+        integrations.ollama_running,
+        integrations.ollama_models.len(),
+        integrations.openrouter_configured
+    );
+
+    print!(
+        "{}",
+        format_onboarding_guide(&integrations, &recommendation)
+    );
+    0
+}
+
 pub fn ai_doctor_cli(json: bool) -> i32 {
     log::info!("cli:ai:doctor: starting hardware scan (json={json})");
 
@@ -709,4 +787,90 @@ pub fn ai_doctor_cli(json: bool) -> i32 {
     }
 
     0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_onboarding_guide, IntegrationReport, ModelRecommendation};
+
+    fn rec(tier: &'static str) -> ModelRecommendation {
+        ModelRecommendation {
+            tier,
+            models: vec!["llama3.2:3b"],
+            note: "test note",
+        }
+    }
+
+    fn cloud_rec() -> ModelRecommendation {
+        ModelRecommendation {
+            tier: "cloud-recommended",
+            models: vec!["openrouter/anthropic/claude-3-haiku"],
+            note: "test note",
+        }
+    }
+
+    #[test]
+    fn onboarding_guides_fresh_profile_without_hidden_prerequisites() {
+        let integrations = IntegrationReport {
+            ollama_installed: false,
+            ollama_running: false,
+            ollama_models: Vec::new(),
+            openrouter_configured: false,
+        };
+
+        let guide = format_onboarding_guide(&integrations, &rec("local-ok"));
+
+        assert!(guide.contains("plexi ai onboard -- first-run setup"));
+        assert!(guide.contains("install Ollama"));
+        assert!(guide.contains("plexi ai setup"));
+        assert!(guide.contains("plexi secret set OPENROUTER_API_KEY --global"));
+        assert!(guide.contains("plexi app install --pack core"));
+        assert!(guide.contains("plexi app install <id>"));
+    }
+
+    #[test]
+    fn onboarding_prefers_ready_cloud_ai_when_openrouter_configured() {
+        let integrations = IntegrationReport {
+            ollama_installed: false,
+            ollama_running: false,
+            ollama_models: Vec::new(),
+            openrouter_configured: true,
+        };
+
+        let guide = format_onboarding_guide(&integrations, &rec("cloud-recommended"));
+
+        assert!(guide.contains("Cloud AI is ready"));
+        assert!(guide.contains("plexi ai doctor"));
+        assert!(guide.contains("plexi app install --pack core"));
+    }
+
+    #[test]
+    fn onboarding_prefers_openrouter_over_incomplete_ollama_setup() {
+        let integrations = IntegrationReport {
+            ollama_installed: true,
+            ollama_running: true,
+            ollama_models: Vec::new(),
+            openrouter_configured: true,
+        };
+
+        let guide = format_onboarding_guide(&integrations, &rec("local-ok"));
+
+        assert!(guide.contains("Cloud AI is ready"));
+        assert!(!guide.contains("ollama pull"));
+    }
+
+    #[test]
+    fn onboarding_never_uses_openrouter_model_id_for_ollama_pull() {
+        let integrations = IntegrationReport {
+            ollama_installed: true,
+            ollama_running: true,
+            ollama_models: Vec::new(),
+            openrouter_configured: false,
+        };
+
+        let guide = format_onboarding_guide(&integrations, &cloud_rec());
+
+        assert!(guide.contains("ollama pull llama3.2:3b"));
+        assert!(!guide.contains("ollama pull openrouter/"));
+    }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -20,7 +20,7 @@ fn plexi_styles() -> Styles {
     name = "plexi",
     about = "Plexi — the last app you'll ever need",
     version = env!("CARGO_PKG_VERSION"),
-    after_help = "Get started: plexi demo | Docs: https://plexiapp.com/docs",
+    after_help = "Get started: plexi ai onboard | Docs: https://plexiapp.com/docs",
     styles = plexi_styles(),
 )]
 pub struct Cli {
@@ -1340,6 +1340,15 @@ pub enum HookAction {
 
 #[derive(Subcommand)]
 pub enum AiCmd {
+    /// Guide first-run AI setup and the next app install step.
+    ///
+    /// Runs the same checks as `plexi ai doctor`, then prints the shortest path
+    /// to usable AI: local Ollama, a user-owned OpenRouter key, or skipping AI
+    /// for now. Ends with the app install command to try next.
+    ///
+    /// Example: plexi ai onboard
+    Onboard,
+
     /// Scan hardware and report recommended AI models.
     ///
     /// Detects your CPU, RAM/VRAM, and GPU, then recommends which local or cloud

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -314,7 +314,7 @@ pub use agent::{
     agent_add, agent_hook_install_cli, agent_hook_uninstall_cli, agent_init, agent_list,
     agent_report_cli, agent_status_cli, agent_update,
 };
-pub use ai::{ai_doctor_cli, ai_setup_cli};
+pub use ai::{ai_doctor_cli, ai_onboard_cli, ai_setup_cli};
 pub use app::{
     app_action_cli, app_info, app_init, app_inspect_cli, app_install_package, app_install_with_pin,
     app_list, app_package_cli, app_render, app_test_cli, app_uninstall, app_update_cli,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1070,6 +1070,7 @@ fn main() -> eframe::Result {
                         std::process::exit(cli::notes::note_capture_cli(&text))
                     }
                     Commands::Ai { cmd } => match cmd {
+                        AiCmd::Onboard => std::process::exit(cli::ai_onboard_cli()),
                         AiCmd::Doctor { json } => std::process::exit(cli::ai_doctor_cli(json)),
                         AiCmd::Setup => std::process::exit(cli::ai_setup_cli()),
                     },

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -942,8 +942,17 @@ AI configuration and diagnostics — scan hardware, check integrations, recommen
 
 | Subcommand | Description |
 |---|---|
+| `onboard` | Guide first-run AI setup and the next app install step |
 | `doctor` | Scan hardware and report recommended AI models |
 | `setup` | Interactive wizard to configure a local AI model via Ollama |
+
+### `plexi ai onboard`
+
+Guide first-run AI setup and the next app install step.
+
+Runs the same checks as `plexi ai doctor`, then prints the shortest path to usable AI: local Ollama, a user-owned OpenRouter key, or skipping AI for now. Ends with the app install command to try next.
+
+Example: plexi ai onboard
 
 ### `plexi ai doctor`
 

--- a/website/src/content/docs/sdk.md
+++ b/website/src/content/docs/sdk.md
@@ -156,7 +156,7 @@ Pointer input in pane coordinates, including buttons, scroll, and region.
 
 ### `UiAction`
 
-Click/activation event from a component with matching ``handler_id``.
+Click/activation event from a component or host action.
 
 ### `UiValueChange`
 


### PR DESCRIPTION
Stint: 0324
Linked GitHub issue: none

## Summary

- Adds `plexi ai onboard` as the first-run guide for AI setup.
- Reuses doctor probes to choose a shortest path: ready local Ollama, ready OpenRouter, local setup, cloud key setup, or skip AI.
- Points first-run users to the next app install command and refreshes README/generated CLI docs.

## Test evidence (attempt 1)

- cargo test: 4 passed, 0 failed — filter: `onboarding_`
- cargo test: 1449 passed, 0 failed, 1 ignored — filters: full bin suite
- cargo build: passed
- docs: `just check-cli-docs` passed
- CLI transcript: `NO_COLOR=1 PLEXI_PROFILE=onboard-smoke PLEXI_CHANNEL=onboard-smoke cargo run --bin plexi -- ai onboard` passed and printed AI path plus app-install commands
- Codex review: two findings found and fixed: OpenRouter model IDs no longer appear in `ollama pull`; configured OpenRouter now takes precedence over incomplete Ollama setup
- Conclusion: install skippable -- CLI-only behavior covered by unit tests, generated docs check, full bin suite, build, and live command transcript