### PR TITLE
Bundle: stints 0343 + 0311 + 0296 + 0298 (drive-host skill, Cmd+P fix, canonical core apps, assistant stub cleanup)

### DIFF
--- a/.agents/skills/drive-host/SKILL.md
+++ b/.agents/skills/drive-host/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: drive-host
+description: "Live headed end-to-end loop for validating a PR (or any channel) build against a real running Plexi host. Boots the host with `plexi host start`, drives it with pane/events commands, observes ground truth from pane state/capture and the channel log, then tears it down. Use when a change can only be verified in the installed binary (PTY/terminal flows, menus, dock, real multi-pane behavior) — not for anything a headless harness can cover."
+risk: medium
+source: local
+date_added: "2026-07-02"
+---
+
+# Drive Host — Live Headed E2E Loop
+
+Validate a change against the real, running host binary. `plexi host start` (stint 0342) turned the old hand-rolled nohup/env/socket dance into one command; this skill is the loop built on top of it.
+
+## When to reach for this layer
+
+Three testing layers exist. Pick the cheapest one that can observe the behavior — only escalate to this skill when nothing headless can see it.
+
+| Layer | What it exercises | Use when | Reference |
+|---|---|---|---|
+| HostHarness / TOML scenes | HostModel logic + egui render, fully headless | return values, effects, overlay/widget layout, anything a scene can assert | `src/testing/TESTING.md` |
+| AppHarness | one PGAP app subprocess over the protocol, headless PNG | Python app layout, key handling, pixel/no-overlap assertions | `src/testing/TESTING.md` |
+| **drive-host (this skill)** | the installed `.app` binary, headed, real IPC | PTY/terminal interaction, keyboard-capture flows, menus/dock/file-associations, real multi-pane orchestration — behavior only observable in the running bundle | here |
+
+If a HostHarness test or committed scene can reproduce it, write that instead — it is deterministic and runs in CI. This skill is the escape hatch for the rest.
+
+## The loop
+
+All four steps run against one channel. For a PR build the channel is `pr-<N>` and the binary is `plexi-pr-<N>`; substitute your channel throughout. `host start/stop/status` resolve the socket from the channel's own config dir (`~/.plexi-<channel>/notify.sock`), so they ignore any inherited `PLEXI_SOCKET` — the drive commands in step 2 do not, which is the whole reason for the env discipline below.
+
+### 1. Boot
+
+Seed a known layout and block until the host answers a socket round-trip:
+
+```bash
+plexi-pr-<N> host start --pane 'cwd=/tmp,cmd=htop' --pane 'cwd=/tmp'
+```
+
+`--pane 'cwd=<dir>[,cmd=<command>][,tab|window]'` is repeatable; `--layout <file.toml>` seeds the same `[[pane]]` specs from a committed fixture (combine both — they append). `--timeout-secs <n>` overrides the 15s readiness wait. `host start` errors loudly if a host for this channel is already up (prints pid + socket) — `host stop` first if so. Full flag surface: `.stint/tasks/0342-host-start-declarative-boot.md`.
+
+Confirm readiness before driving:
+
+```bash
+plexi-pr-<N> host status --json
+```
+
+`ready: true` with the expected `pane_count` means boot succeeded. Never start sending pane commands off an assumption that boot finished.
+
+### 2. Drive
+
+Read the seeded panes, then act on them by explicit id:
+
+```bash
+plexi-pr-<N> pane list
+plexi-pr-<N> pane send <pane-id> "git status\n"
+plexi-pr-<N> pane key <pane-id> enter
+plexi-pr-<N> pane new "npm run dev" -n dev
+```
+
+Every drive command needs the env discipline below. Always target panes by the id from `pane list` — never rely on "current pane" defaults, which read stale `PLEXI_*` vars from the pane you launched this skill in.
+
+**Env discipline (the trap).** `pane list/send/state/capture/key/new` resolve their target from `PLEXI_SOCKET`, not from the channel. Inside another Plexi pane that variable points at *your* host, not the PR host, and `PLEXI_PANE_ID` / `PLEXI_CONTEXT_ID` / `PLEXI_CONTEXT_ROOT` are likewise stale. Point every drive command at the PR host's own socket and strip the inherited pane/context identity:
+
+```bash
+env -u PLEXI_PANE_ID -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_ROOT -u PLEXI_RUNNING \
+  PLEXI_SOCKET=$HOME/.plexi-pr-<N>/notify.sock PLEXI_CHANNEL=pr-<N> \
+  plexi-pr-<N> pane list
+```
+
+To watch an app's event streams, subscribe (NDJSON, one object per line) with the same env prefix:
+
+```bash
+env -u PLEXI_PANE_ID ... PLEXI_SOCKET=$HOME/.plexi-pr-<N>/notify.sock PLEXI_CHANNEL=pr-<N> \
+  plexi-pr-<N> events subscribe <app_id> <stream>
+```
+
+### 3. Observe
+
+Ground truth comes from the host, never from what you expect to have happened:
+
+```bash
+plexi-pr-<N> pane state <pane-id>     # app panes: JSON frame of the L1 UiNode tree; terminals: status
+plexi-pr-<N> pane capture <pane-id> --lines 80
+tail -100 ~/.plexi-pr-<N>/plexi.log
+```
+
+`pane state` is the L1 render tree for app panes — assert against it, not against a screenshot you eyeballed. `pane capture` returns terminal output as a JSON array; use `--from-cursor <n>` to read only lines written since a prior capture. The channel log (`~/.plexi-pr-<N>/plexi.log`) is the source for anything the drive commands can't surface — every feature ships an `info` trace, so grep it for the behavior you seeded.
+
+### 4. Teardown
+
+```bash
+plexi-pr-<N> host stop
+plexi-pr-<N> host status
+```
+
+`host stop` sends a clean shutdown request, falling back to SIGTERM. Confirm the process is gone with `host status` (expect "not running") before declaring done — a lingering host blocks the next `host start` for that channel.
+
+## Rules
+
+- Escalate to this layer only when a HostHarness test or committed scene genuinely cannot observe the behavior. Deterministic headless coverage wins.
+- Verify `host status` readiness before driving, and process-gone after `host stop`. Never chain a step on an assumed prior step.
+- Every drive command (`pane *`, `events subscribe`) carries the env prefix: explicit `PLEXI_SOCKET` for the target channel, explicit `PLEXI_CHANNEL`, and stripped inherited `PLEXI_PANE_ID` / `PLEXI_CONTEXT_ID` / `PLEXI_CONTEXT_ROOT` / `PLEXI_RUNNING`.
+- Target panes by explicit id from `pane list` — never "current pane" defaults, which read the launching pane's stale identity.
+- Observe from `pane state` / `pane capture` / the channel log, never from assumption.
+- One host per channel. `host stop` before re-booting; leave no orphaned host behind.
+- The flag surface lives in stint 0342 and `--help`; do not restate it — link it.

