### PR TITLE
feat: host plexi account CLI + PlexiAccountProvider; delete license machinery (stint 0340)

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -207,12 +207,13 @@ tips = true
 # Publisher submission endpoint. Unset = `plexi app publish` prepares the package
 # locally but does not upload it.
 # submit_url      = "https://plexiapp.com/registry/v1/submit"
-# Paid-app payment backend. Unset / "none" = paid installs fail closed (no charge
-# possible). A real provider is wired in a future release.
-# payment_backend = "none"
-# Account/auth backend. Unset / "none" = login/signup fail closed. Accounts are
-# only ever needed to publish or buy paid apps — free apps install without one.
-# account_backend = "none"
+# Account/auth backend. "plexi" enables plexiapp.com accounts; unset / "none" =
+# login fails closed. Accounts are only ever needed to publish or buy paid apps —
+# free apps install without one.
+# account_backend = "plexi"
+# Accounts service base URL. Unset = the official plexiapp.com service. Override
+# only to point `plexi account login` at a private deployment.
+# account_url     = "https://plexiapp.com"
 # Default email pre-filled by `plexi account login`.
 # account_email   = "you@example.com"
 ```

--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -87,11 +87,10 @@ tips = true
 # Publisher submission endpoint. Unset = `plexi app publish` prepares the package
 # locally but does not upload it.
 # submit_url      = "https://plexiapp.com/registry/v1/submit"
-# Paid-app payment backend. Unset / "none" = paid installs fail closed (no charge
-# possible). A real provider is wired in a future release.
-# payment_backend = "none"
 # Account/auth backend. Unset / "none" = login/signup fail closed. Accounts are
 # only ever needed to publish or buy paid apps — free apps install without one.
 # account_backend = "none"
+# Accounts service host the device-flow login talks to. Defaults to plexiapp.com.
+# account_url     = "https://plexiapp.com"
 # Default email pre-filled by `plexi account login`.
 # account_email   = "you@example.com"

--- a/src/app/account.rs
+++ b/src/app/account.rs
@@ -11,12 +11,14 @@
 //! - **buy** a paid app, or
 //! - use the **Plexi AI subscription**.
 //!
-//! So this module is the identity seam those three flows hang off. It is fully
-//! stubbed today: [`StubAccountProvider`] fails closed on every network
-//! operation, exactly like the payment stub. A real auth backend (the
-//! plexiapp.com API, or a hosted IdP) drops into [`account_provider`] with no
-//! change at any call site — `signup`/`login` start returning real sessions and
-//! everything downstream keeps working.
+//! So this module is the identity seam those three flows hang off. Two
+//! providers exist, chosen by `[marketplace].account_backend`:
+//! [`StubAccountProvider`] (default) fails closed on every network operation,
+//! and [`PlexiAccountProvider`] (`"plexi"`) talks to plexiapp.com. Because
+//! plexiapp.com auth is interactive (a browser magic link, or the device-code
+//! flow), the actual sign-in happens in the CLI (`plexi account login`) using
+//! the [`device_start`] / [`device_poll`] / [`revoke_token`] client here; the
+//! provider itself only reports that accounts are available.
 //!
 //! # The session
 //!
@@ -28,6 +30,13 @@
 
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+/// Product default for the accounts service. The device-flow client and the
+/// [`PlexiAccountProvider`] talk to this host unless `[marketplace].account_url`
+/// overrides it. Always the product domain — never a placeholder.
+pub const DEFAULT_ACCOUNT_URL: &str = "https://plexiapp.com";
 
 /// Proof of an authenticated marketplace account, stored locally. The `token`
 /// is opaque and provider-issued; the host presents it on authenticated
@@ -113,43 +122,181 @@ impl AccountStore {
     }
 }
 
-/// Why an account operation failed.
+/// Why an account operation failed. Message prefixes before the first `:` are
+/// stable machine-readable tags (`account_login_required`, `login_expired`, …)
+/// so callers and tests can match on them.
 #[derive(Debug, thiserror::Error)]
 pub enum AccountError {
-    /// No real auth backend is built in. The stub returns this for every
-    /// signup/login — the honest, expected failure until a provider is wired
-    /// into [`account_provider`].
+    /// Marketplace accounts are not enabled. The stub returns this for every
+    /// signup/login, and CLI login refuses before touching the network. Enable
+    /// accounts with `[marketplace].account_backend = "plexi"`.
     #[error(
-        "marketplace accounts are not enabled in this build yet — sign-up and login require a \
-         configured auth backend. Free apps install without an account. \
-         See https://plexiapp.com/docs/marketplace"
+        "account_backend_disabled: marketplace accounts are off in this profile — set \
+         [marketplace].account_backend = \"plexi\" to enable them. Free apps install without an \
+         account. See https://plexiapp.com/docs/marketplace"
     )]
     NotConfigured,
+
+    /// The accounts service could not be reached (DNS, TLS, connection).
+    #[error("account_network_error: could not reach the accounts service: {0}")]
+    Network(String),
+
+    /// The sign-in link expired or was already consumed (server returned 410).
+    #[error("login_expired: the sign-in link expired or was already used — run `plexi account login` again")]
+    DeviceExpired,
+
+    /// No approval arrived before the device code's own expiry window elapsed.
+    #[error("login_timeout: no approval received before the link expired — run `plexi account login` again")]
+    Timeout,
+
+    /// The accounts service returned an unexpected status or body.
+    #[error("account_service_error: {0}")]
+    Server(String),
 }
 
-/// The identity boundary. A provider turns an email into an [`AccountSession`].
-/// This is the single seam a real auth backend implements; nothing else in the
-/// codebase references a concrete provider.
+/// One `POST /api/auth/device/start` result: the codes the caller polls with
+/// plus the service's human-facing message and the device code's lifetime.
+pub struct DeviceFlowStart {
+    pub device_code: String,
+    pub poll_token: String,
+    /// Seconds until the device code expires. Bounds the CLI's poll loop.
+    pub expires_in: u64,
+    /// Human-facing instruction from the service (names the emailed address).
+    pub message: String,
+}
+
+/// One `POST /api/auth/device/poll` result.
+#[derive(Debug)]
+pub enum PollOutcome {
+    /// The user has not clicked the emailed link yet — keep polling.
+    Pending,
+    /// The link was approved; the session is ready to persist.
+    Approved(Box<AccountSession>),
+    /// The device code expired or was already used — the flow is dead.
+    Gone,
+}
+
+/// Shared blocking HTTP agent for the accounts service, built once and reused
+/// across the whole login flow. The device-code poll loop hits this every few
+/// seconds for up to the code's lifetime; a fresh agent per call would pay a new
+/// TLS handshake each time.
+static AGENT: LazyLock<ureq::Agent> = LazyLock::new(|| crate::app::http::agent(Duration::from_secs(30)));
+
+/// `POST {base}/api/auth/device/start` — ask the service to email a sign-in link
+/// and hand back the codes to poll with. See `website/src/pages/api/auth/device/start.ts`.
 ///
-/// Factory rule (`CLAUDE.md`): no method may panic. The stub returns `Err` for
-/// everything it cannot do.
+/// `ureq` is built without its `json` feature, so JSON bodies are serialized and
+/// `Content-Type` set by hand — the AI backends do the same. The `ureq::Error`
+/// is matched inline (never returned across a function boundary — it is large).
+pub fn device_start(base_url: &str, email: &str) -> Result<DeviceFlowStart, AccountError> {
+    #[derive(Deserialize)]
+    struct Resp {
+        device_code: String,
+        poll_token: String,
+        expires_in: u64,
+        message: String,
+    }
+    let url = crate::app::http::join_url(base_url, "api/auth/device/start");
+    let body = serde_json::json!({ "email": email }).to_string();
+    match AGENT
+        .post(&url)
+        .set("Content-Type", "application/json")
+        .send_string(&body)
+    {
+        Ok(resp) => {
+            let text = resp
+                .into_string()
+                .map_err(|e| AccountError::Network(e.to_string()))?;
+            let r: Resp = serde_json::from_str(&text)
+                .map_err(|e| AccountError::Server(format!("device/start body: {e}")))?;
+            Ok(DeviceFlowStart {
+                device_code: r.device_code,
+                poll_token: r.poll_token,
+                expires_in: r.expires_in,
+                message: r.message,
+            })
+        }
+        Err(ureq::Error::Status(code, resp)) => Err(AccountError::Server(format!(
+            "device/start returned {code}: {}",
+            resp.into_string().unwrap_or_default()
+        ))),
+        Err(ureq::Error::Transport(t)) => Err(AccountError::Network(t.to_string())),
+    }
+}
+
+/// `POST {base}/api/auth/device/poll` — check whether the emailed link was
+/// approved. 202 → pending, 200 → the session, 410 → gone. See
+/// `website/src/pages/api/auth/device/poll.ts`.
+pub fn device_poll(
+    base_url: &str,
+    device_code: &str,
+    poll_token: &str,
+) -> Result<PollOutcome, AccountError> {
+    let url = crate::app::http::join_url(base_url, "api/auth/device/poll");
+    let body =
+        serde_json::json!({ "device_code": device_code, "poll_token": poll_token }).to_string();
+    match AGENT
+        .post(&url)
+        .set("Content-Type", "application/json")
+        .send_string(&body)
+    {
+        Ok(resp) => {
+            if resp.status() == 202 {
+                return Ok(PollOutcome::Pending);
+            }
+            // 200: the approved envelope maps field-for-field onto AccountSession.
+            let text = resp
+                .into_string()
+                .map_err(|e| AccountError::Network(e.to_string()))?;
+            let session: AccountSession = serde_json::from_str(&text)
+                .map_err(|e| AccountError::Server(format!("device/poll body: {e}")))?;
+            Ok(PollOutcome::Approved(Box::new(session)))
+        }
+        Err(ureq::Error::Status(410, _)) => Ok(PollOutcome::Gone),
+        Err(ureq::Error::Status(code, resp)) => Err(AccountError::Server(format!(
+            "device/poll returned {code}: {}",
+            resp.into_string().unwrap_or_default()
+        ))),
+        Err(ureq::Error::Transport(t)) => Err(AccountError::Network(t.to_string())),
+    }
+}
+
+/// `POST {base}/api/auth/revoke` with the bearer token — best-effort server-side
+/// logout. See `website/src/pages/api/auth/revoke.ts`.
+pub fn revoke_token(base_url: &str, token: &str) -> Result<(), AccountError> {
+    let url = crate::app::http::join_url(base_url, "api/auth/revoke");
+    match AGENT
+        .post(&url)
+        .set("Authorization", &format!("Bearer {token}"))
+        .call()
+    {
+        Ok(_) => Ok(()),
+        Err(ureq::Error::Status(code, _)) => {
+            Err(AccountError::Server(format!("revoke returned {code}")))
+        }
+        Err(ureq::Error::Transport(t)) => Err(AccountError::Network(t.to_string())),
+    }
+}
+
+/// The identity backend seam. Because plexiapp.com auth is interactive (browser
+/// magic link, or the CLI device flow), a provider never logs in
+/// programmatically — sign-in is the CLI's job via [`device_start`] /
+/// [`device_poll`]. The trait's remaining role is to name the active backend and
+/// report whether accounts are enabled, so the login command (and future
+/// purchase / publish / subscription seams) can gate on it.
+///
+/// Factory rule (`CLAUDE.md`): no method may panic.
 pub trait AccountProvider: Send + Sync {
-    /// Provider name for logs and session records.
+    /// Provider name for logs and session records (e.g. `"stub"`, `"plexi"`).
     fn name(&self) -> &'static str;
 
-    /// Whether this provider can actually authenticate. The stub returns
-    /// `false` so callers can give a clear "accounts unavailable" message.
+    /// Whether accounts are enabled for this backend. The stub returns `false`
+    /// so callers can give a clear "accounts unavailable" message.
     fn is_configured(&self) -> bool;
-
-    /// Create a new account for `email`, returning a logged-in session.
-    fn signup(&self, email: &str) -> Result<AccountSession, AccountError>;
-
-    /// Log in an existing account, returning a session.
-    fn login(&self, email: &str) -> Result<AccountSession, AccountError>;
 }
 
-/// The fail-closed default provider. Authenticates no one and never panics.
-/// Replacing this is the entire job of adding real accounts.
+/// The fail-closed default provider: accounts disabled. Selected when
+/// `account_backend` is unset or `"none"`.
 pub struct StubAccountProvider;
 
 impl AccountProvider for StubAccountProvider {
@@ -160,36 +307,42 @@ impl AccountProvider for StubAccountProvider {
     fn is_configured(&self) -> bool {
         false
     }
+}
 
-    fn signup(&self, email: &str) -> Result<AccountSession, AccountError> {
-        log::warn!("account: signup({email}) attempted with stub provider — not configured");
-        Err(AccountError::NotConfigured)
+/// The real plexiapp.com account provider, selected by
+/// `account_backend = "plexi"`. It only signals that accounts are available
+/// (`is_configured` = true); the interactive device-flow sign-in lives in the
+/// free [`device_start`] / [`device_poll`] / [`revoke_token`] functions the CLI
+/// drives against [`config::marketplace_account_url`].
+///
+/// [`config::marketplace_account_url`]: crate::config::marketplace_account_url
+pub struct PlexiAccountProvider;
+
+impl AccountProvider for PlexiAccountProvider {
+    fn name(&self) -> &'static str {
+        "plexi"
     }
 
-    fn login(&self, email: &str) -> Result<AccountSession, AccountError> {
-        log::warn!("account: login({email}) attempted with stub provider — not configured");
-        Err(AccountError::NotConfigured)
+    fn is_configured(&self) -> bool {
+        true
     }
 }
 
-/// Resolve the active account provider from config. Today this only returns the
-/// stub; a real provider drops in here keyed on `account_backend` with zero
-/// changes at any call site.
-///
-/// ```ignore
-/// match backend.as_deref() {
-///     Some("plexi") => Box::new(PlexiAuthProvider::from_config(cfg)),
-///     _ => Box::new(StubAccountProvider),
-/// }
-/// ```
+/// Resolve the active account provider from config. `"plexi"` selects the real
+/// plexiapp.com provider; anything else fails closed with the stub.
 pub fn account_provider() -> Box<dyn AccountProvider> {
-    let backend = crate::config::marketplace_account_backend();
-    match backend.as_deref() {
+    select_account_provider(crate::config::marketplace_account_backend().as_deref())
+}
+
+/// Pure provider selection, split out so it is testable without a config file.
+fn select_account_provider(backend: Option<&str>) -> Box<dyn AccountProvider> {
+    match backend {
+        Some("plexi") => Box::new(PlexiAccountProvider),
         Some("none") | None => Box::new(StubAccountProvider),
         Some(other) => {
             log::warn!(
-                "account: account_backend='{other}' configured but no provider is built — \
-                 falling back to stub (login/signup fail closed)"
+                "account: unknown account_backend='{other}' — falling back to stub \
+                 (accounts disabled)"
             );
             Box::new(StubAccountProvider)
         }
@@ -227,20 +380,168 @@ mod tests {
         store.clear().unwrap();
     }
 
-    // Factory-rule stub test: every method runs without panicking and auth
-    // fails closed.
+    // The default (no backend configured) is the fail-closed stub.
     #[test]
-    fn stub_provider_never_panics_and_fails_closed() {
+    fn stub_provider_reports_disabled() {
         let provider = account_provider();
         assert_eq!(provider.name(), "stub");
         assert!(!provider.is_configured());
+    }
+
+    #[test]
+    fn select_account_provider_by_backend() {
+        assert_eq!(select_account_provider(Some("plexi")).name(), "plexi");
+        assert!(select_account_provider(Some("plexi")).is_configured());
+        assert_eq!(select_account_provider(None).name(), "stub");
+        assert!(!select_account_provider(None).is_configured());
+        assert_eq!(select_account_provider(Some("none")).name(), "stub");
+        // Unknown backend fails closed to the stub.
+        assert_eq!(select_account_provider(Some("bogus")).name(), "stub");
+    }
+
+    #[test]
+    fn plexi_provider_reports_enabled() {
+        let p = PlexiAccountProvider;
+        assert_eq!(p.name(), "plexi");
+        assert!(p.is_configured());
+    }
+
+    // ── Device-flow client ──────────────────────────────────────────────────
+    //
+    // Response bodies below are copied verbatim from the website endpoints in
+    // this worktree (`website/src/pages/api/auth/device/{start,poll}.ts` and
+    // `revoke.ts`) — the accounts service is ours, so these are the contract.
+
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    /// Read a full HTTP request (headers + any `Content-Length` body) so we never
+    /// respond while the client is still writing its body — doing so half-closes
+    /// the socket and ureq's body write then fails.
+    fn drain_request(stream: &mut std::net::TcpStream) {
+        let mut buf = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        loop {
+            match stream.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => {
+                    buf.extend_from_slice(&chunk[..n]);
+                    if let Some(end) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                        let headers = String::from_utf8_lossy(&buf[..end]).to_lowercase();
+                        let content_len = headers
+                            .lines()
+                            .find_map(|l| l.strip_prefix("content-length:"))
+                            .and_then(|v| v.trim().parse::<usize>().ok())
+                            .unwrap_or(0);
+                        if buf.len() - (end + 4) >= content_len {
+                            break;
+                        }
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    }
+
+    /// A throwaway HTTP server that replies to N sequential requests with the
+    /// scripted `(status, json_body)` pairs, in order. Each `ureq` call opens a
+    /// fresh connection (`connection: close`), so one script entry == one call.
+    fn scripted_server(responses: Vec<(u16, String)>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        thread::spawn(move || {
+            for (status, body) in responses {
+                let (mut stream, _) = match listener.accept() {
+                    Ok(pair) => pair,
+                    Err(_) => return,
+                };
+                drain_request(&mut stream);
+                let reason = match status {
+                    200 => "OK",
+                    202 => "Accepted",
+                    410 => "Gone",
+                    500 => "Internal Server Error",
+                    _ => "Status",
+                };
+                let headers = format!(
+                    "HTTP/1.1 {status} {reason}\r\ncontent-length: {}\r\n\
+                     content-type: application/json\r\nconnection: close\r\n\r\n",
+                    body.len()
+                );
+                let _ = stream.write_all(headers.as_bytes());
+                let _ = stream.write_all(body.as_bytes());
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    #[test]
+    fn device_start_parses_codes() {
+        let base = scripted_server(vec![(
+            200,
+            r#"{"device_code":"dev_abc","poll_token":"pt_xyz","expires_in":900,"message":"We emailed an approval link to a@b.com. Click it to sign in on this device."}"#.to_string(),
+        )]);
+        let start = device_start(&base, "a@b.com").expect("device/start should parse");
+        assert_eq!(start.device_code, "dev_abc");
+        assert_eq!(start.poll_token, "pt_xyz");
+        assert_eq!(start.expires_in, 900);
+        assert!(start.message.contains("a@b.com"));
+    }
+
+    #[test]
+    fn device_poll_pending_returns_pending() {
+        let base = scripted_server(vec![(202, r#"{"status":"pending"}"#.to_string())]);
         assert!(matches!(
-            provider.signup("a@b.com"),
-            Err(AccountError::NotConfigured)
+            device_poll(&base, "dev_abc", "pt_xyz"),
+            Ok(PollOutcome::Pending)
         ));
+    }
+
+    #[test]
+    fn device_poll_approved_yields_saveable_session() {
+        let base = scripted_server(vec![(
+            200,
+            r#"{"schema_version":1,"token":"tok_live","account_id":"acct_9","email":"a@b.com","provider":"plexi","issued_at":"2026-07-06T00:00:00Z"}"#.to_string(),
+        )]);
+        let outcome = device_poll(&base, "dev_abc", "pt_xyz").expect("poll should succeed");
+        let session = match outcome {
+            PollOutcome::Approved(s) => *s,
+            other => panic!("expected approved, got {other:?}"),
+        };
+        assert_eq!(session.account_id, "acct_9");
+        assert_eq!(session.token, "tok_live");
+        assert_eq!(session.provider, "plexi");
+
+        // The approved session round-trips through the on-disk store.
+        let tmp = std::env::temp_dir().join(format!("plexi-acct-{}.toml", uuid::Uuid::new_v4()));
+        let store = AccountStore::open_at(tmp.clone());
+        store.save(&session).unwrap();
+        assert_eq!(store.current(), Some(session));
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn device_poll_gone_returns_gone() {
+        let base = scripted_server(vec![(
+            410,
+            r#"{"error":"device code expired or already used"}"#.to_string(),
+        )]);
         assert!(matches!(
-            provider.login("a@b.com"),
-            Err(AccountError::NotConfigured)
+            device_poll(&base, "dev_abc", "pt_xyz"),
+            Ok(PollOutcome::Gone)
+        ));
+    }
+
+    #[test]
+    fn revoke_token_ok_and_error() {
+        let ok_base = scripted_server(vec![(200, r#"{"ok":true}"#.to_string())]);
+        assert!(revoke_token(&ok_base, "tok_live").is_ok());
+
+        let err_base = scripted_server(vec![(500, r#"{"error":"server error"}"#.to_string())]);
+        assert!(matches!(
+            revoke_token(&err_base, "tok_live"),
+            Err(AccountError::Server(_))
         ));
     }
 }

--- a/src/app/http.rs
+++ b/src/app/http.rs
@@ -1,0 +1,28 @@
+//! Shared blocking HTTP helpers for the hosted marketplace + accounts clients.
+//!
+//! Both [`crate::app::account`] and [`crate::app::marketplace`] talk to
+//! plexiapp.com with the same pure-Rust `ureq` setup (no tokio) and the same
+//! base-plus-path URL joining. This module owns that shared shape; each caller
+//! keeps its own per-endpoint status-code dispatch, which differs by service.
+
+use std::time::Duration;
+
+/// Build a blocking `ureq` agent with a fixed 10s connect timeout and the given
+/// overall request timeout. Pure-Rust, no tokio — matches the rest of the host's
+/// network CLI commands.
+pub fn agent(timeout: Duration) -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout_connect(Duration::from_secs(10))
+        .timeout(timeout)
+        .build()
+}
+
+/// Join a base URL and a path with exactly one `/` between them, trimming any
+/// stray slashes on either side.
+pub fn join_url(base: &str, path: &str) -> String {
+    format!(
+        "{}/{}",
+        base.trim_end_matches('/'),
+        path.trim_start_matches('/')
+    )
+}

--- a/src/app/marketplace.rs
+++ b/src/app/marketplace.rs
@@ -1,13 +1,22 @@
-//! Hosted marketplace layer — registry catalog, publisher submission, and the
-//! paid-app license + payment boundary (stint `0018`-`0021`).
+//! Hosted marketplace layer — registry catalog and publisher submission
+//! (stints `0018`-`0021`, `0340`).
 //!
 //! # Invariant carried from `docs/marketplace-hosted.md`
 //!
 //! Hosted services **distribute metadata and broker money**. They never become
 //! a dependency for running a local app. Everything in this module is a
-//! discovery / purchase surface layered *on top of* the local package format
+//! discovery / publish surface layered *on top of* the local package format
 //! (`crate::app::package`) and the local install flow. An installed app never
 //! phones home; the registry being down never breaks an installed app.
+//!
+//! # No client-side licensing
+//!
+//! Per `docs/marketplace-monetization.md`, a purchase is a server-side fact (a
+//! row in the plexiapp.com database keyed on the account), never a file on disk.
+//! The host presents its account bearer token when downloading a paid artifact
+//! and the server decides — there is no `License`, no `LicenseStore`, and no
+//! client-side payment provider. Paid checkout completes in the browser (Polar);
+//! the host observes the result, it never charges.
 //!
 //! # What lives here
 //!
@@ -17,15 +26,6 @@
 //! - [`RegistryEntry`] / [`RegistryIndex`] / [`RegistryClient`] — the hosted
 //!   catalog. The index *republishes* what the local validator already produced
 //!   (`crate::app::package::PackageReport`); it does not invent a second schema.
-//! - [`License`] / [`LicenseStore`] — proof-of-ownership for a paid app, stored
-//!   on disk per-channel. Real and tested. A license is the only thing the host
-//!   checks before installing a paid app.
-//! - [`PaymentProvider`] / [`StubPaymentProvider`] / [`payment_provider`] — the
-//!   payment boundary. Today the factory returns the stub, which fails closed
-//!   with [`PaymentError::NotConfigured`]. A real provider (Stripe, Polar, …)
-//!   slots into [`payment_provider`] with no other change anywhere — the license
-//!   store, the install gate, and the CLI all consume the trait, never a
-//!   concrete provider.
 //! - [`PublishClient`] / [`Submission`] — the publisher submission flow. Builds
 //!   a validated submission from a local package and posts it to a configured
 //!   endpoint; fails closed and honestly when no endpoint is set.
@@ -337,10 +337,7 @@ impl RegistryClient {
     }
 
     fn agent() -> ureq::Agent {
-        ureq::AgentBuilder::new()
-            .timeout_connect(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(30))
-            .build()
+        crate::app::http::agent(std::time::Duration::from_secs(30))
     }
 
     /// Fetch and parse the catalog index.
@@ -378,10 +375,9 @@ impl RegistryClient {
     /// Resolve the artifact URL for an entry: explicit `package_url`, else
     /// `<cdn_base>/<checksum>.plexipkg`.
     pub fn artifact_url(&self, entry: &RegistryEntry) -> String {
-        entry
-            .package_url
-            .clone()
-            .unwrap_or_else(|| format!("{}/{}.plexipkg", self.cdn_base, entry.checksum))
+        entry.package_url.clone().unwrap_or_else(|| {
+            crate::app::http::join_url(&self.cdn_base, &format!("{}.plexipkg", entry.checksum))
+        })
     }
 
     /// Download an entry's `.plexipkg` artifact to `dest`, verifying that the
@@ -483,239 +479,6 @@ impl InstalledRegistrySource {
     }
 }
 
-// ── Licenses ──────────────────────────────────────────────────────────────────
-
-/// A receipt proving a user bought a paid app — like owning a purchased
-/// template file. Issued by a [`PaymentProvider`] on a successful purchase and
-/// persisted on disk. It is **never checked to run the app**: once the package
-/// is installed it runs freely, same path as a free app. The receipt only
-/// matters for re-downloading the paid artifact later without paying twice. The
-/// `token` is an opaque provider-issued string a future server uses to verify
-/// ownership on re-download.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct License {
-    pub schema_version: u32,
-    pub app_id: String,
-    /// Version this license covers, or `"*"` for any version.
-    pub version: String,
-    /// ISO-8601 UTC issue time.
-    pub issued_at: String,
-    /// Opaque provider-issued ownership token, used for server-side re-download
-    /// verification when real payment is wired.
-    pub token: String,
-    /// Which provider issued this license (e.g. `"stub"`, `"stripe"`).
-    pub provider: String,
-}
-
-impl License {
-    /// Whether this license authorizes installing the given app id. v1: same id,
-    /// and either a wildcard version or an exact match.
-    pub fn authorizes(&self, app_id: &str, version: &str) -> bool {
-        self.app_id == app_id && (self.version == "*" || self.version == version)
-    }
-}
-
-/// On-disk license store, one TOML file per app id under
-/// `<config_dir>/licenses/<app_id>.toml`. Per-channel by construction because
-/// `config_dir()` is per-channel.
-pub struct LicenseStore {
-    dir: PathBuf,
-}
-
-impl LicenseStore {
-    /// Open the store for the active channel.
-    pub fn open() -> Self {
-        LicenseStore {
-            dir: crate::config::config_dir().join("licenses"),
-        }
-    }
-
-    /// Open a store rooted at an explicit directory (tests).
-    #[cfg(test)]
-    pub fn open_at(dir: PathBuf) -> Self {
-        LicenseStore { dir }
-    }
-
-    fn path_for(&self, app_id: &str) -> PathBuf {
-        self.dir.join(format!("{app_id}.toml"))
-    }
-
-    /// Load the license for an app id, if one is stored.
-    pub fn load(&self, app_id: &str) -> Option<License> {
-        let path = self.path_for(app_id);
-        let text = std::fs::read_to_string(&path).ok()?;
-        match toml::from_str::<License>(&text) {
-            Ok(lic) => Some(lic),
-            Err(e) => {
-                log::warn!("marketplace: corrupt license at {}: {e}", path.display());
-                None
-            }
-        }
-    }
-
-    /// Persist a license, creating the store dir if needed.
-    pub fn save(&self, license: &License) -> Result<(), String> {
-        std::fs::create_dir_all(&self.dir)
-            .map_err(|e| format!("could not create license dir {}: {e}", self.dir.display()))?;
-        let text = toml::to_string_pretty(license)
-            .map_err(|e| format!("could not serialize license: {e}"))?;
-        let path = self.path_for(&license.app_id);
-        std::fs::write(&path, text)
-            .map_err(|e| format!("could not write license {}: {e}", path.display()))?;
-        log::info!(
-            "marketplace: saved license for '{}' v{} (provider {})",
-            license.app_id,
-            license.version,
-            license.provider
-        );
-        Ok(())
-    }
-
-    /// Whether a stored license authorizes installing this app id + version.
-    pub fn has_valid(&self, app_id: &str, version: &str) -> bool {
-        self.load(app_id)
-            .map(|l| l.authorizes(app_id, version))
-            .unwrap_or(false)
-    }
-
-    /// All stored licenses, sorted by app id.
-    pub fn list(&self) -> Vec<License> {
-        let mut out = Vec::new();
-        if let Ok(read) = std::fs::read_dir(&self.dir) {
-            for entry in read.flatten() {
-                if entry.path().extension().and_then(|e| e.to_str()) == Some("toml") {
-                    if let Ok(text) = std::fs::read_to_string(entry.path()) {
-                        if let Ok(lic) = toml::from_str::<License>(&text) {
-                            out.push(lic);
-                        }
-                    }
-                }
-            }
-        }
-        out.sort_by(|a, b| a.app_id.cmp(&b.app_id));
-        out
-    }
-}
-
-// ── Payment boundary ──────────────────────────────────────────────────────────
-
-/// Why a purchase could not complete.
-#[derive(Debug, thiserror::Error)]
-pub enum PaymentError {
-    /// No real payment provider is configured in this build. The stub returns
-    /// this for every purchase — it is the expected, honest failure until a
-    /// provider (Stripe, Polar, …) is wired into [`payment_provider`].
-    #[error(
-        "paid apps require a configured payment provider — none is set up in this build. \
-         Free apps install normally. See https://plexiapp.com/docs/marketplace"
-    )]
-    NotConfigured,
-    /// The user is not signed in to a marketplace account.
-    #[error("a marketplace account is required to purchase paid apps")]
-    NoAccount,
-}
-
-/// The payment boundary. A purchase turns an account + a paid catalog entry into
-/// a [`License`]. This is the single seam a real processor implements; nothing
-/// else in the codebase references a concrete provider.
-///
-/// Factory rule (`CLAUDE.md`): no method may panic. The stub returns `Err` /
-/// noop for everything it cannot do.
-pub trait PaymentProvider: Send + Sync {
-    /// Provider name for logs and license records (e.g. `"stub"`, `"stripe"`).
-    fn name(&self) -> &'static str;
-
-    /// Whether this provider can actually charge. The stub returns `false`, so
-    /// callers can give a clear "paid apps unavailable" message before prompting.
-    fn is_configured(&self) -> bool;
-
-    /// Attempt to purchase `entry` for the logged-in `session`, returning a
-    /// [`License`] on success. The stub always fails with
-    /// [`PaymentError::NotConfigured`].
-    fn purchase(
-        &self,
-        entry: &RegistryEntry,
-        session: &crate::app::account::AccountSession,
-    ) -> Result<License, PaymentError>;
-}
-
-/// The fail-closed default provider. Charges nothing, issues nothing, and never
-/// panics. Replacing this is the entire job of adding real payments.
-pub struct StubPaymentProvider;
-
-impl PaymentProvider for StubPaymentProvider {
-    fn name(&self) -> &'static str {
-        "stub"
-    }
-
-    fn is_configured(&self) -> bool {
-        false
-    }
-
-    fn purchase(
-        &self,
-        entry: &RegistryEntry,
-        _session: &crate::app::account::AccountSession,
-    ) -> Result<License, PaymentError> {
-        log::warn!(
-            "marketplace: purchase of paid app '{}' attempted with stub provider — not configured",
-            entry.id
-        );
-        Err(PaymentError::NotConfigured)
-    }
-}
-
-/// Resolve the active payment provider from config. Today this only ever returns
-/// the stub; a real provider drops in here keyed on `payment_backend` with zero
-/// changes at any call site.
-///
-/// ```ignore
-/// match backend.as_deref() {
-///     Some("stripe") => Box::new(StripeProvider::from_config(cfg)),
-///     _ => Box::new(StubPaymentProvider),
-/// }
-/// ```
-pub fn payment_provider() -> Box<dyn PaymentProvider> {
-    let backend = crate::config::marketplace_payment_backend();
-    match backend.as_deref() {
-        // Real providers slot in here. None exist yet, so everything falls
-        // through to the stub. This is intentional and must fail closed.
-        Some("none") | None => Box::new(StubPaymentProvider),
-        Some(other) => {
-            log::warn!(
-                "marketplace: payment_backend='{other}' is configured but no provider is built — \
-                 falling back to stub (paid installs will fail closed)"
-            );
-            Box::new(StubPaymentProvider)
-        }
-    }
-}
-
-// ── Install license gate ──────────────────────────────────────────────────────
-
-/// The decision for whether a registry install may proceed, based purely on the
-/// entry's price and the local license store. Pure function — no network, no
-/// disk beyond the store passed in — so it is fully unit-testable.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum LicenseDecision {
-    /// Free app, or a paid app the user already owns. Install may proceed.
-    Proceed,
-    /// Paid app with no local license. The caller must purchase (or fail).
-    NeedsPurchase,
-}
-
-/// Decide whether installing `entry` is licensed.
-pub fn license_gate(entry: &RegistryEntry, store: &LicenseStore) -> LicenseDecision {
-    if entry.price.is_free() {
-        return LicenseDecision::Proceed;
-    }
-    if store.has_valid(&entry.id, &entry.version) {
-        LicenseDecision::Proceed
-    } else {
-        LicenseDecision::NeedsPurchase
-    }
-}
-
 // ── Publisher submission ──────────────────────────────────────────────────────
 
 /// Lifecycle of a publisher submission. Mirrors the states in
@@ -781,10 +544,7 @@ impl PublishClient {
         );
         let body = serde_json::to_string(submission)
             .map_err(|e| PublishError::Upload(format!("serialize submission: {e}")))?;
-        let agent = ureq::AgentBuilder::new()
-            .timeout_connect(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(60))
-            .build();
+        let agent = crate::app::http::agent(std::time::Duration::from_secs(60));
         let resp = agent
             .post(url)
             .set("content-type", "application/json")
@@ -943,89 +703,20 @@ mod tests {
     }
 
     #[test]
-    fn license_store_round_trips_and_gates() {
-        let tmp = std::env::temp_dir().join(format!("plexi-lic-test-{}", uuid::Uuid::new_v4()));
-        let store = LicenseStore::open_at(tmp.clone());
-        let paid_entry = entry("pro-app", paid(), Visibility::Public);
-
-        // No license yet → paid app needs purchase.
-        assert_eq!(
-            license_gate(&paid_entry, &store),
-            LicenseDecision::NeedsPurchase
-        );
-
-        // A free app never needs a license.
-        let free_entry = entry("free-app", Price::default(), Visibility::Public);
-        assert_eq!(license_gate(&free_entry, &store), LicenseDecision::Proceed);
-
-        // Save a license, then the paid app proceeds.
-        let lic = License {
-            schema_version: MARKETPLACE_SCHEMA_VERSION,
-            app_id: "pro-app".to_string(),
-            version: "*".to_string(),
-            issued_at: "2026-06-12T00:00:00Z".to_string(),
-            token: "tok_test".to_string(),
-            provider: "stub".to_string(),
-        };
-        store.save(&lic).unwrap();
-        assert_eq!(store.load("pro-app"), Some(lic));
-        assert_eq!(license_gate(&paid_entry, &store), LicenseDecision::Proceed);
-        assert_eq!(store.list().len(), 1);
-
-        let _ = std::fs::remove_dir_all(&tmp);
-    }
-
-    #[test]
-    fn free_registry_entry_needs_no_account_or_license() {
+    fn free_registry_entry_needs_no_account() {
         let tmp = tempfile::tempdir().unwrap();
-        let store = LicenseStore::open_at(tmp.path().join("licenses"));
         let mut free_entry = entry("reviewed-notes", Price::default(), Visibility::Public);
         free_entry.reviewed_native = true;
 
-        assert_eq!(license_gate(&free_entry, &store), LicenseDecision::Proceed);
+        // Free apps carry no price gate and no account requirement — with the
+        // no-license model, `is_free()` is the whole install-time decision.
+        assert!(free_entry.price.is_free());
         assert!(
             crate::app::account::AccountStore::open_at(tmp.path().join("account.toml"))
                 .current()
                 .is_none(),
             "test starts without a marketplace account, but free apps still proceed"
         );
-    }
-
-    #[test]
-    fn license_version_scoping() {
-        let lic = License {
-            schema_version: 1,
-            app_id: "a".to_string(),
-            version: "1.0.0".to_string(),
-            issued_at: "x".to_string(),
-            token: "t".to_string(),
-            provider: "stub".to_string(),
-        };
-        assert!(lic.authorizes("a", "1.0.0"));
-        assert!(!lic.authorizes("a", "2.0.0"));
-        assert!(!lic.authorizes("b", "1.0.0"));
-    }
-
-    // Factory-rule stub test: every trait method runs without panicking, and
-    // purchase fails closed.
-    #[test]
-    fn stub_payment_provider_never_panics_and_fails_closed() {
-        let provider = payment_provider();
-        assert_eq!(provider.name(), "stub");
-        assert!(!provider.is_configured());
-        let e = entry("pro-app", paid(), Visibility::Public);
-        let session = crate::app::account::AccountSession {
-            schema_version: 1,
-            account_id: "acct_1".to_string(),
-            email: "user@example.com".to_string(),
-            token: "tok".to_string(),
-            provider: "stub".to_string(),
-            issued_at: "2026-06-12T00:00:00Z".to_string(),
-        };
-        match provider.purchase(&e, &session) {
-            Err(PaymentError::NotConfigured) => {}
-            other => panic!("stub must fail closed, got {other:?}"),
-        }
     }
 
     #[test]
@@ -1156,10 +847,6 @@ mod tests {
         let hits = fetched.search("notes");
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].id, "reviewed-notes");
-        assert_eq!(
-            license_gate(hits[0], &LicenseStore::open_at(tmp.path().join("licenses"))),
-            LicenseDecision::Proceed
-        );
 
         let dest = tmp.path().join("downloaded.plexipkg");
         client

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,6 +7,7 @@ mod focus;
 pub(crate) mod focus_journal;
 pub mod host_mcp;
 pub mod host_version;
+pub mod http;
 pub(crate) mod launch_spec;
 mod lifecycle;
 pub mod marketplace;

--- a/src/cli/account.rs
+++ b/src/cli/account.rs
@@ -1,32 +1,49 @@
-//! `plexi account` — marketplace account CLI (stint `0021`).
+//! `plexi account` — marketplace account CLI (stints `0021`, `0340`).
 //!
-//! Login/signup go through `crate::app::account::account_provider()`, which is
-//! the fail-closed stub today. Logout and status are fully local (they only
-//! touch the on-disk session), so they work now. An account is only ever needed
-//! to publish, buy a paid app, or use the AI subscription — never to install a
+//! `login` runs the plexiapp.com device-code flow directly over HTTPS: it asks
+//! the service to email a sign-in link, then polls until the user clicks it.
+//! This is a plain network client — it never touches the host socket. `logout`
+//! revokes the token server-side (best effort) and clears the local session;
+//! `status` reads the on-disk session. An account is only ever needed to
+//! publish, buy a paid app, or use the AI subscription — never to install a
 //! free app.
 
-use crate::app::account::{account_provider, AccountStore};
+use crate::app::account::{
+    account_provider, device_poll, device_start, revoke_token, AccountError, AccountSession,
+    AccountStore, PollOutcome,
+};
+use std::time::{Duration, Instant};
+
+/// How often `login` polls the service for approval.
+const POLL_INTERVAL: Duration = Duration::from_secs(3);
 
 /// `plexi account status` — show whether you are logged in.
 pub fn account_status_cli() -> i32 {
     log::info!("account: status");
-    match AccountStore::open().current() {
-        Some(s) => {
-            println!("Logged in as {} (account {})", s.email, s.account_id);
-            println!("  provider: {}", s.provider);
-            println!("  since:    {}", s.issued_at);
-            0
-        }
-        None => {
-            println!("Not logged in. Free apps install without an account.");
-            println!("Run `plexi account login` to publish or buy paid apps.");
-            0
-        }
+    for line in status_lines(AccountStore::open().current().as_ref()) {
+        println!("{line}");
+    }
+    0
+}
+
+/// Human-readable status lines for the current session (or lack of one). Pure so
+/// both branches are unit-testable without capturing stdout.
+fn status_lines(session: Option<&AccountSession>) -> Vec<String> {
+    match session {
+        Some(s) => vec![
+            format!("Logged in as {} (account {})", s.email, s.account_id),
+            format!("  provider: {}", s.provider),
+            format!("  since:    {}", s.issued_at),
+        ],
+        None => vec![
+            "Not logged in. Free apps install without an account.".to_string(),
+            "Run `plexi account login` to publish or buy paid apps.".to_string(),
+        ],
     }
 }
 
-/// `plexi account login [--email X]` — authenticate and store a session.
+/// `plexi account login [--email X]` — run the device-code flow and store the
+/// session on success.
 pub fn account_login_cli(email: Option<&str>) -> i32 {
     let email = match resolve_email(email) {
         Some(e) => e,
@@ -35,52 +52,75 @@ pub fn account_login_cli(email: Option<&str>) -> i32 {
             return 1;
         }
     };
-    log::info!("account: login email={email}");
+
+    // The account backend must be enabled. The device flow only makes sense
+    // against a real accounts service; the stub fails closed here.
     let provider = account_provider();
+    if !provider.is_configured() {
+        eprintln!("error: {}", AccountError::NotConfigured);
+        return 1;
+    }
+    let base = crate::config::marketplace_account_url();
     log::info!(
-        "account: provider '{}' configured={}",
-        provider.name(),
-        provider.is_configured()
+        "account: login email={email} via provider '{}' at {base}",
+        provider.name()
     );
-    match provider.login(&email) {
-        Ok(session) => persist(&session),
+
+    let start = match device_start(&base, &email) {
+        Ok(s) => s,
         Err(e) => {
             eprintln!("error: {e}");
-            1
-        }
-    }
-}
-
-/// `plexi account signup [--email X]` — create an account and store a session.
-pub fn account_signup_cli(email: Option<&str>) -> i32 {
-    let email = match resolve_email(email) {
-        Some(e) => e,
-        None => {
-            eprintln!("error: an email is required — pass `--email you@example.com`");
             return 1;
         }
     };
-    log::info!("account: signup email={email}");
-    let provider = account_provider();
-    log::info!(
-        "account: provider '{}' configured={}",
-        provider.name(),
-        provider.is_configured()
-    );
-    match provider.signup(&email) {
-        Ok(session) => persist(&session),
-        Err(e) => {
-            eprintln!("error: {e}");
-            1
+    println!("{}", start.message);
+    println!("Check your email ({email}) and click the link — waiting...");
+
+    let deadline = Instant::now() + Duration::from_secs(start.expires_in);
+    loop {
+        if Instant::now() >= deadline {
+            eprintln!("error: {}", AccountError::Timeout);
+            return 1;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+        match device_poll(&base, &start.device_code, &start.poll_token) {
+            Ok(PollOutcome::Pending) => continue,
+            Ok(PollOutcome::Approved(session)) => {
+                log::info!(
+                    "account: logged in {} (provider {})",
+                    session.email,
+                    session.provider
+                );
+                return persist(&session);
+            }
+            Ok(PollOutcome::Gone) => {
+                eprintln!("error: {}", AccountError::DeviceExpired);
+                return 1;
+            }
+            Err(e) => {
+                eprintln!("error: {e}");
+                return 1;
+            }
         }
     }
 }
 
-/// `plexi account logout` — clear the local session.
+/// `plexi account logout` — revoke the token server-side (best effort) and clear
+/// the local session.
 pub fn account_logout_cli() -> i32 {
     log::info!("account: logout");
     let store = AccountStore::open();
     let was = store.current();
+
+    // Best-effort server-side revoke — a network failure must not block clearing
+    // the local session.
+    if let Some(session) = &was {
+        let base = crate::config::marketplace_account_url();
+        if let Err(e) = revoke_token(&base, &session.token) {
+            log::warn!("account: server-side token revoke failed (clearing locally anyway): {e}");
+        }
+    }
+
     match store.clear() {
         Ok(()) => {
             match was {
@@ -103,7 +143,7 @@ fn resolve_email(flag: Option<&str>) -> Option<String> {
         .filter(|e| !e.is_empty())
 }
 
-fn persist(session: &crate::app::account::AccountSession) -> i32 {
+fn persist(session: &AccountSession) -> i32 {
     match AccountStore::open().save(session) {
         Ok(()) => {
             println!("Logged in as {}.", session.email);
@@ -113,5 +153,37 @@ fn persist(session: &crate::app::account::AccountSession) -> i32 {
             eprintln!("error: authenticated but could not save session: {e}");
             1
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn session() -> AccountSession {
+        AccountSession {
+            schema_version: 1,
+            account_id: "acct_9".to_string(),
+            email: "a@b.com".to_string(),
+            token: "tok".to_string(),
+            provider: "plexi".to_string(),
+            issued_at: "2026-07-06T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn status_lines_logged_in() {
+        let s = session();
+        let lines = status_lines(Some(&s));
+        assert!(lines[0].contains("a@b.com"));
+        assert!(lines[0].contains("acct_9"));
+        assert!(lines.iter().any(|l| l.contains("provider: plexi")));
+    }
+
+    #[test]
+    fn status_lines_logged_out() {
+        let lines = status_lines(None);
+        assert!(lines[0].contains("Not logged in"));
+        assert!(lines.iter().any(|l| l.contains("plexi account login")));
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -102,8 +102,9 @@ pub enum Commands {
     },
     /// Manage your Plexi marketplace account (only needed to publish or buy paid apps).
     ///
-    /// Free apps install without an account. Login/signup require a configured
-    /// auth backend; until then they fail closed with a clear message.
+    /// Free apps install without an account. Login requires the accounts backend
+    /// enabled (`[marketplace].account_backend = "plexi"`); otherwise it fails
+    /// closed with a clear message.
     #[command(next_help_heading = "Apps")]
     Account {
         #[command(subcommand)]
@@ -779,11 +780,6 @@ pub enum AppCmd {
         /// Substring matched against app id, name, description, and tags
         query: String,
     },
-    /// Inspect paid-app licenses stored on this machine.
-    License {
-        #[command(subcommand)]
-        cmd: LicenseCmd,
-    },
     /// Pull git-backed installed apps to their latest source revision.
     ///
     /// Canonical app update command. Resolves workspace-local apps when run
@@ -862,32 +858,18 @@ pub enum HostCmd {
 pub enum AccountCmd {
     /// Show whether you are logged in.
     Status,
-    /// Log in to an existing marketplace account.
+    /// Log in to your marketplace account via emailed sign-in link.
+    ///
+    /// Runs the device-code flow: plexiapp.com emails a link, you click it in
+    /// any browser, and the CLI stores the session. Magic-link login creates the
+    /// account on first use — there is no separate signup.
     Login {
-        /// Account email (falls back to [marketplace].account_email in config)
-        #[arg(long)]
-        email: Option<String>,
-    },
-    /// Create a new marketplace account.
-    Signup {
         /// Account email (falls back to [marketplace].account_email in config)
         #[arg(long)]
         email: Option<String>,
     },
     /// Log out and clear the local session.
     Logout,
-}
-
-/// `plexi app license <cmd>` — inspect paid-app licenses on this machine.
-#[derive(Subcommand)]
-pub enum LicenseCmd {
-    /// List every stored paid-app license.
-    List,
-    /// Show one license in full.
-    Show {
-        /// App id whose license to show
-        id: String,
-    },
 }
 
 #[derive(Subcommand)]

--- a/src/cli/config_cli.rs
+++ b/src/cli/config_cli.rs
@@ -83,8 +83,8 @@ pub const CONFIG_KEYS: &[(&str, &str, &str)] = &[
     ("marketplace.registry_url", "string", "Override catalog index URL"),
     ("marketplace.cdn_url", "string", "Override package CDN base URL"),
     ("marketplace.submit_url", "string", "Publisher submission endpoint"),
-    ("marketplace.payment_backend", "string", "Payment backend selector"),
-    ("marketplace.account_backend", "string", "Account/auth backend selector"),
+    ("marketplace.account_backend", "string", "Account/auth backend selector (\"plexi\" to enable)"),
+    ("marketplace.account_url", "string", "Accounts service base URL (default plexiapp.com)"),
     ("marketplace.account_email", "string", "Default email for plexi account login"),
 ];
 

--- a/src/cli/marketplace.rs
+++ b/src/cli/marketplace.rs
@@ -1,19 +1,17 @@
 //! Marketplace CLI surface — browse/search the hosted catalog, publish an app,
-//! manage paid-app licenses, and gate paid installs (stint `0018`-`0021`).
+//! and plan bare-id installs (stints `0018`-`0021`, `0340`).
 //!
 //! Every command here is a thin shell over `crate::app::marketplace`. The
 //! invariant from the PRM holds at this layer too: nothing here is required to
 //! run a locally-installed app. Browse/search need the network; if the registry
 //! is unreachable they fail with a clear message and a nonzero code, but they
-//! never touch installed apps. The paid-install gate fails *open* on registry
-//! errors for free/local apps (registry down never blocks a local install) and
-//! fails *closed* only for confirmed paid apps with no license.
+//! never touch installed apps. Paid apps are bought through the marketplace
+//! (browser checkout); the CLI never charges and there is no client-side
+//! license — a bare CLI install of a paid app is blocked with a pointer.
 
-use crate::app::account::AccountStore;
 use crate::app::marketplace::{
-    license_gate, payment_provider, InstalledRegistrySource, LicenseDecision, LicenseStore,
-    MarketplaceManifest, PaymentError, PublishClient, RegistryClient, RegistryEntry, RegistryError,
-    Submission, Visibility,
+    InstalledRegistrySource, MarketplaceManifest, PublishClient, RegistryClient, RegistryEntry,
+    RegistryError, Submission, Visibility,
 };
 use crate::app::package;
 use std::path::{Path, PathBuf};
@@ -92,8 +90,8 @@ fn print_entry_table(entries: &[&RegistryEntry]) {
 /// hosted catalog and the license store. There is no legacy fallback — the
 /// catalog is the only source for a bare id.
 pub enum InstallPlan {
-    /// Catalog app, free or licensed, artifact downloaded + checksum-verified.
-    /// Install this `.plexipkg` directly.
+    /// Free catalog app, artifact downloaded + checksum-verified. Install this
+    /// `.plexipkg` directly.
     Package {
         path: PathBuf,
         reviewed_native: bool,
@@ -108,8 +106,8 @@ pub enum InstallPlan {
     /// resolved through the catalog. (Already-installed apps are unaffected;
     /// only *new* installs need the catalog.)
     Unreachable,
-    /// Paid app with no license, and purchase is unavailable or failed. Abort.
-    /// A message was already printed.
+    /// The install cannot proceed (paid app, malformed entry, or download
+    /// failure). A message was already printed.
     Blocked,
 }
 
@@ -117,9 +115,10 @@ pub enum InstallPlan {
 /// `install_cli`. The catalog is the sole source of truth for a bare id —
 /// there is no legacy resolver and no backwards-compatibility path.
 ///
-/// A paid app the user does not own is taken through purchase (which fails
-/// closed with the stub provider). Free / licensed apps install from the CDN
-/// artifact, or from a declared source spec for github-hosted catalog entries.
+/// Paid apps are blocked here: they are bought through the marketplace (browser
+/// checkout), and the server gates the paid artifact download on the account's
+/// purchase row. Free apps install from the CDN artifact, or from a declared
+/// source spec for github-hosted catalog entries.
 pub fn plan_install(app_id: &str) -> InstallPlan {
     let cli = client();
     let entry = match cli.fetch_entry(app_id) {
@@ -149,11 +148,18 @@ pub fn plan_install(app_id: &str) -> InstallPlan {
         }
     }
 
-    // License gate before any download or source resolution.
-    let store = LicenseStore::open();
-    if license_gate(&entry, &store) == LicenseDecision::NeedsPurchase
-        && !attempt_purchase(&entry, &store)
-    {
+    // Paid apps are purchased through the marketplace, never the CLI: the server
+    // gates the paid artifact download on the account's purchase row. Block a
+    // bare CLI install of a paid app with a clear pointer. Free apps proceed.
+    if !entry.price.is_free() {
+        log::info!("marketplace: bare install of paid app '{app_id}' blocked (buy via marketplace)");
+        eprintln!(
+            "error: '{}' is a paid app ({}). Buy it through the marketplace — open the app in \
+             Plexi or visit https://plexiapp.com — then it installs for your account. \
+             Log in first with `plexi account login`.",
+            entry.id,
+            entry.price.display()
+        );
         return InstallPlan::Blocked;
     }
 
@@ -189,89 +195,6 @@ pub fn plan_install(app_id: &str) -> InstallPlan {
          the registry entry is malformed"
     );
     InstallPlan::Blocked
-}
-
-/// Attempt to buy a paid app the user does not yet own. Requires a logged-in
-/// account; today the stub payment provider always fails closed, telling the
-/// user exactly why. When a real provider is wired into `payment_provider()`,
-/// this issues + persists a license and returns `true` with no other change.
-fn attempt_purchase(entry: &RegistryEntry, store: &LicenseStore) -> bool {
-    println!("'{}' is a paid app ({}).", entry.id, entry.price.display());
-
-    let Some(session) = AccountStore::open().current() else {
-        eprintln!("error: {}", PaymentError::NoAccount);
-        eprintln!("  Log in first: `plexi account login`.");
-        return false;
-    };
-
-    let provider = payment_provider();
-    log::info!(
-        "marketplace: payment provider '{}' configured={}",
-        provider.name(),
-        provider.is_configured()
-    );
-    if !provider.is_configured() {
-        eprintln!("error: {}", PaymentError::NotConfigured);
-        return false;
-    }
-    log::info!(
-        "marketplace: purchasing '{}' as {}",
-        entry.id,
-        session.email
-    );
-    match provider.purchase(entry, &session) {
-        Ok(license) => {
-            if let Err(e) = store.save(&license) {
-                eprintln!("error: purchased but could not save license: {e}");
-                return false;
-            }
-            println!("Purchased '{}'. License saved.", entry.id);
-            true
-        }
-        Err(e) => {
-            eprintln!("error: {e}");
-            false
-        }
-    }
-}
-
-/// `plexi app license list` — show every stored paid-app license.
-pub fn app_license_list_cli() -> i32 {
-    log::info!("marketplace: license list");
-    let store = LicenseStore::open();
-    let licenses = store.list();
-    if licenses.is_empty() {
-        println!("No paid-app licenses on this machine.");
-        return 0;
-    }
-    println!("{} license(s):\n", licenses.len());
-    for lic in &licenses {
-        println!(
-            "  {}  v{}  (provider: {}, issued: {})",
-            lic.app_id, lic.version, lic.provider, lic.issued_at
-        );
-    }
-    0
-}
-
-/// `plexi app license show <id>` — show one license in full.
-pub fn app_license_show_cli(id: &str) -> i32 {
-    log::info!("marketplace: license show id={id}");
-    let store = LicenseStore::open();
-    match store.load(id) {
-        Some(lic) => {
-            println!("app:       {}", lic.app_id);
-            println!("version:   {}", lic.version);
-            println!("provider:  {}", lic.provider);
-            println!("issued_at: {}", lic.issued_at);
-            println!("token:     {}", lic.token);
-            0
-        }
-        None => {
-            eprintln!("no license stored for '{id}'");
-            1
-        }
-    }
 }
 
 /// `plexi app publish [<path>]` — validate, package, and submit an app to the

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -310,7 +310,7 @@ pub(super) fn binary_in_path(name: &str) -> bool {
 }
 
 // ── Public re-exports (preserve crate::cli::fn_name() call sites in main.rs) ──
-pub use account::{account_login_cli, account_logout_cli, account_signup_cli, account_status_cli};
+pub use account::{account_login_cli, account_logout_cli, account_status_cli};
 pub use agent::{
     agent_add, agent_hook_install_cli, agent_hook_uninstall_cli, agent_init, agent_list,
     agent_report_cli, agent_status_cli, agent_update,
@@ -340,9 +340,7 @@ pub use install::{
     self_update_cli, update_cli,
 };
 pub use list::{freeze_cli, parse_notify_choice};
-pub use marketplace::{
-    app_browse_cli, app_license_list_cli, app_license_show_cli, app_publish_cli, app_search_cli,
-};
+pub use marketplace::{app_browse_cli, app_publish_cli, app_search_cli};
 pub use notes::{notes_list_cli, notes_open_cli};
 pub use notify::notify_cli;
 pub use open::{

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -137,8 +137,8 @@ const KNOWN_MARKETPLACE: &[&str] = &[
     "registry_url",
     "cdn_url",
     "submit_url",
-    "payment_backend",
     "account_backend",
+    "account_url",
     "account_email",
 ];
 const KNOWN_KEYBINDINGS: &[&str] = &[
@@ -508,9 +508,9 @@ pub struct CliConfig {
 /// Hosted marketplace configuration (`[marketplace]`). All fields optional —
 /// the hosted catalog/CDN default to `plexiapp.com` in code (see
 /// `crate::app::marketplace::DEFAULT_REGISTRY_URL`), so an empty section uses
-/// the official registry. `submit_url` and `payment_backend` are intentionally
-/// unset by default: publishing and paid purchases fail closed until a real
-/// endpoint / provider is wired up.
+/// the official registry. `submit_url` and `account_backend` are intentionally
+/// unset by default: publishing and accounts fail closed until they are wired
+/// up.
 #[derive(Deserialize, Default, Clone)]
 pub struct MarketplaceConfig {
     /// Override the catalog index URL. Default: official `plexiapp.com` index.
@@ -520,14 +520,13 @@ pub struct MarketplaceConfig {
     /// Publisher submission endpoint. Unset = publishing prepared locally but
     /// not uploaded (fails closed with a clear message).
     pub submit_url: Option<String>,
-    /// Payment backend selector. Unset / `"none"` = stub (paid installs fail
-    /// closed). A real provider (e.g. `"stripe"`) slots into
-    /// `crate::app::marketplace::payment_provider()` keyed on this value.
-    pub payment_backend: Option<String>,
-    /// Account/auth backend selector. Unset / `"none"` = stub (login/signup
-    /// fail closed). A real provider slots into
-    /// `crate::app::account::account_provider()` keyed on this value.
+    /// Account/auth backend selector. `"plexi"` enables plexiapp.com accounts;
+    /// unset / `"none"` = stub (login fails closed). Selects the provider in
+    /// `crate::app::account::account_provider()`.
     pub account_backend: Option<String>,
+    /// Override the accounts service base URL. Default:
+    /// `crate::app::account::DEFAULT_ACCOUNT_URL` (`plexiapp.com`).
+    pub account_url: Option<String>,
     /// Default email pre-filled by `plexi account login`. Unset = prompt.
     pub account_email: Option<String>,
 }
@@ -1374,8 +1373,8 @@ impl MarketplaceConfig {
         overlay_field!(registry_url);
         overlay_field!(cdn_url);
         overlay_field!(submit_url);
-        overlay_field!(payment_backend);
         overlay_field!(account_backend);
+        overlay_field!(account_url);
         overlay_field!(account_email);
     }
 }
@@ -1404,14 +1403,17 @@ pub fn marketplace_submit_url() -> Option<String> {
     marketplace_config().submit_url
 }
 
-/// Payment backend selector (e.g. `"none"`, `"stripe"`). `None` = stub.
-pub fn marketplace_payment_backend() -> Option<String> {
-    marketplace_config().payment_backend
-}
-
 /// Account/auth backend selector (e.g. `"none"`, `"plexi"`). `None` = stub.
 pub fn marketplace_account_backend() -> Option<String> {
     marketplace_config().account_backend
+}
+
+/// Accounts service base URL, defaulting to the product domain at the call site.
+pub fn marketplace_account_url() -> String {
+    marketplace_config()
+        .account_url
+        .filter(|u| !u.is_empty())
+        .unwrap_or_else(|| crate::app::account::DEFAULT_ACCOUNT_URL.to_string())
 }
 
 /// Default email pre-filled by `plexi account login`, if set.
@@ -1654,8 +1656,8 @@ mod tests {
              registry_url = \"https://plexiapp.com/registry/v1/index.json\"\n\
              cdn_url = \"https://plexiapp.com/registry/v1/packages\"\n\
              submit_url = \"https://plexiapp.com/registry/v1/submit\"\n\
-             payment_backend = \"none\"\n\
-             account_backend = \"none\"\n\
+             account_backend = \"plexi\"\n\
+             account_url = \"https://plexiapp.com\"\n\
              account_email = \"publisher@example.com\"\n",
         )
         .unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,7 +218,7 @@ fn main() -> eframe::Result {
         .collect();
     use crate::cli::args::{
         AccountCmd, AgentCmd, AiCmd, AppCmd, Cli, Commands, ConfigCmd, ContextCmd, DescriptorCmd,
-        EventsCmd, HookAction, HostCmd, LicenseCmd, NotesCmd, PaneCmd, PaneSlotCmd, RegistryCmd,
+        EventsCmd, HookAction, HostCmd, NotesCmd, PaneCmd, PaneSlotCmd, RegistryCmd,
         RoutineCmd, SecretCmd,
         UpdateCmd, WorkspaceCmd,
     };
@@ -576,20 +576,6 @@ fn main() -> eframe::Result {
                                 );
                                 std::process::exit(cli::app_search_cli(&query));
                             }
-                            AppCmd::License { cmd } => match cmd {
-                                LicenseCmd::List => {
-                                    exit_if_feature_disabled(
-                                        crate::release::ReleaseFeature::Marketplace,
-                                    );
-                                    std::process::exit(cli::app_license_list_cli())
-                                }
-                                LicenseCmd::Show { id } => {
-                                    exit_if_feature_disabled(
-                                        crate::release::ReleaseFeature::Marketplace,
-                                    );
-                                    std::process::exit(cli::app_license_show_cli(&id))
-                                }
-                            },
                             AppCmd::Update { id } => {
                                 log::info!("app_update:cli: id={id:?}");
                                 std::process::exit(cli::app_update_cli(id.as_deref()));
@@ -1015,9 +1001,6 @@ fn main() -> eframe::Result {
                             AccountCmd::Status => std::process::exit(cli::account_status_cli()),
                             AccountCmd::Login { email } => {
                                 std::process::exit(cli::account_login_cli(email.as_deref()))
-                            }
-                            AccountCmd::Signup { email } => {
-                                std::process::exit(cli::account_signup_cli(email.as_deref()))
                             }
                             AccountCmd::Logout => std::process::exit(cli::account_logout_cli()),
                         }


### PR DESCRIPTION
Implements stint task 0340 (no linked GitHub issue). Wires the host to the plexiapp.com account service (0338) and removes the client-side licensing machinery the monetization spec rejected — `account.toml` is now the host's only commercial credential.

## Summary

- **`plexi account login|logout|status`**: device-code flow against `POST /api/auth/device/{start,poll}` (0338's contract) — request code, print "check your email", poll every 3s to a computed deadline, save `AccountSession` via `AccountStore` on approval. `logout` best-effort revokes server-side then always clears locally. `status` prints identity or "not logged in".
- **`PlexiAccountProvider`** in `src/app/account.rs`, selected by `[marketplace].account_backend = "plexi"` via the drop-in seam the module doc already described; `StubAccountProvider` stays default. New `marketplace.account_url` config key (default `https://plexiapp.com`).
- **Deleted license machinery**: `License`, `LicenseStore`, the `licenses/` config dir, `PaymentProvider`/`PaymentError` and the `AppCmd::License` subcommand — deletion-completeness grepped clean across `src/`.
- Tagged errors (`account_backend_disabled:`, `login_expired:`, etc.), `info`-level traces on login/logout/provider selection.

## Review

Multi-agent review (8 finder angles → 5 verifiers, after one full round was lost to a session-limit outage and cleanly re-run from the still-staged diff): all 4 correctness angles (line-scan, removed-behavior, cross-file trace, altitude) came back clean — device-flow field names, status-code handling, and the license-deletion sweep all verified against the actual server code and the rest of `src/`. 4 confirmed cleanup findings fixed in this branch: reused a single HTTP agent across the poll loop (was handshaking TLS fresh every 3s), extracted shared `src/app/http.rs` (agent builder + URL-join) deduplicating `account.rs`/`marketplace.rs`, synced `scripts/default-config.toml` with the new/removed config keys, added a missing `Debug` derive. One trait-shape candidate (`AccountProvider` post-deletion) came back PLAUSIBLE-but-justified — it's an explicitly documented extension seam for future purchase/publish providers, left as-is.

**Test evidence:**
- `cargo test --bin plexi`: 1510 passed, 0 failed, 1 ignored — full bin suite, run twice for flakiness (clean both times)
- New coverage: device-flow client tests against a local HTTP server whose responses mirror the actual `website/src/pages/api/auth/` endpoints (pending→approved→token saved, 410/expired, revoke-on-logout, both `status` states), provider-selection test (`account_backend="plexi"` → PlexiAccountProvider; unset → stub)
- Conclusion: binary install required — this is a CLI/host-runtime change (new subcommands, network flow); PR install via `just pr-install <PR>` before merge.