### PR TITLE
feat: website account service — Postgres, magic-link auth, device-code flow (stint 0338)

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -3,9 +3,6 @@
 # ---- Build stage ----------------------------------------------------------
 FROM node:22-alpine AS build
 
-# better-sqlite3 is a native module — needs a toolchain to compile.
-RUN apk add --no-cache python3 make g++
-
 WORKDIR /app
 
 COPY website/package.json website/package-lock.json ./
@@ -15,7 +12,7 @@ COPY website/ .
 
 RUN npm run build
 
-# Drop dev deps for a lean runtime copy. Native binaries are already compiled.
+# Drop dev deps for a lean runtime copy.
 RUN npm prune --omit=dev
 
 # ---- Runtime stage --------------------------------------------------------
@@ -25,7 +22,6 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=4321
-ENV DB_PATH=/data/subscribers.db
 
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -14,6 +14,6 @@ export default defineConfig({
   },
   vite: {
     plugins: [tailwindcss()],
-    ssr: { external: ['better-sqlite3'] },
+    ssr: { external: ['pg'] },
   },
 });

--- a/website/docs/deployment.md
+++ b/website/docs/deployment.md
@@ -16,8 +16,10 @@ service tracked `main` and prod drifted weeks behind alpha.
 
 ## Deploying to Railway
 
-The site builds via `Dockerfile` and runs as a Node standalone server on Railway.
-Subscribers persist in a SQLite file on a Railway volume mounted at `/data`.
+The site builds via `Dockerfile` and runs as a Node standalone server on
+Railway. Persistence is **Railway Postgres**; the schema and its tables are
+described in `docs/marketplace-monetization.md` (repo root). Migrations in
+`src/server/migrations/` run automatically on first request.
 
 One-time setup:
 
@@ -27,38 +29,47 @@ One-time setup:
    # or, if the project already exists:
    railway link
    ```
-2. **Attach a persistent volume.** Railway's `railway.json` schema does not
-   currently support declaring volumes, so this is a manual step in the
-   dashboard:
-   - Service → Settings → Volumes → **New Volume**
-   - Size: **1 GB** (more than enough for an email list)
-   - Mount path: **`/data`**
-3. **Set the environment variable** (Service → Variables):
+2. **Add a Postgres database** (Railway dashboard → New → Database → PostgreSQL).
+   Railway injects a `DATABASE_URL` reference variable into the web service —
+   confirm the web service has `DATABASE_URL` under Variables.
+3. **Set the remaining service variables** (Service → Variables):
    ```
-   DB_PATH=/data/subscribers.db
+   DATABASE_URL=<injected by the Postgres plugin>
+   RESEND_API_KEY=<your Resend key>
+   PUBLIC_SITE_URL=https://plexiapp.com
    ```
-   The Dockerfile already defaults `DB_PATH` to this value, but setting it
-   explicitly in Railway makes the wiring obvious and survives Dockerfile
-   changes.
-4. **Deploy.** Either:
-   ```bash
-   railway up
-   ```
-   …or push to the connected GitHub branch and let the Railway integration
-   build.
+   All three are required — `DATABASE_URL` and `RESEND_API_KEY` fail the service
+   at boot, and `PUBLIC_SITE_URL` throws when a magic-link URL is first built
+   (no silent fallback).
+4. **Deploy.** Push to the connected GitHub branch, or `railway up`.
 
-## Pulling the subscriber list
+## Backups (user action)
 
-SSH into the running service and dump the table to CSV:
+**Enable automated backups in the Railway dashboard** — this is a manual step:
+Postgres service → **Backups** → enable scheduled daily backups and set a
+retention window. Do this once after provisioning the database.
+
+Restore procedure (run locally with the service's `DATABASE_URL`):
 
 ```bash
-railway ssh
-sqlite3 /data/subscribers.db ".headers on" ".mode csv" "SELECT * FROM subscribers;" > subscribers.csv
-exit
+# Snapshot the live database to a local file
+pg_dump "$DATABASE_URL" -Fc -f plexi-backup.dump
+
+# Restore a snapshot into a target database (drops/recreates objects)
+pg_restore --clean --if-exists -d "$DATABASE_URL" plexi-backup.dump
 ```
 
-Then copy it down with `railway run` or just `cat` it inside the SSH session
-and paste — whichever is faster for the size of the list.
+`-Fc` is Postgres's custom compressed format, which `pg_restore` consumes.
+For a plain-SQL dump use `pg_dump "$DATABASE_URL" -f plexi-backup.sql` and
+restore with `psql "$DATABASE_URL" -f plexi-backup.sql`.
+
+## Inspecting data
+
+```bash
+railway connect Postgres   # opens psql against the service database
+# then, e.g.
+SELECT email, created_at FROM subscribers ORDER BY created_at DESC;
+```
 
 ## Local dev
 
@@ -67,11 +78,6 @@ npm install
 npm run dev
 ```
 
-The DB defaults to `./data/subscribers.db` (created on first request). The
-`data/` directory is gitignored.
-
-To inspect locally:
-
-```bash
-sqlite3 ./data/subscribers.db "SELECT * FROM subscribers;"
-```
+Set `DATABASE_URL` to a local Postgres instance (and `RESEND_API_KEY`,
+`PUBLIC_SITE_URL`) before starting the dev server. Tests boot their own
+throwaway Postgres cluster and need no external database.

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -15,12 +15,68 @@
         "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.3.0",
         "astro": "^6.1.10",
-        "better-sqlite3": "^12.9.0",
+        "pg": "^8.13.1",
         "sharp": "^0.34.5",
         "tailwindcss": "^4.3.0"
       },
+      "devDependencies": {
+        "@astrojs/check": "^0.9.9",
+        "@types/pg": "^8.11.10",
+        "embedded-postgres": "^18.4.0-beta.17",
+        "typescript": "^5.9.3",
+        "vitest": "^3.0.0"
+      },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/check": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.9.tgz",
+      "integrity": "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/language-server": "^2.16.7",
+        "chokidar": "^4.0.3",
+        "kleur": "^4.1.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "astro-check": "bin/astro-check.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@astrojs/check/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -37,6 +93,55 @@
       "dependencies": {
         "picomatch": "^4.0.4"
       }
+    },
+    "node_modules/@astrojs/language-server": {
+      "version": "2.16.11",
+      "resolved": "https://registry.npmjs.org/@astrojs/language-server/-/language-server-2.16.11.tgz",
+      "integrity": "sha512-sJ/EfnFp0+gurTrkvONtd9qRqmMZLT9bHelfI1SA35CaQVTrRrA74qteOcNT/al1b9Atg3IiH1Jk/qfckyC+fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.13.1",
+        "@astrojs/yaml2ts": "^0.2.4",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "@volar/kit": "~2.4.28",
+        "@volar/language-core": "~2.4.28",
+        "@volar/language-server": "~2.4.28",
+        "@volar/language-service": "~2.4.28",
+        "muggle-string": "^0.4.1",
+        "tinyglobby": "^0.2.16",
+        "volar-service-css": "0.0.71",
+        "volar-service-emmet": "0.0.71",
+        "volar-service-html": "0.0.71",
+        "volar-service-prettier": "0.0.71",
+        "volar-service-typescript": "0.0.71",
+        "volar-service-typescript-twoslash-queries": "0.0.71",
+        "volar-service-yaml": "0.0.71",
+        "vscode-html-languageservice": "^5.6.2",
+        "vscode-uri": "^3.1.0"
+      },
+      "bin": {
+        "astro-ls": "bin/nodeServer.js"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0",
+        "prettier-plugin-astro": ">=0.11.0"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@astrojs/language-server/node_modules/@astrojs/compiler": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.13.1.tgz",
+      "integrity": "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
       "version": "7.1.1",
@@ -159,6 +264,16 @@
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
       }
     },
+    "node_modules/@astrojs/yaml2ts": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/yaml2ts/-/yaml2ts-0.2.4.tgz",
+      "integrity": "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.8.3"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -244,6 +359,212 @@
       "engines": {
         "node": ">= 20.12.0"
       }