--- a/.agents/skills/test-pr/SKILL.md
+++ b/.agents/skills/test-pr/SKILL.md
@@ -95,6 +95,8 @@ Report any errors or warnings before proceeding.
 
 Check for existing POC app in `apps/` or `apps/dev/`. Use it if present.
 
+**To exercise the change in a live headed host yourself** (PTY/terminal flows, menus, real multi-pane orchestration), use the `drive-host` skill — it owns the boot/drive/observe/teardown loop against the PR binary. Do not hand-roll a launch here.
+
 **For multi-step or multi-pane tests:** write `test_pr<N>.py` at repo root.
 
 ```python

--- a/.agents/skills/validate-pr/SKILL.md
+++ b/.agents/skills/validate-pr/SKILL.md
@@ -376,7 +376,7 @@ Read the PR build log first:
 ```bash
 tail -100 ~/.plexi-pr-$PR_NUMBER/plexi.log
 ```
-Report what the log shows.
+Report what the log shows. If the log alone can't reproduce the failure and you need to drive the live binary to confirm the fix, use the `drive-host` skill (boot → drive → observe → teardown) — do not hand-roll a launch.
 
 First run **Step 0b — Resume Guard After User Reply**. Do not inspect or edit production files until `cd "$WORKTREE"` has succeeded.
 
@@ -521,4 +521,5 @@ pipeline_slots_set validate "$ISSUE_NUMBER" "$PR_NUMBER" needs-you "Review the d
 - Never run `test_pr<N>.py` yourself — it blocks on `plexi notify`; use direct Bash for automated checks
 - All subprocess calls in test script must use full absolute path to PR binary
 - Never include `tail` or log-reading in user-facing testing block — read the log yourself, report findings directly
+- When diagnosis needs the live binary driven (not just the log), use the `drive-host` skill — never hand-roll a host launch
 - Cosmetic issues spotted during testing go in separate issues — not blockers or modifies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ When work begins: `stint claim <task-id>`. Do not run or document `stint start`;
 | `src/process_app/` | PGAP lifecycle, capability gating, security model, shell execution inventory |
 | `src/render/` | CLI renderer app contract |
 | `sdk/python/` | SDK traps, SDK_V3.md reference |
-| `apps/` | App rules, Core 9 policy, design philosophy |
+| `apps/` | App rules, maintained-set policy (`packs/core.toml`), design philosophy |
 | `scripts/` | Build channels, branch workflow, releases, install, RELEASE_CHANNELS.md |
 | `registry/` | CLI descriptor guide, embedded descriptor registry |
 | `docs/` | Active PRMs; lifecycle rules in `docs/AGENTS.md` |

--- a/apps/AGENTS.md
+++ b/apps/AGENTS.md
@@ -10,8 +10,8 @@ Each app is a directory with a `manifest.toml` (schema_version + `[app]` id/type
 
 - **Scaffold, never hand-write.** Create a new app with `plexi app init <name>` (or `plexi-pr-<N> app init <name>` on a PR build). Never author a `manifest.toml` by hand — the scaffold sets the correct `schema_version` and a valid manifest.
 - **Prune scaffold imports.** The template imports ~6 SDK symbols; delete the unused ones before finishing. Pyright flags them immediately.
-- **Core 9 only.** Only fix or improve the maintained Core 9 apps. Everything in `dev/` and `examples/` is a throwaway proof-of-concept — do not maintain it. Touch a `dev/` app only when the change is itself a POC demonstrating a new SDK or host capability.
-- **New capability ⇒ POC in `dev/`, not `examples/`.** Every user-visible host/SDK capability ships a small POC app under `apps/dev/`. The install script only flattens `dev/`, so an `examples/` POC will not be picked up.
+- **Maintained set = [`packs/core.toml`](../packs/core.toml).** That pack is the single source of truth for which apps are maintained and ship as the canonical core set — the host re-seeds it on every launch. Only fix or improve apps listed there. Everything under `dev/` and `examples/` is a throwaway proof-of-concept — do not maintain it. Touch a `dev/` app only when the change is itself a POC demonstrating a new SDK or host capability.
+- **New capability ⇒ POC in `dev/`, not `examples/`.** Every user-visible host/SDK capability ships a small POC app under `apps/dev/`. The `alpha`/`pr-*` install flattens `dev/` to the top level (see `scripts/AGENTS.md`), so an `examples/` POC will not be picked up.
 - **PGAP is L1-only.** Build declarative L1 UI trees. L0 is deprecated and its `_l0` fallbacks are gone; the `Raw` escape hatch stays.
 - **Log through the frame.** Use `log.debug/info/warn/error(...)` from `plexi_sdk`. App logs forward into the host log tagged `app::<app_id>`.
 

--- a/docs/wasm-runtime.md
+++ b/docs/wasm-runtime.md
@@ -9,7 +9,7 @@ This spec is the authoritative description of Plexi's WASM runtime destination a
 
 ## Why Rebuild
 
-The v1 runtime (Python subprocess + PGAP over stdio) is the right bootstrap. It ships fast, it works on macOS desktop, and it gets the Core 9 apps in front of users. But every capability Plexi wants to add pulls against it:
+The v1 runtime (Python subprocess + PGAP over stdio) is the right bootstrap. It ships fast, it works on macOS desktop, and it gets the core apps in front of users. But every capability Plexi wants to add pulls against it:
 
 - **Cloud execution**: you cannot run an OS process remotely and pipe stdio over a WebSocket without a pile of per-platform scaffolding.
 - **Mobile**: iOS forbids spawning arbitrary subprocesses. Android makes it painful.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -21,6 +21,7 @@ Build, install, release, and channel management scripts. Called from `justfile` 
 - Scripts are the only place `just` recipes call into. Do not duplicate logic in the justfile.
 - `default-config.toml` is the config template seeded on install. Keep in sync with `src/config/CONFIG.md`.
 - **Bump at release boundaries, not after every PR.** Run `just bump` once at end of a batch or before promoting.
+- **App seeding is channel-gated.** `packs/core.toml` is the single source of truth for the maintained/core app set (owned by `apps/AGENTS.md`). `install.sh` syncs the full `apps/` tree (all apps plus the flattened `dev/` POCs) only on `alpha`/`pr-*`. On `beta`/`main` it seeds exactly the canonical set through the host's own pack applier (`plexi app install --pack core` always; `--pack packs/examples.toml` on a fresh profile) so no app list is duplicated here. Never enumerate app names in this script.
 
 ## Traps
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -21,7 +21,7 @@ Build, install, release, and channel management scripts. Called from `justfile` 
 - Scripts are the only place `just` recipes call into. Do not duplicate logic in the justfile.
 - `default-config.toml` is the config template seeded on install. Keep in sync with `src/config/CONFIG.md`.
 - **Bump at release boundaries, not after every PR.** Run `just bump` once at end of a batch or before promoting.
-- **App seeding is channel-gated.** `packs/core.toml` is the single source of truth for the maintained/core app set (owned by `apps/AGENTS.md`). `install.sh` syncs the full `apps/` tree (all apps plus the flattened `dev/` POCs) only on `alpha`/`pr-*`. On `beta`/`main` it seeds exactly the canonical set through the host's own pack applier (`plexi app install --pack core` always; `--pack packs/examples.toml` on a fresh profile) so no app list is duplicated here. Never enumerate app names in this script.
+- **App seeding is channel-gated.** `packs/core.toml` is the single source of truth for the maintained/core app set (owned by `apps/AGENTS.md`). `install.sh` syncs the full `apps/` tree (all apps plus the flattened `dev/` POCs) only on `alpha`/`pr-*`. On `beta`/`main` it seeds exactly the canonical set through the host's own pack applier (`plexi app install --pack core --refresh` always — `--refresh` re-extracts installed core apps from the new binary so updates reach existing profiles; `--pack packs/examples.toml` on a fresh profile) so no app list is duplicated here. Never enumerate app names in this script.
 
 ## Traps
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -227,18 +227,21 @@ find "$profile_dir/sdk/plexi_sdk" -name '__pycache__' -type d -exec rm -rf {} + 
 #                   app immediately: all top-level app dirs, then the dev/ POCs
 #                   flattened to the top level.
 #   beta / main   → seed exactly the canonical set through the host's own pack
-#                   applier so no app list is duplicated in this script. Core
-#                   apps seed on every host run; example/demo apps seed only for
-#                   a fresh profile (apps_was_empty), matching the host's
-#                   first-launch behavior. POC apps under dev/ and non-pack
-#                   demos never reach stable channels.
+#                   applier so no app list is duplicated in this script.
+#                   --refresh re-extracts already-installed core apps from the
+#                   new binary's embedded tree — this is how core-app updates
+#                   reach existing stable profiles (launch reseed only installs
+#                   missing apps). Example/demo apps seed only for a fresh
+#                   profile (apps_was_empty), matching the host's first-launch
+#                   behavior. POC apps under dev/ and non-pack demos never
+#                   reach stable channels.
 if [[ "$channel" == alpha || "$channel" =~ ^pr- ]]; then
   rsync -a --exclude=dev/ apps/ "$profile_dir/apps/"
   rsync -a apps/dev/ "$profile_dir/apps/"
 else
   bundled_bin="$app_dest/Contents/MacOS/plexi${suffix}"
-  "$bundled_bin" app install --pack core >/dev/null 2>&1 \
-    || echo "note: core pack seed deferred to first launch"
+  "$bundled_bin" app install --pack core --refresh >/dev/null 2>&1 \
+    || echo "warning: core pack refresh failed — launch only installs missing apps; run 'plexi${suffix} app install --pack core --refresh' to update core apps"
   if $apps_was_empty; then
     "$bundled_bin" app install --pack packs/examples.toml >/dev/null 2>&1 \
       || echo "note: examples pack seed deferred to first launch"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -240,10 +240,14 @@ if [[ "$channel" == alpha || "$channel" =~ ^pr- ]]; then
   rsync -a apps/dev/ "$profile_dir/apps/"
 else
   bundled_bin="$app_dest/Contents/MacOS/plexi${suffix}"
-  "$bundled_bin" app install --pack core --refresh >/dev/null 2>&1 \
+  # Unset any inherited PLEXI_CHANNEL (in-pane installs leak it) so the
+  # binary resolves its profile from its own basename — PLEXI_CHANNEL wins
+  # over the basename and would seed the wrong profile ("main" has no valid
+  # PLEXI_CHANNEL value, so setting it explicitly is not an option).
+  env -u PLEXI_CHANNEL "$bundled_bin" app install --pack core --refresh >/dev/null 2>&1 \
     || echo "warning: core pack refresh failed — launch only installs missing apps; run 'plexi${suffix} app install --pack core --refresh' to update core apps"
   if $apps_was_empty; then
-    "$bundled_bin" app install --pack packs/examples.toml >/dev/null 2>&1 \
+    env -u PLEXI_CHANNEL "$bundled_bin" app install --pack packs/examples.toml >/dev/null 2>&1 \
       || echo "note: examples pack seed deferred to first launch"
   fi
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -221,10 +221,28 @@ mv "$profile_dir/sdk/plexi_sdk" "$profile_dir/sdk/plexi_sdk.old" 2>/dev/null || 
 mv "$profile_dir/sdk/plexi_sdk.tmp" "$profile_dir/sdk/plexi_sdk"
 rm -rf "$profile_dir/sdk/plexi_sdk.old" "$profile_dir/sdk/plexi_sdk.py"
 find "$profile_dir/sdk/plexi_sdk" -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
-# Re-seed all production apps on every install; always sync dev apps on alpha/PR.
-rsync -a --exclude=dev/ apps/ "$profile_dir/apps/"
+# App-seeding policy is channel-gated (see scripts/AGENTS.md). packs/core.toml
+# is the single source of truth for the maintained/core app set.
+#   alpha / pr-*  → sync the full working tree so developers can exercise every
+#                   app immediately: all top-level app dirs, then the dev/ POCs
+#                   flattened to the top level.
+#   beta / main   → seed exactly the canonical set through the host's own pack
+#                   applier so no app list is duplicated in this script. Core
+#                   apps seed on every host run; example/demo apps seed only for
+#                   a fresh profile (apps_was_empty), matching the host's
+#                   first-launch behavior. POC apps under dev/ and non-pack
+#                   demos never reach stable channels.
 if [[ "$channel" == alpha || "$channel" =~ ^pr- ]]; then
+  rsync -a --exclude=dev/ apps/ "$profile_dir/apps/"
   rsync -a apps/dev/ "$profile_dir/apps/"
+else
+  bundled_bin="$app_dest/Contents/MacOS/plexi${suffix}"
+  "$bundled_bin" app install --pack core >/dev/null 2>&1 \
+    || echo "note: core pack seed deferred to first launch"
+  if $apps_was_empty; then
+    "$bundled_bin" app install --pack packs/examples.toml >/dev/null 2>&1 \
+      || echo "note: examples pack seed deferred to first launch"
+  fi
 fi
 find "$profile_dir/apps" -maxdepth 2 -name 'plexi_sdk.py' -delete 2>/dev/null || true
 find "$profile_dir/apps" -name '*.py' -exec chmod +x {} \;
@@ -320,7 +338,11 @@ fi
 echo "Installed $app_dest"
 echo "CLI: $bin_dest"
 echo "Config dir: $profile_dir/"
-echo "Apps: $(ls "$profile_dir/apps" | wc -l | tr -d ' ') synced from apps/"
+if [[ "$channel" == alpha || "$channel" =~ ^pr- ]]; then
+  echo "Apps: $(ls "$profile_dir/apps" | wc -l | tr -d ' ') synced from apps/ (dev channel: full tree)"
+else
+  echo "Apps: $(ls "$profile_dir/apps" 2>/dev/null | wc -l | tr -d ' ') seeded from canonical packs (stable channel)"
+fi
 if ! command -v micro &>/dev/null; then
   echo "tip: brew install micro — preferred editor for plexi notes open"
 fi

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "plexi-sdk"
-version = "0.1.13"
+version = "0.1.16"
 source = { editable = "." }

--- a/src/assistant/commands.rs
+++ b/src/assistant/commands.rs
@@ -13,87 +13,34 @@ pub struct ParsedCommand {
     pub args: String,
 }
 
-/// The built-in command table from the spec: `(name, purpose)`.
-/// `/clear`, `/new`, and `/help` are implemented in Phase 1; the rest are
-/// recognized and answered with a "not yet implemented" assistant row.
+/// The built-in command table: `(name, purpose)`. Every entry maps to a real
+/// handler in `AssistantModel::execute_command`; unimplemented ideas live in
+/// stint tasks and `docs/assistant-host-app.md`, never in this surface.
 pub const BUILT_IN_COMMANDS: &[(&str, &str)] = &[
-    (
-        "help",
-        "Show built-in commands, installed skills, and tool packs.",
-    ),
+    ("help", "List the built-in commands."),
     ("clear", "Start a new conversation in the same workspace."),
-    ("resume", "Open a previous Assistant session."),
-    (
-        "compact",
-        "Summarize older turns and keep the active task context.",
-    ),
-    (
-        "context",
-        "Show token use, loaded instructions, active pane/app context, and enabled tools.",
-    ),
-    ("memory", "Show agent prompt files and future memory state."),
-    (
-        "model",
-        "Switch model tier or backend for this session/agent.",
-    ),
-    ("effort", "Switch reasoning effort for this session/agent."),
-    ("agent", "Switch, inspect, create, or edit agents."),
-    ("settings", "Open Assistant settings."),
-    ("config", "Alias for /settings."),
-    (
-        "permissions",
-        "Open grant rules, pending grants, denied tools, and audit history.",
-    ),
-    (
-        "tools",
-        "Show enabled host tools, app connectors, MCP tools, and tool collections.",
-    ),
-    ("apps", "Show app connectors available in the workspace."),
-    (
-        "skills",
-        "Show installed skills and marketplace skill packs.",
-    ),
-    (
-        "install",
-        "Install a local or marketplace skill/tool/agent package.",
-    ),
-    ("hooks", "Show lifecycle hooks and their source."),
-    (
-        "audit",
-        "Show recent Assistant tool calls, grants, app writes, and denied attempts.",
-    ),
-    ("revoke", "Revoke a persisted grant by target id."),
-    ("export", "Export the current transcript and tool-call log."),
-    (
-        "rewind",
-        "Restore the conversation to an earlier checkpoint.",
-    ),
     (
         "new",
         "Create a new named conversation without deleting the current one.",
     ),
     (
-        "history",
-        "Open conversation history and checkpoint browser.",
+        "tools",
+        "Show app connector tools and event streams with their broker decisions.",
+    ),
+    ("apps", "Show app connectors available in the workspace."),
+    (
+        "permissions",
+        "Show persisted grants for the assistant actor.",
+    ),
+    ("revoke", "Revoke a persisted grant by target id."),
+    (
+        "audit",
+        "Show recent Assistant tool calls, grants, app writes, and denied attempts.",
     ),
     (
         "thoughts",
         "Show or hide the model's reasoning for every turn.",
     ),
-];
-
-/// Commands with a real implementation (Phase 1: help/clear/new; Phase 2:
-/// tools/permissions/revoke/audit). Everything else in `BUILT_IN_COMMANDS`
-/// is recognized but stubbed.
-pub const IMPLEMENTED_COMMANDS: &[&str] = &[
-    "help",
-    "clear",
-    "new",
-    "tools",
-    "permissions",
-    "revoke",
-    "audit",
-    "thoughts",
 ];
 
 /// Parse `input` as a slash command. Returns `None` when the input is not a
@@ -136,22 +83,12 @@ pub fn filter_commands(query: &str) -> Vec<(&'static str, &'static str)> {
         .collect()
 }
 
-/// True if `name` appears in the built-in command table.
-pub fn is_builtin(name: &str) -> bool {
-    BUILT_IN_COMMANDS.iter().any(|(n, _)| *n == name)
-}
-
 /// Render the `/help` listing as markdown (the transcript renders assistant
 /// rows through CommonMark).
 pub fn help_text() -> String {
     let mut out = String::from("**Built-in commands:**\n\n");
     for (name, purpose) in BUILT_IN_COMMANDS {
-        let status = if IMPLEMENTED_COMMANDS.contains(name) {
-            ""
-        } else {
-            " (not yet implemented)"
-        };
-        out.push_str(&format!("- `/{name}` — {purpose}{status}\n"));
+        out.push_str(&format!("- `/{name}` — {purpose}\n"));
     }
     out
 }
@@ -202,7 +139,7 @@ mod tests {
     fn unrecognized_name_still_parses() {
         let cmd = parse_slash_command("/frobnicate now").unwrap();
         assert_eq!(cmd.name, "frobnicate");
-        assert!(!is_builtin(&cmd.name));
+        assert!(!BUILT_IN_COMMANDS.iter().any(|(n, _)| *n == cmd.name));
     }
 
     #[test]
@@ -232,11 +169,14 @@ mod tests {
     }
 
     #[test]
-    fn builtin_table_covers_phase1_commands() {
-        for name in IMPLEMENTED_COMMANDS {
-            assert!(is_builtin(name), "{name} missing from BUILT_IN_COMMANDS");
+    fn help_lists_every_builtin_and_marks_none_unimplemented() {
+        let help = help_text();
+        for (name, _) in BUILT_IN_COMMANDS {
+            assert!(help.contains(&format!("/{name}")), "{name} missing from /help");
         }
-        assert!(help_text().contains("/clear"));
-        assert!(help_text().contains("not yet implemented"));
+        assert!(
+            !help.contains("not yet implemented"),
+            "no built-in should advertise itself as unimplemented"
+        );
     }
 }

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -413,10 +413,6 @@ impl AssistantApp {
                     );
                     log::info!("assistant: in-flight turn cancelled by conversation switch");
                 }
-                // Phase 3 stub: correctly shaped, logged, never panics.
-                AssistantEffect::PaneAction { action } => {
-                    log::info!("assistant: PaneAction '{action}' not yet implemented (Phase 3)");
-                }
             }
         }
     }
@@ -1577,16 +1573,6 @@ mod tests {
             last.text
         );
         tool_dispatch::unregister(9201);
-    }
-
-    #[test]
-    fn pane_action_stub_executes_without_panicking() {
-        let ws = tempfile::tempdir().unwrap();
-        let mut app = test_app(ws.path());
-        app.execute_effects(vec![AssistantEffect::PaneAction {
-            action: "focus:1".to_string(),
-        }]);
-        assert!(!app.model.streaming.in_flight);
     }
 
     #[test]

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -123,8 +123,6 @@ pub enum AssistantEffect {
     /// thread waiting on a permission reply. The late outcome is dropped by
     /// the stale-conversation guard in `finish_turn`.
     CancelTurn,
-    /// Phase 3: host pane control (open/focus/read).
-    PaneAction { action: String },
 }
 
 fn new_conversation_id() -> String {
@@ -336,8 +334,8 @@ impl AssistantModel {
         }
     }
 
-    /// Execute a parsed slash command. `/clear`, `/new`, and `/help` are
-    /// real; other built-ins answer with a stub row; unknown names error.
+    /// Execute a parsed slash command. Every built-in has a real handler
+    /// below; unknown names answer with an error row.
     fn execute_command(&mut self, cmd: &ParsedCommand) -> Vec<AssistantEffect> {
         log::info!(
             "assistant[{}]: command /{} args='{}'",
@@ -432,23 +430,6 @@ impl AssistantModel {
                         target_id: cmd.args.clone(),
                     }]
                 }
-            }
-            name if commands::is_builtin(name) => {
-                self.turns.push(Turn::now(
-                    TurnRole::Assistant,
-                    format!("/{name} is not yet implemented."),
-                ));
-                let mut effects = vec![AssistantEffect::SessionWrite {
-                    conversation_id: self.conversation_id.clone(),
-                }];
-                // Phase 3: pane-read commands go through PaneAction so the
-                // executor seam is exercised before the full impl lands.
-                if name == "context" {
-                    effects.push(AssistantEffect::PaneAction {
-                        action: "read_context".to_string(),
-                    });
-                }
-                effects
             }
             name => {
                 self.turns.push(Turn::now(
@@ -842,11 +823,11 @@ mod tests {
     }
 
     #[test]
-    fn stubbed_builtin_answers_not_yet_implemented() {
+    fn removed_builtin_is_now_an_unknown_command() {
         let mut m = AssistantModel::fresh();
         submitted(&mut m, "/skills");
-        assert_eq!(m.turns[0].role, TurnRole::Assistant);
-        assert!(m.turns[0].text.contains("not yet implemented"));
+        assert_eq!(m.turns[0].role, TurnRole::Error);
+        assert!(m.turns[0].text.contains("Unknown command /skills"));
     }
 
     #[test]

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -450,6 +450,11 @@ pub enum AppCmd {
         /// Install from a pack file or 'core'
         #[arg(long)]
         pack: Option<String>,
+        /// With --pack: re-extract already-installed `local:` apps from this
+        /// binary's embedded tree, replacing the installed copy. The update
+        /// path for bundled core apps on stable channels.
+        #[arg(long, requires = "pack")]
+        refresh: bool,
         /// Pin a local path or package install to a specific version (e.g. --version 1.2.3).
         #[arg(long, value_name = "SEMVER")]
         version: Option<String>,

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -77,6 +77,10 @@ pub fn install_cli(spec: &str, assume_yes: bool) -> i32 {
                 ));
                 0
             }
+            crate::cli::install_host::InstallStatus::Refreshed(path) => {
+                println!("refreshed '{}' at {}", outcome.id, path.display());
+                0
+            }
             crate::cli::install_host::InstallStatus::AlreadyAtVersion => {
                 println!("already at requested version");
                 0
@@ -105,7 +109,9 @@ pub fn install_cli(spec: &str, assume_yes: bool) -> i32 {
 }
 
 /// `plexi install --pack <path|core>` — apply a whole pack file.
-pub fn install_pack_cli(spec: &str) -> i32 {
+/// `refresh_local`: re-extract already-installed `local:` apps from the
+/// embedded tree (see `install_host::apply_pack`).
+pub fn install_pack_cli(spec: &str, refresh_local: bool) -> i32 {
     let pack = if spec == "core" {
         match crate::app::packs::Pack::from_toml_str(crate::cli::install_host::CORE_PACK_TOML) {
             Ok(p) => p,
@@ -129,12 +135,16 @@ pub fn install_pack_cli(spec: &str) -> i32 {
         return 1;
     }
     let cloner = crate::cli::install_host::GitCloner;
-    let outcomes = crate::cli::install_host::apply_pack(&cloner, &pack, &target_root);
+    let outcomes =
+        crate::cli::install_host::apply_pack(&cloner, &pack, &target_root, refresh_local);
     let mut any_failed = false;
     for o in &outcomes {
         match &o.status {
             crate::cli::install_host::InstallStatus::Installed(p) => {
                 println!("  installed  {:30} → {}", o.id, p.display());
+            }
+            crate::cli::install_host::InstallStatus::Refreshed(p) => {
+                println!("  refreshed  {:30} → {}", o.id, p.display());
             }
             crate::cli::install_host::InstallStatus::AlreadyAtVersion => {
                 println!("  up-to-date {:30}", o.id);
@@ -250,6 +260,9 @@ pub fn install_workspace_pack_cli() -> i32 {
         match &o.status {
             crate::cli::install_host::InstallStatus::Installed(p) => {
                 println!("  installed  {:30} → {}", o.id, p.display());
+            }
+            crate::cli::install_host::InstallStatus::Refreshed(p) => {
+                println!("  refreshed  {:30} → {}", o.id, p.display());
             }
             crate::cli::install_host::InstallStatus::AlreadyAtVersion => {
                 println!("  up-to-date {:30}", o.id);

--- a/src/cli/install_host.rs
+++ b/src/cli/install_host.rs
@@ -1370,6 +1370,61 @@ mod core_pack_tests {
         }
     }
 
+    /// Drift guard (stint 0296): `packs/core.toml` is the single source of
+    /// truth for the maintained/core app set. Every entry must resolve to a
+    /// bundled app directory whose manifest id matches, and the installer must
+    /// not carry a competing hardcoded list of those same apps.
+    #[test]
+    fn core_pack_is_canonical_and_consistent() {
+        let pack = Pack::from_toml_str(CORE_PACK_TOML).expect("core pack must parse");
+        assert!(!pack.apps.is_empty(), "core pack must list at least one app");
+
+        for entry in &pack.apps {
+            // Maintained apps ship from the embedded tree via `local:<id>`.
+            let spec = parse_source_spec(&entry.source)
+                .unwrap_or_else(|e| panic!("core entry '{}' has invalid source: {e}", entry.id));
+            let name = match spec {
+                SourceSpec::Local(n) => n,
+                SourceSpec::Git(_) => panic!(
+                    "core entry '{}' must use a local: source (maintained apps ship bundled), got '{}'",
+                    entry.id, entry.source
+                ),
+            };
+            assert_eq!(
+                name, entry.id,
+                "core entry id '{}' must match its local: source name '{name}'",
+                entry.id
+            );
+            let dir = EMBEDDED_APPS
+                .get_dir(&name)
+                .unwrap_or_else(|| panic!("core app '{name}' has no directory under apps/"));
+            let manifest_text = dir
+                .get_file(format!("{name}/manifest.toml"))
+                .and_then(|f| f.contents_utf8())
+                .unwrap_or_else(|| panic!("core app '{name}' has no manifest.toml"));
+            let manifest: AppManifest = toml::from_str(manifest_text)
+                .unwrap_or_else(|e| panic!("core app '{name}' manifest invalid: {e}"));
+            assert_eq!(
+                manifest.app.id, entry.id,
+                "core app '{name}' manifest id '{}' must match pack id '{}'",
+                manifest.app.id, entry.id
+            );
+        }
+
+        // The maintained set lives ONLY in packs/core.toml. install.sh must
+        // never re-enumerate it: it may only rsync `apps/` or `apps/dev/`
+        // wholesale, never a specific `apps/<core-id>/` path.
+        let install_sh = include_str!("../../scripts/install.sh");
+        for entry in &pack.apps {
+            let needle = format!("apps/{}/", entry.id);
+            assert!(
+                !install_sh.contains(&needle),
+                "install.sh hardcodes '{needle}' — the maintained app list must come \
+                 only from packs/core.toml, not be enumerated in the installer"
+            );
+        }
+    }
+
     #[test]
     fn split_source_and_ref_handles_at_suffix() {
         let (s, r) = split_source_and_ref("github:owner/repo@v1.0.0");

--- a/src/cli/install_host.rs
+++ b/src/cli/install_host.rs
@@ -43,6 +43,10 @@ pub struct InstallOutcome {
 pub enum InstallStatus {
     /// Newly installed at the given path.
     Installed(PathBuf),
+    /// Re-extracted a bundled `local:` app over an existing install (pack
+    /// apply with `refresh_local`) — how core-app updates reach existing
+    /// profiles on stable channels.
+    Refreshed(PathBuf),
     /// Already present at the requested version — no-op (pack apply
     /// idempotency).
     AlreadyAtVersion,
@@ -413,13 +417,59 @@ fn provision_venv(app_id: &str, app_dir: &Path, manifest: &AppManifest) {
 /// aggregated per app so one bad entry doesn't abort the whole apply.
 /// Idempotent: an entry whose id is already installed at the same version is
 /// reported as `AlreadyAtVersion`.
-pub fn apply_pack(cloner: &dyn Cloner, pack: &Pack, target_root: &Path) -> Vec<InstallOutcome> {
+///
+/// `refresh_local`: re-extract already-installed `local:` entries from this
+/// binary's embedded tree, replacing the installed directory wholesale. This
+/// is the update path for bundled core apps — `local:` versions are
+/// `"bundled"` on both sides, so content, not version, is the ground truth.
+/// Only the explicit installer path (`plexi app install --pack core
+/// --refresh`) sets this; launch-time reseeding never clobbers an existing
+/// install.
+pub fn apply_pack(
+    cloner: &dyn Cloner,
+    pack: &Pack,
+    target_root: &Path,
+    refresh_local: bool,
+) -> Vec<InstallOutcome> {
     let mut outcomes = Vec::with_capacity(pack.apps.len());
     let installed = installed_versions(target_root);
     for entry in &pack.apps {
-        outcomes.push(apply_pack_entry(cloner, entry, target_root, &installed));
+        outcomes.push(apply_pack_entry(
+            cloner,
+            entry,
+            target_root,
+            &installed,
+            refresh_local,
+        ));
     }
     outcomes
+}
+
+/// Replace an installed `local:` app with the copy embedded in this binary.
+fn refresh_one_local(name: &str, id: &str, target_root: &Path) -> InstallOutcome {
+    let dest = target_root.join(id);
+    if let Err(e) = std::fs::remove_dir_all(&dest) {
+        return InstallOutcome {
+            id: id.to_string(),
+            status: InstallStatus::Failed(format!("refresh: remove {}: {e}", dest.display())),
+        };
+    }
+    match install_one_local(name, target_root) {
+        Ok(o) => {
+            log::info!("install: refreshed {} ← local:{name}", o.id);
+            InstallOutcome {
+                id: o.id,
+                status: match o.status {
+                    InstallStatus::Installed(p) => InstallStatus::Refreshed(p),
+                    other => other,
+                },
+            }
+        }
+        Err(e) => InstallOutcome {
+            id: id.to_string(),
+            status: InstallStatus::Failed(format!("refresh: {e}")),
+        },
+    }
 }
 
 fn apply_pack_entry(
@@ -427,8 +477,14 @@ fn apply_pack_entry(
     entry: &PackApp,
     target_root: &Path,
     installed: &HashMap<String, String>,
+    refresh_local: bool,
 ) -> InstallOutcome {
     if let Some(installed_version) = installed.get(&entry.id) {
+        if refresh_local {
+            if let Ok(SourceSpec::Local(name)) = parse_source_spec(&entry.source) {
+                return refresh_one_local(&name, &entry.id, target_root);
+            }
+        }
         if installed_version == &entry.version {
             return InstallOutcome {
                 id: entry.id.clone(),
@@ -719,7 +775,7 @@ pub fn apply_core_pack_always(cloner: &dyn Cloner, target_root: &Path) -> Vec<In
         "install: core pack reseed={:?}",
         pack.reseed.as_deref().unwrap_or("once")
     );
-    apply_pack(cloner, &pack, target_root)
+    apply_pack(cloner, &pack, target_root, false)
 }
 
 /// Apply the bundled examples pack into `target_root` only if `target_root` is
@@ -756,7 +812,7 @@ pub fn apply_examples_pack_if_empty(
         "install: examples pack reseed={:?}",
         pack.reseed.as_deref().unwrap_or("once")
     );
-    Some(apply_pack(cloner, &pack, target_root))
+    Some(apply_pack(cloner, &pack, target_root, false))
 }
 
 /// Returns the set of app IDs defined in the bundled core pack.
@@ -800,7 +856,7 @@ pub fn apply_workspace_pack(
         workspace_apps.display(),
         pack.apps.len()
     );
-    Ok(apply_pack(cloner, &pack, &workspace_apps))
+    Ok(apply_pack(cloner, &pack, &workspace_apps, false))
 }
 
 /// Return the set of app IDs declared in `<workspace_root>/<channel_dir>/apps.toml`.
@@ -1119,12 +1175,57 @@ mod pack_tests {
         let cloner = MockCloner::new();
         let pack = pack_with(&[("foo", "github:owner/foo", "0.0.1")]);
 
-        let first = apply_pack(&cloner, &pack, target.path());
+        let first = apply_pack(&cloner, &pack, target.path(), false);
         assert!(matches!(first[0].status, InstallStatus::Installed(_)));
 
         // Second apply: same id at same version → AlreadyAtVersion.
-        let second = apply_pack(&cloner, &pack, target.path());
+        let second = apply_pack(&cloner, &pack, target.path(), false);
         assert!(matches!(second[0].status, InstallStatus::AlreadyAtVersion));
+    }
+
+    /// Regression guard (stint 0296 / PR #2359 validation): `refresh_local`
+    /// must re-extract an installed `local:` app from the embedded tree —
+    /// this is the only path by which core-app updates reach existing
+    /// profiles on stable channels (launch reseed installs missing apps
+    /// only).
+    #[test]
+    fn pack_apply_refresh_local_replaces_stale_install() {
+        let target = tempfile::tempdir().unwrap();
+        let cloner = MockCloner::new();
+        let pack = pack_with(&[("logs", "local:logs", "bundled")]);
+
+        let first = apply_pack(&cloner, &pack, target.path(), false);
+        assert!(matches!(first[0].status, InstallStatus::Installed(_)));
+
+        // Simulate a stale profile: drift the installed copy from the
+        // embedded ground truth.
+        let manifest_path = target.path().join("logs/manifest.toml");
+        let embedded = std::fs::read_to_string(&manifest_path).unwrap();
+        std::fs::write(&manifest_path, format!("{embedded}\n# stale drift\n")).unwrap();
+        let stray = target.path().join("logs/stray_file.txt");
+        std::fs::write(&stray, "left behind by an old version").unwrap();
+
+        // Without refresh: untouched (skipped or up-to-date — the installed
+        // manifest's real version never equals the pack's "bundled", which is
+        // precisely why version comparison can't drive core-app updates).
+        let plain = apply_pack(&cloner, &pack, target.path(), false);
+        assert!(matches!(
+            plain[0].status,
+            InstallStatus::AlreadyAtVersion | InstallStatus::SkippedOtherVersion { .. }
+        ));
+        assert!(std::fs::read_to_string(&manifest_path)
+            .unwrap()
+            .contains("stale drift"));
+
+        // With refresh: replaced wholesale from the embedded tree.
+        let refreshed = apply_pack(&cloner, &pack, target.path(), true);
+        assert!(
+            matches!(refreshed[0].status, InstallStatus::Refreshed(_)),
+            "expected Refreshed, got {:?}",
+            refreshed[0].status
+        );
+        assert_eq!(std::fs::read_to_string(&manifest_path).unwrap(), embedded);
+        assert!(!stray.exists(), "refresh must remove files not in the embedded tree");
     }
 
     #[test]
@@ -1139,7 +1240,7 @@ mod pack_tests {
             ("beta", "github:owner/beta", "v1"),
         ]);
 
