### PR TITLE
fix: host start windowless boot drops seeded/spawned panes (stint 0348)

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -948,29 +948,43 @@ impl PlexiApp {
                                     {
                                         (active, tile)
                                     } else {
-                                        // Window is empty — let split_focused handle it
-                                        log::info!("pane_ipc: spawn_pane terminal layout={layout_str} (empty context fallback)");
-                                        self.split_focused(
-                                            vertical,
+                                        // Active window is empty (windowless boot):
+                                        // split_focused would no-op, so seed a root
+                                        // pane in place instead of dropping the spawn.
+                                        log::info!("pane_ipc: spawn_pane terminal layout={layout_str} (empty active window — seeding root)");
+                                        match self.seed_root_pane(
                                             initial_cmd.as_deref(),
                                             spec.ephemeral,
-                                            new_pane_first,
                                             cwd_override,
-                                        );
+                                        ) {
+                                            Some(seeded_id) => response_pane_id = seeded_id,
+                                            None => {
+                                                launch_result =
+                                                    Err("failed to seed root pane".into())
+                                            }
+                                        }
                                         if spec.no_focus {
                                             self.active_window = active;
                                         }
-                                        if let Some(ref pane_name) = spec.name {
-                                            if !pane_name.is_empty() {
-                                                self.apply_inline_pane_name(
-                                                    response_pane_id,
-                                                    pane_name,
-                                                );
+                                        if launch_result.is_ok() {
+                                            if let Some(ref pane_name) = spec.name {
+                                                if !pane_name.is_empty() {
+                                                    self.apply_inline_pane_name(
+                                                        response_pane_id,
+                                                        pane_name,
+                                                    );
+                                                }
                                             }
                                         }
                                         if let Some(rf) = &spec.response_file {
-                                            let json =
-                                                format!("{{\"pane_id\":{response_pane_id}}}");
+                                            let json = match &launch_result {
+                                                Ok(()) => {
+                                                    format!("{{\"pane_id\":{response_pane_id}}}")
+                                                }
+                                                Err(msg) => {
+                                                    format!("{{\"error\":{}}}", serde_json::json!(msg))
+                                                }
+                                            };
                                             if let Err(e) = std::fs::write(rf, &json) {
                                                 log::error!("pane_ipc: spawn_pane: could not write response file: {e}");
                                             }
@@ -985,29 +999,40 @@ impl PlexiApp {
                         {
                             (active, tile)
                         } else {
-                            // Truly empty window — fall back to split_focused
+                            // Truly empty window (windowless boot): no root pane to
+                            // split, so `split_focused` would no-op and drop the
+                            // spawn. Seed a root pane into the existing active window
+                            // instead. The seeded pane's id is the id we report.
                             log::info!(
-                                "pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} new_pane_first={new_pane_first} initial_cmd={initial_cmd:?} ephemeral={}",
+                                "pane_ipc: spawn_pane terminal layout={layout_str} vertical={vertical} new_pane_first={new_pane_first} initial_cmd={initial_cmd:?} ephemeral={} (empty active window — seeding root)",
                                 spec.ephemeral
                             );
-                            self.split_focused(
-                                vertical,
+                            match self.seed_root_pane(
                                 initial_cmd.as_deref(),
                                 spec.ephemeral,
-                                new_pane_first,
                                 cwd_override,
-                            );
+                            ) {
+                                Some(seeded_id) => response_pane_id = seeded_id,
+                                None => launch_result = Err("failed to seed root pane".into()),
+                            }
                             if spec.no_focus {
                                 self.active_window = active;
                             }
-                            if let Some(ref pane_name) = spec.name {
-                                if !pane_name.is_empty() {
-                                    self.apply_inline_pane_name(response_pane_id, pane_name);
+                            if launch_result.is_ok() {
+                                if let Some(ref pane_name) = spec.name {
+                                    if !pane_name.is_empty() {
+                                        self.apply_inline_pane_name(response_pane_id, pane_name);
+                                    }
                                 }
                             }
                             // Skip rest of split path
                             if let Some(rf) = &spec.response_file {
-                                let json = format!("{{\"pane_id\":{response_pane_id}}}");
+                                let json = match &launch_result {
+                                    Ok(()) => format!("{{\"pane_id\":{response_pane_id}}}"),
+                                    Err(msg) => {
+                                        format!("{{\"error\":{}}}", serde_json::json!(msg))
+                                    }
+                                };
                                 if let Err(e) = std::fs::write(rf, &json) {
                                     log::error!(
                                         "pane_ipc: spawn_pane: could not write response file: {e}"

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -371,3 +371,114 @@ fn spawn_pane_tab_anchors_to_from_pane_window_not_active() {
         );
     }
 }
+
+/// When `plexi host start` boots windowless (active window has no root pane and
+/// no focused pane), a `plexi pane new` split request must still materialize a
+/// pane. Regression for stint 0348: the empty-window fallback routed through
+/// `split_focused`, which returns early with no focused pane to split, so the
+/// spawn was silently dropped — `pane list` returned `[]` and the requested
+/// name never applied. The fallback must seed a root pane instead, apply the
+/// requested name, and write the actually-created pane id to the response file.
+#[test]
+fn spawn_pane_seeds_root_in_empty_window() {
+    let ctx = egui::Context::default();
+    let ft = crate::platform::logging::new_frame_tick();
+    let (mut app, ipc_tx) = PlexiApp::new_for_test(ctx, ft);
+
+    // new_for_test's sole window boots empty — no root, no focused pane —
+    // exactly the windowless-boot state.
+    assert!(
+        app.windows[0].tree.root.is_none(),
+        "precondition: window boots with no root pane"
+    );
+    assert!(
+        app.windows[0].focused_pane.is_none(),
+        "precondition: window boots with no focused pane"
+    );
+
+    let response_file = std::env::temp_dir().join(format!(
+        "plexi_test_seed_root_{}.json",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&response_file);
+
+    // Split spawn (not --window), no from_pane_id: falls into the empty-window
+    // fallback branch.
+    let _ = ipc_tx.send(crate::app_protocol::AppRequest::SpawnPane {
+        type_id: "terminal".to_string(),
+        layout: Some("split_h".to_string()),
+        args: vec![],
+        from_pane_id: None,
+        request_id: None,
+        response_file: Some(response_file.to_string_lossy().to_string()),
+        ephemeral: false,
+        cwd: None,
+        no_focus: false,
+        path: None,
+        workspace_root: None,
+        target_context: None,
+        name: Some("seeded".to_string()),
+    });
+    app.drain_pane_cmd_channel();
+
+    // Determine PTY availability independently of the code under test:
+    // `create_page_at` spawns a terminal via the same `TerminalPane::new` path.
+    // If it can't create one here (a headless CI without a PTY), the fallback
+    // likewise can't, so skip. When it CAN, the empty-window fallback must
+    // produce a pane — so we assert unconditionally below. This split is
+    // deliberate: guarding the real assertions on "panes.is_empty()" would let
+    // the very bug under test (a silently dropped spawn) masquerade as a
+    // skipped PTY failure.
+    let pty_available = {
+        let ctx = egui::Context::default();
+        let ft = crate::platform::logging::new_frame_tick();
+        let (mut probe, _tx) = PlexiApp::new_for_test(ctx, ft);
+        let before = probe.windows.len();
+        probe.create_page_at(9, 9, 1, None, false, None);
+        probe.windows.len() > before
+    };
+    if !pty_available {
+        let _ = std::fs::remove_file(&response_file);
+        return; // no PTY in this environment; cannot exercise terminal spawn
+    }
+
+    assert_eq!(
+        app.windows[0].panes.len(),
+        1,
+        "empty-window spawn must seed exactly one root pane"
+    );
+    assert!(
+        app.windows[0].tree.root.is_some(),
+        "seeded window must have a tree root"
+    );
+
+    let pane_id = *app.windows[0]
+        .panes
+        .keys()
+        .next()
+        .expect("seeded pane must exist");
+
+    // Requested name must have applied to the seeded pane.
+    let name = app.windows[0]
+        .panes
+        .get(&pane_id)
+        .and_then(|p| p.as_terminal())
+        .and_then(|t| t.name.clone());
+    assert_eq!(
+        name.as_deref(),
+        Some("seeded"),
+        "requested pane name must apply to the seeded root pane"
+    );
+
+    // Response file must report the id of the pane actually created.
+    let raw = std::fs::read_to_string(&response_file)
+        .expect("spawn_pane must write a response file");
+    let _ = std::fs::remove_file(&response_file);
+    let json: serde_json::Value =
+        serde_json::from_str(&raw).expect("response file must be valid JSON");
+    assert_eq!(
+        json["pane_id"].as_u64(),
+        Some(pane_id),
+        "response file pane_id must match the seeded pane's id"
+    );
+}

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -733,6 +733,50 @@ impl PlexiApp {
         self.minimap.visible = true;
     }
 
+    /// Seed a root terminal pane into the active window when it has no tree root
+    /// and no focused pane yet (the windowless-boot state). Returns the id of the
+    /// pane actually created, or `None` if terminal creation failed.
+    ///
+    /// The spawn_pane IPC fallback needs this because `split_focused` returns
+    /// early when there is no focused pane to split, silently dropping the spawn.
+    /// Unlike `create_page_at`, this populates the *existing* active window in
+    /// place rather than pushing a new one, so a seeded/queued `pane new` lands
+    /// in the window the host booted with.
+    pub(crate) fn seed_root_pane(
+        &mut self,
+        initial_cmd: Option<&str>,
+        close_on_exit: bool,
+        cwd_override: Option<PathBuf>,
+    ) -> Option<crate::spatial::tiling::PaneId> {
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+        let cwd = cwd_override
+            .or_else(|| {
+                self.resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
+            })
+            .filter(|p| p != &PathBuf::from("/"))
+            .unwrap_or(home);
+        let Some((tree, panes, root_tile)) =
+            self.create_single_pane_tree(Some(cwd), initial_cmd, close_on_exit)
+        else {
+            log::error!("seed_root_pane: failed to create terminal for empty active window");
+            return None;
+        };
+        let pane_id = *panes
+            .keys()
+            .next()
+            .expect("create_single_pane_tree always yields exactly one pane");
+        let win = &mut self.windows[self.active_window];
+        win.tree = tree;
+        win.panes = panes;
+        win.focused_pane = Some(root_tile);
+        win.zoomed_pane = None;
+        log::info!(
+            "seed_root_pane: seeded root pane_id={pane_id} into empty window_id={} (windowless-boot spawn fallback) initial_cmd={initial_cmd:?} close_on_exit={close_on_exit}",
+            win.window_id
+        );
+        Some(pane_id)
+    }
+
     pub(crate) fn reset_active_context(&mut self) {
         let cwd = self.cwd_for_welcome_tab();
         log::info!(


### PR DESCRIPTION
Stint task 0348 (no linked GitHub issue). Found live-driving the event-bus PR validation.

## Summary

- On a windowless `plexi host start` boot, the spawn_pane IPC fallback called `split_focused`, which returns early with no focused pane — seeded (`--pane`) and socket (`pane new`) spawns silently vanished ("could not apply name to pane_id=1", `pane list` → `[]`).
- New `seed_root_pane` populates the empty active window with a root terminal in place, returns the pane id actually created; the response file and inline naming use the real id; seeding failure propagates as an error instead of a phantom success.

## Test evidence (attempt 1)

- cargo test: 1504 passed, 0 failed — full bin suite (×2 consecutive runs). New regression test `spawn_pane_seeds_root_in_empty_window` (failed pre-fix).
- Conclusion: binary install required — the repro is the installed `host start` boot path; validating via `just pr-install` + windowless-boot drive (hands-off).