### PR TITLE
feat(cli): plexi host start — CLI-driven host launch with declarative boot state

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1775,6 +1775,15 @@ impl PlexiApp {
                 // in flight and queued work (spawn-queue, channels) drains.
                 log::debug!("pane_ipc: kind=wake (no-op)");
             }
+            crate::app_protocol::AppRequest::Shutdown => {
+                // Sent by `plexi host stop` over a direct notify.sock
+                // connection. This handler has no `egui::Context`, so it
+                // cannot send ViewportCommand::Close directly — it sets a
+                // flag consumed at the top of the next frame
+                // (`update_preamble`, mirrors `update_quit_pending`).
+                log::info!("pane_ipc: kind=shutdown — closing on next frame");
+                self.shutdown_requested = true;
+            }
             _ => {
                 log::warn!("pane_ipc: unsupported command kind, dropping");
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -361,6 +361,10 @@ pub struct PlexiApp {
     pub(crate) update_available: Option<String>,
     pub(crate) update_quit_pending: bool,
     pub(crate) update_confirm_prompt: bool,
+    /// Set by `AppRequest::Shutdown` (`plexi host stop`'s clean-shutdown
+    /// path). Consumed at the top of the next frame in `update_preamble`,
+    /// which sends `ViewportCommand::Close`. Mirrors `update_quit_pending`.
+    pub(crate) shutdown_requested: bool,
     /// Receiver for AppRequests sent over the PLEXI_SOCKET Unix socket listener.
     /// Drained each frame in `drain_pane_cmd_channel`.
     pane_ipc_rx: std::sync::mpsc::Receiver<crate::app_protocol::AppRequest>,
@@ -1207,6 +1211,7 @@ impl PlexiApp {
                     update_available: None,
                     update_quit_pending: false,
                     update_confirm_prompt: false,
+                    shutdown_requested: false,
                     pane_ipc_rx,
                     host_subscriptions,
                     event_subscribe_rx,
@@ -1453,6 +1458,7 @@ impl PlexiApp {
             update_available: None,
             update_quit_pending: false,
             update_confirm_prompt: false,
+            shutdown_requested: false,
             pane_ipc_rx,
             host_subscriptions,
             event_subscribe_rx,
@@ -1674,6 +1680,7 @@ impl PlexiApp {
                 update_available: None,
                 update_quit_pending: false,
                 update_confirm_prompt: false,
+                shutdown_requested: false,
                 pane_ipc_rx,
                 host_subscriptions,
                 event_subscribe_rx,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -71,6 +71,13 @@ impl PlexiApp {
             }
         }
         self.drain_pane_cmd_channel();
+        if self.shutdown_requested {
+            // `plexi host stop`'s clean-shutdown path (AppRequest::Shutdown).
+            // Save state before closing so the next `host start` restores it.
+            log::info!("host: shutdown requested — saving workspace and closing");
+            self.save_workspace();
+            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+        }
         if let Some(rx) = &self.update_rx {
             if let Ok(version) = rx.try_recv() {
                 log::info!("update check: badge set to v{version}");

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -243,6 +243,17 @@ pub enum Commands {
         #[arg(long = "yes", short = 'y')]
         yes: bool,
     },
+    /// Launch, stop, or check a headless-friendly Plexi host from the CLI.
+    ///
+    /// `host start` launches this channel's app bundle detached from the
+    /// calling shell, optionally seeding panes from a `--layout` TOML file
+    /// or repeated `--pane` flags, then blocks until the host confirms it's
+    /// ready. Works identically on alpha, beta, main, and PR builds — the
+    /// channel is resolved from the running CLI binary's own name.
+    Host {
+        #[command(subcommand)]
+        cmd: HostCmd,
+    },
 
     // ── Hidden ────────────────────────────────────────────────────────────────
     /// Descriptor probe
@@ -727,6 +738,41 @@ pub enum UpdateCmd {
     Apps {
         /// App id to update (omit to update all installed apps)
         id: Option<String>,
+    },
+}
+
+/// `plexi host <cmd>` — CLI-driven host launch with declarative boot state.
+#[derive(Subcommand)]
+pub enum HostCmd {
+    /// Launch this channel's app bundle detached and wait for readiness.
+    ///
+    /// Errors if a host for this channel is already running. Seeds any
+    /// declared panes via the spawn-queue before the app boots, so they
+    /// appear on its first frame.
+    ///
+    /// Example: plexi-pr-2357 host start --pane 'cwd=/tmp,cmd=htop'
+    Start {
+        /// TOML file with `[[pane]]` tables to seed on boot
+        #[arg(long)]
+        layout: Option<String>,
+        /// A pane to seed: 'cwd=<dir>[,cmd=<command>][,tab|window]'. Repeatable.
+        #[arg(long = "pane")]
+        panes: Vec<String>,
+        /// Seconds to wait for the host to confirm readiness (default 15)
+        #[arg(long)]
+        timeout_secs: Option<u64>,
+    },
+    /// Stop the running host for this channel.
+    ///
+    /// Sends a clean shutdown request first, falling back to SIGTERM if the
+    /// host doesn't confirm exit in time.
+    Stop,
+    /// Report whether this channel's host is running, its pid, socket path,
+    /// and pane count.
+    Status {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 }
 

--- a/src/cli/host.rs
+++ b/src/cli/host.rs
@@ -9,9 +9,15 @@
 //! in-pane CLI command.
 //!
 //! `host start` seeds panes via the same spawn-queue directory `plexi open`
-//! and `plexi pane new` use outside a pane (`config_dir().join("spawn-queue")`),
+//! and `plexi pane new` use outside a pane (`host_config_dir(channel).join("spawn-queue")`),
 //! so no new host-side boot protocol is introduced — `drain_spawn_queue()`
 //! picks the seeded panes up on the launched app's first frame.
+//!
+//! All channel-scoped paths here go through `host_config_dir(channel)`, not
+//! `crate::config::config_dir()` — the latter prefers an inherited
+//! `PLEXI_CHANNEL` env var over the running binary's own name, which would
+//! let `host start/stop/status` silently target the wrong channel's profile
+//! when invoked from inside a pane.
 
 use serde::Deserialize;
 use std::io::Write;
@@ -151,6 +157,26 @@ pub(crate) fn filter_child_env(
     env
 }
 
+/// The channel-scoped profile dir (`~/.plexi<-suffix>`) for `channel`, e.g.
+/// `None` → `~/.plexi`, `Some("alpha")` → `~/.plexi-alpha`.
+///
+/// Deliberately does **not** call `crate::config::config_dir()`, which
+/// prefers `PLEXI_CHANNEL` from the environment over the running binary's
+/// own name. `host start/stop/status` can be invoked from inside a pane
+/// (e.g. an agent driving a nested PR-channel test), where the calling
+/// pane's `PLEXI_CHANNEL` would silently redirect every socket/spawn-queue
+/// path to the wrong channel's profile — the exact leak trap this command
+/// exists to eliminate (see root CLAUDE.md Traps: "`PLEXI_CHANNEL` leaks
+/// into app tooling"). This function always derives the profile dir from
+/// `channel`, which callers resolve once via `resolve_channel_paths()`
+/// (binary-basename-only, ignoring env).
+fn host_config_dir(channel: Option<&str>) -> PathBuf {
+    let suffix = channel.map(|c| format!("-{c}")).unwrap_or_default();
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(format!(".plexi{suffix}"))
+}
+
 /// Resolve the app bundle + binary-inside-bundle paths for the *running CLI
 /// binary's own channel* (never `PLEXI_CHANNEL` — that env var is exactly
 /// what must be stripped from the launched child).
@@ -249,10 +275,12 @@ fn poll_response_file(response_file: &str, timeout: Duration) -> Result<String, 
 /// One-shot readiness/pane-count query: connect to `notify.sock`, send
 /// `AppRequest::ListPanes`, and wait up to 5s for the JSON array response.
 /// `None` means either the socket is not reachable (host not running) or the
-/// round trip did not complete in time.
-fn query_ready_status(socket_path: &Path) -> Option<usize> {
+/// round trip did not complete in time. `channel` picks the response-file
+/// directory via `host_config_dir` — never the (possibly env-shadowed)
+/// `config::config_dir()`.
+fn query_ready_status(socket_path: &Path, channel: Option<&str>) -> Option<usize> {
     let mut stream = UnixStream::connect(socket_path).ok()?;
-    let response_file = crate::config::config_dir()
+    let response_file = host_config_dir(channel)
         .join(format!("host-status-{}.json", uuid::Uuid::new_v4()))
         .to_string_lossy()
         .into_owned();
@@ -271,12 +299,12 @@ fn query_ready_status(socket_path: &Path) -> Option<usize> {
 /// Retry `query_ready_status` until it answers or `timeout` elapses. Used
 /// after spawning the bundle process — the socket listener thread may not be
 /// bound yet on the first attempt.
-fn wait_for_ready(socket_path: &Path, timeout: Duration) -> Result<usize, String> {
+fn wait_for_ready(socket_path: &Path, timeout: Duration, channel: Option<&str>) -> Result<usize, String> {
     let start = Instant::now();
     let deadline = start + timeout;
     log::info!("host_start: readiness poll start socket={socket_path:?} timeout={timeout:?}");
     loop {
-        if let Some(count) = query_ready_status(socket_path) {
+        if let Some(count) = query_ready_status(socket_path, channel) {
             log::info!(
                 "host_start: readiness poll end — ready in {:?}, pane_count={count}",
                 start.elapsed()
@@ -355,7 +383,8 @@ pub fn host_start_cli(layout_file: Option<&str>, panes: &[String], timeout_secs:
         }
     };
 
-    let socket_path = crate::config::config_dir().join("notify.sock");
+    let (channel, bundle_path, binary_path) = resolve_channel_paths();
+    let socket_path = host_config_dir(channel.as_deref()).join("notify.sock");
     log::info!("host_start: socket={socket_path:?} pane_count={}", specs.len());
 
     if matches!(probe_notify_socket(&socket_path), RunningState::Running) {
@@ -374,7 +403,6 @@ pub fn host_start_cli(layout_file: Option<&str>, panes: &[String], timeout_secs:
         return 1;
     }
 
-    let (channel, bundle_path, binary_path) = resolve_channel_paths();
     if !bundle_path.exists() {
         log::error!("host_start: bundle not found at {bundle_path:?}");
         eprintln!(
@@ -392,7 +420,7 @@ pub fn host_start_cli(layout_file: Option<&str>, panes: &[String], timeout_secs:
         return 1;
     }
 
-    let queue_dir = crate::config::config_dir().join("spawn-queue");
+    let queue_dir = host_config_dir(channel.as_deref()).join("spawn-queue");
     if let Err(e) = std::fs::create_dir_all(&queue_dir) {
         log::error!("host_start: could not create spawn-queue dir {queue_dir:?}: {e}");
         eprintln!("error: could not create spawn queue: {e}");
@@ -441,7 +469,7 @@ pub fn host_start_cli(layout_file: Option<&str>, panes: &[String], timeout_secs:
     log::info!("host_start: process spawned pid={} detached=true", child.id());
 
     let timeout = Duration::from_secs(timeout_secs.unwrap_or(15));
-    match wait_for_ready(&socket_path, timeout) {
+    match wait_for_ready(&socket_path, timeout, channel.as_deref()) {
         Ok(count) => {
             println!(
                 "Plexi host started (pid {}), {count} pane(s) ready.",
@@ -461,9 +489,10 @@ pub fn host_start_cli(layout_file: Option<&str>, panes: &[String], timeout_secs:
 /// (`AppRequest::Shutdown`), falling back to `kill -TERM <pid>` (pid via
 /// `lsof -t`) if the socket doesn't confirm exit within a short timeout.
 pub fn host_stop_cli() -> i32 {
-    let socket_path = crate::config::config_dir().join("notify.sock");
+    let channel = crate::config::build_channel();
+    let socket_path = host_config_dir(channel.as_deref()).join("notify.sock");
     let pid = detect_pid(&socket_path);
-    log::info!("host_stop: socket={socket_path:?} pid={pid:?}");
+    log::info!("host_stop: channel={channel:?} socket={socket_path:?} pid={pid:?}");
 
     match UnixStream::connect(&socket_path) {
         Ok(mut stream) => {
@@ -554,11 +583,14 @@ pub fn host_stop_cli() -> i32 {
 
 /// `plexi host status [--json]` — ready/not-ready, pane count, pid, socket path.
 pub fn host_status_cli(json: bool) -> i32 {
-    let socket_path = crate::config::config_dir().join("notify.sock");
+    let channel = crate::config::build_channel();
+    let socket_path = host_config_dir(channel.as_deref()).join("notify.sock");
     let pid = detect_pid(&socket_path);
-    let pane_count = query_ready_status(&socket_path);
+    let pane_count = query_ready_status(&socket_path, channel.as_deref());
     let ready = pane_count.is_some();
-    log::info!("host_status: pid={pid:?} socket={socket_path:?} ready={ready} pane_count={pane_count:?}");
+    log::info!(
+        "host_status: channel={channel:?} pid={pid:?} socket={socket_path:?} ready={ready} pane_count={pane_count:?}"
+    );
 
     if json {
         let payload = serde_json::json!({
@@ -745,6 +777,32 @@ mod tests {
             env.iter().all(|(k, _)| k != "PLEXI_CHANNEL"),
             "main channel must never inherit a stale PLEXI_CHANNEL: {env:?}"
         );
+    }
+
+    // ── host_config_dir ─────────────────────────────────────────────────
+
+    #[test]
+    fn host_config_dir_depends_only_on_channel_argument() {
+        // Regression for a P1 found in Codex review of stint 0342: host
+        // start/stop/status must resolve their profile dir from the
+        // resolved binary channel only, never from an inherited
+        // PLEXI_CHANNEL env var (e.g. when run from inside a
+        // differently-channeled pane). Unlike `config::config_dir()`,
+        // `host_config_dir` reads no environment or global state at all —
+        // calling it twice with the same argument from concurrent test
+        // threads (this suite runs threaded) must always agree, which
+        // would not hold if it consulted process env underneath.
+        assert_eq!(host_config_dir(Some("alpha")), host_config_dir(Some("alpha")));
+        assert!(
+            host_config_dir(Some("alpha")).ends_with(".plexi-alpha"),
+            "expected .plexi-alpha profile dir"
+        );
+    }
+
+    #[test]
+    fn host_config_dir_main_channel_has_no_suffix() {
+        let dir = host_config_dir(None);
+        assert!(dir.ends_with(".plexi"), "expected .plexi profile dir, got {dir:?}");
     }
 
     // ── collect_pane_specs ordering ───────────────────────────────────────

--- a/src/cli/host.rs
+++ b/src/cli/host.rs
@@ -324,7 +324,7 @@ fn wait_for_ready(socket_path: &Path, timeout: Duration, channel: Option<&str>) 
 /// Write one spawn-queue JSON file for `spec`, matching the schema
 /// `open.rs`'s fallback (no-`PLEXI_SOCKET`) spawn path writes and
 /// `drain_spawn_queue` reads: `type_id`, `args`, `layout`, `cwd`.
-fn seed_pane(queue_dir: &Path, index: usize, spec: &PaneSpec) -> Result<(), String> {
+fn seed_pane(queue_dir: &Path, index: usize, spec: &PaneSpec) -> Result<PathBuf, String> {
     let layout = placement_to_layout(spec)?;
     let args: Vec<String> = spec.cmd.clone().into_iter().collect();
     let payload = serde_json::json!({
@@ -345,7 +345,7 @@ fn seed_pane(queue_dir: &Path, index: usize, spec: &PaneSpec) -> Result<(), Stri
         spec.cwd,
         spec.cmd.is_some()
     );
-    Ok(())
+    Ok(file)
 }
 
 /// Collect the ordered pane list from `--layout <file>` (its `[[pane]]`
@@ -382,6 +382,19 @@ pub fn host_start_cli(layout_file: Option<&str>, panes: &[String], timeout_secs:
             return 1;
         }
     };
+    // Validate every spec's placement before writing anything to the
+    // spawn-queue. Codex review (attempt 1 fix) flagged that writing specs
+    // one at a time let an earlier valid pane's JSON file survive a later
+    // spec's validation failure — the next unrelated `host start` (or any
+    // `plexi` launch) would then drain and open that stale, half-seeded
+    // layout. Fail the whole batch atomically instead.
+    for spec in &specs {
+        if let Err(e) = placement_to_layout(spec) {
+            log::error!("host_start: {e}");
+            eprintln!("error: {e}");
+            return 1;
+        }
+    }
 
     let (channel, bundle_path, binary_path) = resolve_channel_paths();
     let socket_path = host_config_dir(channel.as_deref()).join("notify.sock");
@@ -426,11 +439,18 @@ pub fn host_start_cli(layout_file: Option<&str>, panes: &[String], timeout_secs:
         eprintln!("error: could not create spawn queue: {e}");
         return 1;
     }
+    let mut seeded_files = Vec::with_capacity(specs.len());
     for (i, spec) in specs.iter().enumerate() {
-        if let Err(e) = seed_pane(&queue_dir, i, spec) {
-            log::error!("host_start: {e}");
-            eprintln!("error: {e}");
-            return 1;
+        match seed_pane(&queue_dir, i, spec) {
+            Ok(file) => seeded_files.push(file),
+            Err(e) => {
+                log::error!("host_start: {e} — removing {} already-seeded file(s)", seeded_files.len());
+                for f in &seeded_files {
+                    let _ = std::fs::remove_file(f);
+                }
+                eprintln!("error: {e}");
+                return 1;
+            }
         }
     }
 

--- a/src/cli/host.rs
+++ b/src/cli/host.rs
@@ -1,0 +1,782 @@
+//! `plexi host start/stop/status` — CLI-driven host launch with declarative
+//! boot state (stint 0342).
+//!
+//! Unlike every other command in `src/cli/`, `host start/stop/status` run
+//! *outside* a Plexi pane by definition — there is no running instance yet
+//! to own `PLEXI_SOCKET`. All three talk to the channel's `notify.sock`
+//! directly (same socket `src/app/mod.rs` binds and `nudge_running_instance`
+//! connects to), never through the `PLEXI_SOCKET` env-var path used by every
+//! in-pane CLI command.
+//!
+//! `host start` seeds panes via the same spawn-queue directory `plexi open`
+//! and `plexi pane new` use outside a pane (`config_dir().join("spawn-queue")`),
+//! so no new host-side boot protocol is introduced — `drain_spawn_queue()`
+//! picks the seeded panes up on the launched app's first frame.
+
+use serde::Deserialize;
+use std::io::Write;
+use std::os::unix::net::UnixStream;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+/// One declarative pane to seed on `host start`, either parsed from a
+/// `--pane` flag (`parse_pane_flag`) or a `[[pane]]` table in a `--layout`
+/// TOML file (`LayoutFile`).
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct PaneSpec {
+    pub cwd: Option<String>,
+    pub cmd: Option<String>,
+    pub placement: Option<String>,
+}
+
+/// `--layout <file.toml>` wrapper: one or more `[[pane]]` tables.
+///
+/// Not to be confused with the `[[steps]]` scene format under `src/testing/`
+/// — that is an unrelated format for the in-process headless test harness.
+#[derive(Debug, Deserialize)]
+pub struct LayoutFile {
+    #[serde(default)]
+    pub pane: Vec<PaneSpec>,
+}
+
+/// Parse a `--pane 'cwd=<dir>[,cmd=<command>][,tab|window]'` flag.
+///
+/// Comma-separated `key=value` pairs (`cwd`, `cmd`) plus bare `tab`/`window`
+/// placement tokens. `cwd` is required. Omitting a placement token maps to a
+/// plain split (`"split_h"`) at seed time — see `placement_to_layout`.
+///
+/// Known limitation: this format has no escaping, so a `cmd` value that
+/// itself contains a comma will be split incorrectly. Accepted as a
+/// consequence of the flag format specified for this task; commands needing
+/// commas should go through `--layout` instead, where TOML string values are
+/// unambiguous.
+pub fn parse_pane_flag(s: &str) -> Result<PaneSpec, String> {
+    let mut spec = PaneSpec::default();
+    let mut have_cwd = false;
+    for segment in s.split(',') {
+        let segment = segment.trim();
+        if segment.is_empty() {
+            return Err(format!("malformed --pane spec {s:?}: empty segment"));
+        }
+        if let Some((key, value)) = segment.split_once('=') {
+            match key.trim() {
+                "cwd" => {
+                    if have_cwd {
+                        return Err(format!("malformed --pane spec {s:?}: duplicate cwd"));
+                    }
+                    spec.cwd = Some(value.to_string());
+                    have_cwd = true;
+                }
+                "cmd" => {
+                    if spec.cmd.is_some() {
+                        return Err(format!("malformed --pane spec {s:?}: duplicate cmd"));
+                    }
+                    spec.cmd = Some(value.to_string());
+                }
+                other => {
+                    return Err(format!(
+                        "malformed --pane spec {s:?}: unknown key {other:?} (expected cwd or cmd)"
+                    ));
+                }
+            }
+        } else {
+            match segment {
+                "tab" | "window" => {
+                    if spec.placement.is_some() {
+                        return Err(format!(
+                            "malformed --pane spec {s:?}: duplicate placement token"
+                        ));
+                    }
+                    spec.placement = Some(segment.to_string());
+                }
+                other => {
+                    return Err(format!(
+                        "malformed --pane spec {s:?}: unrecognized token {other:?} \
+                         (expected key=value or tab/window)"
+                    ));
+                }
+            }
+        }
+    }
+    if !have_cwd {
+        return Err(format!("malformed --pane spec {s:?}: cwd=<dir> is required"));
+    }
+    Ok(spec)
+}
+
+/// Maps `PaneSpec.placement` to the `"layout"` field values already
+/// understood by `drain_spawn_queue`/`PaneLaunchSpec::from_spawn_pane`.
+fn placement_to_layout(spec: &PaneSpec) -> Result<&'static str, String> {
+    match spec.placement.as_deref() {
+        None => Ok("split_h"),
+        Some("tab") => Ok("tab"),
+        Some("window") => Ok("new_window"),
+        Some(other) => Err(format!(
+            "invalid pane placement {other:?}: expected \"tab\" or \"window\" (omit for default split)"
+        )),
+    }
+}
+
+/// The five pane/context-scoped `PLEXI_*` vars that must never leak into a
+/// `host start`-launched process — reading them to decide what to launch
+/// would reintroduce the exact channel-leak trap this command exists to
+/// eliminate (see root CLAUDE.md Traps: "`PLEXI_CHANNEL` leaks into app
+/// tooling"). `PLEXI_CHANNEL` itself is stripped unconditionally too, then
+/// re-added explicitly from the resolved channel — never inherited.
+const STRIP_VARS: &[&str] = &[
+    "PLEXI_SOCKET",
+    "PLEXI_PANE_ID",
+    "PLEXI_CONTEXT_ID",
+    "PLEXI_CONTEXT_ROOT",
+    "PLEXI_RUNNING",
+    "PLEXI_CHANNEL",
+];
+
+/// Pure env-filter used to build the launched child's environment. Takes the
+/// parent env as a plain `Vec` (rather than reading `std::env::vars()`
+/// directly) so it is deterministically testable without mutating real
+/// process env — mirrors `src/process_app/tests/env_isolation_tests.rs`.
+pub(crate) fn filter_child_env(
+    parent_env: Vec<(String, String)>,
+    channel: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut env: Vec<(String, String)> = parent_env
+        .into_iter()
+        .filter(|(k, _)| !STRIP_VARS.contains(&k.as_str()))
+        .collect();
+    if let Some(c) = channel {
+        env.push(("PLEXI_CHANNEL".to_string(), c.to_string()));
+    }
+    env
+}
+
+/// Resolve the app bundle + binary-inside-bundle paths for the *running CLI
+/// binary's own channel* (never `PLEXI_CHANNEL` — that env var is exactly
+/// what must be stripped from the launched child).
+fn resolve_channel_paths() -> (Option<String>, PathBuf, PathBuf) {
+    let channel = crate::config::build_channel();
+    let cap = crate::cli::install::channel_bundle_cap(channel.as_deref());
+    let bundle_path = PathBuf::from(format!("/Applications/Plexi{cap}.app"));
+    let suffix = channel
+        .as_deref()
+        .map(|c| format!("-{c}"))
+        .unwrap_or_default();
+    let binary_path = bundle_path
+        .join("Contents/MacOS")
+        .join(format!("plexi{suffix}"));
+    log::info!(
+        "host: resolved channel={channel:?} cap={cap:?} bundle={bundle_path:?} binary={binary_path:?}"
+    );
+    (channel, bundle_path, binary_path)
+}
+
+/// Best-effort pid lookup for the process holding `notify.sock` open. No
+/// pid-file mechanism exists anywhere in this codebase (confirmed: `src/app/`
+/// and `src/config/` have no precedent), so this shells out to `lsof -t` as a
+/// diagnostic only — failure here never blocks the caller, it just means pid
+/// is reported as unknown.
+fn detect_pid(socket_path: &Path) -> Option<u32> {
+    match std::process::Command::new("lsof")
+        .arg("-t")
+        .arg(socket_path)
+        .output()
+    {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .next()
+            .and_then(|l| l.trim().parse::<u32>().ok()),
+        Ok(out) => {
+            log::debug!("host: lsof found no owner for {socket_path:?} (status {:?})", out.status);
+            None
+        }
+        Err(e) => {
+            log::warn!("host: lsof unavailable ({e}) — pid unknown for {socket_path:?}");
+            None
+        }
+    }
+}
+
+enum RunningState {
+    Running,
+    NotRunning,
+}
+
+/// Probe whether a host for this channel is already up. Reuses the same
+/// stale-socket cleanup idiom as `src/cli/mod.rs`'s `send_to_socket`:
+/// `ConnectionRefused` means the socket file is stale (owning process died
+/// without cleanup) — remove it and treat as not-running.
+fn probe_notify_socket(socket_path: &Path) -> RunningState {
+    match UnixStream::connect(socket_path) {
+        Ok(_) => RunningState::Running,
+        Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+            log::info!("host: stale socket at {socket_path:?} (connection refused) — removing");
+            let _ = std::fs::remove_file(socket_path);
+            RunningState::NotRunning
+        }
+        Err(e) => {
+            log::info!(
+                "host: notify.sock not reachable at {socket_path:?}: {e} — treating as not running"
+            );
+            RunningState::NotRunning
+        }
+    }
+}
+
+/// Poll a response file until it appears or `timeout` elapses. Distinct from
+/// (but structurally identical to) `open.rs`'s `wait_for_response`: this
+/// variant returns the raw content instead of printing it, and takes a
+/// caller-supplied timeout instead of a fixed 5s — `host start` needs a
+/// longer, configurable boot timeout, and `host status`/`host stop` need the
+/// parsed pane count rather than `wait_for_response`'s stdout side effect.
+fn poll_response_file(response_file: &str, timeout: Duration) -> Result<String, String> {
+    let path = PathBuf::from(response_file);
+    let deadline = Instant::now() + timeout;
+    loop {
+        if path.exists() {
+            let content = std::fs::read_to_string(&path)
+                .map_err(|e| format!("could not read response file {path:?}: {e}"))?;
+            let _ = std::fs::remove_file(&path);
+            return Ok(content);
+        }
+        if Instant::now() >= deadline {
+            return Err(format!("timed out after {timeout:?} waiting for {path:?}"));
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+/// One-shot readiness/pane-count query: connect to `notify.sock`, send
+/// `AppRequest::ListPanes`, and wait up to 5s for the JSON array response.
+/// `None` means either the socket is not reachable (host not running) or the
+/// round trip did not complete in time.
+fn query_ready_status(socket_path: &Path) -> Option<usize> {
+    let mut stream = UnixStream::connect(socket_path).ok()?;
+    let response_file = crate::config::config_dir()
+        .join(format!("host-status-{}.json", uuid::Uuid::new_v4()))
+        .to_string_lossy()
+        .into_owned();
+    let request = crate::app_protocol::AppRequest::ListPanes {
+        response_file: response_file.clone(),
+        context_id: None,
+    };
+    let line = serde_json::to_string(&request).ok()?;
+    stream.write_all(format!("{line}\n").as_bytes()).ok()?;
+    let content = poll_response_file(&response_file, Duration::from_secs(5)).ok()?;
+    serde_json::from_str::<Vec<serde_json::Value>>(&content)
+        .ok()
+        .map(|v| v.len())
+}
+
+/// Retry `query_ready_status` until it answers or `timeout` elapses. Used
+/// after spawning the bundle process — the socket listener thread may not be
+/// bound yet on the first attempt.
+fn wait_for_ready(socket_path: &Path, timeout: Duration) -> Result<usize, String> {
+    let start = Instant::now();
+    let deadline = start + timeout;
+    log::info!("host_start: readiness poll start socket={socket_path:?} timeout={timeout:?}");
+    loop {
+        if let Some(count) = query_ready_status(socket_path) {
+            log::info!(
+                "host_start: readiness poll end — ready in {:?}, pane_count={count}",
+                start.elapsed()
+            );
+            return Ok(count);
+        }
+        if Instant::now() >= deadline {
+            log::error!("host_start: readiness poll end — timeout after {:?}", start.elapsed());
+            return Err(format!(
+                "timed out after {timeout:?} waiting for Plexi host to become ready"
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
+/// Write one spawn-queue JSON file for `spec`, matching the schema
+/// `open.rs`'s fallback (no-`PLEXI_SOCKET`) spawn path writes and
+/// `drain_spawn_queue` reads: `type_id`, `args`, `layout`, `cwd`.
+fn seed_pane(queue_dir: &Path, index: usize, spec: &PaneSpec) -> Result<(), String> {
+    let layout = placement_to_layout(spec)?;
+    let args: Vec<String> = spec.cmd.clone().into_iter().collect();
+    let payload = serde_json::json!({
+        "type_id": "terminal",
+        "args": args,
+        "layout": layout,
+        "cwd": spec.cwd,
+    });
+    let id = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let file = queue_dir.join(format!("{id}-{index}.json"));
+    std::fs::write(&file, payload.to_string())
+        .map_err(|e| format!("could not write spawn-queue file {file:?}: {e}"))?;
+    log::info!(
+        "host_start: seeded pane index={index} type_id=terminal cwd={:?} cmd_present={} placement={layout}",
+        spec.cwd,
+        spec.cmd.is_some()
+    );
+    Ok(())
+}
+
+/// Collect the ordered pane list from `--layout <file>` (its `[[pane]]`
+/// tables first) followed by repeated `--pane` flags in the order given on
+/// the command line.
+fn collect_pane_specs(layout_file: Option<&str>, panes: &[String]) -> Result<Vec<PaneSpec>, String> {
+    let mut specs = Vec::new();
+    if let Some(path) = layout_file {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("could not read layout file {path:?}: {e}"))?;
+        let layout: LayoutFile = toml::from_str(&content)
+            .map_err(|e| format!("could not parse layout file {path:?}: {e}"))?;
+        specs.extend(layout.pane);
+    }
+    for raw in panes {
+        specs.push(parse_pane_flag(raw)?);
+    }
+    Ok(specs)
+}
+
+/// `plexi host start [--layout <file>] [--pane <spec>]... [--timeout-secs <n>]`
+///
+/// Launches this channel's app bundle detached (survives the CLI process
+/// exiting), seeds any declared panes via the spawn-queue before launch, and
+/// blocks until a `notify.sock` round trip confirms the host is ready (or the
+/// timeout elapses). Errors non-zero if a host for this channel is already
+/// running.
+pub fn host_start_cli(layout_file: Option<&str>, panes: &[String], timeout_secs: Option<u64>) -> i32 {
+    let specs = match collect_pane_specs(layout_file, panes) {
+        Ok(s) => s,
+        Err(e) => {
+            log::error!("host_start: {e}");
+            eprintln!("error: {e}");
+            return 1;
+        }
+    };
+
+    let socket_path = crate::config::config_dir().join("notify.sock");
+    log::info!("host_start: socket={socket_path:?} pane_count={}", specs.len());
+
+    if matches!(probe_notify_socket(&socket_path), RunningState::Running) {
+        let pid = detect_pid(&socket_path);
+        log::warn!("host_start: already running — pid={pid:?} socket={socket_path:?}");
+        match pid {
+            Some(p) => eprintln!(
+                "error: a Plexi host for this channel is already running (pid {p}, socket {})",
+                socket_path.display()
+            ),
+            None => eprintln!(
+                "error: a Plexi host for this channel is already running (pid unknown, socket {})",
+                socket_path.display()
+            ),
+        }
+        return 1;
+    }
+
+    let (channel, bundle_path, binary_path) = resolve_channel_paths();
+    if !bundle_path.exists() {
+        log::error!("host_start: bundle not found at {bundle_path:?}");
+        eprintln!(
+            "error: Plexi is not installed for this channel (expected {})",
+            bundle_path.display()
+        );
+        return 1;
+    }
+    if !binary_path.exists() {
+        log::error!("host_start: binary not found at {binary_path:?}");
+        eprintln!(
+            "error: Plexi binary missing inside bundle (expected {})",
+            binary_path.display()
+        );
+        return 1;
+    }
+
+    let queue_dir = crate::config::config_dir().join("spawn-queue");
+    if let Err(e) = std::fs::create_dir_all(&queue_dir) {
+        log::error!("host_start: could not create spawn-queue dir {queue_dir:?}: {e}");
+        eprintln!("error: could not create spawn queue: {e}");
+        return 1;
+    }
+    for (i, spec) in specs.iter().enumerate() {
+        if let Err(e) = seed_pane(&queue_dir, i, spec) {
+            log::error!("host_start: {e}");
+            eprintln!("error: {e}");
+            return 1;
+        }
+    }
+
+    let child_env = filter_child_env(std::env::vars().collect(), channel.as_deref());
+    log::info!(
+        "host_start: child env constructed — {} vars retained, PLEXI_CHANNEL={:?}",
+        child_env.len(),
+        channel
+    );
+
+    let mut cmd = std::process::Command::new(&binary_path);
+    cmd.env_clear()
+        .envs(child_env)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+    // SAFETY: the pre_exec closure only calls libc::setsid(), an
+    // async-signal-safe syscall, between fork and exec — no allocation, no
+    // locking, no access to the parent's heap state.
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            log::error!("host_start: spawn failed for {binary_path:?}: {e}");
+            eprintln!("error: could not launch Plexi: {e}");
+            return 1;
+        }
+    };
+    log::info!("host_start: process spawned pid={} detached=true", child.id());
+
+    let timeout = Duration::from_secs(timeout_secs.unwrap_or(15));
+    match wait_for_ready(&socket_path, timeout) {
+        Ok(count) => {
+            println!(
+                "Plexi host started (pid {}), {count} pane(s) ready.",
+                child.id()
+            );
+            0
+        }
+        Err(e) => {
+            log::error!("host_start: {e}");
+            eprintln!("error: {e}");
+            1
+        }
+    }
+}
+
+/// `plexi host stop` — clean shutdown request over `notify.sock` first
+/// (`AppRequest::Shutdown`), falling back to `kill -TERM <pid>` (pid via
+/// `lsof -t`) if the socket doesn't confirm exit within a short timeout.
+pub fn host_stop_cli() -> i32 {
+    let socket_path = crate::config::config_dir().join("notify.sock");
+    let pid = detect_pid(&socket_path);
+    log::info!("host_stop: socket={socket_path:?} pid={pid:?}");
+
+    match UnixStream::connect(&socket_path) {
+        Ok(mut stream) => {
+            let payload = serde_json::to_string(&crate::app_protocol::AppRequest::Shutdown)
+                .unwrap_or_else(|_| "{\"type\":\"shutdown\"}".to_string());
+            match stream.write_all(format!("{payload}\n").as_bytes()) {
+                Ok(()) => {
+                    log::info!("host_stop: shutdown request sent, waiting for process exit");
+                    // The socket *file* is only unlinked by the next process's
+                    // startup cleanup (`spawn_socket_listener` in src/app/mod.rs),
+                    // never on exit — so `socket_path.exists()` never turns false
+                    // here and cannot be used as an exit signal. Instead, poll a
+                    // fresh connect attempt: once the listening process has
+                    // actually exited, the OS answers new connects to the
+                    // now-unheld socket path with `ConnectionRefused` (the same
+                    // stale-socket idiom `probe_notify_socket` uses).
+                    let deadline = Instant::now() + Duration::from_secs(5);
+                    loop {
+                        match UnixStream::connect(&socket_path) {
+                            Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+                                log::info!(
+                                    "host_stop: method=socket pid={pid:?} — clean shutdown confirmed"
+                                );
+                                let _ = std::fs::remove_file(&socket_path);
+                                println!("Plexi host stopped (clean shutdown).");
+                                return 0;
+                            }
+                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                                log::info!(
+                                    "host_stop: method=socket pid={pid:?} — clean shutdown confirmed (socket removed)"
+                                );
+                                println!("Plexi host stopped (clean shutdown).");
+                                return 0;
+                            }
+                            _ => {
+                                // Still connectable (or a transient error) — host
+                                // hasn't exited yet, keep polling.
+                            }
+                        }
+                        if Instant::now() >= deadline {
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(200));
+                    }
+                    log::warn!(
+                        "host_stop: clean shutdown did not complete within timeout — falling back to SIGTERM"
+                    );
+                }
+                Err(e) => {
+                    log::error!("host_stop: could not send shutdown request: {e} — falling back to SIGTERM");
+                }
+            }
+        }
+        Err(e) => {
+            log::warn!(
+                "host_stop: could not connect to {socket_path:?}: {e} — falling back to SIGTERM"
+            );
+        }
+    }
+
+    let Some(pid) = pid else {
+        log::error!("host_stop: no host running for this channel (no pid, socket {socket_path:?})");
+        eprintln!("error: no Plexi host is running for this channel");
+        return 1;
+    };
+    match std::process::Command::new("kill")
+        .arg("-TERM")
+        .arg(pid.to_string())
+        .status()
+    {
+        Ok(status) if status.success() => {
+            log::info!("host_stop: method=sigterm pid={pid}");
+            println!("Plexi host stopped (SIGTERM sent to pid {pid}).");
+            0
+        }
+        Ok(status) => {
+            log::error!("host_stop: kill -TERM pid={pid} failed with status {status:?}");
+            eprintln!("error: could not stop process {pid} (kill exited with {status:?})");
+            1
+        }
+        Err(e) => {
+            log::error!("host_stop: could not run kill -TERM pid={pid}: {e}");
+            eprintln!("error: could not run kill: {e}");
+            1
+        }
+    }
+}
+
+/// `plexi host status [--json]` — ready/not-ready, pane count, pid, socket path.
+pub fn host_status_cli(json: bool) -> i32 {
+    let socket_path = crate::config::config_dir().join("notify.sock");
+    let pid = detect_pid(&socket_path);
+    let pane_count = query_ready_status(&socket_path);
+    let ready = pane_count.is_some();
+    log::info!("host_status: pid={pid:?} socket={socket_path:?} ready={ready} pane_count={pane_count:?}");
+
+    if json {
+        let payload = serde_json::json!({
+            "ready": ready,
+            "pane_count": pane_count,
+            "pid": pid,
+            "socket": socket_path.to_string_lossy(),
+        });
+        println!("{payload}");
+    } else if ready {
+        println!(
+            "Plexi host is running (pid {}), {} pane(s), socket {}",
+            pid.map(|p| p.to_string()).unwrap_or_else(|| "unknown".to_string()),
+            pane_count.unwrap_or(0),
+            socket_path.display()
+        );
+    } else {
+        println!("Plexi host is not running (socket {})", socket_path.display());
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── parse_pane_flag ─────────────────────────────────────────────────
+
+    #[test]
+    fn parse_pane_flag_cwd_only() {
+        let spec = parse_pane_flag("cwd=/tmp").expect("valid spec");
+        assert_eq!(
+            spec,
+            PaneSpec {
+                cwd: Some("/tmp".to_string()),
+                cmd: None,
+                placement: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_pane_flag_cwd_and_cmd() {
+        let spec = parse_pane_flag("cwd=/tmp,cmd=htop").expect("valid spec");
+        assert_eq!(spec.cwd, Some("/tmp".to_string()));
+        assert_eq!(spec.cmd, Some("htop".to_string()));
+        assert_eq!(spec.placement, None);
+    }
+
+    #[test]
+    fn parse_pane_flag_tab_placement() {
+        let spec = parse_pane_flag("cwd=/tmp,tab").expect("valid spec");
+        assert_eq!(spec.placement, Some("tab".to_string()));
+    }
+
+    #[test]
+    fn parse_pane_flag_window_placement() {
+        let spec = parse_pane_flag("cwd=/tmp,cmd=top,window").expect("valid spec");
+        assert_eq!(spec.placement, Some("window".to_string()));
+        assert_eq!(spec.cmd, Some("top".to_string()));
+    }
+
+    #[test]
+    fn parse_pane_flag_errors_on_missing_cwd() {
+        let err = parse_pane_flag("cmd=htop").unwrap_err();
+        assert!(err.contains("cwd"), "error should mention missing cwd: {err}");
+    }
+
+    #[test]
+    fn parse_pane_flag_errors_on_unknown_key() {
+        let err = parse_pane_flag("cwd=/tmp,bogus=1").unwrap_err();
+        assert!(err.contains("bogus"), "error should name the bad key: {err}");
+    }
+
+    #[test]
+    fn parse_pane_flag_errors_on_unrecognized_token() {
+        let err = parse_pane_flag("cwd=/tmp,overlay").unwrap_err();
+        assert!(err.contains("overlay"), "error should name the bad token: {err}");
+    }
+
+    #[test]
+    fn parse_pane_flag_errors_on_empty_string() {
+        assert!(parse_pane_flag("").is_err());
+    }
+
+    #[test]
+    fn parse_pane_flag_errors_on_duplicate_cwd() {
+        assert!(parse_pane_flag("cwd=/tmp,cwd=/other").is_err());
+    }
+
+    // ── PaneSpec / LayoutFile TOML deserialization ─────────────────────
+
+    #[test]
+    fn layout_file_parses_multiple_pane_tables() {
+        let toml_src = r#"
+            [[pane]]
+            cwd = "/tmp"
+            cmd = "htop"
+
+            [[pane]]
+            cwd = "/tmp/two"
+            placement = "tab"
+        "#;
+        let layout: LayoutFile = toml::from_str(toml_src).expect("valid layout toml");
+        assert_eq!(layout.pane.len(), 2);
+        assert_eq!(layout.pane[0].cwd, Some("/tmp".to_string()));
+        assert_eq!(layout.pane[0].cmd, Some("htop".to_string()));
+        assert_eq!(layout.pane[1].placement, Some("tab".to_string()));
+    }
+
+    #[test]
+    fn layout_file_defaults_to_empty_pane_list() {
+        let layout: LayoutFile = toml::from_str("").expect("empty layout toml is valid");
+        assert!(layout.pane.is_empty());
+    }
+
+    #[test]
+    fn pane_spec_placement_omitted_is_none() {
+        let toml_src = r#"cwd = "/tmp""#;
+        let spec: PaneSpec = toml::from_str(toml_src).expect("valid pane toml");
+        assert_eq!(spec.placement, None);
+    }
+
+    // ── placement_to_layout ─────────────────────────────────────────────
+
+    #[test]
+    fn placement_to_layout_defaults_to_split_h() {
+        let spec = PaneSpec::default();
+        assert_eq!(placement_to_layout(&spec).unwrap(), "split_h");
+    }
+
+    #[test]
+    fn placement_to_layout_maps_tab_and_window() {
+        let tab = PaneSpec {
+            placement: Some("tab".to_string()),
+            ..Default::default()
+        };
+        let window = PaneSpec {
+            placement: Some("window".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(placement_to_layout(&tab).unwrap(), "tab");
+        assert_eq!(placement_to_layout(&window).unwrap(), "new_window");
+    }
+
+    #[test]
+    fn placement_to_layout_rejects_unknown_value() {
+        let spec = PaneSpec {
+            placement: Some("overlay".to_string()),
+            ..Default::default()
+        };
+        assert!(placement_to_layout(&spec).is_err());
+    }
+
+    // ── filter_child_env ─────────────────────────────────────────────────
+
+    #[test]
+    fn filter_child_env_strips_pane_scoped_vars_and_sets_channel() {
+        let parent = vec![
+            ("PLEXI_SOCKET".to_string(), "/tmp/x.sock".to_string()),
+            ("PLEXI_PANE_ID".to_string(), "7".to_string()),
+            ("PLEXI_CONTEXT_ID".to_string(), "3".to_string()),
+            ("PLEXI_CONTEXT_ROOT".to_string(), "/tmp".to_string()),
+            ("PLEXI_RUNNING".to_string(), "1".to_string()),
+            ("PLEXI_CHANNEL".to_string(), "beta".to_string()), // must be overridden, not inherited
+            ("PATH".to_string(), "/usr/bin".to_string()),
+        ];
+        let env = filter_child_env(parent, Some("alpha"));
+        let map: std::collections::HashMap<_, _> = env.into_iter().collect();
+        assert_eq!(map.get("PLEXI_SOCKET"), None);
+        assert_eq!(map.get("PLEXI_PANE_ID"), None);
+        assert_eq!(map.get("PLEXI_CONTEXT_ID"), None);
+        assert_eq!(map.get("PLEXI_CONTEXT_ROOT"), None);
+        assert_eq!(map.get("PLEXI_RUNNING"), None);
+        assert_eq!(map.get("PLEXI_CHANNEL"), Some(&"alpha".to_string()));
+        assert_eq!(map.get("PATH"), Some(&"/usr/bin".to_string()));
+    }
+
+    #[test]
+    fn filter_child_env_leaves_channel_unset_for_main() {
+        let parent = vec![("PLEXI_CHANNEL".to_string(), "beta".to_string())];
+        let env = filter_child_env(parent, None);
+        assert!(
+            env.iter().all(|(k, _)| k != "PLEXI_CHANNEL"),
+            "main channel must never inherit a stale PLEXI_CHANNEL: {env:?}"
+        );
+    }
+
+    // ── collect_pane_specs ordering ───────────────────────────────────────
+
+    #[test]
+    fn collect_pane_specs_layout_file_before_cli_panes() {
+        let dir = std::env::temp_dir().join(format!("plexi-host-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let layout_path = dir.join("layout.toml");
+        std::fs::write(&layout_path, "[[pane]]\ncwd = \"/from/layout\"\n").unwrap();
+
+        let panes = vec!["cwd=/from/flag".to_string()];
+        let specs = collect_pane_specs(Some(layout_path.to_str().unwrap()), &panes)
+            .expect("valid combined specs");
+
+        assert_eq!(specs.len(), 2);
+        assert_eq!(specs[0].cwd, Some("/from/layout".to_string()));
+        assert_eq!(specs[1].cwd, Some("/from/flag".to_string()));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn collect_pane_specs_errors_on_malformed_layout_toml() {
+        let dir = std::env::temp_dir().join(format!("plexi-host-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let layout_path = dir.join("bad.toml");
+        std::fs::write(&layout_path, "not valid toml [[[").unwrap();
+
+        let err = collect_pane_specs(Some(layout_path.to_str().unwrap()), &[]).unwrap_err();
+        assert!(err.contains("could not parse layout file"), "got: {err}");
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -276,6 +276,43 @@ pub fn install_workspace_pack_cli() -> i32 {
     }
 }
 
+/// Maps a release channel (as returned by `config::build_channel()`, e.g.
+/// `None` for the main channel, `Some("alpha")`, `Some("pr-2357")`, or an
+/// arbitrary named channel) to the capitalized bundle-name suffix used for
+/// `/Applications/Plexi<cap>.app`.
+///
+/// `None` → `""`, `Some("alpha")` → `" Alpha"`, `Some("beta")` → `" Beta"`,
+/// `Some("pr-2357")` → `" PR2357"`, `Some("foo")` → `" Foo"` (title-cased).
+///
+/// Single source of truth for this mapping — previously duplicated inline in
+/// `plexi_uninstall_cli` (this file) and `scripts/channel-clean.sh`. Both the
+/// uninstaller and `plexi host start/stop/status` (`src/cli/host.rs`) call
+/// this so the bundle path resolution never drifts between the two.
+pub(crate) fn channel_bundle_cap(channel: Option<&str>) -> String {
+    match channel {
+        None => String::new(),
+        Some(c) => {
+            if let Some(n) = c.strip_prefix("pr-") {
+                format!(" PR{n}")
+            } else {
+                match c {
+                    "alpha" => " Alpha".to_string(),
+                    "beta" => " Beta".to_string(),
+                    other => {
+                        let mut chars = other.chars();
+                        match chars.next() {
+                            Some(first) => {
+                                format!(" {}{}", first.to_uppercase(), chars.as_str())
+                            }
+                            None => String::new(),
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// `plexi uninstall [--keep-data] [--yes]` — remove Plexi itself from the Mac.
 pub fn plexi_uninstall_cli(keep_data: bool, assume_yes: bool) -> i32 {
     // Detect channel suffix from binary name (e.g. "plexi-alpha" → "-alpha", "plexi" → "")
@@ -290,15 +327,8 @@ pub fn plexi_uninstall_cli(keep_data: bool, assume_yes: bool) -> i32 {
     } else {
         binary_name.strip_prefix("plexi").unwrap_or("").to_string()
     };
-    let cap_owned = if let Some(n) = suffix.strip_prefix("-pr-") {
-        format!(" PR{n}")
-    } else {
-        match suffix.as_str() {
-            "-alpha" => " Alpha".to_string(),
-            "-beta" => " Beta".to_string(),
-            _ => String::new(),
-        }
-    };
+    let channel = suffix.strip_prefix('-').filter(|s| !s.is_empty());
+    let cap_owned = channel_bundle_cap(channel);
     let cap = cap_owned.as_str();
 
     let profile_dir = dirs::home_dir().unwrap().join(format!(".plexi{suffix}"));
@@ -719,5 +749,36 @@ pub fn self_update_cli() -> i32 {
             eprintln!("{msg}");
             1
         }
+    }
+}
+
+#[cfg(test)]
+mod channel_bundle_cap_tests {
+    use super::channel_bundle_cap;
+
+    #[test]
+    fn main_channel_has_no_cap() {
+        assert_eq!(channel_bundle_cap(None), "");
+    }
+
+    #[test]
+    fn alpha_channel() {
+        assert_eq!(channel_bundle_cap(Some("alpha")), " Alpha");
+    }
+
+    #[test]
+    fn beta_channel() {
+        assert_eq!(channel_bundle_cap(Some("beta")), " Beta");
+    }
+
+    #[test]
+    fn pr_channel() {
+        assert_eq!(channel_bundle_cap(Some("pr-2357")), " PR2357");
+    }
+
+    #[test]
+    fn arbitrary_named_channel_is_title_cased() {
+        assert_eq!(channel_bundle_cap(Some("gpui")), " Gpui");
+        assert_eq!(channel_bundle_cap(Some("foo")), " Foo");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -216,6 +216,7 @@ pub mod demo;
 pub mod descriptor;
 pub mod doctor;
 pub mod events;
+pub mod host;
 pub mod install;
 pub mod install_host;
 pub mod list;
@@ -330,6 +331,7 @@ pub use context_cli::{
 pub use demo::demo_cli;
 pub use events::{events_list_cli, events_mcp_config_cli, events_subscribe_cli};
 pub use doctor::doctor_cli;
+pub use host::{host_start_cli, host_status_cli, host_stop_cli};
 pub use install::{
     install_cli, install_pack_cli, install_workspace_pack_cli, plexi_uninstall_cli,
     self_update_cli, update_cli,

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -5,7 +5,12 @@ use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
 /// Poll a response file until it appears (or timeout). Shared by all spawn paths.
-fn wait_for_response(response_file: &str) -> i32 {
+///
+/// `pub(super)` so `host.rs` can reference the same convention. `host.rs`'s
+/// own readiness/status polling uses a bespoke variant (`poll_response_file`)
+/// instead — it needs the raw JSON content and a configurable timeout rather
+/// than this function's fixed 5s timeout and print-to-stdout side effect.
+pub(super) fn wait_for_response(response_file: &str) -> i32 {
     let response_path = std::path::PathBuf::from(response_file);
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,8 +218,8 @@ fn main() -> eframe::Result {
         .collect();
     use crate::cli::args::{
         AccountCmd, AgentCmd, AiCmd, AppCmd, Cli, Commands, ConfigCmd, ContextCmd, DescriptorCmd,
-        EventsCmd, HookAction, LicenseCmd, NotesCmd, PaneCmd, PaneSlotCmd, RegistryCmd, RoutineCmd,
-        SecretCmd,
+        EventsCmd, HookAction, HostCmd, LicenseCmd, NotesCmd, PaneCmd, PaneSlotCmd, RegistryCmd,
+        RoutineCmd, SecretCmd,
         UpdateCmd, WorkspaceCmd,
     };
     use clap::Parser;
@@ -612,6 +612,19 @@ fn main() -> eframe::Result {
                             std::process::exit(cli::update_cli(id.as_deref()))
                         }
                         None => std::process::exit(cli::self_update_cli()),
+                    },
+                    Commands::Host { cmd } => match cmd {
+                        HostCmd::Start {
+                            layout,
+                            panes,
+                            timeout_secs,
+                        } => std::process::exit(cli::host_start_cli(
+                            layout.as_deref(),
+                            &panes,
+                            timeout_secs,
+                        )),
+                        HostCmd::Stop => std::process::exit(cli::host_stop_cli()),
+                        HostCmd::Status { json } => std::process::exit(cli::host_status_cli(json)),
                     },
                     Commands::Notify {
                         title,

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -31,6 +31,17 @@ impl ProcessApp {
             AppRequest::Wake => {
                 log::debug!("ProcessApp[{}]: wake request (no-op)", self.type_id);
             }
+            // ── Shutdown (CLI-only, never app-reachable) ────────────────────
+            // `AppRequest::Shutdown` is `plexi host stop`'s clean-shutdown
+            // signal, sent over a direct notify.sock connection outside any
+            // pane. No capability grants a sandboxed process app the ability
+            // to terminate the whole host — unconditionally deny and drop.
+            AppRequest::Shutdown => {
+                log::warn!(
+                    "ProcessApp[{}]: app sent Shutdown request — denied, apps cannot terminate the host",
+                    self.type_id
+                );
+            }
             // ── Capability request ─────────────────────────────────────────
             AppRequest::CapabilityRequest {
                 request_id,

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -1473,6 +1473,14 @@ pub enum AppRequest {
     /// when no `PLEXI_SOCKET` is set. Fire-and-forget; the handler does
     /// nothing — the wake effect is the socket listener's repaint request.
     Wake,
+
+    /// Request a clean host shutdown. Sent by `plexi host stop` over a direct
+    /// `notify.sock` connection (never over `PLEXI_SOCKET` — `host stop` runs
+    /// outside a pane by definition). Fire-and-forget; the handler sets a
+    /// close-pending flag consumed at the top of the next frame, which sends
+    /// `egui::ViewportCommand::Close`. `host stop` falls back to `SIGTERM` if
+    /// this request goes unanswered within its short timeout.
+    Shutdown,
 }
 
 /// Who caused an app state change (`AppRequest::EmitEvent`).


### PR DESCRIPTION
No linked GitHub issue — tracked as stint task 0342.

## Summary

- `plexi host start` launches this channel's app bundle detached (any channel, including PR builds), with a clean child env (strips `PLEXI_SOCKET`/`PLEXI_PANE_ID`/`PLEXI_CONTEXT_ID`/`PLEXI_CONTEXT_ROOT`/`PLEXI_RUNNING`, sets `PLEXI_CHANNEL` explicitly), and blocks until a `notify.sock` round trip confirms readiness or times out loudly. Errors if a host for that channel is already running.
- Declarative boot layout via `--layout <file.toml>` (`[[pane]]` tables) and/or repeated `--pane 'cwd=<dir>[,cmd=<command>][,tab|window]'` flags — both build the same `PaneSpec` list, seeded into the existing spawn-queue before launch so no new host-side boot protocol is needed.
- `plexi host stop` (clean shutdown via a new `AppRequest::Shutdown`, falling back to `SIGTERM`) and `plexi host status` (pid, socket, ready/not-ready, pane count).
- `AppRequest::Shutdown` is explicitly denied at the process-app routing boundary — no sandboxed app can trigger a host shutdown.

## Test evidence

- `cargo test --bin plexi cli::host`: 19 passed, 0 failed (new unit tests: pane-flag parsing, TOML layout deserialization, placement mapping, env-stripping, pane-spec ordering).
- `cargo test --bin plexi host`: 209 passed, 0 failed.
- Full `cargo test --bin plexi`: green aside from one pre-existing, unrelated flaky (`host::wasm_app::tests::g11_gpu_render_pass_executes_on_device`, a timing-sensitive perf assertion untouched by this diff).
- Conclusion: **binary install required** — this changes host-runtime/app-launch/process-spawn/socket-IPC behavior that unit tests can't fully exercise. Validate with `just pr-install <PR>` then `plexi-pr-<PR> host start/status/stop`.

## Done When

- [ ] `plexi-pr-<N> host start --pane 'cwd=/tmp,cmd=htop'` boots an isolated PR host end-to-end
- [ ] `plexi-pr-<N> host status` reports ready + correct pane count
- [ ] `plexi-pr-<N> host stop` cleanly exits it