-        let outcomes = apply_pack(&cloner, &pack, target.path());
+        let outcomes = apply_pack(&cloner, &pack, target.path(), false);
         assert_eq!(outcomes.len(), 2);
         // Exactly one failure, one install — order depends on apply_pack
         // iteration, just count by status.
@@ -1163,7 +1264,7 @@ mod pack_tests {
         let target = tempfile::tempdir().unwrap();
         let cloner = MockCloner::new();
         let pack = pack_with(&[("ok", "github:owner/ok", "v1"), ("bad", "ftp://nope", "v1")]);
-        let outcomes = apply_pack(&cloner, &pack, target.path());
+        let outcomes = apply_pack(&cloner, &pack, target.path(), false);
         let bad = outcomes.iter().find(|o| o.id == "bad").unwrap();
         match &bad.status {
             InstallStatus::Failed(msg) => assert!(msg.contains("unknown source scheme")),
@@ -1180,7 +1281,7 @@ mod pack_tests {
         cloner.fail_next_checkout("git checkout 0.0.1 failed");
         let pack = pack_with(&[("fallback", "github:owner/fallback", "0.0.1")]);
 
-        let outcomes = apply_pack(&cloner, &pack, target.path());
+        let outcomes = apply_pack(&cloner, &pack, target.path(), false);
 
         assert_eq!(cloner.checkouts.lock().unwrap().as_slice(), ["0.0.1"]);
         assert!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -443,12 +443,13 @@ fn main() -> eframe::Result {
                             AppCmd::Install {
                                 spec_or_path,
                                 pack,
+                                refresh,
                                 version,
                                 yes,
                             } => {
                                 if let Some(p) = pack {
-                                    log::info!("app_install:cli: pack={p}");
-                                    std::process::exit(cli::install_pack_cli(&p));
+                                    log::info!("app_install:cli: pack={p} refresh={refresh}");
+                                    std::process::exit(cli::install_pack_cli(&p, refresh));
                                 }
                                 match spec_or_path {
                                     None => {

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -269,44 +269,48 @@ impl PlexiApp {
         };
 
         if matches!(hint, Some("overlay")) {
-            let Some(focused_tile) = self.windows[active].focused_pane else {
-                log::warn!("app::{app_id}: overlay launch skipped — no focused pane");
-                return None;
-            };
-            let Some(Tile::Pane(focused_pane_id)) =
-                self.windows[active].tree.tiles.get(focused_tile)
-            else {
-                log::warn!("app::{app_id}: overlay launch skipped — focused tile is not a pane");
-                return None;
-            };
-            let pane_id = *focused_pane_id;
-            let Some(replaced_pane) = self.windows[active].panes.remove(&pane_id) else {
-                log::warn!(
-                    "app::{app_id}: overlay launch skipped — pane {pane_id} missing from pane map"
-                );
-                return None;
-            };
-            process.set_pane_id(pane_id);
-            self.windows[active].panes.insert(
-                pane_id,
-                new_app_pane(
+            if let Some(focused_tile) = self.windows[active].focused_pane {
+                let Some(Tile::Pane(focused_pane_id)) =
+                    self.windows[active].tree.tiles.get(focused_tile)
+                else {
+                    log::warn!(
+                        "app::{app_id}: overlay launch skipped — focused tile is not a pane"
+                    );
+                    return None;
+                };
+                let pane_id = *focused_pane_id;
+                let Some(replaced_pane) = self.windows[active].panes.remove(&pane_id) else {
+                    log::warn!(
+                        "app::{app_id}: overlay launch skipped — pane {pane_id} missing from pane map"
+                    );
+                    return None;
+                };
+                process.set_pane_id(pane_id);
+                self.windows[active].panes.insert(
                     pane_id,
-                    process,
-                    workspace_root,
-                    group,
-                    None,
-                    Some(Box::new(replaced_pane)),
-                ),
+                    new_app_pane(
+                        pane_id,
+                        process,
+                        workspace_root,
+                        group,
+                        None,
+                        Some(Box::new(replaced_pane)),
+                    ),
+                );
+                self.set_window_focused_pane(active, focused_tile);
+                log::info!("app::{app_id}: launched as overlay on pane {pane_id}");
+                crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
+                    app_id: app_id.to_string(),
+                    type_id: app_id.to_string(),
+                    pane_id,
+                    timestamp: crate::host::event_log::now_timestamp(),
+                });
+                return Some(pane_id);
+            }
+            log::info!(
+                "app::{app_id}: overlay requested but empty context — launching as root pane"
             );
-            self.set_window_focused_pane(active, focused_tile);
-            log::info!("app::{app_id}: launched as overlay on pane {pane_id}");
-            crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
-                app_id: app_id.to_string(),
-                type_id: app_id.to_string(),
-                pane_id,
-                timestamp: crate::host::event_log::now_timestamp(),
-            });
-            return Some(pane_id);
+            // fall through to root-pane path below
         }
 
         if self.windows[active].zoomed_pane.take().is_some() {
@@ -2476,10 +2480,12 @@ mod tests {
         assert!(result.is_some(), "overlay launch must return Some(pane_id)");
     }
 
-    /// Regression guard for issue #1706: overlay launch with no focused pane returns
-    /// None (nothing was created) so callers do not try to start a watcher.
+    /// Regression guard for stint 0311: launching an app via overlay hint (the
+    /// default layout for Cmd+P) when no pane is open must not be a silent no-op.
+    /// With an empty context the overlay path falls through to the root-pane path,
+    /// installs the app as the tree root, and returns its pane id.
     #[test]
-    fn open_process_app_pane_overlay_no_focused_pane_returns_none() {
+    fn open_process_app_pane_overlay_no_focused_pane_launches_root() {
         let mut h = HostHarness::new();
         assert!(
             h.app.windows[0].focused_pane.is_none(),
@@ -2494,9 +2500,17 @@ mod tests {
             None,
             Some("overlay"),
         );
-        assert!(
-            result.is_none(),
-            "overlay with no focused pane must return None"
+        let pane_id = result.expect("overlay with empty context must launch as root pane");
+        let root = h.app.windows[0].tree.root.expect("root tile installed");
+        assert_eq!(
+            h.app.windows[0].focused_pane,
+            Some(root),
+            "new root pane must be focused"
+        );
+        assert_eq!(
+            h.app.windows[0].tree.tiles.get(root),
+            Some(&Tile::Pane(pane_id)),
+            "root tile must hold the launched app pane"
         );
     }
 


### PR DESCRIPTION
Four independent stint tasks implemented in parallel worktrees from the same alpha HEAD and octopus-merged. No linked GitHub issues — stint tasks are authoritative.

## 0343 (P0) — drive-host skill
New `.agents/skills/drive-host/SKILL.md`: codified live headed E2E loop for PR builds (boot via `plexi-pr-<N> host start` → drive → observe from pane state + channel log → teardown), with a routing table against HostHarness/AppHarness. Pointer-only references wired into `test-pr` and `validate-pr`.

## 0311 (P2) — Cmd+P empty-context silent no-op
`open_process_app_pane` with `hint="overlay"` and no focused pane now falls through to the root-pane path instead of returning `None`. The old #1706 regression test was updated to assert the new behavior (root pane installed + focused, pane id returned).

## 0296 (P2) — canonical core app install set
`packs/core.toml` is now the single source of truth for the maintained app set. `install.sh` is channel-gated: alpha/pr-* sync the full tree (+ flattened `dev/`); beta/main seed exactly the canonical set through `plexi app install --pack core` (examples pack only on fresh profiles). New embedded drift-guard test (`core_pack_is_canonical_and_consistent`) asserts every pack entry resolves to a bundled app with matching manifest id and that install.sh never re-enumerates core app names. `apps/AGENTS.md` / `scripts/AGENTS.md` updated to point at the pack.

## 0298 (P3) — assistant stub cleanup
Deleted all "not yet implemented" built-in commands from the assistant registry (resume, compact, context, memory, model, effort, agent, settings, config, skills, install, hooks, export, rewind, history) plus the `PaneAction` stub effect and the stub-text dispatch arm. Every remaining built-in maps to a real handler; removed names now answer as unknown commands. Tests rewritten for shipping behavior.

**Test evidence:**
- cargo test: 1476 passed, 0 failed — full bin suite on the merged tree
- Per-branch: overlay tests (0311), assistant module 68 passed (0298), core_pack tests 5 passed incl. new drift guard (0296)
- Conclusion: binary install required — 0311 changes visible Cmd+P launch behavior and 0296 changes installer seeding; validate with `just pr-install <PR>` from this worktree, drive with `plexi-pr-<PR>`
- 0343 is docs-only; 0298 is deletion covered by the assistant test module

🤖 Generated with [Claude Code](https://claude.com/claude-code)