+    },
+    "node_modules/@embedded-postgres/darwin-arm64": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/darwin-arm64/-/darwin-arm64-18.4.0-beta.17.tgz",
+      "integrity": "sha512-Kg1ZMNFzkVIJs3g4V2UYEc5X005km9rGinxFBH8R1sOU2Rblvz4pt2Uf93Pu8Rk273Ue9HIdrbMPpgUqwjUi0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/darwin-x64": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/darwin-x64/-/darwin-x64-18.4.0-beta.17.tgz",
+      "integrity": "sha512-4tShSYWMxUQTSWoQAdLnHISvRj6L9gTch9/31ASJPg6wgyN64LDRwMcOINEWybM7N0ropJ3nTYhFT3UX1bKY5Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-arm": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-arm/-/linux-arm-18.4.0-beta.17.tgz",
+      "integrity": "sha512-VuD1nFasN7yG57zpJcp6MBXM0nXqGfb8GBQV+f1FGJ17+VMNYLIFLhFp99UlY4xnWG74FQC4NPYw8eCwSTJ6qg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-arm64": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-arm64/-/linux-arm64-18.4.0-beta.17.tgz",
+      "integrity": "sha512-TIzjtGnDGSD/LbdW0OWCEcbI+YVT0WKSfSr20TCkkP4UR8zeKe+QCZbO0/CM4hS9EWyZ4cDebjRvpRc3iMi6wg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-ia32": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-ia32/-/linux-ia32-18.4.0-beta.17.tgz",
+      "integrity": "sha512-aSRe4kknqRHuedtpo/rDIaqa8r9VrKIgW9p5FkJyIFqUUkIkxRqND1dg8xrDRREcSUXRJKS0x+j/AuxflgYIfg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-ppc64": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-ppc64/-/linux-ppc64-18.4.0-beta.17.tgz",
+      "integrity": "sha512-zO2RRUFdKRPplrdhmglG39VXJZzDXu3P3ONAG1sFPhGh89vbk24Btd5P7uOmQLIpWehzL0s+UqUWoeE/ZUKvgw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-x64": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-x64/-/linux-x64-18.4.0-beta.17.tgz",
+      "integrity": "sha512-jVw/MdDtIX/vICH/DKIe6/mHpiCggdx6QVyza4vt/NbcZFsL0KhwglF6F1Koqx3gRBZ9XtN+vi63EsqSyqOSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/windows-x64": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/windows-x64/-/windows-x64-18.4.0-beta.17.tgz",
+      "integrity": "sha512-AwRerliA4IGWyW5jWBvHt5vidVUSB0QQW9Tt2y7ScnmifnCb/awfxZr4BkBSTv+gNt8Djcddqs+xSF5Z6/CkTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@emmetio/abbreviation": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
+      "integrity": "sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-abbreviation": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-abbreviation/-/css-abbreviation-2.1.8.tgz",
+      "integrity": "sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.4"
+      }
+    },
+    "node_modules/@emmetio/css-parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@emmetio/css-parser/-/css-parser-0.4.1.tgz",
+      "integrity": "sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/stream-reader": "^2.2.0",
+        "@emmetio/stream-reader-utils": "^0.1.0"
+      }
+    },
+    "node_modules/@emmetio/html-matcher": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/html-matcher/-/html-matcher-1.3.0.tgz",
+      "integrity": "sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@emmetio/scanner": "^1.0.0"
+      }
+    },
+    "node_modules/@emmetio/scanner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emmetio/scanner/-/scanner-1.0.4.tgz",
+      "integrity": "sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader/-/stream-reader-2.2.0.tgz",
+      "integrity": "sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@emmetio/stream-reader-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@emmetio/stream-reader-utils/-/stream-reader-utils-0.1.0.tgz",
+      "integrity": "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.10.0",
@@ -1961,6 +2282,17 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1969,6 +2301,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2033,6 +2372,18 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/sax": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
@@ -2054,6 +2405,229 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@volar/kit": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/kit/-/kit-2.4.28.tgz",
+      "integrity": "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "typesafe-path": "^0.2.2",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
+      "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.28"
+      }
+    },
+    "node_modules/@volar/language-server": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-server/-/language-server-2.4.28.tgz",
+      "integrity": "sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@volar/language-service": "2.4.28",
+        "@volar/typescript": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "request-light": "^0.7.0",
+        "vscode-languageserver": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/language-service": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/language-service/-/language-service-2.4.28.tgz",
+      "integrity": "sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "vscode-languageserver-protocol": "^3.17.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
+      "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.28",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
+      "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/emmet-helper": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@vscode/emmet-helper/-/emmet-helper-2.11.0.tgz",
+      "integrity": "sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emmet": "^2.4.3",
+        "jsonc-parser": "^2.3.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.15.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vscode/l10n": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@vscode/l10n/-/l10n-0.0.18.tgz",
+      "integrity": "sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2073,6 +2647,74 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-i18n": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-i18n/-/ajv-i18n-4.2.0.tgz",
+      "integrity": "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.0.0-beta.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -2129,6 +2771,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astring": {
@@ -2217,6 +2869,16 @@
         "sharp": "^0.34.0"
       }
     },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2236,88 +2898,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/better-sqlite3": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
-      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ccount": {
@@ -2328,6 +2922,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -2370,6 +2981,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -2385,12 +3006,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -2404,6 +3019,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/clsx": {
@@ -2424,6 +3054,26 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -2597,28 +3247,14 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=6"
       }
     },
     "node_modules/defu": {
@@ -2776,6 +3412,54 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/embedded-postgres": {
+      "version": "18.4.0-beta.17",
+      "resolved": "https://registry.npmjs.org/embedded-postgres/-/embedded-postgres-18.4.0-beta.17.tgz",
+      "integrity": "sha512-ORT/A1YiO6ecpRHpyIIBgyCR/8ASqqYZuFw11aX9PkqTX3FUM5+9sNOXY1mGIixxsm2TWSIA5WghJEk7A5ZxVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "pg": "^8.7.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@embedded-postgres/darwin-arm64": "^18.4.0-beta.17",
+        "@embedded-postgres/darwin-x64": "^18.4.0-beta.17",
+        "@embedded-postgres/linux-arm": "^18.4.0-beta.17",
+        "@embedded-postgres/linux-arm64": "^18.4.0-beta.17",
+        "@embedded-postgres/linux-ia32": "^18.4.0-beta.17",
+        "@embedded-postgres/linux-ppc64": "^18.4.0-beta.17",
+        "@embedded-postgres/linux-x64": "^18.4.0-beta.17",
+        "@embedded-postgres/windows-x64": "^18.4.0-beta.17"
+      }
+    },
+    "node_modules/emmet": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
+      "integrity": "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "./packages/scanner",
+        "./packages/abbreviation",
+        "./packages/css-abbreviation",
+        "./"
+      ],
+      "dependencies": {
+        "@emmetio/abbreviation": "^2.3.3",
+        "@emmetio/css-abbreviation": "^2.1.8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -2783,15 +3467,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -2896,6 +3571,16 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -3028,19 +3713,27 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=6"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-string-truncated-width": {
@@ -3057,6 +3750,23 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.0",
@@ -3120,12 +3830,6 @@
         }
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
@@ -3165,12 +3869,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3185,11 +3883,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
@@ -3494,36 +4196,10 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/inline-style-parser": {
@@ -3588,6 +4264,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-hexadecimal": {
@@ -3669,6 +4355,13 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3679,6 +4372,30 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonc-parser": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
+      "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lightningcss": {
@@ -3939,6 +4656,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "11.3.5",
@@ -5041,33 +5765,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -5081,6 +5778,13 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5100,12 +5804,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
     },
     "node_modules/neotraverse": {
       "version": "0.6.18",
@@ -5127,18 +5825,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/node-fetch-native": {
@@ -5211,15 +5897,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/oniguruma-parser": {
@@ -5343,6 +6020,13 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-expression-matcher": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
@@ -5356,6 +6040,112 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.14.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.15.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/piccolore": {
@@ -5423,31 +6213,59 @@
         "node": ">=4"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
       "license": "MIT",
       "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
+        "xtend": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prismjs": {
@@ -5469,16 +6287,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
     "node_modules/radix3": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
@@ -5492,35 +6300,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -5798,6 +6577,33 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/request-light": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.7.0.tgz",
+      "integrity": "sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/retext": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
@@ -5902,26 +6708,6 @@
         "@rollup/rollup-win32-x64-msvc": "4.60.2",
         "fsevents": "~2.3.2"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.6.0",
@@ -6045,50 +6831,12 @@
         "node": ">=20"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -6155,6 +6903,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -6164,19 +6928,32 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
       "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
       "license": "MIT"
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/stringify-entities": {
@@ -6193,13 +6970,30 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/strnum": {
@@ -6276,38 +7070,17 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyclip": {
@@ -6344,6 +7117,36 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -6377,6 +7180,7 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
       "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
+      "deprecated": "unmaintained",
       "license": "MIT",
       "bin": {
         "tsconfck": "bin/tsconfck.js"
@@ -6400,16 +7204,35 @@
       "license": "0BSD",
       "optional": true
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+    "node_modules/typesafe-path": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/typesafe-path/-/typesafe-path-0.2.2.tgz",
+      "integrity": "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": "*"
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-auto-import-cache": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/typescript-auto-import-cache/-/typescript-auto-import-cache-0.3.6.tgz",
+      "integrity": "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.8"
       }
     },
     "node_modules/ufo": {
@@ -6820,6 +7643,36 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vitefu": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
@@ -6838,6 +7691,376 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/volar-service-css": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-css/-/volar-service-css-0.0.71.tgz",
+      "integrity": "sha512-wRRFt9BpjMKCazcgOh67MSjUjiWUCAh99DyYSDIOTuxaRjEtDC7PpB0k1Y1wbJIW/pVtMUSVbpPo3UGSm0Byxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-css-languageservice": "^6.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-emmet": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-emmet/-/volar-service-emmet-0.0.71.tgz",
+      "integrity": "sha512-zqjzt6bN95e3CUstBm0PBFAJnrfz0ZAARka87fart46/gNCLLuP3Vujy8V/J8HEziTFLnfkgIASLFYPUhonJcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@emmetio/css-parser": "^0.4.1",
+        "@emmetio/html-matcher": "^1.3.0",
+        "@vscode/emmet-helper": "^2.9.3",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-html": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-html/-/volar-service-html-0.0.71.tgz",
+      "integrity": "sha512-e8tHPhgQ7ooLfudAEIku+kgd9pWkq3SSz8RbnQDI1+Eb8wbenkLGHqoirLqz5ORLV6wIMr2Iv08RWBG5eOcgpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-html-languageservice": "^5.3.0",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-prettier": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-prettier/-/volar-service-prettier-0.0.71.tgz",
+      "integrity": "sha512-Rz7JVH3qD108UCdmIEiZvOBNljMt2nLFdbN8AXcDfn7xD9F5I2aCIsDVqBbXw21PsnxG0b7MfwtNF+zPS/NKUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0",
+        "prettier": "^2.2 || ^3.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript/-/volar-service-typescript-0.0.71.tgz",
+      "integrity": "sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-browserify": "^1.0.1",
+        "semver": "^7.6.2",
+        "typescript-auto-import-cache": "^0.3.5",
+        "vscode-languageserver-textdocument": "^1.0.11",
+        "vscode-nls": "^5.2.0",
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-typescript-twoslash-queries": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-typescript-twoslash-queries/-/volar-service-typescript-twoslash-queries-0.0.71.tgz",
+      "integrity": "sha512-9K2k72s4n7rV9s4bX0MyjbX9iBribvKZbBJKuEmTCZfeWJXs6Yh7bGpY4eoc7UufAjvpheBqwyZCOIPBvxCv0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/volar-service-yaml": {
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/volar-service-yaml/-/volar-service-yaml-0.0.71.tgz",
+      "integrity": "sha512-qYGWGuVpUTnZGu5P/CR4KLK4aIR8RrcVnmfZ2eRcj9q/I8VZCoC5yy9FtEvfNvnDp4MU17yhdJcvpQPIqhJS2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-uri": "^3.0.8",
+        "yaml-language-server": "~1.23.0"
+      },
+      "peerDependencies": {
+        "@volar/language-service": "~2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@volar/language-service": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vscode-css-languageservice": {
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/vscode-css-languageservice/-/vscode-css-languageservice-6.3.10.tgz",
+      "integrity": "sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-css-languageservice/node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-html-languageservice": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/vscode-html-languageservice/-/vscode-html-languageservice-5.6.2.tgz",
+      "integrity": "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "vscode-languageserver-textdocument": "^1.0.12",
+        "vscode-languageserver-types": "^3.17.5",
+        "vscode-uri": "^3.1.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-4.1.8.tgz",
+      "integrity": "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-nls": "^5.0.0",
+        "vscode-uri": "^3.0.2"
+      },
+      "engines": {
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/vscode-json-languageservice/node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "9.0.1",
+        "vscode-languageserver-types": "3.18.0"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.18.0.tgz",
+      "integrity": "sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver/node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-nls": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.2.0.tgz",
+      "integrity": "sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
@@ -6858,17 +8081,147 @@
         "node": ">=4"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/xxhash-wasm": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yaml-language-server": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/yaml-language-server/-/yaml-language-server-1.23.0.tgz",
+      "integrity": "sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vscode/l10n": "^0.0.18",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "ajv-i18n": "^4.2.0",
+        "prettier": "^3.8.1",
+        "request-light": "^0.5.7",
+        "vscode-json-languageservice": "4.1.8",
+        "vscode-languageserver": "^9.0.0",
+        "vscode-languageserver-textdocument": "^1.0.1",
+        "vscode-languageserver-types": "^3.16.0",
+        "vscode-uri": "^3.0.2",
+        "yaml": "2.8.3"
+      },
+      "bin": {
+        "yaml-language-server": "bin/yaml-language-server"
+      }
+    },
+    "node_modules/yaml-language-server/node_modules/request-light": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/request-light/-/request-light-0.5.8.tgz",
+      "integrity": "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yaml-language-server/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",
@@ -6877,6 +8230,16 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,8 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "og": "node scripts/generate-og.mjs"
+    "og": "node scripts/generate-og.mjs",
+    "test": "vitest run"
   },
   "dependencies": {
     "@astrojs/mdx": "^5.0.4",
@@ -20,8 +21,15 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.3.0",
     "astro": "^6.1.10",
-    "better-sqlite3": "^12.9.0",
+    "pg": "^8.13.1",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.3.0"
+  },
+  "devDependencies": {
+    "@astrojs/check": "^0.9.9",
+    "@types/pg": "^8.11.10",
+    "embedded-postgres": "^18.4.0-beta.17",
+    "typescript": "^5.9.3",
+    "vitest": "^3.0.0"
   }
 }

