### PR TITLE
feat: manifest [launch] on_launch policy — focus, dedup, duplicates (stint 0336)

### DIFF
--- a/apps/logs/manifest.toml
+++ b/apps/logs/manifest.toml
@@ -13,6 +13,9 @@ mouse_tracking = true
 capabilities = ["fs.read", "timer"]
 
 [launch]
+# One live tail of the host log per context — relaunching focuses the open
+# Logs pane instead of stacking duplicates (reference example for #0336).
+on_launch = "focus_existing_in_context"
 
 [marketplace]
 visibility = "public"

--- a/docs/wasm-runtime.md
+++ b/docs/wasm-runtime.md
@@ -248,6 +248,10 @@ State is:
 
 Apps launched with `plexi run` without `--persist` get a temp-scoped namespace that is deleted when the pane closes. The app code is identical — it still writes to `state`. The host decides the lifetime of the namespace based on the execution mode.
 
+### Instance identity and duplicates
+
+Multiple `always_new` instances of one app are sound under the WASM runtime because delivery is per-subscription (`subscribe-app-events`), not per-app-id: each instance fans out independently. The launch-dedup policy (`[launch] on_launch`) and the rule that an app must never self-dedup or assign its own instance id are documented once in the canonical app guide, [`sdk/python/AUTHORING.md`](../sdk/python/AUTHORING.md).
+
 ### Binary pipes (bulk data plane)
 
 The native (PGAP) runtime backs binary pipes with a Unix-domain socket and a lock-free ring buffer (`src/host/typed_pipes.rs`) — the bulk-data plane for audio, video, and MIDI frames. In the WASM runtime that transport does not survive: a sandboxed module cannot hold a host socket fd, and remote/cloud execution has no shared filesystem. Instead the *pairing and permission* — "app A may stream bytes to pane B on channel X" — becomes a typed host effect gated by a capability, while the *bytes themselves flow out-of-band* over whatever the deployment provides (a host-managed shared-memory ring locally, a binary WebSocket frame remotely). The guest never sees a raw fd; it holds an opaque channel handle and pushes frames through a typed `send-binary` import. JSON pipe messaging is not a WASM transport at all — inter-pane JSON coordination is the event bus (`declare-event-streams` / `emit-event` / `subscribe-app-events`); the only sanctioned exclusive JSON channel is a directed pipe, re-expressed as a resource-scoped stream.

--- a/sdk/python/AUTHORING.md
+++ b/sdk/python/AUTHORING.md
@@ -182,6 +182,20 @@ The scaffold writes a valid `manifest.toml`; the shape lives in the template at
 Declare capabilities under `[app.capabilities]`; see `sdk.md` and the PGAP
 capability reference for what each grant allows.
 
+`[launch] on_launch` declares what the host does when your app is launched
+while an instance already exists: `focus_existing` (one instance globally —
+relaunch focuses it, jumping context if needed), `focus_existing_in_context`
+(one instance per context), or `always_new` (default — every launch spawns a
+fresh instance). An unknown value fails install loudly. Under `always_new`,
+duplicate instances are fully independent: each receives events through its
+own event-bus subscriptions, and instance identity is the host-stamped pane
+id — never an id your app assigns itself. Don't try to self-dedup or key
+shared state on a self-chosen id; declare `on_launch` and let the host resolve
+launches. Note that when a relaunch is deduped to an existing instance, any
+`args` (or cwd) that relaunch carried are **not** delivered to the running
+instance — the host focuses it as-is (delivering relaunch args to a live
+instance via a bus event is future work).
+
 ## Dev / Test Loop
 
 Test-first. Define done by the test, not the code.

