### PR TITLE
fix: pane new --tab anchors to caller pane's window, not active (stint 0337)

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -879,7 +879,10 @@ impl PlexiApp {
                             .map(|w| w.grid_x)
                             .max();
                         let new_x = max_x.map(|x| x + 1).unwrap_or(1);
-                        log::info!("pane_ipc: spawn_pane terminal layout=new_window context={ws_id} grid=({new_x},{active_y}) initial_cmd={initial_cmd:?} ephemeral={}", spec.ephemeral);
+                        log::info!(
+                            "pane_ipc: spawn_pane terminal layout=new_window from_pane_id={:?} target_win_idx={target_win_idx} context={ws_id} grid=({new_x},{active_y}) response_pane_id={response_pane_id} cwd={cwd_override:?} initial_cmd={initial_cmd:?} ephemeral={}",
+                            spec.from_pane_id, spec.ephemeral
+                        );
                         self.create_page_at(
                             new_x,
                             active_y,
@@ -892,16 +895,29 @@ impl PlexiApp {
                             self.active_window = active;
                         }
                     } else if layout_str == "tab" {
+                        // Derive target window from the calling pane's window; fall back to active.
+                        let target_win_idx = spec
+                            .from_pane_id
+                            .and_then(|fid| self.find_pane_in_any_window(fid).map(|(idx, _)| idx))
+                            .unwrap_or(active);
+                        let original_focused = self.windows[target_win_idx].focused_pane;
                         log::info!(
-                            "pane_ipc: spawn_pane terminal layout=tab initial_cmd={initial_cmd:?} ephemeral={}",
-                            spec.ephemeral
+                            "pane_ipc: spawn_pane terminal layout=tab from_pane_id={:?} target_win_idx={target_win_idx} window_id={} response_pane_id={response_pane_id} cwd={cwd_override:?} initial_cmd={initial_cmd:?} ephemeral={}",
+                            spec.from_pane_id, self.windows[target_win_idx].window_id, spec.ephemeral
                         );
-                        let original_focused = self.windows[active].focused_pane;
-                        self.new_tab(initial_cmd.as_deref(), spec.ephemeral, cwd_override);
+                        self.new_tab(
+                            target_win_idx,
+                            initial_cmd.as_deref(),
+                            spec.ephemeral,
+                            cwd_override,
+                        );
                         if spec.no_focus {
-                            self.active_window = active;
-                            self.restore_window_focused_pane(active, original_focused);
+                            self.restore_window_focused_pane(target_win_idx, original_focused);
                         }
+                        // self.active_window is intentionally left untouched here, matching
+                        // the split path below: a from_pane_id spawn must never steal the
+                        // user's currently active Plexi window, only set the new tab as the
+                        // target window's own focused pane (done inside new_tab above).
                     } else {
                         let vertical =
                             matches!(layout_str, "split_h" | "split_right" | "split_left");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3260,7 +3260,7 @@ impl eframe::App for PlexiApp {
                     self.step_focus_history_forward();
                 }
                 Action::NewTab => {
-                    self.new_tab(None, false, None);
+                    self.new_tab(self.active_window, None, false, None);
                     self.save_workspace();
                 }
                 Action::ToggleZoom => {

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -333,8 +333,12 @@ fn spawn_pane_tab_anchors_to_from_pane_window_not_active() {
     });
     app.drain_pane_cmd_channel();
 
-    // PTY creation may fail in some CI environments; guard before asserting.
-    if app.windows[0].panes.len() == panes_in_w0_before {
+    // PTY creation may fail in some CI environments; guard on total pane count
+    // (not just window 0's) so a regression that lands the tab in window 1
+    // instead of window 0 doesn't get mistaken for a skipped spawn failure.
+    let total_before = panes_in_w0_before + panes_in_w1_before;
+    let total_after = app.windows[0].panes.len() + app.windows[1].panes.len();
+    if total_after == total_before {
         return; // terminal spawn failed; skip remainder
     }
 

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -266,3 +266,106 @@ fn spawn_pane_new_window_uses_caller_context_not_active() {
         "new window must be in row 0 (caller's grid row), not row 1 (active context's row)"
     );
 }
+
+/// When `plexi pane new --tab` is called with a `from_pane_id` in a non-active
+/// window, the new tab must land in that pane's window — not the active window.
+/// Regression for stint 0337: the `tab` IPC branch called `new_tab()` against
+/// `self.active_window` unconditionally, ignoring `from_pane_id` entirely.
+#[test]
+fn spawn_pane_tab_anchors_to_from_pane_window_not_active() {
+    let ctx = egui::Context::default();
+    let ft = crate::platform::logging::new_frame_tick();
+    let (mut app, ipc_tx) = PlexiApp::new_for_test(ctx, ft);
+
+    // Window 0 is created by new_for_test; give it a caller pane.
+    let (tile_in_w0, pane_id_ctx1) = app.add_test_pane();
+    app.windows[0].focused_pane = Some(tile_in_w0);
+
+    // Add a second window and make it the active one.
+    let ctx2_id: u64 = 2;
+    app.router.push(crate::host::context::Context {
+        name: "Context 2".into(),
+        path: std::env::temp_dir(),
+        root: None,
+        description: None,
+        context_id: ctx2_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    app.windows.push(crate::host::context::Window {
+        name: "Context 2".into(),
+        path: std::env::temp_dir(),
+        tree: egui_tiles::Tree::empty("ctx2_tree"),
+        panes: std::collections::HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 0,
+        grid_y: 1,
+        window_id: 10,
+        context_id: ctx2_id,
+    });
+    app.active_window = 1;
+    app.router.set_active(1);
+
+    let panes_in_w0_before = app.windows[0].panes.len();
+    let panes_in_w1_before = app.windows[1].panes.len();
+
+    let requested_cwd = std::env::temp_dir();
+
+    // Inject a spawn-pane IPC from window 0's pane (pane_id_ctx1) with layout=tab,
+    // while window 1 is active.
+    let _ = ipc_tx.send(crate::app_protocol::AppRequest::SpawnPane {
+        type_id: "terminal".to_string(),
+        layout: Some("tab".to_string()),
+        args: vec![],
+        pipe_id: None,
+        from_pane_id: Some(pane_id_ctx1),
+        request_id: None,
+        response_file: None,
+        ephemeral: false,
+        cwd: Some(requested_cwd.to_string_lossy().to_string()),
+        no_focus: false,
+        path: None,
+        workspace_root: None,
+        target_context: None,
+        name: None,
+    });
+    app.drain_pane_cmd_channel();
+
+    // PTY creation may fail in some CI environments; guard before asserting.
+    if app.windows[0].panes.len() == panes_in_w0_before {
+        return; // terminal spawn failed; skip remainder
+    }
+
+    assert_eq!(
+        app.windows[0].panes.len(),
+        panes_in_w0_before + 1,
+        "new tab must be added to window 0 (caller's window), not window 1 (active)"
+    );
+    assert_eq!(
+        app.windows[1].panes.len(),
+        panes_in_w1_before,
+        "active window 1 must be untouched by a tab anchored to a different caller pane"
+    );
+
+    let new_pane_id = *app.windows[0]
+        .panes
+        .keys()
+        .find(|id| **id != pane_id_ctx1)
+        .expect("a new pane must have been added to window 0");
+    let new_tile = app.windows[0]
+        .tree
+        .tiles
+        .find_pane(&new_pane_id)
+        .expect("new pane must be present in window 0's tile tree");
+    // lsof-based cwd lookup races the freshly spawned child reporting its own
+    // cwd; only assert when it resolved in time.
+    if let Some(new_pane_cwd) = app.windows[0].get_focused_pane_cwd(new_tile) {
+        assert_eq!(
+            new_pane_cwd.canonicalize().unwrap_or(new_pane_cwd),
+            requested_cwd.canonicalize().unwrap_or(requested_cwd),
+            "new tab must honor the requested --cwd"
+        );
+    }
+}

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -409,26 +409,30 @@ impl PlexiApp {
 
     pub(crate) fn new_tab(
         &mut self,
+        target_win_idx: usize,
         initial_cmd: Option<&str>,
         close_on_exit: bool,
         cwd_override: Option<PathBuf>,
     ) {
         // Empty context (welcome screen): create the first pane as tree root.
-        if self.windows[self.active_window].panes.is_empty() {
+        if self.windows[target_win_idx].panes.is_empty() {
             let new_id = self.host.alloc_pane_id();
             let ctx_id = self
                 .windows
-                .get(self.active_window)
+                .get(target_win_idx)
                 .map(|w| w.context_id)
                 .unwrap_or(0);
             let ctx_name = self.context_name_for(ctx_id);
             let ctx_desc = self.context_description_for(ctx_id);
             let ctx_root = self.context_root_for(ctx_id);
             let ctx_depth = self.context_depth_for(ctx_id);
-            let cwd = cwd_override.unwrap_or_else(|| self.cwd_for_welcome_tab());
+            // Resolve against the target window's own context, not the ambient
+            // active context — target_win_idx may differ from self.active_window.
+            let cwd = cwd_override.or_else(|| ctx_root.clone()).unwrap_or_else(|| {
+                dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/"))
+            });
             log::info!(
-                "new_tab (empty context): cwd={cwd:?} context_root={:?}",
-                self.router.active().root
+                "new_tab (empty context): target_win_idx={target_win_idx} cwd={cwd:?} context_root={ctx_root:?}"
             );
             let mut settings = Self::make_backend_settings(
                 new_id,
@@ -457,7 +461,7 @@ impl PlexiApp {
                 return;
             };
             pane.ephemeral = close_on_exit;
-            let ctx = &mut self.windows[self.active_window];
+            let ctx = &mut self.windows[target_win_idx];
             ctx.panes.insert(new_id, Pane::Terminal(Box::new(pane)));
             let pane_tile = ctx.tree.tiles.insert_pane(new_id);
             let tab_tile = ctx.tree.tiles.insert_tab_tile(vec![pane_tile]);
@@ -466,28 +470,32 @@ impl PlexiApp {
             return;
         }
 
-        let old_window_id = self.windows[self.active_window].window_id;
-        let old_focus = self.windows[self.active_window].focused_pane;
-        let Some(focused) = self.windows[self.active_window].focused_pane else {
+        let old_window_id = self.windows[target_win_idx].window_id;
+        let old_focus = self.windows[target_win_idx].focused_pane;
+        let Some(focused) = self.windows[target_win_idx].focused_pane else {
             return;
         };
 
         let new_id = self.host.alloc_pane_id();
 
-        let cwd = cwd_override.or_else(|| self.resolve_new_pane_cwd(None, Some(focused)));
-        log::info!(
-            "new_tab: cwd={cwd:?} context_root={:?}",
-            self.router.active().root
-        );
         let ctx_id = self
             .windows
-            .get(self.active_window)
+            .get(target_win_idx)
             .map(|w| w.context_id)
             .unwrap_or(0);
         let ctx_name = self.context_name_for(ctx_id);
         let ctx_desc = self.context_description_for(ctx_id);
         let ctx_root = self.context_root_for(ctx_id);
         let ctx_depth = self.context_depth_for(ctx_id);
+
+        // Resolve against the target window's own context/pane, not the ambient
+        // active window — target_win_idx may differ from self.active_window when
+        // anchored to a caller pane in another window.
+        let cwd = cwd_override
+            .or_else(|| ctx_root.clone())
+            .or_else(|| self.windows[target_win_idx].get_focused_pane_cwd(focused))
+            .or_else(dirs::home_dir);
+        log::info!("new_tab: target_win_idx={target_win_idx} cwd={cwd:?} context_root={ctx_root:?}");
         let mut settings = Self::make_backend_settings(
             new_id,
             cwd,
@@ -513,12 +521,12 @@ impl PlexiApp {
             return;
         };
         pane.ephemeral = close_on_exit;
-        self.windows[self.active_window]
+        self.windows[target_win_idx]
             .panes
             .insert(new_id, Pane::Terminal(Box::new(pane)));
         self.push_focus_history(old_window_id, old_focus);
 
-        let ctx = &mut self.windows[self.active_window];
+        let ctx = &mut self.windows[target_win_idx];
         let new_tile = ctx.tree.tiles.insert_pane(new_id);
 
         if let Some((tabs_id, _)) = ctx.find_ancestor_tabs(focused) {


### PR DESCRIPTION
Stint task: 0337. No linked GitHub issue.

## Summary

- `plexi pane new --tab --from <pane-id>` ignored `from_pane_id` entirely — it always created the tab in the currently active window instead of the caller's window.
- `new_tab()` now takes an explicit target window index instead of implicitly using `self.active_window`, and the IPC `tab` branch derives that index from `from_pane_id` via `find_pane_in_any_window` (mirroring the existing `new_window` and split paths).
- Fixed two related cwd-fallback bugs surfaced by review: the empty-window and non-empty-window cwd fallbacks inside `new_tab` were still reading the ambient active window/router context instead of the target window's own context when no explicit `--cwd` was given.
- Added an info-level trace for both `tab` and `new_window` placement decisions (from_pane_id, resolved target window, resulting pane/window id, cwd).
- `self.active_window` is deliberately left untouched when anchoring to a caller pane in another window, matching the existing split-path behavior — a `--from` spawn must never steal the user's currently active Plexi window.

## Related

Task 0304 (pane-new-window-use-caller-context) already shipped and confirmed the `--window` path already correctly anchors to `from_pane_id`. This PR only needed to fix the `--tab` path.

## Done When

- [x] `pane new --tab --from <non-focused-pane>` lands the tab in the caller's window, not the active window
- [x] Requested `--cwd` is honored for both the empty-window and non-empty-window tab paths
- [x] Regression test: `spawn_pane_tab_anchors_to_from_pane_window_not_active`
- [x] `cargo test --bin plexi` green (1450 passed)