### PR TITLE
feat: refresh website visual design

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -5,12 +5,12 @@ import Logo from './Logo.astro';
   <div class="wrap row">
     <div class="foot-brand">
       <Logo size={22} stroke="#6a727c" ariaLabel="" />
-      <span class="copy">© 2026 Plexi</span>
+      <span class="copy">© 2026 Plexi · macOS · open source</span>
     </div>
     <div class="links">
       <a href="https://github.com/ianjamesburke/PLEXI">GitHub</a>
-      {/* <a href="#">YouTube</a> */}
       <a href="/docs">Docs</a>
+      <a href="/apps">Apps</a>
       <a href="/blog">Blog</a>
       <a href="/rss.xml">RSS</a>
     </div>

--- a/website/src/components/Hero.astro
+++ b/website/src/components/Hero.astro
@@ -2,17 +2,29 @@
 ---
 <header class="hero">
   <div class="wrap">
-    <div class="inner">
-      <h1>The last app you'll ever need.</h1>
-      <p class="tagline">Your terminal, your agents, your apps — all in one window. Build tools with AI, run them side by side, and own everything you make.</p>
-      <a class="btn lg" href="/download">Download the App <span class="arrow">→</span></a>
-      <div class="meta-under">macOS · open source</div>
-    </div>
-  </div>
+    <div class="hero-grid">
+      <div class="inner">
+        <h1>The last app you'll ever need.</h1>
+        <p class="tagline">Your terminal, your agents, and your apps in one window. Build tools with AI, run them side by side, and own what you make.</p>
+        <div class="hero-actions">
+          <a class="btn lg" href="/download">Download the App <span class="arrow">→</span></a>
+          <a class="text-link" href="/docs">Read the docs</a>
+        </div>
+        <div class="meta-under">macOS · open source · local-first</div>
+      </div>
 
-  <div class="wrap preview-stage">
-    <div class="preview-halo">
-      <img src="/screenshot-4.png" alt="Plexi — code editor alongside a live app pane" class="preview-screenshot" />
+      <div class="preview-stage" aria-label="Plexi product screenshot">
+        <div class="preview-halo">
+          <div class="preview-frame">
+            <div class="preview-titlebar">
+              <span></span><span></span><span></span>
+              <strong>workspace</strong>
+              <em>agent + app panes</em>
+            </div>
+            <img src="/screenshot-4.png" alt="Plexi with code beside a live app pane" class="preview-screenshot" />
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </header>

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -64,11 +64,11 @@ import Logo from './Logo.astro';
     transition: color 150ms;
   }
   .mobile-menu a:last-child { border-bottom: none; margin-top: 8px; }