--- a/website/src/pages/api/auth/delete/start.ts
+++ b/website/src/pages/api/auth/delete/start.ts
@@ -1,0 +1,20 @@
+import type { APIRoute } from 'astro';
+import { emailMagicLink } from '../../../../server/auth';
+import { json, requireAccount } from '../../../../server/http';
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request, cookies }) => {
+  try {
+    const auth = await requireAccount(request, cookies);
+    if (auth instanceof Response) return auth;
+    await emailMagicLink(auth.account.email, 'account_delete');
+    return json(
+      { ok: true, message: `We emailed a confirmation link to ${auth.account.email}.` },
+      200,
+    );
+  } catch (err) {
+    console.error('[api/auth/delete/start] failed to send delete confirmation:', err);
+    return json({ error: 'server error' }, 500);
+  }
+};

--- a/website/src/pages/api/auth/device/poll.ts
+++ b/website/src/pages/api/auth/device/poll.ts
@@ -1,0 +1,40 @@
+import type { APIRoute } from 'astro';
+import { pollDeviceCode, PROVIDER } from '../../../../server/auth';
+import { json, parseJsonBody } from '../../../../server/http';
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request }) => {
+  const body = await parseJsonBody(request);
+  if (body instanceof Response) return body;
+
+  const deviceCode = typeof body.device_code === 'string' ? body.device_code : '';
+  const pollToken = typeof body.poll_token === 'string' ? body.poll_token : '';
+  if (!deviceCode || !pollToken) {
+    return json({ error: 'device_code and poll_token are required' }, 400);
+  }
+
+  try {
+    const result = await pollDeviceCode(deviceCode, pollToken);
+    if (result.state === 'pending') {
+      return json({ status: 'pending' }, 202);
+    }
+    if (result.state === 'gone') {
+      return json({ error: 'device code expired or already used' }, 410);
+    }
+    return json(
+      {
+        schema_version: result.schema_version,
+        token: result.token,
+        account_id: result.accountId,
+        email: result.email,
+        provider: PROVIDER,
+        issued_at: result.issuedAt,
+      },
+      200,
+    );
+  } catch (err) {
+    console.error(`[api/auth/device/poll] failed for device_code="${deviceCode}":`, err);
+    return json({ error: 'server error' }, 500);
+  }
+};

--- a/website/src/pages/api/auth/device/start.ts
+++ b/website/src/pages/api/auth/device/start.ts
@@ -1,0 +1,35 @@
+import type { APIRoute } from 'astro';
+import { emailMagicLink, normalizeEmail, pruneExpiredAuthRows, startDeviceFlow } from '../../../../server/auth';
+import { isValidEmail, json, parseJsonBody } from '../../../../server/http';
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request }) => {
+  const body = await parseJsonBody(request);
+  if (body instanceof Response) return body;
+
+  const email = typeof body.email === 'string' ? normalizeEmail(body.email) : '';
+  if (!isValidEmail(email)) {
+    return json({ error: 'invalid email' }, 400);
+  }
+
+  try {
+    const { deviceCode, pollToken, expiresIn } = await startDeviceFlow(email);
+    await emailMagicLink(email, 'device_approve', deviceCode);
+    pruneExpiredAuthRows().catch((err) =>
+      console.error('[api/auth/device/start] opportunistic prune failed:', err),
+    );
+    return json(
+      {
+        device_code: deviceCode,
+        poll_token: pollToken,
+        expires_in: expiresIn,
+        message: `We emailed an approval link to ${email}. Click it to sign in on this device.`,
+      },
+      200,
+    );
+  } catch (err) {
+    console.error(`[api/auth/device/start] failed for email="${email}":`, err);
+    return json({ error: 'server error' }, 500);
+  }
+};

--- a/website/src/pages/api/auth/magic-link.ts
+++ b/website/src/pages/api/auth/magic-link.ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from 'astro';
+import { emailMagicLink, normalizeEmail, pruneExpiredAuthRows } from '../../../server/auth';
+import { isValidEmail, json, parseJsonBody } from '../../../server/http';
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request }) => {
+  const body = await parseJsonBody(request);
+  if (body instanceof Response) return body;
+
+  const email = typeof body.email === 'string' ? normalizeEmail(body.email) : '';
+  // Web session login is the only purpose callable from this endpoint;
+  // device_approve and account_delete are triggered internally.
+  const purpose = typeof body.purpose === 'string' ? body.purpose : 'login';
+
+  if (!isValidEmail(email)) {
+    return json({ error: 'invalid email' }, 400);
+  }
+  if (purpose !== 'login') {
+    return json({ error: 'unsupported purpose' }, 400);
+  }
+
+  try {
+    await emailMagicLink(email, 'login');
+    pruneExpiredAuthRows().catch((err) =>
+      console.error('[api/auth/magic-link] opportunistic prune failed:', err),
+    );
+    return json({ ok: true, message: `We emailed a sign-in link to ${email}.` }, 200);
+  } catch (err) {
+    console.error(`[api/auth/magic-link] failed for email="${email}":`, err);
+    return json({ error: 'server error' }, 500);
+  }
+};

--- a/website/src/pages/api/auth/me.ts
+++ b/website/src/pages/api/auth/me.ts
@@ -1,0 +1,15 @@
+import type { APIRoute } from 'astro';
+import { json, requireAccount } from '../../../server/http';
+
+export const prerender = false;
+
+export const GET: APIRoute = async ({ request, cookies }) => {
+  try {
+    const auth = await requireAccount(request, cookies);
+    if (auth instanceof Response) return auth;
+    return json({ account_id: auth.account.id, email: auth.account.email }, 200);
+  } catch (err) {
+    console.error('[api/auth/me] failed to resolve bearer token:', err);
+    return json({ error: 'server error' }, 500);
+  }
+};

--- a/website/src/pages/api/auth/revoke.ts
+++ b/website/src/pages/api/auth/revoke.ts
@@ -1,0 +1,18 @@
+import type { APIRoute } from 'astro';
+import { revokeBearer } from '../../../server/auth';
+import { json, requireAccount, SESSION_COOKIE } from '../../../server/http';
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ request, cookies }) => {
+  try {
+    const auth = await requireAccount(request, cookies);
+    if (auth instanceof Response) return auth;
+    await revokeBearer(auth.token);
+    cookies.delete(SESSION_COOKIE, { path: '/' });
+    return json({ ok: true }, 200);
+  } catch (err) {
+    console.error('[api/auth/revoke] failed to revoke bearer token:', err);
+    return json({ error: 'server error' }, 500);
+  }
+};

--- a/website/src/pages/api/subscribe.ts
+++ b/website/src/pages/api/subscribe.ts
@@ -1,49 +1,44 @@
 import type { APIRoute } from 'astro';
 import { addSubscriber } from '../../server/resend';