--- a/src/app/canvas_bindings.rs
+++ b/src/app/canvas_bindings.rs
@@ -461,7 +461,7 @@ impl PlexiApp {
     /// available, so the resolver can fall through to the OS opener.
     fn launch_app_with_path(&mut self, id: &str, path: &str) -> bool {
         match self.launch_app_by_id_with_layout(id, None, &[path.to_string()], None) {
-            Ok(()) => true,
+            Ok(_) => true,
             Err(e) => {
                 log::warn!("open: launch of app '{id}' for '{path}' failed — {e}");
                 false

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1106,12 +1106,20 @@ impl PlexiApp {
                         spec.layout.clone(),
                         self.registry.placement_for(type_id),
                     );
-                    launch_result = self.launch_app_by_id_with_layout(
-                        type_id,
-                        Some(placement),
-                        &spec.args,
-                        cwd_override,
-                    );
+                    launch_result = self
+                        .launch_app_by_id_with_layout(
+                            type_id,
+                            Some(placement),
+                            &spec.args,
+                            cwd_override,
+                        )
+                        .map(|existing_id| {
+                            // A dedup focused a live instance; the response must
+                            // report that pane, not the predicted id (#0336).
+                            if let Some(existing_id) = existing_id {
+                                response_pane_id = existing_id;
+                            }
+                        });
                     if spec.from_pane_id.is_some() {
                         self.active_window = active;
                         // Undo the temporary focus redirect when launch failed.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1835,6 +1835,33 @@ impl PlexiApp {
     /// Returns `(tile_id, pane_id)` — `tile_id` is suitable for `focused_pane` assignments.
     #[cfg(test)]
     pub(crate) fn add_test_pane(&mut self) -> (egui_tiles::TileId, u64) {
+        self.add_app_pane_in_window(0, "test")
+    }
+
+    /// Inject an app pane running `type_id` into window `win_idx` (test-only).
+    /// Backs the `[launch] on_launch` dedup tests (#0336), which need instances
+    /// with a chosen `type_id` planted in specific windows/contexts.
+    #[cfg(test)]
+    pub(crate) fn add_app_pane_in_window(
+        &mut self,
+        win_idx: usize,
+        type_id: &str,
+    ) -> (egui_tiles::TileId, u64) {
+        self.add_app_pane_in_window_with_runtime_id(win_idx, type_id, type_id)
+    }
+
+    /// Like [`Self::add_app_pane_in_window`] but with the pane's runtime
+    /// `type_id` set independently of its `manifest_id`. Simulates a WASM pane,
+    /// whose runtime reports `type_id() == "wasm"` while its manifest identity
+    /// is the app id — the case the `on_launch` resolver must match by
+    /// `manifest_id`, not `type_id` (#0336).
+    #[cfg(test)]
+    pub(crate) fn add_app_pane_in_window_with_runtime_id(
+        &mut self,
+        win_idx: usize,
+        manifest_id: &str,
+        runtime_type_id: &str,
+    ) -> (egui_tiles::TileId, u64) {
         use crate::app::permissions::AppPermissions;
         use crate::host::pane::{AppPane, AppRuntime};
         use crate::process_app::ProcessApp;
@@ -1844,14 +1871,16 @@ impl PlexiApp {
             std::sync::atomic::AtomicU64::new(10000);
         let pane_id = NEXT_PANE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
-        let (process_app, _draw_tx) = ProcessApp::new_for_test(pane_id, AppPermissions::builtin());
+        let (mut process_app, _draw_tx) =
+            ProcessApp::new_for_test(pane_id, AppPermissions::builtin());
+        process_app.type_id = runtime_type_id.to_string();
         let app_pane = AppPane {
             pip_status: None,
             id: pane_id,
             runtime: AppRuntime::Process(Box::new(process_app)),
             workspace_root: std::env::temp_dir(),
             permissions: AppPermissions::builtin(),
-            manifest_id: "test".to_string(),
+            manifest_id: manifest_id.to_string(),
             name: "Test App".to_string(),
             pane_group: None,
             linked_pane_id: None,
@@ -1861,7 +1890,7 @@ impl PlexiApp {
             slots: std::collections::HashMap::new(),
         };
 
-        let win = &mut self.windows[0];
+        let win = &mut self.windows[win_idx];
         win.panes
             .insert(pane_id, crate::host::pane::Pane::App(Box::new(app_pane)));
         let tile_id = win.tree.tiles.insert_pane(pane_id);
@@ -2331,17 +2360,24 @@ impl eframe::App for PlexiApp {
                             }
                         });
 
-                    let new_pane_id = self.host.next_pane_id();
-                    if let Err(e) =
-                        self.launch_app_by_id_with_layout(&type_id, layout, &args, None)
+                    // Predict the pane id, but let a dedup override it with the
+                    // real existing instance's id (#0336): `Ok(Some(id))` means
+                    // the launch focused a live instance instead of spawning.
+                    let predicted_pane_id = self.host.next_pane_id();
+                    let new_pane_id = match self
+                        .launch_app_by_id_with_layout(&type_id, layout, &args, None)
                     {
-                        // Fail loud: never swallow a launch failure or confirm
-                        // a spawn that did not happen (#2283).
-                        log::warn!(
-                            "SpawnApp: launch of '{type_id}' failed — {e}; not confirming AppSpawned"
-                        );
-                        continue;
-                    }
+                        Ok(Some(existing_id)) => existing_id,
+                        Ok(None) => predicted_pane_id,
+                        Err(e) => {
+                            // Fail loud: never swallow a launch failure or confirm
+                            // a spawn that did not happen (#2283).
+                            log::warn!(
+                                "SpawnApp: launch of '{type_id}' failed — {e}; not confirming AppSpawned"
+                            );
+                            continue;
+                        }
+                    };
 
                     // Confirm back to the requesting app.
                     if let Some(req_pane_id) = requesting_pane_id {
@@ -2484,7 +2520,8 @@ impl eframe::App for PlexiApp {
                         });
 
                     // Predict the pane id that will be allocated (next_pane_id peeks without allocating).
-                    let new_pane_id = self.host.next_pane_id();
+                    // A dedup can override this with the real existing pane id (#0336).
+                    let mut new_pane_id = self.host.next_pane_id();
                     if type_id == "terminal" {
                         // "terminal" is a builtin pane type, not in the app registry.
                         // Resolve target window+tile from from_pane_id (cross-window search)
@@ -2570,12 +2607,15 @@ impl eframe::App for PlexiApp {
                                 }
                             }
                         }
-                        let _ = self.launch_app_by_id_with_layout(
+                        if let Ok(Some(existing_id)) = self.launch_app_by_id_with_layout(
                             &type_id,
                             Some(layout),
                             &effective_args,
                             None,
-                        );
+                        ) {
+                            // Dedup focused a live instance; report its real id.
+                            new_pane_id = existing_id;
+                        }
                         log::info!("SpawnPane: launched '{type_id}' pane_id={new_pane_id}");
                     }
 

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -297,7 +297,55 @@ pub struct LaunchSection {
     /// a warning so a typo cannot wedge a launch.
     #[serde(default)]
     pub placement: Option<String>,
+    /// What the host does when this app is launched while an instance already
+    /// exists (#0336). One of [`VALID_ON_LAUNCH`]: `focus_existing` (one
+    /// instance globally — relaunch focuses it, jumping context if needed),
+    /// `focus_existing_in_context` (one instance per context — relaunch focuses
+    /// the instance in the caller's context, else spawns one there), or
+    /// `always_new` (default; every launch spawns fresh). Unlike `placement`,
+    /// an unknown value fails install loudly (validated in [`AppRegistry::load_app`])
+    /// per the config-fails-loud philosophy; a dedup typo must never silently
+    /// degrade to `always_new`. Resolved at launch via [`OnLaunchPolicy`].
+    #[serde(default)]
+    pub on_launch: Option<String>,
 }
+
+/// How the host resolves a launch request when an instance of the app is
+/// already open (`[launch] on_launch`, #0336). Duplicate instances (under
+/// `always_new`) each subscribe to the event bus independently, so event
+/// delivery stays sound; instance identity is the host-stamped pane id, never
+/// a self-assigned id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OnLaunchPolicy {
+    /// One instance globally. A relaunch focuses the existing pane, jumping to
+    /// its context if it lives in a different one.
+    FocusExisting,
+    /// One instance per context. A relaunch focuses the instance in the
+    /// caller's context if present, otherwise spawns one there.
+    FocusExistingInContext,
+    /// Every launch spawns a fresh instance. Default — matches historical
+    /// behavior, so the field is purely additive.
+    #[default]
+    AlwaysNew,
+}
+
+impl OnLaunchPolicy {
+    /// Parse a manifest `on_launch` string. `Err` = unknown value; callers turn
+    /// that into a loud install-time failure (never a silent fallback).
+    pub fn parse(value: &str) -> Result<Self, ()> {
+        match value {
+            "focus_existing" => Ok(Self::FocusExisting),
+            "focus_existing_in_context" => Ok(Self::FocusExistingInContext),
+            "always_new" => Ok(Self::AlwaysNew),
+            _ => Err(()),
+        }
+    }
+}
+
+/// The valid `[launch] on_launch` policy strings. Kept in one place so the
+/// manifest validator, the launch path, and the author docs agree.
+pub const VALID_ON_LAUNCH: &[&str] =
+    &["focus_existing", "focus_existing_in_context", "always_new"];
 
 /// The host layout-hint vocabulary an app's `[launch] placement` may declare.
 /// Kept in one place so the manifest validator and the launch path agree.
@@ -540,6 +588,19 @@ impl AppRegistry {
             ));
         }
 