-  .mobile-menu a:hover { color: var(--fg-1); }
+  .mobile-menu a:hover { color: var(--fg); }
 
   @media (max-width: 980px) {
     .mobile-menu-btn { display: flex; }
-    .cta { display: none; }
+    nav.top .cta { display: none; }
     nav.top.open .mobile-menu { display: flex; }
     nav.top.open .mobile-menu-btn .bar:first-child { transform: rotate(45deg) translate(2px, 2px); }
     nav.top.open .mobile-menu-btn .bar:last-child { transform: rotate(-45deg) translate(2px, -2px); }

--- a/website/src/components/Newsletter.astro
+++ b/website/src/components/Newsletter.astro
@@ -8,42 +8,48 @@ const headline = blog
   ? 'want to know when i write something?'
   : compact
   ? 'want a heads-up when a new version ships?'
-  : 'want to stay in the loop?';
+  : 'follow the build';
 const sub = blog
   ? "one email per post. that's it."
-  : "new versions, the occasional rant. that's it.";
+  : "New releases, sharp notes from the build, and no drip campaign.";
 const showSub = !compact;
 const formId = blog ? 'newsletter-form-blog' : compact ? 'newsletter-form-compact' : 'newsletter-form';
 ---
 <section class={`newsletter ${compact ? 'compact' : ''} ${blog ? 'blog' : ''}`}>
   <div class="wrap">
     <div class="nl-inner">
-      <h2 class="nl-headline">{headline}</h2>
-      {showSub && (
-        <p class="nl-sub">{sub}</p>
-      )}
-      <form id={formId} class="nl-form" novalidate>
-        <input
-          type="email"
-          name="email"
-          placeholder="you@example.com"
-          required
-          autocomplete="email"
-          class="nl-input"
-        />
-        <button type="submit" class="btn nl-btn">Subscribe <span class="arrow">→</span></button>
-      </form>
-      <div class="nl-message" data-form-id={formId} aria-live="polite"></div>
+      <div class="nl-copy">
+        <h2 class="nl-headline">{headline}</h2>
+        {showSub && (
+          <p class="nl-sub">{sub}</p>
+        )}
+      </div>
+      <div class="nl-signup">
+        <form id={formId} class="nl-form" novalidate>
+          <input
+            type="email"
+            name="email"
+            placeholder="you@example.com"
+            required
+            autocomplete="email"
+            class="nl-input"
+          />
+          <button type="submit" class="btn nl-btn">Subscribe <span class="arrow">→</span></button>
+        </form>
+        <div class="nl-message" data-form-id={formId} aria-live="polite"></div>
+      </div>
     </div>
   </div>
 </section>
 
 <style>
   .newsletter {
-    padding: 80px 0;
+    padding: 76px 0;
     border-top: 1px solid var(--border);
     border-bottom: 1px solid var(--border);
-    background: linear-gradient(180deg, transparent, rgba(107, 33, 168, 0.10), transparent);
+    background:
+      linear-gradient(90deg, rgba(52, 211, 153, 0.08), transparent 34%),
+      linear-gradient(180deg, rgba(255,255,255,0.035), rgba(139, 92, 246, 0.08), rgba(0,0,0,0.08));
   }
   .newsletter.compact {
     padding: 48px 0;
@@ -52,18 +58,22 @@ const formId = blog ? 'newsletter-form-blog' : compact ? 'newsletter-form-compac
     padding: 64px 0 80px;
   }
   .nl-inner {
-    max-width: 560px;
+    max-width: 760px;
     margin: 0 auto;
-    text-align: center;
+    text-align: left;
+    display: grid;
+    grid-template-columns: minmax(0, 0.8fr) minmax(320px, 0.85fr);
+    gap: 34px;
+    align-items: center;
   }
   .nl-headline {
     font-family: var(--mono);
     font-size: 28px;
     line-height: 1.25;
-    letter-spacing: -0.015em;
+    letter-spacing: 0;
     font-weight: 600;
     color: var(--fg);
-    margin-bottom: 14px;
+    margin-bottom: 10px;
   }
   .newsletter.compact .nl-headline {
     font-size: 20px;
@@ -72,8 +82,11 @@ const formId = blog ? 'newsletter-form-blog' : compact ? 'newsletter-form-compac
   .nl-sub {
     color: var(--fg-3);
     font-size: 14px;
-    margin-bottom: 26px;
     line-height: 1.6;
+  }
+  .nl-signup {
+    display: grid;
+    gap: 10px;
   }
   .nl-form {
     display: flex;
@@ -84,13 +97,13 @@ const formId = blog ? 'newsletter-form-blog' : compact ? 'newsletter-form-compac
   }
   .nl-input {
     flex: 1;
-    min-width: 240px;
-    max-width: 340px;
+    min-width: 0;
+    max-width: none;
     padding: 12px 14px;
     font-family: var(--mono);
     font-size: 13px;
     color: var(--fg);
-    background: var(--bg-2);
+    background: rgba(9, 10, 12, 0.72);
     border: 1px solid var(--border-2);
     border-radius: 6px;
     outline: none;
@@ -99,11 +112,10 @@ const formId = blog ? 'newsletter-form-blog' : compact ? 'newsletter-form-compac
   .nl-input::placeholder { color: var(--fg-4); }
   .nl-input:focus {
     border-color: var(--accent);
-    box-shadow: 0 0 0 1px rgba(147, 51, 234, 0.35);
+    box-shadow: 0 0 0 1px rgba(139, 92, 246, 0.35);
   }
   .nl-btn { white-space: nowrap; }
   .nl-message {
-    margin-top: 14px;
     font-size: 13px;
     min-height: 16px;
     color: var(--fg-3);
@@ -112,8 +124,9 @@ const formId = blog ? 'newsletter-form-blog' : compact ? 'newsletter-form-compac
   .nl-message.error { color: var(--warn); }
   .nl-form.hidden { display: none; }
 
-  @media (max-width: 480px) {
+  @media (max-width: 760px) {
     .nl-headline { font-size: 22px; }
+    .nl-inner { grid-template-columns: 1fr; gap: 22px; }
     .nl-form { flex-direction: column; }
     .nl-input { max-width: none; min-width: 0; width: 100%; }
   }

--- a/website/src/components/Story.astro
+++ b/website/src/components/Story.astro
@@ -2,31 +2,37 @@
 ---
 <section id="product" class="story">
   <div class="wrap">
-
-    <div class="story-block">
-      <div class="story-label">01</div>
-      <h2>The terminal hasn't changed.</h2>
-      <p>AI rewrote how we build software. But the place where you actually work? Same tabs, same alt-tabbing, same chaos. Your coding agent is in one window. Your terminal is in another. Your app is in a third. Context dies every time you switch.</p>
+    <div class="story-intro">
+      <h2>Build the workspace around the way you actually work.</h2>
+      <p>Plexi gives your terminal, apps, and agents the same place to live. Start with the Mac app, connect AI when you want it, then install or build the tools you need.</p>
     </div>
 
-    <div class="story-block">
-      <div class="story-label">02</div>
-      <h2>App dev should be this simple.</h2>
-      <p>You built something with Claude. Now what — roll your own auth, send someone a localhost link, and pray? Plexi makes it as simple as sharing a Python file. Simple dashboards all the way up to full AI-powered workflows. No deploy pipeline. No infrastructure. Just the app.</p>
-    </div>
+    <div class="story-grid">
+      <div class="story-block">
+        <div class="story-label">01</div>
+        <h3>The terminal hasn't changed.</h3>
+        <p>AI changed how software gets made. The workspace stayed stuck in tabs, windows, and scattered context.</p>
+      </div>
 
-    <div class="story-block">
-      <div class="story-label">03</div>
-      <h2>Workflows are grown, not built.</h2>
-      <p>The best AI agents aren't shipped in a sprint. They're shaped by use, trained by your data, refined by your taste. Plexi is the garden — a workspace where your tools take root and get better the more you use them. Think Shopify, but for AI apps.</p>
-    </div>
+      <div class="story-block">
+        <div class="story-label">02</div>
+        <h3>App dev should be this simple.</h3>
+        <p>Build a local app with an agent, check it against the host, and install it without turning a small tool into a web service.</p>
+      </div>
 
-    <div class="story-block">
-      <div class="story-label">04</div>
-      <h2>One home that stretches.</h2>
-      <p>Three projects. Twelve panes. Your agents, your apps, your terminal — side by side. No context switching. No window management. Everything you build lives in one place, and everything you make is yours.</p>
-      <a class="btn lg" href="/download">Download the App <span class="arrow">→</span></a>
-      <div class="meta-under">macOS · open source</div>
+      <div class="story-block">
+        <div class="story-label">03</div>
+        <h3>Workflows are grown, not built.</h3>
+        <p>Your tools improve as you use them. Apps keep their state on disk, agents work in context, and permissions stay visible.</p>
+      </div>
+
+      <div class="story-block action-block">
+        <div class="story-label">04</div>
+        <h3>One home that stretches.</h3>
+        <p>Open a project, connect AI, install an app, and keep everything side by side in one workspace.</p>
+        <a class="btn lg" href="/download">Download the App <span class="arrow">→</span></a>
+        <div class="meta-under">Start with <code>plexi ai onboard</code></div>
+      </div>
     </div>
 
   </div>
@@ -34,13 +40,58 @@
 
 <style>
   .story {
-    padding: 0;
+    padding: 110px 0 120px;
+  }
+
+  .story-intro {
+    display: grid;
+    grid-template-columns: minmax(0, 0.95fr) minmax(280px, 0.7fr);
+    gap: 72px;
+    align-items: end;
+    margin-bottom: 46px;
+  }
+
+  .story-intro h2 {
+    font-size: 42px;
+    line-height: 1.12;
+    letter-spacing: 0;
+    font-weight: 600;
+    color: var(--fg);
+    max-width: 760px;
+  }
+
+  .story-intro p {
+    color: var(--fg-2);
+    font-size: 15px;
+    line-height: 1.75;
+    max-width: 440px;
+  }
+
+  .story-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    border: 1px solid var(--border);
+    background: linear-gradient(180deg, rgba(18, 20, 22, 0.92), rgba(10, 11, 13, 0.96));
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
   }
 
   .story-block {
-    padding: 96px 0;
-    border-top: 1px solid var(--border);
-    max-width: 640px;
+    min-height: 330px;
+    padding: 30px;
+    border-right: 1px solid var(--border);
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+  }
+
+  .story-block:last-child {
+    border-right: 0;
+  }
+
+  .story-block.action-block {
+    background:
+      linear-gradient(180deg, rgba(99, 102, 241, 0.08), transparent 56%),
+      linear-gradient(135deg, rgba(32, 211, 153, 0.10), transparent 48%);
   }
 
   .story-label {
@@ -53,41 +104,63 @@
     font-family: var(--mono);
   }
 
-  .story-block h2 {
-    font-size: 36px;
+  .story-block h3 {
+    font-size: 24px;
     font-weight: 600;
-    letter-spacing: -0.025em;
-    line-height: 1.15;
-    margin-bottom: 20px;
+    letter-spacing: 0;
+    line-height: 1.22;
+    margin-bottom: 18px;
     color: var(--fg);
   }
 
   .story-block p {
     color: var(--fg-2);
-    font-size: 15px;
+    font-size: 14px;
     line-height: 1.7;
-    max-width: 560px;
   }
 
   .story-block .btn {
-    margin-top: 32px;
+    margin-top: auto;
+    width: fit-content;
   }
 
   .story-block .meta-under {
     margin-top: 14px;
     color: var(--fg-3);
-    font-size: 13px;
+    font-size: 12px;
+  }
+
+  .story-block code {
+    color: var(--good);
+    background: rgba(52, 211, 153, 0.08);
+    border: 1px solid rgba(52, 211, 153, 0.18);
+    border-radius: 4px;
+    padding: 2px 5px;
   }
 
   @media (max-width: 980px) {
-    .story-block { padding: 64px 0; }
-    .story-block h2 { font-size: 28px; }
-    .story-block p { font-size: 14px; }
+    .story { padding: 80px 0; }
+    .story-intro { grid-template-columns: 1fr; gap: 20px; }
+    .story-intro h2 { font-size: 30px; }
+    .story-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .story-block { border-bottom: 1px solid var(--border); }
+    .story-block:nth-child(2n) { border-right: 0; }
+    .story-block:nth-last-child(-n + 2) { border-bottom: 0; }
   }
 
   @media (max-width: 480px) {
-    .story-block { padding: 48px 0; }
-    .story-block h2 { font-size: 24px; }
+    .story { padding: 58px 0; }
+    .story-intro h2 { font-size: 25px; }
+    .story-grid { grid-template-columns: 1fr; }
+    .story-block {
+      min-height: 0;
+      padding: 24px;
+      border-right: 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .story-block:nth-last-child(-n + 2) { border-bottom: 1px solid var(--border); }
+    .story-block:last-child { border-bottom: 0; }
+    .story-block h3 { font-size: 22px; }
     .story-block .btn.lg { width: 100%; text-align: center; justify-content: center; }
   }
 </style>

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -151,7 +151,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site).toString();
   .doc-header h1 {
     font-size: 32px;
     font-weight: 600;
-    letter-spacing: -0.02em;
+    letter-spacing: 0;
     line-height: 1.15;
     color: var(--fg);
   }

--- a/website/src/pages/apps/[id].astro
+++ b/website/src/pages/apps/[id].astro
@@ -133,7 +133,7 @@ const installCmd = `plexi app install ${app.id}`;
   h1 {
     font-size: 42px;
     font-weight: 700;
-    letter-spacing: -0.04em;
+    letter-spacing: 0;
     line-height: 1;
     color: var(--fg);
   }

--- a/website/src/pages/apps/index.astro
+++ b/website/src/pages/apps/index.astro
@@ -101,7 +101,7 @@ function priceLabel(price: Entry['price']): string {
   .apps-header h1 {
     font-size: 52px;
     font-weight: 700;
-    letter-spacing: -0.04em;
+    letter-spacing: 0;
     line-height: 1;
     margin-bottom: 16px;
     color: var(--fg);

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -45,7 +45,7 @@ const fmt = (d: Date) =>
 <style>
   .section-head { margin-bottom: 48px; }
   .section-head h2 {
-    font-size: 40px; line-height: 1.1; letter-spacing: -0.02em;
+    font-size: 40px; line-height: 1.1; letter-spacing: 0;
     font-weight: 600; margin: 0 0 12px;
   }
   .section-head p { font-size: 15px; color: var(--fg-2); max-width: 480px; margin: 0; }
@@ -85,7 +85,7 @@ const fmt = (d: Date) =>
   .date { font-size: 12px; color: var(--fg-3); padding-top: 4px; }
   .post-row h3 {
     font-size: 18px; font-weight: 600; margin: 0 0 6px;
-    letter-spacing: -0.01em;
+    letter-spacing: 0;
   }
   .post-row p { font-size: 13px; color: var(--fg-2); margin: 0; }
 

--- a/website/src/pages/docs/index.astro
+++ b/website/src/pages/docs/index.astro
@@ -37,7 +37,7 @@ import { docsNav } from '../../lib/docsNav';
   .index-header h1 {
     font-size: 40px;
     font-weight: 600;
-    letter-spacing: -0.02em;
+    letter-spacing: 0;
     margin-bottom: 10px;
   }
 .sections {

--- a/website/src/pages/download.astro
+++ b/website/src/pages/download.astro
@@ -62,7 +62,7 @@ const INSTALL_CMD = 'curl -fsSL https://plexiapp.com/install | sh';
 <style>
   .dl-hero { padding: 120px 0 40px; }
   .dl-hero h1 {
-    font-size: 56px; line-height: 1.05; letter-spacing: -0.02em;
+    font-size: 56px; line-height: 1.05; letter-spacing: 0;
     font-weight: 600; margin: 0 0 16px;
   }
   .dl-hero .tagline { font-size: 16px; color: var(--fg-2); max-width: 560px; }

--- a/website/src/pages/support.astro
+++ b/website/src/pages/support.astro
@@ -34,14 +34,14 @@ const SPONSOR_URL = 'https://buymeacoffee.com/ianjamesbu8';
 
 <style>
   .support-page { padding: 120px 0 80px; }
-  .support-page h1 { font-size: 48px; font-weight: 700; letter-spacing: -0.03em; margin-bottom: 16px; }
+  .support-page h1 { font-size: 48px; font-weight: 700; letter-spacing: 0; margin-bottom: 16px; }
   .support-page .lead { color: var(--fg-2); font-size: 17px; line-height: 1.6; max-width: 580px; margin-bottom: 56px; }
   .vision, .how-to-help { margin-bottom: 56px; }
-  .vision h2, .how-to-help h2 { font-size: 24px; font-weight: 600; margin-bottom: 16px; letter-spacing: -0.01em; }
+  .vision h2, .how-to-help h2 { font-size: 24px; font-weight: 600; margin-bottom: 16px; letter-spacing: 0; }
   .vision p { color: var(--fg-2); font-size: 15px; line-height: 1.7; max-width: 620px; margin-bottom: 16px; }
   .how-to-help ul { list-style: none; padding: 0; margin: 0 0 32px; }
   .how-to-help li { color: var(--fg-2); font-size: 15px; line-height: 1.7; margin-bottom: 12px; max-width: 620px; }
-  .how-to-help li strong { color: var(--fg-1); }
+  .how-to-help li strong { color: var(--fg); }
 
   @media (max-width: 980px) {
     .support-page { padding: 88px 0 60px; }

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -2,24 +2,25 @@
 @plugin "@tailwindcss/typography";
 
 :root {
-  --bg: #07080a;
-  --bg-2: #0e1013;
-  --bg-3: #14171b;
-  --bg-4: #181c21;
-  --border: #1c2026;
-  --border-2: #262b32;
-  --border-3: #323843;
-  --fg: #f0f3f6;
-  --fg-2: #b8c0c8;
-  --fg-3: #8a9299;
-  --fg-4: #5c636b;
-  --accent: #9333ea;
-  --accent-2: #7e22ce;
-  --accent-3: #6b21a8;
-  --accent-light: #a855f7;
-  --accent-dim: rgba(147, 51, 234, 0.14);
+  --bg: #090a0c;
+  --bg-2: #101214;
+  --bg-3: #171a1e;
+  --bg-4: #20242a;
+  --border: #252a31;
+  --border-2: #333944;
+  --border-3: #454c59;
+  --fg: #f5f2ea;
+  --fg-2: #c6c2b8;
+  --fg-3: #918d84;
+  --fg-4: #67635c;
+  --accent: #8b5cf6;
+  --accent-2: #6d5dfc;
+  --accent-3: #4f46e5;
+  --accent-light: #b08cff;
+  --accent-dim: rgba(139, 92, 246, 0.14);
   --warn: #f59e0b;
   --good: #34d399;
+  --amber: #f6b44b;
   --mono: "Berkeley Mono", "JetBrains Mono", "Fira Code", "SF Mono", ui-monospace, Menlo, monospace;
 }
 
@@ -146,7 +147,7 @@ body::after {
   content: "";
   position: fixed;
   inset: 0;
-  background: radial-gradient(ellipse at center, transparent 55%, rgba(0,0,0,0.5) 100%);
+  background: linear-gradient(180deg, rgba(246, 180, 75, 0.04), transparent 28%, rgba(139, 92, 246, 0.04) 68%, rgba(0,0,0,0.42));
   pointer-events: none;
   z-index: 999;
 }
@@ -155,22 +156,22 @@ body::after {
 
 .atmosphere { position: absolute; inset: 0; pointer-events: none; z-index: 0; overflow: hidden; }
 .atmosphere .glow-hero {
-  position: absolute; top: -260px; left: 18%;
-  width: 1100px; height: 760px;
-  background: radial-gradient(ellipse at center, rgba(107, 33, 168, 0.22), rgba(107, 33, 168, 0.06) 38%, transparent 68%);
-  filter: blur(30px);
+  position: absolute; inset: 0 0 auto 0;
+  height: 760px;
+  background:
+    linear-gradient(90deg, rgba(52, 211, 153, 0.08), transparent 34%),
+    linear-gradient(135deg, rgba(139, 92, 246, 0.14), transparent 42%),
+    linear-gradient(180deg, rgba(246, 180, 75, 0.05), transparent 70%);
 }
 .atmosphere .glow-funding {
-  position: absolute; top: 1180px; left: 50%; transform: translateX(-50%);
-  width: 900px; height: 320px;
-  background: radial-gradient(ellipse at center, rgba(107, 33, 168, 0.14), transparent 70%);
-  filter: blur(40px);
+  position: absolute; top: 980px; left: 0; right: 0;
+  height: 420px;
+  background:
+    linear-gradient(180deg, transparent, rgba(255,255,255,0.035), transparent),
+    repeating-linear-gradient(90deg, transparent 0 79px, rgba(255,255,255,0.035) 80px);
 }
 .atmosphere .glow-mission {
-  position: absolute; top: 2900px; left: 50%; transform: translateX(-50%);
-  width: 1000px; height: 480px;
-  background: radial-gradient(ellipse at center, rgba(107, 33, 168, 0.12), transparent 70%);
-  filter: blur(50px);
+  display: none;
 }
 .atmosphere .grain {
   position: absolute; inset: 0;
@@ -183,73 +184,117 @@ main, header, nav, section, footer { position: relative; z-index: 1; }
 
 nav.top {
   position: sticky; top: 0; z-index: 50;
-  background: rgba(10, 10, 11, 0.96); backdrop-filter: blur(18px); -webkit-backdrop-filter: blur(18px);
+  background: rgba(9, 10, 12, 0.88); backdrop-filter: blur(18px); -webkit-backdrop-filter: blur(18px);
   border-bottom: 1px solid var(--border);
 }
 nav.top .row { display: flex; align-items: center; justify-content: space-between; height: 64px; }
-nav.top .brand { display: flex; align-items: center; gap: 11px; font-weight: 600; letter-spacing: 0; font-size: 14px; text-transform: lowercase; }
+nav.top .brand { display: flex; align-items: center; gap: 11px; font-weight: 650; letter-spacing: 0; font-size: 14px; text-transform: lowercase; }
 nav.top .brand svg { display: block; }
-nav.top .links { display: flex; gap: 28px; color: var(--fg-2); font-size: 13px; text-transform: uppercase; letter-spacing: 0.06em; }
+nav.top .links { display: flex; gap: 26px; color: var(--fg-2); font-size: 12px; text-transform: uppercase; letter-spacing: 0; }
 nav.top .links a { transition: color 150ms; }
 nav.top .links a:hover { color: var(--fg); }
 nav.top .cta { display: flex; gap: 10px; align-items: center; }
 
 .btn {
   display: inline-flex; align-items: center; gap: 10px;
-  padding: 10px 18px; font-size: 13px; font-weight: 500; line-height: 1;
+  padding: 10px 18px; font-size: 13px; font-weight: 600; line-height: 1;
   border-radius: 6px; cursor: pointer; font-family: var(--mono);
   color: #ffffff; letter-spacing: 0;
-  background: var(--accent);
-  border: none;
-  transition: background-color 150ms ease, box-shadow 150ms ease;
+  background: linear-gradient(180deg, var(--accent-light), var(--accent));
+  border: 1px solid rgba(255,255,255,0.16);
+  box-shadow: 0 10px 26px rgba(139, 92, 246, 0.22);
+  transition: background-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
 }
 .btn:hover {
-  background: var(--accent-light);
-  box-shadow: 0 0 0 1px rgba(168, 85, 247, 0.35);
+  box-shadow: 0 12px 34px rgba(139, 92, 246, 0.30);
+  transform: translateY(-1px);
 }
 .btn:active {
   background: var(--accent-2);
   box-shadow: none;
+  transform: translateY(0);
 }
 .btn.lg {
   padding: 14px 22px; font-size: 13px; border-radius: 6px;
 }
 .btn .arrow { font-weight: 400; opacity: 0.85; }
 
-.hero { padding: 120px 0 60px; }
-.hero .inner { max-width: 720px; display: flex; flex-direction: column; align-items: flex-start; }
+.hero { padding: 96px 0 72px; min-height: auto; display: flex; align-items: center; }
+.hero-grid { display: grid; grid-template-columns: minmax(0, 0.82fr) minmax(540px, 1.18fr); gap: 58px; align-items: center; }
+.hero .inner { max-width: 650px; display: flex; flex-direction: column; align-items: flex-start; }
 .hero h1 {
-  font-size: 64px; line-height: 1.05; letter-spacing: -0.025em; font-weight: 600;
-  margin-bottom: 28px;
+  font-size: 68px; line-height: 1.02; letter-spacing: 0; font-weight: 650;
+  margin-bottom: 26px;
   text-align: left;
 }
 .hero p.tagline {
-  font-size: 16px; color: var(--fg-2); max-width: 580px;
-  margin-bottom: 40px; line-height: 1.65; letter-spacing: 0;
+  font-size: 16px; color: var(--fg-2); max-width: 590px;
+  margin-bottom: 34px; line-height: 1.75; letter-spacing: 0;
   text-align: left;
 }
+.hero-actions { display: flex; align-items: center; gap: 20px; flex-wrap: wrap; }
+.hero .text-link {
+  color: var(--fg-2);
+  font-size: 13px;
+  border-bottom: 1px solid var(--border-3);
+  padding-bottom: 3px;
+  transition: color 150ms, border-color 150ms;
+}
+.hero .text-link:hover { color: var(--fg); border-color: var(--accent-light); }
 .hero .meta-under { margin-top: 18px; color: var(--fg-3); font-size: 13px; text-align: left; }
 
-.preview-stage { padding: 64px 0 0; perspective: 2000px; }
+.preview-stage { padding: 0; perspective: 2000px; }
 .preview-halo { position: relative; }
 .preview-halo::before {
-  content: ''; position: absolute; inset: 30px 60px -40px 60px;
-  background: radial-gradient(ellipse at center, rgba(147, 51, 234, 0.20), transparent 60%);
-  filter: blur(55px); z-index: 0; pointer-events: none;
+  content: ''; position: absolute; inset: -1px;
+  background: linear-gradient(135deg, rgba(52, 211, 153, 0.18), rgba(139, 92, 246, 0.18), rgba(246, 180, 75, 0.12));
+  z-index: 0; pointer-events: none;
 }
-.preview-screenshot {
+.preview-frame {
   position: relative; z-index: 1;
-  display: block;
-  width: 100%;
-  border: 1px solid var(--border-2);
-  border-radius: 12px;
   overflow: hidden;
-  transform: rotateX(2deg);
-  transform-origin: center bottom;
+  border: 1px solid var(--border-2);
+  background: var(--bg-2);
   box-shadow:
     0 1px 0 rgba(255,255,255,0.04) inset,
-    0 30px 80px -20px rgba(0,0,0,0.75),
-    0 0 1px rgba(147, 51, 234, 0.25);
+    0 28px 80px rgba(0,0,0,0.52);
+}
+.preview-screenshot {
+  display: block;
+  width: 100%;
+  min-height: 420px;
+  object-fit: cover;
+  object-position: center top;
+}
+.preview-titlebar {
+  height: 40px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border-bottom: 1px solid var(--border);
+  background: rgba(14, 16, 18, 0.96);
+  padding: 0 14px;
+  color: var(--fg-3);
+  font-size: 11px;
+}
+.preview-titlebar span {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--border-3);
+}
+.preview-titlebar span:first-child { background: var(--warn); }
+.preview-titlebar span:nth-child(2) { background: var(--amber); }
+.preview-titlebar span:nth-child(3) { background: var(--good); }
+.preview-titlebar strong {
+  margin-left: 8px;
+  color: var(--fg-2);
+  font-weight: 600;
+}
+.preview-titlebar em {
+  margin-left: auto;
+  color: var(--fg-4);
+  font-style: normal;
 }
 .preview .titlebar { display: flex; align-items: center; gap: 10px; padding: 11px 14px; border-bottom: 1px solid var(--border); background: var(--bg-3); }
 .preview .titlebar .dots { display: flex; gap: 6px; }
@@ -305,7 +350,7 @@ nav.top .cta { display: flex; gap: 10px; align-items: center; }
 section { padding: 140px 0; }
 section + section { border-top: 1px solid var(--border); }
 .section-head { margin-bottom: 64px; }
-.section-head h2 { font-size: 44px; letter-spacing: -0.02em; font-weight: 600; max-width: 18ch; margin-bottom: 16px; line-height: 1.1; }
+.section-head h2 { font-size: 44px; letter-spacing: 0; font-weight: 600; max-width: 18ch; margin-bottom: 16px; line-height: 1.1; }
 .section-head h2 .quiet { color: var(--fg-3); }
 .section-head p { color: var(--fg-2); font-size: 15px; max-width: 64ch; line-height: 1.6; }
 
@@ -313,7 +358,7 @@ section + section { border-top: 1px solid var(--border); }
 .mission .quote {
   font-size: 36px;
   line-height: 1.35;
-  letter-spacing: -0.015em;
+  letter-spacing: 0;
   font-weight: 500;
   max-width: 28ch;
   margin: 0 auto 40px;
@@ -337,11 +382,11 @@ section + section { border-top: 1px solid var(--border); }
 }
 .mission .sponsor-link:hover { color: var(--fg); border-bottom-color: var(--fg); }
 
-footer { padding: 56px 0 64px; border-top: 1px solid var(--border); color: var(--fg-3); font-size: 13px; }
+footer { padding: 42px 0 52px; border-top: 1px solid var(--border); color: var(--fg-3); font-size: 13px; background: rgba(8, 9, 11, 0.72); }
 footer .row { display: flex; justify-content: space-between; align-items: center; gap: 24px; flex-wrap: wrap; }
 footer .foot-brand { display: flex; align-items: center; gap: 14px; }
 footer .foot-brand .copy { font-size: 13px; }
-footer .links { display: flex; gap: 28px; text-transform: uppercase; letter-spacing: 0.05em; font-size: 13px; }
+footer .links { display: flex; gap: 24px; text-transform: uppercase; letter-spacing: 0; font-size: 12px; }
 footer .links a { transition: color 150ms; }
 footer .links a:hover { color: var(--fg); }
 
@@ -353,16 +398,16 @@ footer .links a:hover { color: var(--fg); }
 .posts-list .post-row:last-child { border-bottom: none; }
 .posts-list .post-row:hover { background: var(--bg-3); }
 .posts-list .post-row .date { font-size: 13px; color: var(--fg-4); letter-spacing: 0.04em; }
-.posts-list .post-row h3 { font-size: 18px; font-weight: 600; letter-spacing: -0.01em; margin-bottom: 8px; color: var(--fg); }
+.posts-list .post-row h3 { font-size: 18px; font-weight: 600; letter-spacing: 0; margin-bottom: 8px; color: var(--fg); }
 .posts-list .post-row p { font-size: 13px; color: var(--fg-2); line-height: 1.6; }
 
 .post-article { padding: 96px 0 80px; max-width: 720px; margin: 0 auto; }
 .post-article .post-header { margin-bottom: 48px; }
 .post-article .post-header .date { font-size: 13px; color: var(--fg-4); letter-spacing: 0.04em; margin-bottom: 16px; display: block; }
-.post-article .post-header h1 { font-size: 40px; letter-spacing: -0.02em; font-weight: 600; line-height: 1.15; margin-bottom: 16px; }
+.post-article .post-header h1 { font-size: 40px; letter-spacing: 0; font-weight: 600; line-height: 1.15; margin-bottom: 16px; }
 .post-article .post-header .description { color: var(--fg-2); font-size: 15px; line-height: 1.6; }
 .post-article .prose { color: var(--fg); font-size: 14px; line-height: 1.8; }
-.post-article .prose h2 { font-size: 22px; letter-spacing: -0.01em; font-weight: 600; margin: 40px 0 16px; }
+.post-article .prose h2 { font-size: 22px; letter-spacing: 0; font-weight: 600; margin: 40px 0 16px; }
 .post-article .prose h3 { font-size: 17px; font-weight: 600; margin: 32px 0 12px; }
 .post-article .prose p { margin-bottom: 18px; color: var(--fg-2); }
 .post-article .prose a { color: var(--accent-light); border-bottom: 1px solid rgba(147, 51, 234, 0.35); transition: color 150ms, border-color 150ms; }
@@ -377,11 +422,11 @@ footer .links a:hover { color: var(--fg); }
 .post-article .back-link:hover { color: var(--accent-light); }
 
 @media (max-width: 980px) {
-  .hero { padding: 80px 0 40px; }
-  .hero h1 { font-size: 40px; letter-spacing: -0.02em; }
+  .hero { min-height: 0; padding: 80px 0 56px; }
+  .hero-grid { grid-template-columns: 1fr; gap: 42px; }
+  .hero h1 { font-size: 44px; letter-spacing: 0; }
   .hero p.tagline { font-size: 15px; max-width: 480px; }
-  .hero .btn.lg { width: 100%; text-align: center; justify-content: center; }
-  .preview-stage { padding: 40px 0 0; }
+  .preview-screenshot { min-height: 320px; }
   .preview .panes { grid-template-columns: 1fr; }
   .preview .pane { border-right: none; border-bottom: 1px solid var(--border); }
   .preview { transform: none; }
@@ -396,11 +441,16 @@ footer .links a:hover { color: var(--fg); }
 
 @media (max-width: 480px) {
   .wrap { padding: 0 20px; }
-  .hero { padding: 64px 0 32px; }
-  .hero h1 { font-size: 32px; margin-bottom: 20px; }
-  .hero p.tagline { font-size: 14px; margin-bottom: 28px; }
+  .hero { padding: 46px 0 32px; }
+  .hero h1 { font-size: 31px; margin-bottom: 18px; }
+  .hero p.tagline { font-size: 14px; margin-bottom: 24px; }
+  .hero-actions { width: 100%; gap: 16px; }
+  .hero .btn.lg { width: 100%; text-align: center; justify-content: center; }
+  .hero .text-link { width: 100%; text-align: center; }
   .hero .meta-under { font-size: 12px; margin-top: 14px; }
-  .preview-stage { padding: 32px 0 0; }
+  .preview-stage { padding: 24px 0 0; }
+  .preview-titlebar em { display: none; }
+  .preview-screenshot { min-height: 210px; }
   .preview .titlebar { padding: 8px 12px; }
   .preview .titlebar .crumbs { font-size: 10px; }
   .preview .titlebar .right-meta { display: none; }
@@ -412,4 +462,5 @@ footer .links a:hover { color: var(--fg); }
   .funding .progress { flex-direction: column; align-items: flex-start; gap: 10px; }
   .funding .bar { min-width: 0; width: 100%; }
   footer .row { flex-direction: column; align-items: flex-start; gap: 16px; }
+  footer .links { flex-wrap: wrap; gap: 16px; }
 }


### PR DESCRIPTION
## Summary
- refresh the homepage hero with a host-product screenshot, tighter CTAs, and first-viewport story peek
- restyle story, newsletter, footer, and mobile nav behavior without a structural rebuild
- normalize stale website tracking/color-token usage across top-level pages

## Validation
- npm run build
- git diff --check
- cargo build
- Playwright desktop/mobile screenshots: /tmp/plexi-0272-home-desktop.png, /tmp/plexi-0272-home-mobile.png
- Codex review: no blocking defects

Stint: 0272