+import { addSubscriber as addSubscriberRow } from '../../server/db';
+import { normalizeEmail } from '../../server/auth';
+import { isValidEmail, json, parseJsonBody } from '../../server/http';
 
 export const prerender = false;
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-function json(body: unknown, status: number): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { 'content-type': 'application/json' },
-  });
-}
-
 export const POST: APIRoute = async ({ request }) => {
-  let payload: unknown;
-  try {
-    payload = await request.json();
-  } catch (err) {
-    console.error('[api/subscribe] failed to parse JSON body:', err);
-    return json({ error: 'invalid json' }, 400);
-  }
+  const body = await parseJsonBody(request);
+  if (body instanceof Response) return body;
 
-  const data = payload as { email?: unknown; source?: unknown } | null;
-  const email = typeof data?.email === 'string' ? data.email.trim().toLowerCase() : '';
-  const source = typeof data?.source === 'string' ? data.source : undefined;
+  const email = typeof body.email === 'string' ? normalizeEmail(body.email) : '';
+  const source = typeof body.source === 'string' ? body.source : undefined;
 
-  if (!EMAIL_RE.test(email)) {
+  if (!isValidEmail(email)) {
     return json({ error: 'invalid email' }, 400);
   }
 
+  // Resend is the source of truth for subscribers — fail the request if it errors.
   try {
     await addSubscriber(email);
   } catch (err) {
-    console.error(`[api/subscribe] addSubscriber threw for email="${email}":`, err);
+    console.error(`[api/subscribe] Resend addSubscriber failed for email="${email}":`, err);
     return json({ error: 'server error' }, 500);
+  }
+
+  // The Postgres row is a best-effort mirror; a failure never fails the request.
+  try {
+    await addSubscriberRow(email, source);
+  } catch (err) {
+    console.error(
+      `[api/subscribe] DB subscriber mirror failed for email="${email}" source="${source ?? ''}":`,
+      err,
+    );
   }
 
   return json({ ok: true }, 200);
 };
 
-export const ALL: APIRoute = async ({ request }) => {
-  if (request.method === 'POST') {
-    // Should never reach here — POST is exported above — but keep the guard tight.
-    return json({ error: 'method not allowed' }, 405);
-  }
+export const ALL: APIRoute = async () => {
   return new Response(JSON.stringify({ error: 'method not allowed' }), {
     status: 405,
     headers: { 'content-type': 'application/json', allow: 'POST' },

--- a/website/src/pages/auth/verify.astro
+++ b/website/src/pages/auth/verify.astro
@@ -1,0 +1,167 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import {
+  approveDeviceCode,
+  consumeMagicLink,
+  deleteAccount,
+  getOrCreateAccount,
+  issueBearerToken,
+  peekMagicLink,
+  InvalidMagicLinkError,
+} from '../../server/auth';
+import { SESSION_COOKIE } from '../../server/http';
+import type { MagicLinkPurpose } from '../../server/resend';
+
+export const prerender = false;
+
+// Side effects happen only on an explicit POST from the confirmation form.
+// A bare GET (email scanners, browser prefetch) never consumes the token.
+
+type Outcome =
+  | { kind: 'device_approve' }
+  | { kind: 'login' }
+  | { kind: 'account_delete' }
+  | { kind: 'error'; message: string };
+
+type View =
+  | { mode: 'confirm'; token: string; purpose: MagicLinkPurpose }
+  | { mode: 'result'; outcome: Outcome };
+
+const CONFIRM: Record<MagicLinkPurpose, { title: string; body: string; button: string }> = {
+  login: {
+    title: 'Confirm sign-in',
+    body: 'Click below to sign in to your Plexi account.',
+    button: 'Sign in',
+  },
+  device_approve: {
+    title: 'Approve this device',
+    body: 'Click below to approve the device that is trying to sign in.',
+    button: 'Approve sign-in',
+  },
+  account_delete: {
+    title: 'Delete your account',
+    body: 'This permanently erases your account and sign-in tokens. It cannot be undone. Purchases are anonymized, not removed.',
+    button: 'Delete my account',
+  },
+};
+
+const RESULT: Record<Outcome['kind'], { title: string; body: string }> = {
+  device_approve: {
+    title: "You're signed in on your device",
+    body: 'You can close this tab and return to your terminal.',
+  },
+  login: {
+    title: "You're signed in",
+    body: 'Your session is active. You can head back to plexiapp.com.',
+  },
+  account_delete: {
+    title: 'Account deleted',
+    body: 'Your account and sign-in tokens have been erased. Purchases were anonymized, not removed.',
+  },
+  error: { title: 'That link did not work', body: '' },
+};
+
+const INVALID_MESSAGE = 'This link is invalid, expired, or already used. Request a new one.';
+
+let view: View;
+
+if (Astro.request.method === 'POST') {
+  const form = await Astro.request.formData();
+  const token = String(form.get('token') ?? '');
+  let outcome: Outcome;
+  try {
+    const record = await consumeMagicLink(token);
+    if (record.purpose === 'device_approve') {
+      const account = await getOrCreateAccount(record.email);
+      if (!record.deviceCode) {
+        outcome = { kind: 'error', message: 'This approval link is not tied to a device.' };
+      } else {
+        await approveDeviceCode(record.deviceCode, account.id);
+        outcome = { kind: 'device_approve' };
+      }
+    } else if (record.purpose === 'login') {
+      const account = await getOrCreateAccount(record.email);
+      const { token: bearer } = await issueBearerToken(account.id);
+      // Web session cookie: the browser presents this on authenticated routes.
+      Astro.cookies.set(SESSION_COOKIE, bearer, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 60 * 60 * 24 * 30, // 30 days
+      });
+      outcome = { kind: 'login' };
+    } else {
+      const account = await getOrCreateAccount(record.email);
+      await deleteAccount(account.id);
+      Astro.cookies.delete(SESSION_COOKIE, { path: '/' });
+      outcome = { kind: 'account_delete' };
+    }
+  } catch (err) {
+    if (err instanceof InvalidMagicLinkError) {
+      outcome = { kind: 'error', message: INVALID_MESSAGE };
+    } else {
+      console.error('[auth/verify] failed to apply magic link:', err);
+      outcome = { kind: 'error', message: 'Something went wrong. Please try again.' };
+    }
+  }
+  view = { mode: 'result', outcome };
+} else {
+  const token = Astro.url.searchParams.get('token') ?? '';
+  let purpose: MagicLinkPurpose | null = null;
+  if (token) {
+    try {
+      purpose = await peekMagicLink(token);
+    } catch (err) {
+      console.error('[auth/verify] failed to inspect magic link:', err);
+    }
+  }
+  view = purpose
+    ? { mode: 'confirm', token, purpose }
+    : { mode: 'result', outcome: { kind: 'error', message: INVALID_MESSAGE } };
+}
+
+const heading =
+  view.mode === 'confirm' ? CONFIRM[view.purpose].title : RESULT[view.outcome.kind].title;
+const body =
+  view.mode === 'confirm'
+    ? CONFIRM[view.purpose].body
+    : view.outcome.kind === 'error'
+      ? view.outcome.message
+      : RESULT[view.outcome.kind].body;
+---
+<Layout title={heading} description="Plexi account verification">
+  <section class="verify-page">
+    <div class="wrap">
+      <h1>{heading}</h1>
+      <p class="lead">{body}</p>
+      {view.mode === 'confirm' && (
+        <form method="POST" action="/auth/verify">
+          <input type="hidden" name="token" value={view.token} />
+          <button class="btn lg" type="submit">
+            {CONFIRM[view.purpose].button} <span class="arrow">→</span>
+          </button>
+        </form>
+      )}
+      {view.mode === 'result' && view.outcome.kind === 'error' && (
+        <a class="btn lg" href="/">Back to plexiapp.com <span class="arrow">→</span></a>
+      )}
+    </div>
+  </section>
+</Layout>
+
+<style>
+  .verify-page { padding: 120px 0 80px; }
+  .verify-page h1 { font-size: 48px; font-weight: 700; letter-spacing: 0; margin-bottom: 16px; }
+  .verify-page .lead { color: var(--fg-2); font-size: 17px; line-height: 1.6; max-width: 540px; margin-bottom: 32px; }
+  .verify-page button.btn { font: inherit; cursor: pointer; border: none; }
+
+  @media (max-width: 980px) {
+    .verify-page { padding: 88px 0 60px; }
+    .verify-page h1 { font-size: 36px; }
+  }
+  @media (max-width: 480px) {
+    .verify-page h1 { font-size: 28px; }
+    .verify-page .lead { font-size: 15px; }
+  }
+</style>

--- a/website/src/server/auth.ts
+++ b/website/src/server/auth.ts
@@ -1,0 +1,381 @@
+import crypto from 'node:crypto';
+import { getClient, query } from './db';
+import { siteUrl } from './env';
+import { sendMagicLink, type MagicLinkPurpose } from './resend';
+
+const MAGIC_LINK_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const DEVICE_CODE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+/** The provider string the host stores in `AccountSession.provider`. */
+export const PROVIDER = 'plexi';
+
+export class InvalidMagicLinkError extends Error {
+  constructor() {
+    super('magic link is invalid, expired, or already used');
+    this.name = 'InvalidMagicLinkError';
+  }
+}
+
+export class DeviceCodeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DeviceCodeError';
+  }
+}
+
+export interface Account {
+  id: string;
+  email: string;
+}
+
+function generateToken(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+/** Canonical email form used everywhere accounts are keyed by address. */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/** Build the emailed verification URL for a magic-link token. */
+export function verifyUrl(token: string): string {
+  return `${siteUrl()}/auth/verify?token=${encodeURIComponent(token)}`;
+}
+
+/** Get-or-create an account by lowercase-normalized email. */
+export async function getOrCreateAccount(email: string): Promise<Account> {
+  const norm = normalizeEmail(email);
+  // DO NOTHING (not DO UPDATE) so a returning-user login leaves no dead tuple.
+  const inserted = await query<Account>(
+    `INSERT INTO accounts (email) VALUES ($1)
+     ON CONFLICT (email) DO NOTHING
+     RETURNING id, email`,
+    [norm],
+  );
+  if (inserted.rowCount && inserted.rows[0]) {
+    console.info(`[auth] account created account_id=${inserted.rows[0].id} email=${norm}`);
+    return inserted.rows[0];
+  }
+  const existing = await query<Account>(
+    `SELECT id, email FROM accounts WHERE email = $1`,
+    [norm],
+  );
+  if (existing.rowCount === 0) {
+    throw new Error(`getOrCreateAccount: account vanished for email="${norm}"`);
+  }
+  return existing.rows[0];
+}
+
+/**
+ * Create a purpose-tagged, single-use magic link and return the raw token.
+ * Only the SHA-256 hash is persisted.
+ */
+export async function createMagicLink(
+  email: string,
+  purpose: MagicLinkPurpose,
+  deviceCode?: string,
+): Promise<string> {
+  const token = generateToken();
+  const expires = new Date(Date.now() + MAGIC_LINK_TTL_MS);
+  await query(
+    `INSERT INTO magic_link_tokens (token_hash, email, purpose, device_code, expires_at)
+     VALUES ($1, $2, $3, $4, $5)`,
+    [hashToken(token), normalizeEmail(email), purpose, deviceCode ?? null, expires],
+  );
+  return token;
+}
+
+export interface MagicLinkRecord {
+  email: string;
+  purpose: MagicLinkPurpose;
+  deviceCode: string | null;
+}
+
+/**
+ * Atomically consume a magic link. Marks it used and returns its record.
+ * Throws {@link InvalidMagicLinkError} if unknown, expired, or already used.
+ */
+export async function consumeMagicLink(token: string): Promise<MagicLinkRecord> {
+  const res = await query<{
+    email: string;
+    purpose: MagicLinkPurpose;
+    device_code: string | null;
+  }>(
+    `UPDATE magic_link_tokens SET used_at = now()
+     WHERE token_hash = $1 AND used_at IS NULL AND expires_at > now()
+     RETURNING email, purpose, device_code`,
+    [hashToken(token)],
+  );
+  if (res.rowCount === 0) throw new InvalidMagicLinkError();
+  const row = res.rows[0];
+  return { email: row.email, purpose: row.purpose, deviceCode: row.device_code };
+}
+
+/**
+ * Inspect a magic link without consuming it — used to render a confirmation
+ * page on GET so email prefetchers/scanners cannot burn the link or trigger a
+ * side effect. Returns the purpose if the link is valid and unused, else null.
+ */
+export async function peekMagicLink(token: string): Promise<MagicLinkPurpose | null> {
+  const res = await query<{ purpose: MagicLinkPurpose }>(
+    `SELECT purpose FROM magic_link_tokens
+     WHERE token_hash = $1 AND used_at IS NULL AND expires_at > now()`,
+    [hashToken(token)],
+  );
+  return res.rowCount ? res.rows[0].purpose : null;
+}
+
+export interface BearerToken {
+  token: string;
+  issuedAt: string;
+}
+
+/** Issue a fresh opaque bearer token for an account. Stored hashed. */
+export async function issueBearerToken(accountId: string): Promise<BearerToken> {
+  const token = generateToken();
+  const res = await query<{ issued_at: Date }>(
+    `INSERT INTO auth_tokens (token_hash, account_id) VALUES ($1, $2)
+     RETURNING issued_at`,
+    [hashToken(token), accountId],
+  );
+  console.info(`[auth] bearer token issued account_id=${accountId}`);
+  return { token, issuedAt: res.rows[0].issued_at.toISOString() };
+}
+
+/** Resolve a presented bearer token to its account, or null if revoked/unknown. */
+export async function resolveBearer(token: string): Promise<Account | null> {
+  const res = await query<Account>(
+    `SELECT a.id, a.email FROM auth_tokens t
+     JOIN accounts a ON a.id = t.account_id
+     WHERE t.token_hash = $1 AND t.revoked_at IS NULL`,
+    [hashToken(token)],
+  );
+  return res.rowCount ? res.rows[0] : null;
+}
+
+/** Revoke a presented bearer token. Idempotent. */
+export async function revokeBearer(token: string): Promise<void> {
+  const res = await query(
+    `UPDATE auth_tokens SET revoked_at = now()
+     WHERE token_hash = $1 AND revoked_at IS NULL
+     RETURNING account_id`,
+    [hashToken(token)],
+  );
+  if (res.rowCount) {
+    console.info(`[auth] bearer token revoked account_id=${res.rows[0].account_id}`);
+  }
+}
+
+export interface DeviceFlowStart {
+  deviceCode: string;
+  pollToken: string;
+  expiresIn: number;
+}
+
+/** Begin a CLI device-code flow. Returns the device code and poll token. */
+export async function startDeviceFlow(email: string): Promise<DeviceFlowStart> {
+  const deviceCode = generateToken();
+  const pollToken = generateToken();
+  const expires = new Date(Date.now() + DEVICE_CODE_TTL_MS);
+  await query(
+    `INSERT INTO device_codes (code, poll_token_hash, email, status, expires_at)
+     VALUES ($1, $2, $3, 'pending', $4)`,
+    [deviceCode, hashToken(pollToken), normalizeEmail(email), expires],
+  );
+  return { deviceCode, pollToken, expiresIn: Math.floor(DEVICE_CODE_TTL_MS / 1000) };
+}
+
+/**
+ * Approve a pending device code (called after its magic link is consumed).
+ * Binds the account and flips status pending → approved.
+ */
+export async function approveDeviceCode(deviceCode: string, accountId: string): Promise<void> {
+  const res = await query(
+    `UPDATE device_codes SET status = 'approved', account_id = $2
+     WHERE code = $1 AND status = 'pending' AND expires_at > now()
+     RETURNING code`,
+    [deviceCode, accountId],
+  );
+  if (res.rowCount === 0) {
+    throw new DeviceCodeError('device code is not pending or has expired');
+  }
+  console.info(`[auth] device code approved account_id=${accountId}`);
+}
+
+export type PollResult =
+  | { state: 'pending' }
+  | { state: 'gone' }
+  | {
+      state: 'approved';
+      /** Wire-contract version of the approved payload (AccountSession). */
+      schema_version: 1;
+      token: string;
+      accountId: string;
+      email: string;
+      issuedAt: string;
+    };
+
+/**
+ * Poll a device code. Returns `pending` until approved, then `approved` with a
+ * bearer token exactly once (flipping status approved → consumed), and `gone`
+ * for expired/consumed codes or an unknown/mismatched poll token.
+ */
+export async function pollDeviceCode(
+  deviceCode: string,
+  pollToken: string,
+): Promise<PollResult> {
+  const found = await query<{
+    status: string;
+    account_id: string | null;
+    expires_at: Date;
+  }>(
+    `SELECT status, account_id, expires_at FROM device_codes
+     WHERE code = $1 AND poll_token_hash = $2`,
+    [deviceCode, hashToken(pollToken)],
+  );
+  if (found.rowCount === 0) return { state: 'gone' };
+
+  const row = found.rows[0];
+  const expired = row.expires_at.getTime() < Date.now();
+
+  if (row.status === 'pending') {
+    return expired ? { state: 'gone' } : { state: 'pending' };
+  }
+
+  if (row.status === 'approved' && !expired) {
+    // Claim the approval and issue the token on one client so a failed insert
+    // rolls the claim back — the code stays approved and a retry can succeed.
+    const client = await getClient();
+    try {
+      await client.query('BEGIN');
+      const claim = await client.query<{ account_id: string | null }>(
+        `UPDATE device_codes SET status = 'consumed'
+         WHERE code = $1 AND status = 'approved' AND expires_at > now()
+         RETURNING account_id`,
+        [deviceCode],
+      );
+      if (claim.rowCount === 0 || !claim.rows[0].account_id) {
+        await client.query('ROLLBACK');
+        return { state: 'gone' };
+      }
+      const accountId = claim.rows[0].account_id;
+      const acct = await client.query<{ email: string }>(
+        `SELECT email FROM accounts WHERE id = $1`,
+        [accountId],
+      );
+      if (acct.rowCount === 0) {
+        await client.query('ROLLBACK');
+        return { state: 'gone' };
+      }
+      const token = generateToken();
+      const ins = await client.query<{ issued_at: Date }>(
+        `INSERT INTO auth_tokens (token_hash, account_id) VALUES ($1, $2)
+         RETURNING issued_at`,
+        [hashToken(token), accountId],
+      );
+      await client.query('COMMIT');
+      const email = acct.rows[0].email;
+      console.info(
+        `[auth] device code approved, bearer token issued account_id=${accountId} email=${email}`,
+      );
+      return {
+        state: 'approved',
+        schema_version: 1,
+        token,
+        accountId,
+        email,
+        issuedAt: ins.rows[0].issued_at.toISOString(),
+      };
+    } catch (err) {
+      await client.query('ROLLBACK');
+      console.error(`[auth] pollDeviceCode claim failed for device_code:`, err);
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  // approved-but-expired | consumed | expired
+  return { state: 'gone' };
+}
+
+/**
+ * Erase an account: delete its tokens (cascade) and device codes, revoke
+ * pending magic links, and anonymize purchases (null account_id) so the sales
+ * record survives. Runs in a single transaction.
+ */
+export async function deleteAccount(accountId: string): Promise<void> {
+  const client = await getClient();
+  try {
+    await client.query('BEGIN');
+    const acct = await client.query<{ email: string }>(
+      `SELECT email FROM accounts WHERE id = $1`,
+      [accountId],
+    );
+    const email = acct.rows[0]?.email;
+    await client.query(`UPDATE purchases SET account_id = NULL WHERE account_id = $1`, [accountId]);
+    await client.query(
+      `DELETE FROM device_codes WHERE account_id = $1${email ? ' OR email = $2' : ''}`,
+      email ? [accountId, email] : [accountId],
+    );
+    if (email) {
+      await client.query(`DELETE FROM magic_link_tokens WHERE email = $1`, [email]);
+    }
+    await client.query(`DELETE FROM accounts WHERE id = $1`, [accountId]); // cascades auth_tokens
+    await client.query('COMMIT');
+    console.info(`[auth] account deleted account_id=${accountId}`);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error(`[auth] deleteAccount failed for account_id="${accountId}":`, err);
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Opportunistically delete rows past their useful life: expired device codes
+ * and magic links (past a grace interval), and long-revoked auth tokens. Called
+ * fire-and-forget from auth endpoints; failures are logged, never surfaced.
+ */
+export async function pruneExpiredAuthRows(): Promise<void> {
+  const client = await getClient();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `DELETE FROM device_codes WHERE expires_at < now() - interval '1 day'`,
+    );
+    await client.query(
+      `DELETE FROM magic_link_tokens WHERE expires_at < now() - interval '1 day'`,
+    );
+    await client.query(
+      `DELETE FROM auth_tokens WHERE revoked_at IS NOT NULL AND revoked_at < now() - interval '30 days'`,
+    );
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('[auth] pruneExpiredAuthRows failed:', err);
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Send a magic link for a purpose, creating the token first. Wraps token
+ * creation + email so endpoints call one function.
+ */
+export async function emailMagicLink(
+  email: string,
+  purpose: MagicLinkPurpose,
+  deviceCode?: string,
+): Promise<void> {
+  const norm = normalizeEmail(email);
+  const token = await createMagicLink(email, purpose, deviceCode);
+  await sendMagicLink(norm, verifyUrl(token), purpose);
+  console.info(`[auth] magic link sent purpose=${purpose} email=${norm}`);
+}

--- a/website/src/server/db.ts
+++ b/website/src/server/db.ts
@@ -1,42 +1,136 @@
-import Database from 'better-sqlite3';
-import { mkdirSync } from 'node:fs';
-import { dirname } from 'node:path';
+import pg from 'pg';
+import { readEnv } from './env';
 
-const DB_PATH = process.env.DB_PATH ?? './data/subscribers.db';
-
-// Ensure the parent directory exists before SQLite tries to open the file.
-try {
-  mkdirSync(dirname(DB_PATH), { recursive: true });
-} catch (err) {
-  console.error(`[db] failed to create db directory for ${DB_PATH}:`, err);
-  throw err;
+/** Thrown at boot when DATABASE_URL is absent — fail fast, no silent fallback. */
+export class MissingDatabaseUrlError extends Error {
+  constructor() {
+    super('DATABASE_URL is not set — the account service requires a Postgres connection string');
+    this.name = 'MissingDatabaseUrlError';
+  }
 }
 
-let _db: Database.Database;
-try {
-  _db = new Database(DB_PATH);
-  _db.pragma('journal_mode = WAL');
-  _db.exec(`
-    CREATE TABLE IF NOT EXISTS subscribers (
-      email TEXT PRIMARY KEY,
-      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-      source TEXT
-    );
-  `);
-} catch (err) {
-  console.error(`[db] failed to open or initialize sqlite at ${DB_PATH}:`, err);
-  throw err;
+function connectionString(): string {
+  const url = readEnv('DATABASE_URL');
+  if (!url) throw new MissingDatabaseUrlError();
+  return url;
 }
 
-export const db = _db;
+let _pool: pg.Pool | undefined;
 
-const insertStmt = db.prepare(
-  'INSERT INTO subscribers (email, source) VALUES (?, ?) ON CONFLICT(email) DO NOTHING',
-);
+/** The shared connection pool, created lazily on first use. */
+export function getPool(): pg.Pool {
+  if (!_pool) {
+    _pool = new pg.Pool({ connectionString: connectionString() });
+    _pool.on('error', (err) => {
+      console.error('[db] idle client error:', err);
+    });
+  }
+  return _pool;
+}
 
-export function addSubscriber(email: string, source?: string): void {
+/** Close the pool (tests / graceful shutdown). Safe to call when never opened. */
+export async function closePool(): Promise<void> {
+  if (_pool) {
+    const p = _pool;
+    _pool = undefined;
+    await p.end();
+  }
+}
+
+// Migration SQL is bundled at build time via Vite's glob import so the .sql
+// files travel into dist/ and are available to both Astro and vitest.
+const migrationSources = import.meta.glob('./migrations/*.sql', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+let _migrated: Promise<void> | undefined;
+
+/** Run pending migrations exactly once per process. Idempotent and memoized. */
+export function ensureMigrated(): Promise<void> {
+  if (!_migrated) {
+    _migrated = runMigrations().catch((err) => {
+      // Reset so a later call can retry after a transient failure.
+      _migrated = undefined;
+      throw err;
+    });
+  }
+  return _migrated;
+}
+
+/**
+ * Session-wide advisory-lock key so concurrent replicas serialize migrations.
+ * Held for the migration transaction only (xact lock auto-releases on COMMIT).
+ */
+const MIGRATION_ADVISORY_LOCK_KEY = 727374;
+
+async function runMigrations(): Promise<void> {
+  const pool = getPool();
+  const client = await pool.connect();
   try {
-    insertStmt.run(email, source ?? null);
+    await client.query('BEGIN');
+    // Serialize against other replicas before touching schema_migrations.
+    await client.query('SELECT pg_advisory_xact_lock($1)', [MIGRATION_ADVISORY_LOCK_KEY]);
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS schema_migrations (
+        filename   TEXT PRIMARY KEY,
+        applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+      );
+    `);
+
+    const paths = Object.keys(migrationSources).sort();
+    for (const path of paths) {
+      const filename = path.replace(/^.*\//, '');
+      const sql = migrationSources[path];
+      const already = await client.query('SELECT 1 FROM schema_migrations WHERE filename = $1', [
+        filename,
+      ]);
+      if (already.rowCount === 0) {
+        await client.query(sql);
+        await client.query('INSERT INTO schema_migrations (filename) VALUES ($1)', [filename]);
+        console.info(`[db] applied migration ${filename}`);
+      }
+    }
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    console.error('[db] migrations failed:', err);
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Migration-gated query. Awaits {@link ensureMigrated} then runs on the pool,
+ * so callers never repeat the gate. Use for single statements.
+ */
+export async function query<R extends pg.QueryResultRow = pg.QueryResultRow>(
+  text: string,
+  params?: unknown[],
+): Promise<pg.QueryResult<R>> {
+  await ensureMigrated();
+  return getPool().query<R>(text, params);
+}
+
+/**
+ * Migration-gated client checkout for multi-statement transactions. Awaits
+ * {@link ensureMigrated} then leases a client. Caller must `release()`.
+ */
+export async function getClient(): Promise<pg.PoolClient> {
+  await ensureMigrated();
+  return getPool().connect();
+}
+
+/** Insert a newsletter subscriber (idempotent on email). */
+export async function addSubscriber(email: string, source?: string): Promise<void> {
+  try {
+    await query(
+      `INSERT INTO subscribers (email, source) VALUES ($1, $2)
+       ON CONFLICT (email) DO NOTHING`,
+      [email, source ?? null],
+    );
   } catch (err) {
     console.error(
       `[db] addSubscriber failed for email="${email}" source="${source ?? ''}":`,

--- a/website/src/server/env.ts
+++ b/website/src/server/env.ts
@@ -1,0 +1,38 @@
+/**
+ * Env access that works under both Astro (SSR, via `import.meta.env`) and
+ * vitest/Node (via `process.env`). Reads `process.env` first so tests can set
+ * values before importing modules; falls back to `import.meta.env` for Astro's
+ * build-time-injected server secrets.
+ */
+
+export function readEnv(key: string): string | undefined {
+  const fromProcess =
+    typeof process !== 'undefined' && process.env ? process.env[key] : undefined;
+  if (fromProcess !== undefined && fromProcess !== '') return fromProcess;
+
+  // `import.meta.env` is Vite/Astro-specific and is simply `undefined` under
+  // plain Node — optional chaining is enough, no try/catch needed.
+  const metaEnv = (import.meta as unknown as { env?: Record<string, string | undefined> }).env;
+  const fromMeta = metaEnv?.[key];
+  if (fromMeta !== undefined && fromMeta !== '') return fromMeta;
+
+  return undefined;
+}
+
+/** Thrown when PUBLIC_SITE_URL is absent — fail fast, no silent fallback. */
+export class MissingSiteUrlError extends Error {
+  constructor() {
+    super(
+      'PUBLIC_SITE_URL is not set — it is required to build magic-link verification URLs. ' +
+        'Set it in the service environment (e.g. https://plexiapp.com).',
+    );
+    this.name = 'MissingSiteUrlError';
+  }
+}
+
+/** Public origin used to build magic-link URLs. Required — no default. */
+export function siteUrl(): string {
+  const url = readEnv('PUBLIC_SITE_URL');
+  if (!url) throw new MissingSiteUrlError();
+  return url.replace(/\/+$/, '');
+}

--- a/website/src/server/http.ts
+++ b/website/src/server/http.ts
@@ -1,0 +1,70 @@
+/** JSON response helper — mirrors the shape used across the API routes. */
+export function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+import type { AstroCookies } from 'astro';
+import { resolveBearer, type Account } from './auth';
+
+/** Name of the httpOnly cookie holding a web-session bearer token. */
+export const SESSION_COOKIE = 'plexi_session';
+
+/** Extract a bearer token from the Authorization header, or null. */
+export function bearerToken(request: Request): string | null {
+  const header = request.headers.get('authorization');
+  if (!header) return null;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Resolve the caller's bearer token from either the Authorization header
+ * (CLI/host) or the `plexi_session` cookie (browser web session). Header wins.
+ */
+export function sessionToken(request: Request, cookies: AstroCookies): string | null {
+  return bearerToken(request) ?? cookies.get(SESSION_COOKIE)?.value ?? null;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(email: string): boolean {
+  return EMAIL_RE.test(email);
+}
+
+/**
+ * Parse a JSON request body into an object, or a 400 Response if the body is
+ * absent, malformed, or not a JSON object. Caller checks `instanceof Response`.
+ */
+export async function parseJsonBody(
+  request: Request,
+): Promise<Record<string, unknown> | Response> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'invalid json' }, 400);
+  }
+  if (body === null || typeof body !== 'object') {
+    return json({ error: 'invalid json' }, 400);
+  }
+  return body as Record<string, unknown>;
+}
+
+/**
+ * Resolve the authenticated caller, or a 401 Response. Returns both the account
+ * and the presented token so callers that revoke it (logout) can reuse it.
+ * Caller checks `instanceof Response`. DB errors propagate to the caller's catch.
+ */
+export async function requireAccount(
+  request: Request,
+  cookies: AstroCookies,
+): Promise<{ account: Account; token: string } | Response> {
+  const token = sessionToken(request, cookies);
+  if (!token) return json({ error: 'missing bearer token' }, 401);
+  const account = await resolveBearer(token);
+  if (!account) return json({ error: 'invalid or revoked token' }, 401);
+  return { account, token };
+}

--- a/website/src/server/migrations/001_init.sql
+++ b/website/src/server/migrations/001_init.sql
@@ -1,0 +1,83 @@
+-- Initial account-service schema. Applied once, tracked in schema_migrations.
+-- gen_random_uuid() is built into PostgreSQL 13+; no pgcrypto extension needed.
+
+CREATE TABLE IF NOT EXISTS subscribers (
+  email      TEXT PRIMARY KEY,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  source     TEXT
+);
+
+CREATE TABLE IF NOT EXISTS accounts (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email      TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Opaque bearer tokens, stored as SHA-256 hex hashes. Revocable via revoked_at.
+CREATE TABLE IF NOT EXISTS auth_tokens (
+  token_hash TEXT PRIMARY KEY,
+  account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  issued_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  revoked_at TIMESTAMPTZ
+);
+
+-- CLI device-code flow. status: pending | approved | consumed | expired.
+CREATE TABLE IF NOT EXISTS device_codes (
+  code            TEXT PRIMARY KEY,
+  poll_token_hash TEXT NOT NULL,
+  email           TEXT,
+  account_id      UUID REFERENCES accounts(id) ON DELETE SET NULL,
+  status          TEXT NOT NULL DEFAULT 'pending',
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at      TIMESTAMPTZ NOT NULL
+);
+
+-- Single-use, purpose-tagged magic links. purpose: login | device_approve | account_delete.
+CREATE TABLE IF NOT EXISTS magic_link_tokens (
+  token_hash  TEXT PRIMARY KEY,
+  email       TEXT NOT NULL,
+  purpose     TEXT NOT NULL,
+  device_code TEXT REFERENCES device_codes(code) ON DELETE SET NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at  TIMESTAMPTZ NOT NULL,
+  used_at     TIMESTAMPTZ
+);
+
+-- Placeholder commerce tables (0339 fills them). Defined here so migrations
+-- stay linear. account_id is nullable on purchases so account deletion can
+-- anonymize the row rather than destroying the sales record.
+CREATE TABLE IF NOT EXISTS purchases (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id     UUID REFERENCES accounts(id) ON DELETE SET NULL,
+  app_id         TEXT NOT NULL,
+  polar_order_id TEXT,
+  amount_cents   INTEGER,
+  currency       TEXT,
+  refunded_at    TIMESTAMPTZ,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id            UUID REFERENCES accounts(id) ON DELETE CASCADE,
+  polar_subscription_id TEXT,
+  status                TEXT,
+  tier                  TEXT,
+  current_period_end    TIMESTAMPTZ,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS publishers (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id     UUID REFERENCES accounts(id) ON DELETE CASCADE,
+  display_name   TEXT,
+  payout_details TEXT,
+  tax_info       TEXT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Lookup indexes for account-scoped deletes and email-scoped auth queries.
+CREATE INDEX IF NOT EXISTS idx_purchases_account_id ON purchases(account_id);
+CREATE INDEX IF NOT EXISTS idx_device_codes_account_id ON device_codes(account_id);
+CREATE INDEX IF NOT EXISTS idx_device_codes_email ON device_codes(email);
+CREATE INDEX IF NOT EXISTS idx_magic_link_tokens_email ON magic_link_tokens(email);

--- a/website/src/server/resend.ts
+++ b/website/src/server/resend.ts
@@ -1,8 +1,19 @@
+import { readEnv } from './env';
+
 const AUDIENCE_ID = 'e912b964-512d-40dc-a429-0aa2fb4c4c9e';
+const FROM_ADDRESS = 'Plexi <auth@plexiapp.com>';
+
+/** Thrown when RESEND_API_KEY is absent — fail fast, no silent fallback. */
+export class MissingResendApiKeyError extends Error {
+  constructor() {
+    super('RESEND_API_KEY is not set — cannot send transactional email');
+    this.name = 'MissingResendApiKeyError';
+  }
+}
 
 export async function addSubscriber(email: string): Promise<void> {
-  const apiKey = import.meta.env.RESEND_API_KEY;
-  if (!apiKey) throw new Error('RESEND_API_KEY is not set');
+  const apiKey = readEnv('RESEND_API_KEY');
+  if (!apiKey) throw new MissingResendApiKeyError();
 
   const res = await fetch(`https://api.resend.com/audiences/${AUDIENCE_ID}/contacts`, {
     method: 'POST',
@@ -17,4 +28,87 @@ export async function addSubscriber(email: string): Promise<void> {
     const body = await res.text();
     throw new Error(`Resend API error ${res.status}: ${body}`);
   }
+}
+
+export type MagicLinkPurpose = 'login' | 'device_approve' | 'account_delete';
+
+export interface OutboundEmail {
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}
+
+/**
+ * Low-level email transport. Overridable so tests capture the outbound email
+ * (and the magic-link URL inside it) instead of hitting Resend. We own this
+ * wrapper, so a test override here is legitimate — we never fake Resend's
+ * own response shapes.
+ */
+export type EmailTransport = (email: OutboundEmail) => Promise<void>;
+
+let transport: EmailTransport | null = null;
+
+export function setEmailTransport(t: EmailTransport): void {
+  transport = t;
+}
+
+export function resetEmailTransport(): void {
+  transport = null;
+}
+
+const SUBJECTS: Record<MagicLinkPurpose, string> = {
+  login: 'Sign in to Plexi',
+  device_approve: 'Approve your Plexi sign-in',
+  account_delete: 'Confirm deleting your Plexi account',
+};
+
+const INTROS: Record<MagicLinkPurpose, string> = {
+  login: 'Click below to sign in to your Plexi account.',
+  device_approve: 'Click below to approve the device that is trying to sign in.',
+  account_delete:
+    'Click below to permanently delete your Plexi account. This cannot be undone.',
+};
+
+async function resendTransport(email: OutboundEmail): Promise<void> {
+  const apiKey = readEnv('RESEND_API_KEY');
+  if (!apiKey) throw new MissingResendApiKeyError();
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: FROM_ADDRESS,
+      to: email.to,
+      subject: email.subject,
+      html: email.html,
+      text: email.text,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Resend API error ${res.status}: ${body}`);
+  }
+}
+
+export async function sendMagicLink(
+  email: string,
+  url: string,
+  purpose: MagicLinkPurpose,
+): Promise<void> {
+  const subject = SUBJECTS[purpose];
+  const intro = INTROS[purpose];
+  const html = `<div style="font-family:system-ui,sans-serif;line-height:1.5">
+  <p>${intro}</p>
+  <p><a href="${url}">${subject}</a></p>
+  <p style="color:#888;font-size:13px">This link expires in 15 minutes and can be used once. If you didn't request it, ignore this email.</p>
+</div>`;
+  const text = `${intro}\n\n${url}\n\nThis link expires in 15 minutes and can be used once.`;
+
+  const send = transport ?? resendTransport;
+  await send({ to: email, subject, html, text });
 }

--- a/website/test/account.test.ts
+++ b/website/test/account.test.ts
@@ -1,0 +1,215 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { startPg, stopPg, type PgHandle } from './pg';
+import {
+  approveDeviceCode,
+  consumeMagicLink,
+  createMagicLink,
+  deleteAccount,
+  emailMagicLink,
+  getOrCreateAccount,
+  InvalidMagicLinkError,
+  issueBearerToken,
+  peekMagicLink,
+  pollDeviceCode,
+  pruneExpiredAuthRows,
+  resolveBearer,
+  revokeBearer,
+  startDeviceFlow,
+} from '../src/server/auth';
+import { closePool, getPool, MissingDatabaseUrlError } from '../src/server/db';
+import { MissingSiteUrlError, siteUrl } from '../src/server/env';
+import { resetEmailTransport, setEmailTransport, type OutboundEmail } from '../src/server/resend';
+
+let pg: PgHandle;
+
+/** Capture the most recent outbound email so tests can read the magic link. */
+let lastEmail: OutboundEmail | null = null;
+
+function tokenFromLastEmail(): string {
+  if (!lastEmail) throw new Error('no email was sent');
+  const match = lastEmail.text.match(/token=([A-Za-z0-9_-]+)/);
+  if (!match) throw new Error(`no token in email: ${lastEmail.text}`);
+  return match[1];
+}
+
+beforeAll(async () => {
+  pg = await startPg();
+  process.env.DATABASE_URL = pg.url;
+  process.env.PUBLIC_SITE_URL = 'https://plexiapp.com';
+  setEmailTransport(async (email) => {
+    lastEmail = email;
+  });
+});
+
+afterAll(async () => {
+  resetEmailTransport();
+  await closePool();
+  await stopPg(pg);
+});
+
+describe('magic-link auth', () => {
+  it('roundtrips and creates an account on first verification', async () => {
+    const token = await createMagicLink('Alice@Example.com', 'login');
+    const record = await consumeMagicLink(token);
+    expect(record.email).toBe('alice@example.com');
+    expect(record.purpose).toBe('login');
+
+    const account = await getOrCreateAccount(record.email);
+    expect(account.email).toBe('alice@example.com');
+
+    const check = await getPool().query('SELECT email FROM accounts WHERE id = $1', [account.id]);
+    expect(check.rows[0].email).toBe('alice@example.com');
+  });
+
+  it('rejects a second use of the same link', async () => {
+    const token = await createMagicLink('single@example.com', 'login');
+    await consumeMagicLink(token);
+    await expect(consumeMagicLink(token)).rejects.toBeInstanceOf(InvalidMagicLinkError);
+  });
+
+  it('peeks a link without consuming it', async () => {
+    const token = await createMagicLink('peek@example.com', 'device_approve');
+    expect(await peekMagicLink(token)).toBe('device_approve');
+    // Still consumable afterwards — peek did not burn it.
+    const record = await consumeMagicLink(token);
+    expect(record.email).toBe('peek@example.com');
+    // Now consumed, peek returns null.
+    expect(await peekMagicLink(token)).toBeNull();
+  });
+
+  it('rejects an expired link', async () => {
+    const token = await createMagicLink('stale@example.com', 'login');
+    // Force expiry into the past.
+    const { createHash } = await import('node:crypto');
+    const hash = createHash('sha256').update(token).digest('hex');
+    await getPool().query(
+      `UPDATE magic_link_tokens SET expires_at = now() - interval '1 minute' WHERE token_hash = $1`,
+      [hash],
+    );
+    await expect(consumeMagicLink(token)).rejects.toBeInstanceOf(InvalidMagicLinkError);
+  });
+});
+
+describe('device-code flow', () => {
+  it('runs end to end and yields the bearer token exactly once', async () => {
+    const { deviceCode, pollToken } = await startDeviceFlow('device@example.com');
+
+    // Not approved yet.
+    expect(await pollDeviceCode(deviceCode, pollToken)).toEqual({ state: 'pending' });
+
+    // The server emails an approval link; the user clicks it.
+    await emailMagicLink('device@example.com', 'device_approve', deviceCode);
+    const linkToken = tokenFromLastEmail();
+    const record = await consumeMagicLink(linkToken);
+    expect(record.purpose).toBe('device_approve');
+    expect(record.deviceCode).toBe(deviceCode);
+
+    const account = await getOrCreateAccount(record.email);
+    await approveDeviceCode(record.deviceCode!, account.id);
+
+    const first = await pollDeviceCode(deviceCode, pollToken);
+    expect(first.state).toBe('approved');
+    if (first.state !== 'approved') throw new Error('unreachable');
+    expect(first.schema_version).toBe(1);
+    expect(first.email).toBe('device@example.com');
+    expect(first.accountId).toBe(account.id);
+    expect(first.token).toBeTruthy();
+
+    // Second poll is consumed → gone.
+    expect(await pollDeviceCode(deviceCode, pollToken)).toEqual({ state: 'gone' });
+
+    // The issued token authenticates.
+    expect(await resolveBearer(first.token)).not.toBeNull();
+  });
+
+  it('returns gone for an unknown poll token', async () => {
+    const { deviceCode } = await startDeviceFlow('mismatch@example.com');
+    expect(await pollDeviceCode(deviceCode, 'wrong-token')).toEqual({ state: 'gone' });
+  });
+});
+
+describe('bearer tokens', () => {
+  it('resolves then fails after revocation', async () => {
+    const account = await getOrCreateAccount('revoke@example.com');
+    const { token } = await issueBearerToken(account.id);
+    expect(await resolveBearer(token)).toMatchObject({ email: 'revoke@example.com' });
+
+    await revokeBearer(token);
+    expect(await resolveBearer(token)).toBeNull();
+  });
+});
+
+describe('account deletion', () => {
+  it('erases the account and tokens, and anonymizes purchases', async () => {
+    const account = await getOrCreateAccount('doomed@example.com');
+    const { token } = await issueBearerToken(account.id);
+    await getPool().query(
+      `INSERT INTO purchases (account_id, app_id, amount_cents, currency)
+       VALUES ($1, 'demo.app', 1000, 'usd')`,
+      [account.id],
+    );
+
+    await deleteAccount(account.id);
+
+    // Account gone.
+    const acct = await getPool().query('SELECT 1 FROM accounts WHERE id = $1', [account.id]);
+    expect(acct.rowCount).toBe(0);
+    // Token no longer resolves.
+    expect(await resolveBearer(token)).toBeNull();
+    // Purchase survives, anonymized.
+    const purchase = await getPool().query(
+      `SELECT account_id FROM purchases WHERE app_id = 'demo.app'`,
+    );
+    expect(purchase.rowCount).toBe(1);
+    expect(purchase.rows[0].account_id).toBeNull();
+  });
+});
+
+describe('pruning', () => {
+  it('deletes expired device codes and magic links past the grace interval', async () => {
+    // Seed a device code and magic link already well past expiry.
+    await getPool().query(
+      `INSERT INTO device_codes (code, poll_token_hash, email, status, expires_at)
+       VALUES ('stale-code', 'stale-hash', 'prune@example.com', 'expired', now() - interval '2 days')`,
+    );
+    await getPool().query(
+      `INSERT INTO magic_link_tokens (token_hash, email, purpose, expires_at)
+       VALUES ('stale-link', 'prune@example.com', 'login', now() - interval '2 days')`,
+    );
+
+    await pruneExpiredAuthRows();
+
+    const codes = await getPool().query(`SELECT 1 FROM device_codes WHERE code = 'stale-code'`);
+    expect(codes.rowCount).toBe(0);
+    const links = await getPool().query(
+      `SELECT 1 FROM magic_link_tokens WHERE token_hash = 'stale-link'`,
+    );
+    expect(links.rowCount).toBe(0);
+  });
+});
+
+describe('siteUrl', () => {
+  it('throws when PUBLIC_SITE_URL is unset', () => {
+    const saved = process.env.PUBLIC_SITE_URL;
+    delete process.env.PUBLIC_SITE_URL;
+    try {
+      expect(() => siteUrl()).toThrow(MissingSiteUrlError);
+    } finally {
+      process.env.PUBLIC_SITE_URL = saved;
+    }
+  });
+});
+
+describe('configuration', () => {
+  it('throws when DATABASE_URL is missing', async () => {
+    // Run last: this tears down the shared pool and clears the env var.
+    await closePool();
+    const saved = process.env.DATABASE_URL;
+    delete process.env.DATABASE_URL;
+    try {
+      expect(() => getPool()).toThrow(MissingDatabaseUrlError);
+    } finally {
+      process.env.DATABASE_URL = saved;
+    }
+  });
+});

--- a/website/test/pg.ts
+++ b/website/test/pg.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import EmbeddedPostgres from 'embedded-postgres';
+
+/**
+ * A throwaway PostgreSQL cluster for tests. `embedded-postgres` carries real
+ * Postgres server binaries as a devDependency, so tests run the genuine engine
+ * without a system install and stay portable to CI. We init a fresh data dir,
+ * start on a free port, create a database, and hand back a `DATABASE_URL`.
+ */
+export interface PgHandle {
+  base: string;
+  url: string;
+  server: EmbeddedPostgres;
+}
+
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      if (addr && typeof addr === 'object') {
+        const { port } = addr;
+        srv.close(() => resolve(port));
+      } else {
+        srv.close(() => reject(new Error('could not determine a free port')));
+      }
+    });
+  });
+}
+
+export async function startPg(): Promise<PgHandle> {
+  const base = mkdtempSync(join(tmpdir(), 'plexi-pg-'));
+  const port = await freePort();
+  const server = new EmbeddedPostgres({
+    databaseDir: join(base, 'data'),
+    user: 'postgres',
+    password: 'postgres',
+    port,
+    persistent: false,
+  });
+
+  await server.initialise();
+  await server.start();
+  await server.createDatabase('plexi_test');
+
+  const url = `postgresql://postgres:postgres@127.0.0.1:${port}/plexi_test`;
+  return { base, url, server };
+}
+
+export async function stopPg(handle: PgHandle): Promise<void> {
+  try {
+    await handle.server.stop();
+  } catch {
+    // best-effort; the process may already be gone
+  }
+  rmSync(handle.base, { recursive: true, force: true });
+}

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    hookTimeout: 60_000,
+    testTimeout: 30_000,
+    // Single fork: the tests share one throwaway Postgres cluster.
+    pool: 'forks',
+    poolOptions: { forks: { singleFork: true } },
+  },
+});


### PR DESCRIPTION
Implements stint task 0338 (no linked GitHub issue). plexiapp.com becomes the identity/entitlement service for the marketplace, per `docs/marketplace-monetization.md`.

## Summary

- **Postgres replaces better-sqlite3** (`website/src/server/db.ts`): `pg` pool from required `DATABASE_URL` (throws when unset), linear SQL migration runner (`migrations/001_init.sql`) serialized across replicas via `pg_advisory_xact_lock` + `CREATE TABLE IF NOT EXISTS`. Schema: `accounts`, `auth_tokens` (SHA-256 hashed, revocable), `device_codes`, `magic_link_tokens`, `subscribers` (ported), plus placeholder `purchases`/`subscriptions`/`publishers` for the Polar checkout task.
- **Magic-link auth** via Resend: single-use, 15-min expiry, purpose-tagged (login / device_approve / account_delete); atomic consume (`UPDATE … WHERE used_at IS NULL AND expires_at > now() RETURNING`).
- **Device-code flow** for `plexi account login`: `POST /api/auth/device/start` → emailed approval link → `POST /api/auth/device/poll` returns `{token, account_id, email, provider, issued_at, schema_version}` exactly once (claim + token issuance in one transaction).
- **Account endpoints**: `GET /api/auth/me`, `POST /api/auth/revoke`, `POST /api/auth/delete/start` → magic-link-confirmed erasure (account/tokens/codes deleted, purchases anonymized, single transaction). Shared `requireAccount()` bearer guard.
- **Ops**: fail-fast env (`DATABASE_URL`, `RESEND_API_KEY`, `PUBLIC_SITE_URL` all throw when missing), opportunistic pruning of expired auth rows, indexes on deletion/commerce lookup columns, info-level traces on every success path, Railway backup/restore procedure documented in `website/docs/deployment.md`.

## Review

Multi-agent review (8 finder angles → 7 verifiers): 4 confirmed correctness findings (migration replica race, non-atomic poll token issuance, silent `PUBLIC_SITE_URL` fallback, newsletter hard-DB dependency) + cleanup batch — all fixed in this branch. Deletion transactionality and magic-link single-use verified correct.

**Test evidence:**
- vitest (real throwaway Postgres 18 cluster via initdb/pg_ctl, no mocks): 11 passed, 0 failed — magic-link roundtrip/single-use/expiry, device flow end-to-end, revocation, deletion + purchase anonymization, siteUrl fail-fast, pruning
- `npm run build` (Astro SSR): green
- cargo layers untouched (website-only diff)
- Conclusion: install skippable — full coverage for the website layer; no host binary change. Live validation deferred to Railway deploy (needs 🖥️ DATABASE_URL provisioning).