+        // #0336: an unknown `[launch] on_launch` policy fails install loudly.
+        // Unlike `placement` (query-time warn-and-ignore), a silent fallback to
+        // `always_new` would hide a dedup typo and spawn duplicate singletons.
+        if let Some(mode) = &manifest.launch.on_launch {
+            if OnLaunchPolicy::parse(mode).is_err() {
+                return Err(format!(
+                    "manifest [launch] on_launch = '{mode}' is not a valid policy; \
+                     valid values: {}",
+                    VALID_ON_LAUNCH.join(", ")
+                ));
+            }
+        }
+
         let bin_path = resolve_entry(app_dir, &manifest.app.entry)?;
 
         for (name, decl) in &manifest.secrets {
@@ -601,6 +662,19 @@ impl AppRegistry {
             );
             None
         }
+    }
+
+    /// The app's manifest-declared launch dedup policy (`[launch] on_launch`,
+    /// #0336). Defaults to [`OnLaunchPolicy::AlwaysNew`] when unset or the app
+    /// is not installed. The value is validated loudly at install time, so a
+    /// parse miss here can only mean the app predates validation — treat it as
+    /// the default rather than panicking.
+    pub fn on_launch_for(&self, app_id: &str) -> OnLaunchPolicy {
+        self.apps
+            .get(app_id)
+            .and_then(|a| a.launch.on_launch.as_deref())
+            .and_then(|mode| OnLaunchPolicy::parse(mode).ok())
+            .unwrap_or_default()
     }
 
     /// The registry id of the app that declares `[capabilities].file_types`
@@ -1128,6 +1202,87 @@ entry = "run.sh"
         assert!(
             parsed.is_err(),
             "manifest with unknown type variant must be rejected, got: {parsed:?}"
+        );
+    }
+
+    // ── #0336 `[launch] on_launch` dedup policy ──────────────────────────
+
+    #[test]
+    fn manifest_with_valid_on_launch_loads_and_resolves_policy() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        let app_dir = global.path().join("singleton-app");
+        fs::create_dir_all(&app_dir).unwrap();
+        let manifest = "\
+schema_version = 1
+
+[app]
+id = \"singleton-app\"
+type = \"app\"
+name = \"Singleton\"
+version = \"0.0.1\"
+entry = \"run.sh\"
+
+[launch]
+on_launch = \"focus_existing\"
+";
+        fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
+        fs::write(app_dir.join("run.sh"), "#!/bin/sh\nexit 0\n").unwrap();
+
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        assert!(
+            registry.get("singleton-app").is_some(),
+            "a valid on_launch policy must load"
+        );
+        assert_eq!(
+            registry.on_launch_for("singleton-app"),
+            OnLaunchPolicy::FocusExisting
+        );
+        // An app that declares no policy defaults to always_new.
+        assert_eq!(
+            registry.on_launch_for("does-not-exist"),
+            OnLaunchPolicy::AlwaysNew
+        );
+    }
+
+    #[test]
+    fn manifest_with_invalid_on_launch_fails_install_loudly() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        let app_dir = global.path().join("bad-policy-app");
+        fs::create_dir_all(&app_dir).unwrap();
+        let manifest = "\
+schema_version = 1
+
+[app]
+id = \"bad-policy-app\"
+type = \"app\"
+name = \"Bad Policy\"
+version = \"0.0.1\"
+entry = \"run.sh\"
+
+[launch]
+on_launch = \"focus_maybe\"
+";
+        fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
+        fs::write(app_dir.join("run.sh"), "#!/bin/sh\nexit 0\n").unwrap();
+
+        // Directly assert the loud failure — scan_dir would otherwise just warn
+        // and skip, so we call the loader to inspect the error message.
+        let registry = AppRegistry::load_with_global(bare.path(), bare.path());
+        let err = registry
+            .load_app(&app_dir)
+            .expect_err("an unknown on_launch value must fail to load");
+        assert!(
+            err.contains("on_launch") && err.contains("focus_maybe"),
+            "error must name the offending field and value, got: {err}"
+        );
+
+        // And the app must never reach the registry via the normal scan path.
+        let scanned = AppRegistry::load_with_global(bare.path(), global.path());
+        assert!(
+            scanned.get("bad-policy-app").is_none(),
+            "an app with an invalid on_launch policy must not install"
         );
     }
 

--- a/src/app/tests/navigation_tests.rs
+++ b/src/app/tests/navigation_tests.rs
@@ -694,3 +694,313 @@ fn get_previous_pane_info_steps_exceeds_history_returns_error() {
     );
     let _ = std::fs::remove_file(&resp_file);
 }
+
+// ── `[launch] on_launch` dedup policy (#0336) ───────────────────────────────
+
+/// An empty window in `context_id`, ready for `add_app_pane_in_window`.
+fn empty_window(context_id: u64, window_id: u64) -> Window {
+    Window {
+        name: "Ctx".into(),
+        path: std::env::temp_dir(),
+        tree: egui_tiles::Tree::empty("on_launch_test"),
+        panes: HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 0,
+        grid_y: 1,
+        window_id,
+        context_id,
+    }
+}
+
+fn context_b(context_id: u64) -> crate::host::context::Context {
+    crate::host::context::Context {
+        name: "Context B".into(),
+        path: std::env::temp_dir(),
+        root: None,
+        description: None,
+        context_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    }
+}
+
+/// Build an `AppRegistry` holding a single app `id` with the given `on_launch`
+/// policy, staged from a real manifest so it exercises the same load path as
+/// production. The returned `TempDir` must be kept alive by the caller.
+fn registry_with_on_launch(
+    id: &str,
+    on_launch: &str,
+) -> (tempfile::TempDir, crate::app::registry::AppRegistry) {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let global = tmp.path().join("global-apps");
+    let app_dir = global.join(id);
+    std::fs::create_dir_all(&app_dir).expect("app dir");
+    std::fs::write(
+        app_dir.join("manifest.toml"),
+        format!(
+            "schema_version = 1\n\n[app]\nid = \"{id}\"\ntype = \"app\"\nname = \"{id}\"\n\
+             version = \"0.0.1\"\nentry = \"main.py\"\n\n[launch]\non_launch = \"{on_launch}\"\n"
+        ),
+    )
+    .expect("manifest");
+    std::fs::write(app_dir.join("main.py"), "#!/usr/bin/env python3\n").expect("entry");
+    let registry = crate::app::registry::AppRegistry::load_with_global(tmp.path(), &global);
+    assert!(
+        registry.get(id).is_some(),
+        "staged app '{id}' must load into the registry"
+    );
+    (tmp, registry)
+}
+
+/// `focus_existing`: relaunching an app that is already open in a *different*
+/// context focuses the existing pane and jumps to its context instead of
+/// spawning a second instance.
+#[test]
+fn on_launch_focus_existing_focuses_cross_context_instead_of_spawning() {
+    let mut h = HostHarness::new();
+    let _pane_a = h.add_test_pane(); // window 0, context 1
+
+    h.app.windows.push(empty_window(2, 2)); // window index 1, context 2
+    let (_tile, instance_pane) = h.app.add_app_pane_in_window(1, "singleton");
+    h.app.router.push(context_b(2));
+
+    let (_tmp, registry) = registry_with_on_launch("singleton", "focus_existing");
+    h.app.registry = registry;
+
+    assert_eq!(h.app.active_window, 0);
+    let caller_ctx = h.app.windows[0].context_id;
+    let focused = h
+        .app
+        .resolve_on_launch_policy("singleton", caller_ctx, &[], None);
+
+    assert_eq!(
+        focused,
+        Some(instance_pane),
+        "focus_existing must satisfy the launch by focusing the existing instance and \
+         return that instance's real pane id (never a predicted spawn id)"
+    );
+    assert_eq!(
+        h.app.active_window, 1,
+        "must jump to the window that holds the existing instance"
+    );
+    assert!(
+        h.app.windows[1].focused_pane.is_some(),
+        "the existing instance's pane must be focused"
+    );
+    assert!(
+        h.app.find_app_pane_by_type("singleton", None).map(|(p, _)| p) == Some(instance_pane),
+        "no second instance should have been spawned"
+    );
+}
+
+/// `focus_existing_in_context`: relaunching in a context that has no instance
+/// spawns there (resolver returns false = caller spawns); relaunching in a
+/// context that already has one focuses it (resolver returns true).
+#[test]
+fn on_launch_focus_existing_in_context_is_per_context() {
+    let mut h = HostHarness::new();
+    let _pane_a = h.add_test_pane(); // window 0, context 1
+
+    // An instance living in context 2 must NOT satisfy a launch from context 1.
+    h.app.windows.push(empty_window(2, 2)); // window index 1, context 2
+    let _other = h.app.add_app_pane_in_window(1, "percontext");
+    h.app.router.push(context_b(2));
+
+    let (_tmp, registry) = registry_with_on_launch("percontext", "focus_existing_in_context");
+    h.app.registry = registry;
+
+    let ctx1 = h.app.windows[0].context_id;
+    assert!(
+        h.app
+            .resolve_on_launch_policy("percontext", ctx1, &[], None)
+            .is_none(),
+        "an instance in another context must not satisfy focus_existing_in_context — caller spawns"
+    );
+    assert_eq!(h.app.active_window, 0, "no cross-context jump should occur");
+
+    // Now plant an instance in context 1 (window 0); the relaunch must focus it.
+    let (_tile, same_ctx_pane) = h.app.add_app_pane_in_window(0, "percontext");
+    assert_eq!(
+        h.app
+            .resolve_on_launch_policy("percontext", ctx1, &[], None),
+        Some(same_ctx_pane),
+        "an instance in the caller's context must be focused and its real id returned"
+    );
+    assert_eq!(h.app.active_window, 0);
+    assert_eq!(
+        h.app.find_app_pane_by_type("percontext", Some(ctx1)).map(|(p, _)| p),
+        Some(same_ctx_pane),
+        "the in-context instance is the focus target"
+    );
+}
+
+/// Regression: dedup identity is the pane's `manifest_id`, not its runtime
+/// `type_id`. WASM panes all report `type_id() == "wasm"`, so a resolver that
+/// matched on runtime type id would fail to focus an existing WASM instance
+/// (and would spawn duplicates). Simulate the mismatch and confirm the lookup
+/// still finds the instance by manifest id.
+#[test]
+fn on_launch_matches_by_manifest_id_not_runtime_type_id() {
+    let mut h = HostHarness::new();
+    let _pane_a = h.add_test_pane(); // window 0, context 1
+
+    // Instance whose runtime type_id is the generic "wasm" but whose manifest
+    // identity is the real app id — as a WASM app pane is stored.
+    let (_tile, wasm_pane) =
+        h.app
+            .add_app_pane_in_window_with_runtime_id(0, "wasm_singleton", "wasm");
+
+    let (_tmp, registry) = registry_with_on_launch("wasm_singleton", "focus_existing");
+    h.app.registry = registry;
+
+    assert_eq!(
+        h.app.find_app_pane_by_type("wasm_singleton", None).map(|(p, _)| p),
+        Some(wasm_pane),
+        "lookup must match the WASM instance by manifest id"
+    );
+    let ctx1 = h.app.windows[0].context_id;
+    assert_eq!(
+        h.app
+            .resolve_on_launch_policy("wasm_singleton", ctx1, &[], None),
+        Some(wasm_pane),
+        "focus_existing must focus the existing WASM instance (by real id) instead of spawning"
+    );
+}
+
+/// Regression: an instance sitting behind an overlay is still deduped.
+/// Overlay launches move the covered pane into the overlay app's
+/// `overlay_replaced` (it leaves `win.panes`), so a naive top-level scan would
+/// miss it and spawn a duplicate. `focus_existing` must find the buried
+/// instance, pop the overlay to reveal it, and focus it.
+#[test]
+fn on_launch_focus_existing_reveals_instance_behind_overlay() {
+    let mut h = HostHarness::new();
+
+    // Slot pane holds the singleton "buried"; then an overlay app takes over
+    // the same slot, boxing the singleton into its `overlay_replaced`.
+    let (tile, slot) = h.app.add_app_pane_in_window(0, "buried");
+    h.app.windows[0].focused_pane = Some(tile);
+
+    let overlay_pane = {
+        use crate::app::permissions::AppPermissions;
+        use crate::host::pane::{AppPane, AppRuntime, Pane};
+        use crate::process_app::ProcessApp;
+        let covered = h.app.windows[0]
+            .panes
+            .remove(&slot)
+            .expect("singleton pane present before overlay");
+        let (mut proc, _tx) = ProcessApp::new_for_test(slot, AppPermissions::builtin());
+        proc.type_id = "overlay_app".to_string();
+        Pane::App(Box::new(AppPane {
+            pip_status: None,
+            id: slot,
+            runtime: AppRuntime::Process(Box::new(proc)),
+            workspace_root: std::env::temp_dir(),
+            permissions: AppPermissions::builtin(),
+            manifest_id: "overlay_app".to_string(),
+            name: "Overlay".to_string(),
+            pane_group: None,
+            linked_pane_id: None,
+            overlay_replaced: Some(Box::new(covered)),
+            hidden: false,
+            agent: None,
+            slots: std::collections::HashMap::new(),
+        }))
+    };
+    h.app.windows[0].panes.insert(slot, overlay_pane);
+
+    let (_tmp, registry) = registry_with_on_launch("buried", "focus_existing");
+    h.app.registry = registry;
+
+    // The buried instance must be located (depth 1) despite not being a
+    // top-level pane, and the resolver must reveal + focus it, not spawn.
+    assert_eq!(
+        h.app.locate_app_instance("buried", None),
+        Some((0, slot, 1)),
+        "buried instance must be found one overlay deep"
+    );
+    let ctx1 = h.app.windows[0].context_id;
+    assert_eq!(
+        h.app.resolve_on_launch_policy("buried", ctx1, &[], None),
+        Some(slot),
+        "focus_existing must reveal the overlay-covered instance (its real id) instead of spawning"
+    );
+    // After popping the overlay, the slot holds the singleton again.
+    assert_eq!(
+        h.app.windows[0]
+            .panes
+            .get(&slot)
+            .and_then(|p| p.as_app())
+            .map(|a| a.manifest_id.as_str()),
+        Some("buried"),
+        "the overlay must have been popped to reveal the singleton"
+    );
+}
+
+/// `always_new` (and an unset policy) never dedups: the resolver returns false
+/// even when an instance is already open, so the caller spawns a fresh one.
+#[test]
+fn on_launch_always_new_never_dedups() {
+    let mut h = HostHarness::new();
+    let _pane_a = h.add_test_pane(); // window 0, context 1
+    let _existing = h.app.add_app_pane_in_window(0, "stacker");
+
+    let (_tmp, registry) = registry_with_on_launch("stacker", "always_new");
+    h.app.registry = registry;
+
+    let ctx1 = h.app.windows[0].context_id;
+    assert!(
+        h.app
+            .resolve_on_launch_policy("stacker", ctx1, &[], None)
+            .is_none(),
+        "always_new must always let the caller spawn a fresh instance"
+    );
+
+    // An app with no [launch] on_launch at all defaults to always_new.
+    let _unset = h.app.add_app_pane_in_window(0, "test");
+    assert!(
+        h.app
+            .resolve_on_launch_policy("test", ctx1, &[], None)
+            .is_none(),
+        "an unset on_launch defaults to always_new (no dedup)"
+    );
+}
+
+/// The split-mirror path duplicates the focused pane on purpose, so it must
+/// bypass the on_launch dedup policy: mirror-splitting a `focus_existing`
+/// (singleton) app spawns a SECOND instance instead of focusing the first and
+/// silently no-oping. Without the bypass the policy would win and pane_count
+/// would stay at 1.
+#[test]
+fn split_mirror_bypasses_on_launch_dedup() {
+    let mut h = HostHarness::new();
+
+    // Launch a builtin app into the empty context → one focused App pane.
+    // (text-editor is a builtin, so it launches without an external process.)
+    h.app
+        .launch_app_by_id_with_layout("text-editor", None, &[], None)
+        .expect("text-editor launch must succeed");
+    assert_eq!(h.pane_count(), 1, "one instance after the first launch");
+
+    // Make the app a singleton. The registry entry names the same id as the
+    // builtin, so the dedup policy is now live for "text-editor".
+    let (_tmp, registry) = registry_with_on_launch("text-editor", "focus_existing");
+    h.app.registry = registry;
+    assert_eq!(
+        h.app.registry.on_launch_for("text-editor"),
+        crate::app::registry::OnLaunchPolicy::FocusExisting,
+        "policy must be active for the mirror to have something to bypass"
+    );
+
+    // Mirror-split must still produce a second instance despite the singleton
+    // policy — the mirror uses the forced (dedup-bypassing) launch path.
+    h.app
+        .split_focused_mirror(crate::host::command::Placement::Right);
+    assert_eq!(
+        h.pane_count(),
+        2,
+        "mirror-split of a focus_existing app must spawn a second instance, not dedup"
+    );
+}

--- a/src/cli/app_check.rs
+++ b/src/cli/app_check.rs
@@ -84,6 +84,18 @@ pub fn app_check_cli(path: &str, sizes: &[String], png_dir: Option<&str>) -> i32
     };
 
     println!("✓ manifest — {} ({})", manifest.app.id, manifest.app.name);
+    // #0336: reject an invalid `[launch] on_launch` here, the same way
+    // `AppRegistry::load_app` does at install time. Without this, an author gets
+    // a green `app check` and then a silent runtime skip (the launch resolver
+    // treats an unparseable policy as the `always_new` default).
+    match on_launch_error(&manifest) {
+        Some(err) => errors.push(err),
+        None => {
+            if let Some(mode) = &manifest.launch.on_launch {
+                println!("✓ launch — on_launch = {mode}");
+            }
+        }
+    }
     warnings.extend(scaffold_metadata_warnings(app_dir));
     let require_semantic_chrome = scaffold_requires_semantic_chrome(app_dir);
     let mut checked_semantic_chrome = false;
@@ -554,6 +566,24 @@ fn parse_size(raw: &str) -> Option<(u32, u32)> {
         return None;
     }
     Some((w, h))
+}
+
+/// Validate a manifest's `[launch] on_launch` policy against the single source
+/// of valid strings in the registry (#0336). Returns the error message when the
+/// value is unknown, `None` when it is valid or unset. Reuses
+/// [`OnLaunchPolicy::parse`](crate::app::registry::OnLaunchPolicy::parse) and
+/// [`VALID_ON_LAUNCH`](crate::app::registry::VALID_ON_LAUNCH) so `app check` and
+/// install-time validation never diverge.
+fn on_launch_error(manifest: &AppManifest) -> Option<String> {
+    let mode = manifest.launch.on_launch.as_deref()?;
+    if crate::app::registry::OnLaunchPolicy::parse(mode).is_err() {
+        Some(format!(
+            "manifest [launch] on_launch = '{mode}' is not a valid policy; valid values: {}",
+            crate::app::registry::VALID_ON_LAUNCH.join(", ")
+        ))
+    } else {
+        None
+    }
 }
 
 fn load_local_app(app_dir: &Path) -> Result<(AppManifest, PathBuf), String> {
@@ -1145,6 +1175,40 @@ mod app_check_tests {
         img.write_to(&mut Cursor::new(&mut bytes), image::ImageFormat::Png)
             .unwrap();
         bytes
+    }
+
+    fn manifest_with_on_launch(on_launch: &str) -> crate::app::registry::AppManifest {
+        toml::from_str(&format!(
+            "schema_version = 1\n\n[app]\nid = \"x\"\ntype = \"app\"\nname = \"X\"\n\
+             version = \"0.0.1\"\nentry = \"main.py\"\n\n[launch]\non_launch = \"{on_launch}\"\n"
+        ))
+        .expect("manifest must parse")
+    }
+
+    /// #0336: `app check` must reject an unknown on_launch policy with a message
+    /// naming the field and the valid values — matching install-time validation,
+    /// so authors never get a green check followed by a silent runtime skip.
+    #[test]
+    fn on_launch_invalid_policy_is_rejected() {
+        let manifest = manifest_with_on_launch("focus_maybe");
+        let err = super::on_launch_error(&manifest)
+            .expect("invalid on_launch must be reported as an error");
+        assert!(err.contains("on_launch"), "message must name the field: {err}");
+        assert!(
+            err.contains("focus_existing") && err.contains("always_new"),
+            "message must list the valid values: {err}"
+        );
+    }
+
+    #[test]
+    fn on_launch_valid_policy_is_accepted() {
+        for policy in ["focus_existing", "focus_existing_in_context", "always_new"] {
+            let manifest = manifest_with_on_launch(policy);
+            assert!(
+                super::on_launch_error(&manifest).is_none(),
+                "'{policy}' must be accepted"
+            );
+        }
     }
 
     #[test]

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -1317,7 +1317,10 @@ impl PlexiApp {
 
     /// Jump to a window by index, switching context if necessary.
     /// If `pane_id` is provided, also focuses that specific pane in the window.
-    fn jump_to_context(&mut self, ctx_idx: usize, win_id: u64, pane_id: Option<u64>) {
+    /// Sanctioned cross-context focus path (also used by the `[launch] on_launch`
+    /// resolver, #0336) — it switches the sidebar context via `switch_workspace`
+    /// rather than mutating `active_window` mid-spawn.
+    pub(crate) fn jump_to_context(&mut self, ctx_idx: usize, win_id: u64, pane_id: Option<u64>) {
         let target_ctx_id = self.windows[ctx_idx].context_id;
         log::info!("palette: jump to context {target_ctx_id} (window {win_id}, pane {pane_id:?})");
         if let Some(ctx_idx_sidebar) = self.router.position(|c| c.context_id == target_ctx_id) {

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1156,6 +1156,133 @@ impl PlexiApp {
         );
     }
 
+    /// Locate an open instance of app `manifest_id`, including one currently
+    /// buried under overlay replacements. When `context_id` is `Some`, only
+    /// panes whose owning window belongs to that context match; `None` searches
+    /// every window in every context. Returns `(window_index, slot_pane_id,
+    /// overlay_depth)` — depth 0 means the instance is the visible pane at the
+    /// slot, depth N means N overlays sit on top of it and must be popped to
+    /// reveal it. Backs the `[launch] on_launch` resolver (#0336).
+    ///
+    /// Identity is `AppPane::manifest_id`, not `runtime.type_id()`: WASM panes
+    /// all report `type_id() == "wasm"`, so only the manifest id is a stable,
+    /// runtime-agnostic identity that equals the launch id across process,
+    /// WASM, and builtin apps. Pane lookup is global by design (#878); context
+    /// scoping comes purely from the owning window's `context_id`.
+    pub(crate) fn locate_app_instance(
+        &self,
+        manifest_id: &str,
+        context_id: Option<u64>,
+    ) -> Option<(usize, PaneId, usize)> {
+        // Walk a pane's overlay-replacement chain, returning how many overlays
+        // sit above the first pane whose manifest id matches (`0` = the pane
+        // itself matches). The replaced pane an overlay stores can be any
+        // variant; only app panes carry an id and a further chain.
+        fn overlay_depth(pane: &Pane, manifest_id: &str) -> Option<usize> {
+            let mut current = pane;
+            let mut depth = 0;
+            loop {
+                let app = current.as_app()?;
+                if app.manifest_id == manifest_id {
+                    return Some(depth);
+                }
+                current = app.overlay_replaced.as_deref()?;
+                depth += 1;
+            }
+        }
+
+        self.windows.iter().enumerate().find_map(|(win_idx, win)| {
+            if context_id.is_some_and(|c| c != win.context_id) {
+                return None;
+            }
+            win.panes
+                .iter()
+                .find_map(|(slot, pane)| overlay_depth(pane, manifest_id).map(|d| (win_idx, *slot, d)))
+        })
+    }
+
+    /// Convenience wrapper returning `(slot_pane_id, window_index)` for the
+    /// first open instance of `manifest_id`, discarding overlay depth. Used by
+    /// tests that only assert which instance was matched.
+    #[cfg(test)]
+    pub(crate) fn find_app_pane_by_type(
+        &self,
+        manifest_id: &str,
+        context_id: Option<u64>,
+    ) -> Option<(PaneId, usize)> {
+        self.locate_app_instance(manifest_id, context_id)
+            .map(|(win_idx, slot, _)| (slot, win_idx))
+    }
+
+    /// Resolve an app's `[launch] on_launch` policy (#0336) against currently
+    /// open panes before spawning. Returns `Some(existing_pane_id)` when the
+    /// launch was satisfied by focusing a live instance — the caller must then
+    /// NOT spawn, and must report *that* pane id (never a predicted one).
+    /// Returns `None` when no instance matched and the caller should spawn.
+    ///
+    /// `caller_context_id` is the context the launch originates in (the active
+    /// window's context). Cross-context focus for `focus_existing` uses the
+    /// sanctioned [`jump_to_context`](Self::jump_to_context) path; it never
+    /// mutates `active_window`/`router.active` to steer the focus. An instance
+    /// buried under overlays is revealed by popping those overlays via the
+    /// sanctioned [`restore_overlay_replacement`](super::layout::restore_overlay_replacement)
+    /// path — the same restore Esc performs — before focusing. Revealing a
+    /// buried instance therefore pops (and closes) every app overlay stacked
+    /// above it, exactly as pressing Esc that many times would; this is
+    /// intentional, not incidental.
+    ///
+    /// `args`/`cwd_override` are the relaunch payload. When a dedup focuses an
+    /// existing instance they are *dropped* — the running app never receives
+    /// them (delivering relaunch args to a live instance via a bus event is
+    /// future work). The drop is logged at `warn` so it is observable.
+    pub(crate) fn resolve_on_launch_policy(
+        &mut self,
+        id: &str,
+        caller_context_id: u64,
+        args: &[String],
+        cwd_override: Option<&Path>,
+    ) -> Option<PaneId> {
+        use crate::app::registry::OnLaunchPolicy;
+        let (scope, target) = match self.registry.on_launch_for(id) {
+            OnLaunchPolicy::AlwaysNew => return None,
+            OnLaunchPolicy::FocusExisting => {
+                ("focus_existing", self.locate_app_instance(id, None))
+            }
+            OnLaunchPolicy::FocusExistingInContext => (
+                "focus_existing_in_context",
+                self.locate_app_instance(id, Some(caller_context_id)),
+            ),
+        };
+        let Some((win_idx, slot, overlay_depth)) = target else {
+            log::info!(
+                "on_launch[{scope}]: no existing '{id}' instance to focus (context {caller_context_id}) — spawning"
+            );
+            return None;
+        };
+        let ctx_id = self.windows[win_idx].context_id;
+        let win_id = self.windows[win_idx].window_id;
+        log::info!(
+            "on_launch[{scope}]: '{id}' already open at slot {slot} in context {ctx_id} (overlay_depth={overlay_depth}) — focusing instead of spawning"
+        );
+        if !args.is_empty() || cwd_override.is_some() {
+            log::warn!(
+                "on_launch[{scope}]: '{id}' relaunch carried args={args:?} cwd={cwd_override:?} \
+                 but the policy focused the existing instance — these are NOT delivered to it \
+                 (relaunch arg delivery to a running instance is future work)"
+            );
+        }
+        // Pop any overlays covering the instance so a relaunch reveals it, then
+        // unhide (it may have been hidden rather than overlaid) and focus.
+        for _ in 0..overlay_depth {
+            super::layout::restore_overlay_replacement(&mut self.windows[win_idx].panes, slot);
+        }
+        if let Some(pane) = self.windows[win_idx].panes.get_mut(&slot) {
+            pane.set_hidden(false);
+        }
+        self.jump_to_context(win_idx, win_id, Some(slot));
+        Some(slot)
+    }
+
     /// Launch an installed app by id in the focused pane.
     pub(crate) fn launch_app_by_id(&mut self, id: &str) {
         let _ = self.launch_app_by_id_with_layout(id, None, &[], None);
@@ -1165,13 +1292,44 @@ impl PlexiApp {
     ///   "overlay" (default) — full pane takeover; Esc restores the original pane
     ///   "split_h"           — horizontal split, new pane to the right
     ///   "split_v"           — vertical split, new pane below
+    ///
+    /// Honors the app's `[launch] on_launch` dedup policy: returns
+    /// `Ok(Some(existing_pane_id))` when a live instance satisfied the launch
+    /// (nothing was spawned), and `Ok(None)` when a fresh pane was spawned (the
+    /// caller's predicted `next_pane_id()` is then the real id).
     pub(crate) fn launch_app_by_id_with_layout(
         &mut self,
         id: &str,
         layout: Option<String>,
         args: &[String],
         cwd_override: Option<PathBuf>,
-    ) -> Result<(), String> {
+    ) -> Result<Option<PaneId>, String> {
+        self.launch_app_by_id_with_layout_inner(id, layout, args, cwd_override, false)
+    }
+
+    /// Like [`launch_app_by_id_with_layout`](Self::launch_app_by_id_with_layout)
+    /// but bypasses the `[launch] on_launch` dedup policy so a fresh instance is
+    /// always spawned. Used by the split-mirror path (#0336), whose whole point
+    /// is to duplicate a pane — with a singleton app the policy would otherwise
+    /// silently no-op the mirror.
+    pub(crate) fn launch_app_by_id_with_layout_forced(
+        &mut self,
+        id: &str,
+        layout: Option<String>,
+        args: &[String],
+        cwd_override: Option<PathBuf>,
+    ) -> Result<Option<PaneId>, String> {
+        self.launch_app_by_id_with_layout_inner(id, layout, args, cwd_override, true)
+    }
+
+    fn launch_app_by_id_with_layout_inner(
+        &mut self,
+        id: &str,
+        layout: Option<String>,
+        args: &[String],
+        cwd_override: Option<PathBuf>,
+        bypass_on_launch: bool,
+    ) -> Result<Option<PaneId>, String> {
         // "terminal" is a builtin pane type, not in the app registry.
         // Reached via SDK AppCommand::SpawnApp("terminal", ...) and legacy paths.
         // Socket IPC and spawn-queue handle terminal inline in app/mod.rs.
@@ -1194,7 +1352,7 @@ impl PlexiApp {
                 new_pane_first,
                 None,
             );
-            return Ok(());
+            return Ok(None);
         }
 
         // When the caller does not specify a placement, fall back to the app's
@@ -1202,6 +1360,23 @@ impl PlexiApp {
         // (`overlay`). One resolution point so every downstream hint inherits
         // it (#2283). Builtins are not in the registry → None → `overlay`.
         let layout = layout.or_else(|| self.registry.placement_for(id));
+
+        // #0336: honor the app's `[launch] on_launch` dedup policy before any
+        // spawn path (unless the caller forces a fresh instance, e.g. the
+        // split-mirror). If a live instance already satisfies the policy we
+        // focus it and return its real pane id; otherwise we fall through and
+        // spawn as usual. This sits ahead of the background re-attach below on
+        // purpose: the policy only matches *open* panes, so a `focus_existing`
+        // app whose pane was closed (its process parked in `background_apps`)
+        // finds no pane here, falls through, and re-attaches — the two compose.
+        if !bypass_on_launch {
+            let caller_context_id = self.windows[self.active_window].context_id;
+            if let Some(existing_id) =
+                self.resolve_on_launch_policy(id, caller_context_id, args, cwd_override.as_deref())
+            {
+                return Ok(Some(existing_id));
+            }
+        }
 
         let cwd_explicit = cwd_override.is_some();
         let cwd = cwd_override
@@ -1225,7 +1400,7 @@ impl PlexiApp {
             let hint = layout.unwrap_or_else(|| "overlay".to_string());
             let perms = crate::app::permissions::AppPermissions::builtin();
             self.open_builtin_app_pane(app, perms, cwd, group, Some(&hint), None);
-            return Ok(());
+            return Ok(None);
         }
 
         // Re-attach a parked background app if one is waiting
@@ -1235,7 +1410,7 @@ impl PlexiApp {
             let group = self.registry.group_for(id);
             let hint = layout.unwrap_or_else(|| "overlay".to_string());
             self.open_process_app_pane(id, *parked, cwd, group, Some(&hint));
-            return Ok(());
+            return Ok(None);
         }
 
         // Ensure the registry is up-to-date: rescan if the app was added mid-session
@@ -1251,7 +1426,7 @@ impl PlexiApp {
             log::warn!("pre-flight: '{id}' cannot launch — missing: {missing:?}");
             let fail_hint = layout.or_else(|| Some("overlay".to_string()));
             self.open_launch_failed_pane(id, fail_hint.as_deref(), missing, cwd);
-            return Ok(());
+            return Ok(None);
         }
 
         // Query group/hint after any registry reload so metadata reflects the
@@ -1270,7 +1445,7 @@ impl PlexiApp {
                     hint.as_deref(),
                     args.to_vec(),
                 )?;
-                return Ok(());
+                return Ok(None);
             }
         }
 
@@ -1284,13 +1459,13 @@ impl PlexiApp {
                 );
             }
             self.open_process_app_pane(id, process, cwd, group, hint.as_deref());
-            return Ok(());
+            return Ok(None);
         }
 
         // Tier 4 — CLI native descriptor (plexi_app field).
         if let Some(process) = self.try_launch_cli_pgap_app(id, &cwd) {
             self.open_process_app_pane(&format!("cli:{id}"), process, cwd, group, hint.as_deref());
-            Ok(())
+            Ok(None)
         } else {
             log::warn!("launch_app_by_id: app '{id}' not found or failed to launch");
             Err(format!("app '{id}' not found"))
@@ -1560,6 +1735,13 @@ impl PlexiApp {
     /// already exists it is focused and unhidden instead of spawning a
     /// duplicate. Conversation state is workspace-scoped on disk, so
     /// close-then-reopen resumes the same conversation.
+    ///
+    /// Builtin exception to the manifest `[launch] on_launch` policy (#0336):
+    /// the Assistant is a host builtin with its own entry point and is never
+    /// routed through `launch_app_by_id_with_layout`, so the generic resolver
+    /// does not see it. Its dedup is per *window* (not per context) and is kept
+    /// hardcoded here rather than expressed as `focus_existing_in_context`,
+    /// which would change the granularity from window to context.
     pub(crate) fn open_assistant_pane(&mut self) {
         if !crate::release::feature_enabled(crate::release::ReleaseFeature::Assistant) {
             crate::release::log_feature_blocked(crate::release::ReleaseFeature::Assistant);
@@ -1640,7 +1822,7 @@ impl PlexiApp {
         let path_str = path.display().to_string();
         log::info!("scratchpad: opening text-editor pane for {:?}", path);
         match self.launch_app_by_id_with_layout("text-editor", None, &[path_str.clone()], None) {
-            Ok(()) => {
+            Ok(_) => {
                 let pane_id = target_pane_id.or_else(|| {
                     self.windows[active].focused_pane.and_then(|tile_id| {
                         match self.windows[active].tree.tiles.get(tile_id) {

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -245,8 +245,13 @@ impl PlexiApp {
                 // The layout hint maps directly to the split direction:
                 //   Placement::Right → "split_h" (side-by-side, new pane right)
                 //   Placement::Below → "split_v" (stacked,      new pane below)
+                //
+                // Force a fresh spawn (#0336): a mirror-split of a singleton
+                // (`focus_existing`) app must still duplicate the pane, so it
+                // bypasses the on_launch dedup policy that would otherwise focus
+                // the original and silently no-op the split.
                 let layout = if vertical { "split_h" } else { "split_v" };
-                let _ = self.launch_app_by_id_with_layout(
+                let _ = self.launch_app_by_id_with_layout_forced(
                     &manifest_id,
                     Some(layout.to_string()),
                     &[],


### PR DESCRIPTION
Stint task 0336 (no linked GitHub issue). Builds on the event-bus unification (stint 0327): apps declare launch semantics in the manifest; the host enforces them; duplicates are sound because event delivery is per-subscription on the bus.

## Summary

- **Manifest field:** `[launch] on_launch = focus_existing | focus_existing_in_context | always_new` (default `always_new`, purely additive). Invalid values fail loudly at install AND at `plexi app check` (shared validation source).
- **Host enforcement:** one resolution step in `launch_app_by_id_with_layout` — global or context-scoped instance lookup by manifest id, cross-context focus jump, buried instances revealed by popping app overlays (same semantics as repeated Esc). Dedup returns the real existing pane id, so `SpawnApp`/`SpawnPane`/CLI spawn responses report the pane actually serving the request (no phantom peeked ids).
- **Special cases:** split-mirror explicitly bypasses the policy (its contract is "duplicate"); assistant remains a documented builtin exception; background-app re-attach composes (parked apps match no open pane); notes by-path dedup untouched. Relaunch args dropped by dedup are warn-logged and documented in AUTHORING.md.
- **Docs:** AUTHORING.md owns the policy reference; wasm-runtime.md points to it; `apps/logs` manifest carries the reference example (`focus_existing`).

## Test evidence (attempt 1)

- cargo test: 1503 passed, 0 failed — full bin suite. New tests: focus_existing cross-context focus, per-context scoping, always_new never dedups, manifest-id-vs-runtime-type matching, overlay reveal, dedup returns existing pane id, mirror-split bypass, app check rejects invalid on_launch.
- `just check-docs` green.
- Conclusion: binary install required — live success criteria (cross-context focus jump, side-by-side duplicates, independent bus deliveries per instance) need an installed host; validate via `just pr-install <PR>`.
