### PR TITLE
Add native Explorer media viewers (stint 0349)

### DIFF
--- a/src/app/audio_player_app.rs
+++ b/src/app/audio_player_app.rs
@@ -1,0 +1,163 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::app::app_trait::{App, AppRenderContext};
+use crate::media::audio::{PlaybackRequest, PlaybackSession};
+
+pub struct AudioPlayerApp {
+    path: PathBuf,
+    session: Option<PlaybackSession>,
+    duration_ms: Option<u64>,
+    position_ms: u64,
+    playing: bool,
+    volume: f32,
+    error: Option<String>,
+}
+
+impl AudioPlayerApp {
+    pub fn new(path: PathBuf) -> Self {
+        log::info!(
+            "AudioPlayerApp: launch app_id=audio-player path={}",
+            path.display()
+        );
+        let duration_ms = crate::media::audio::source_duration_ms(&path.to_string_lossy());
+        Self {
+            path,
+            session: None,
+            duration_ms,
+            position_ms: 0,
+            playing: false,
+            volume: 1.0,
+            error: None,
+        }
+    }
+
+    fn filename(&self) -> String {
+        self.path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("Audio")
+            .to_string()
+    }
+
+    fn ensure_session(&mut self) -> bool {
+        if self.session.is_some() {
+            return true;
+        }
+        let request = PlaybackRequest {
+            source: self.path.to_string_lossy().to_string(),
+            volume: self.volume,
+        };
+        match crate::media::audio::start_playback(request) {
+            Ok(session) => {
+                self.session = Some(session);
+                true
+            }
+            Err(err) => {
+                let msg = format!("Unable to play audio: {err}");
+                log::warn!("AudioPlayerApp: {} path={}", msg, self.path.display());
+                self.error = Some(msg);
+                false
+            }
+        }
+    }
+
+    fn set_playing(&mut self, playing: bool) {
+        if playing && !self.ensure_session() {
+            return;
+        }
+        if let Some(session) = &self.session {
+            if playing {
+                session.resume();
+            } else {
+                session.pause();
+            }
+        }
+        self.playing = playing;
+    }
+
+    fn seek(&mut self, position_ms: u64) {
+        self.position_ms = self
+            .duration_ms
+            .map(|duration| position_ms.min(duration))
+            .unwrap_or(position_ms);
+        if let Some(session) = &self.session {
+            if let Err(err) = session.seek(Duration::from_millis(self.position_ms)) {
+                self.error = Some(format!("Seek failed: {err}"));
+            }
+        }
+    }
+
+    fn sync_position(&mut self) {
+        if let Some(session) = &self.session {
+            self.position_ms = session.position().as_millis() as u64;
+        }
+    }
+}
+
+impl App for AudioPlayerApp {
+    fn type_id(&self) -> &'static str {
+        "audio-player"
+    }
+
+    fn display_name(&self) -> String {
+        format!("Audio - {}", self.filename())
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, _ctx: &AppRenderContext<'_>) {
+        self.sync_position();
+        if self.playing {
+            ui.ctx().request_repaint();
+        }
+        ui.heading(self.filename());
+        ui.horizontal(|ui| {
+            let label = if self.playing { "Pause" } else { "Play" };
+            if ui.button(label).clicked() {
+                self.set_playing(!self.playing);
+            }
+            let duration = self.duration_ms.unwrap_or(0).max(self.position_ms);
+            let mut pos = self.position_ms.min(duration);
+            let response = ui.add(egui::Slider::new(&mut pos, 0..=duration).show_value(false));
+            if response.changed() {
+                self.seek(pos);
+            }
+            ui.label(format!(
+                "{} / {}",
+                format_time(self.position_ms),
+                self.duration_ms
+                    .map(format_time)
+                    .unwrap_or_else(|| "--:--".to_string())
+            ));
+        });
+        ui.horizontal(|ui| {
+            ui.label("Volume");
+            if ui
+                .add(egui::Slider::new(&mut self.volume, 0.0..=2.0))
+                .changed()
+            {
+                if let Some(session) = &self.session {
+                    session.set_volume(self.volume);
+                }
+            }
+        });
+        if let Some(error) = &self.error {
+            ui.label(error);
+        }
+    }
+
+    fn serialize_state(&self) -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "path": self.path.display().to_string(),
+            "position_ms": self.position_ms,
+            "duration_ms": self.duration_ms,
+            "volume": self.volume,
+        }))
+    }
+}
+
+fn format_time(ms: u64) -> String {
+    let total_seconds = ms / 1000;
+    let minutes = total_seconds / 60;
+    let seconds = total_seconds % 60;
+    format!("{minutes:02}:{seconds:02}")
+}

--- a/src/app/canvas_bindings.rs
+++ b/src/app/canvas_bindings.rs
@@ -462,7 +462,7 @@ impl PlexiApp {
         }
 
         // (d) OS default — mandatory fallback.
-        log::info!("open: '{path}' → OS default (no Plexi handler)");
+        log::info!("open: '{path}' → OS default (resolver fallthrough: no Plexi handler)");
         shell_open(path, false);
     }
 
@@ -471,7 +471,9 @@ impl PlexiApp {
     /// Returns `true` on a successful launch; `false` when the app is not
     /// available, so the resolver can fall through to the OS opener.
     fn launch_app_with_path(&mut self, id: &str, path: &str) -> bool {
-        match self.launch_app_by_id_with_layout(id, None, &[path.to_string()], None) {
+        let layout = matches!(id, "image-viewer" | "video-player" | "audio-player")
+            .then(|| "split_h".to_string());
+        match self.launch_app_by_id_with_layout(id, layout, &[path.to_string()], None) {
             Ok(_) => true,
             Err(e) => {
                 log::warn!("open: launch of app '{id}' for '{path}' failed — {e}");

--- a/src/app/image_viewer_app.rs
+++ b/src/app/image_viewer_app.rs
@@ -1,0 +1,139 @@
+use std::path::PathBuf;
+
+use crate::app::app_trait::{App, AppRenderContext};
+
+pub struct ImageViewerApp {
+    path: PathBuf,
+    texture: Option<egui::TextureHandle>,
+    image_size: Option<[usize; 2]>,
+    error: Option<String>,
+    zoom: f32,
+    fit_to_view: bool,
+}
+
+impl ImageViewerApp {
+    pub fn new(path: PathBuf) -> Self {
+        log::info!(
+            "ImageViewerApp: launch app_id=image-viewer path={}",
+            path.display()
+        );
+        Self {
+            path,
+            texture: None,
+            image_size: None,
+            error: None,
+            zoom: 1.0,
+            fit_to_view: true,
+        }
+    }
+
+    fn filename(&self) -> String {
+        self.path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("Image")
+            .to_string()
+    }
+
+    fn load_texture(&mut self, ctx: &egui::Context) {
+        if self.texture.is_some() || self.error.is_some() {
+            return;
+        }
+        match image::open(&self.path) {
+            Ok(decoded) => {
+                let rgba = decoded.to_rgba8();
+                let size = [rgba.width() as usize, rgba.height() as usize];
+                let color = egui::ColorImage::from_rgba_unmultiplied(size, rgba.as_raw());
+                self.texture = Some(ctx.load_texture(
+                    format!("image-viewer:{}", self.path.display()),
+                    color,
+                    egui::TextureOptions::LINEAR,
+                ));
+                self.image_size = Some(size);
+                log::info!(
+                    "ImageViewerApp: decoded path={} size={}x{}",
+                    self.path.display(),
+                    size[0],
+                    size[1]
+                );
+            }
+            Err(err) => {
+                let msg = format!("Unable to load image: {err}");
+                log::warn!("ImageViewerApp: {} path={}", msg, self.path.display());
+                self.error = Some(msg);
+            }
+        }
+    }
+}
+
+impl App for ImageViewerApp {
+    fn type_id(&self) -> &'static str {
+        "image-viewer"
+    }
+
+    fn display_name(&self) -> String {
+        format!("Image - {}", self.filename())
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, _ctx: &AppRenderContext<'_>) {
+        self.load_texture(ui.ctx());
+
+        ui.horizontal(|ui| {
+            if ui.selectable_label(self.fit_to_view, "Fit").clicked() {
+                self.fit_to_view = true;
+            }
+            if ui.button("100%").clicked() {
+                self.fit_to_view = false;
+                self.zoom = 1.0;
+            }
+            let zoom_response = ui.add(
+                egui::Slider::new(&mut self.zoom, 0.1..=8.0)
+                    .logarithmic(true)
+                    .text("Zoom"),
+            );
+            if zoom_response.changed() {
+                self.fit_to_view = false;
+            }
+        });
+
+        ui.separator();
+        if let Some(error) = &self.error {
+            ui.label(error);
+            return;
+        }
+        let Some(texture) = &self.texture else {
+            ui.label("Loading image...");
+            return;
+        };
+        let tex_size = texture.size_vec2();
+        let available = ui.available_size().max(egui::vec2(1.0, 1.0));
+        let scale = if self.fit_to_view {
+            (available.x / tex_size.x)
+                .min(available.y / tex_size.y)
+                .min(1.0)
+        } else {
+            self.zoom
+        };
+        let display_size = tex_size * scale.max(0.1);
+        egui::ScrollArea::both()
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                let response = ui.add(egui::Image::new((texture.id(), display_size)));
+                if response.hovered() {
+                    let zoom_delta = ui.input(|i| i.zoom_delta());
+                    if (zoom_delta - 1.0).abs() > f32::EPSILON {
+                        self.fit_to_view = false;
+                        self.zoom = (self.zoom * zoom_delta).clamp(0.1, 8.0);
+                    }
+                }
+            });
+    }
+
+    fn serialize_state(&self) -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "path": self.path.display().to_string(),
+            "zoom": self.zoom,
+            "fit_to_view": self.fit_to_view,
+        }))
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,6 @@
 pub mod account;
 pub mod app_trait;
+pub mod audio_player_app;
 mod canvas_bindings;
 mod dispatch;
 pub mod file_handlers;
@@ -8,6 +9,7 @@ pub(crate) mod focus_journal;
 pub mod host_mcp;
 pub mod host_version;
 pub mod http;
+pub mod image_viewer_app;
 pub(crate) mod launch_spec;
 mod lifecycle;
 pub mod marketplace;
@@ -24,6 +26,7 @@ mod render;
 pub mod secrets_app;
 mod sync;
 pub mod text_editor_app;
+pub mod video_player_app;
 
 #[cfg(test)]
 pub(crate) use focus::FocusLogOutcome;

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -222,6 +222,119 @@ fn file_handler_config_routes_extension_to_app() {
     );
 }
 
+#[test]
+fn media_files_route_to_native_viewer_apps() {
+    let ctx = egui::Context::default();
+    let ft = crate::platform::logging::new_frame_tick();
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, ft);
+    let (_tile, _pane) = app.add_test_pane();
+
+    for (filename, expected_id) in [
+        ("photo.png", "image-viewer"),
+        ("clip.mp4", "video-player"),
+        ("song.mp3", "audio-player"),
+    ] {
+        let panes_before: usize = app.windows.iter().map(|w| w.panes.len()).sum();
+        let path = std::env::temp_dir()
+            .join(filename)
+            .to_string_lossy()
+            .to_string();
+
+        app.dispatch_open_artifact(0, path, crate::app_protocol::ArtifactOpenMode::OpenInPane);
+
+        let panes_after: usize = app.windows.iter().map(|w| w.panes.len()).sum();
+        assert_eq!(
+            panes_after,
+            panes_before + 1,
+            "{filename} should open exactly one in-Plexi pane"
+        );
+        assert!(
+            app.windows.iter().any(|w| {
+                w.panes.values().any(|p| {
+                    p.as_app()
+                        .map(|a| a.runtime.type_id() == expected_id)
+                        .unwrap_or(false)
+                })
+            }),
+            "{filename} should route to {expected_id}"
+        );
+    }
+}
+
+#[test]
+fn explorer_media_viewer_close_returns_focus_and_preserves_selection() {
+    let ctx = egui::Context::default();
+    let ft = crate::platform::logging::new_frame_tick();
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, ft);
+    let dir = tempfile::tempdir().expect("tempdir");
+    let selected_path = dir.path().join("photo.png");
+    std::fs::write(&selected_path, b"not decoded in this test").expect("write image");
+
+    let browser: Box<dyn crate::app::app_trait::App> =
+        Box::new(crate::file_browser::FileBrowserApp::new(dir.path().to_path_buf()));
+    app.open_builtin_app_pane(
+        browser,
+        crate::app::permissions::AppPermissions::builtin(),
+        dir.path().to_path_buf(),
+        Some("cwd".to_string()),
+        Some("split_v"),
+        Some(0.5),
+    );
+
+    let browser_tile = app.windows[0].focused_pane.expect("browser focused");
+    let browser_pane_id = match app.windows[0].tree.tiles.get(browser_tile) {
+        Some(egui_tiles::Tile::Pane(id)) => *id,
+        other => panic!("expected browser pane tile, got {other:?}"),
+    };
+    let browser_state_before = app.windows[0]
+        .panes
+        .get(&browser_pane_id)
+        .and_then(|p| p.as_app())
+        .and_then(|a| a.runtime.serialize_state())
+        .expect("browser state before");
+    assert_eq!(browser_state_before["selected"], 0);
+
+    app.dispatch_open_artifact(
+        browser_pane_id,
+        selected_path.to_string_lossy().to_string(),
+        crate::app_protocol::ArtifactOpenMode::OpenInPane,
+    );
+
+    let viewer_tile = app.windows[0].focused_pane.expect("viewer focused");
+    assert_ne!(viewer_tile, browser_tile, "viewer should open as split sibling");
+    let viewer_pane_id = match app.windows[0].tree.tiles.get(viewer_tile) {
+        Some(egui_tiles::Tile::Pane(id)) => *id,
+        other => panic!("expected viewer pane tile, got {other:?}"),
+    };
+    assert!(
+        app.windows[0]
+            .panes
+            .get(&viewer_pane_id)
+            .and_then(|p| p.as_app())
+            .map(|a| a.runtime.type_id() == "image-viewer")
+            .unwrap_or(false),
+        "selected image should open in native image viewer"
+    );
+
+    app.close_focused();
+
+    assert_eq!(
+        app.windows[0].focused_pane,
+        Some(browser_tile),
+        "closing viewer should return focus to explorer sibling"
+    );
+    let browser_state_after = app.windows[0]
+        .panes
+        .get(&browser_pane_id)
+        .and_then(|p| p.as_app())
+        .and_then(|a| a.runtime.serialize_state())
+        .expect("browser state after");
+    assert_eq!(
+        browser_state_after["selected"], browser_state_before["selected"],
+        "browser selection should survive viewer open and close"
+    );
+}
+
 /// The file browser must open at the context root when one is set, not the
 /// focused pane's CWD. Mirrors `resolve_new_pane_cwd`'s precedence
 /// (context.root → focused cwd → home) that every other new-pane path uses.

--- a/src/app/video_player_app.rs
+++ b/src/app/video_player_app.rs
@@ -1,0 +1,267 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use crossbeam_queue::ArrayQueue;
+
+use crate::app::app_trait::{App, AppRenderContext};
+use crate::media::video::{VideoDecoder, VideoHandle, VideoState};
+
+pub struct VideoPlayerApp {
+    path: PathBuf,
+    decoder: Arc<dyn VideoDecoder>,
+    frame_ring: Arc<ArrayQueue<Vec<u8>>>,
+    handle: Option<VideoHandle>,
+    frame_texture: Option<egui::TextureHandle>,
+    frame_size: Option<[usize; 2]>,
+    duration_ms: Option<u64>,
+    position_ms: u64,
+    playing: bool,
+    pause_after_seek: bool,
+    last_tick: Instant,
+    error: Option<String>,
+}
+
+impl VideoPlayerApp {
+    pub fn new(path: PathBuf) -> Self {
+        log::info!(
+            "VideoPlayerApp: launch app_id=video-player path={}",
+            path.display()
+        );
+        Self {
+            path,
+            decoder: crate::media::video::default_video_device(),
+            frame_ring: Arc::new(ArrayQueue::new(3)),
+            handle: None,
+            frame_texture: None,
+            frame_size: None,
+            duration_ms: None,
+            position_ms: 0,
+            playing: false,
+            pause_after_seek: false,
+            last_tick: Instant::now(),
+            error: None,
+        }
+    }
+
+    fn filename(&self) -> String {
+        self.path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("Video")
+            .to_string()
+    }
+
+    fn ensure_open(&mut self) -> bool {
+        if self.handle.is_some() {
+            return true;
+        }
+        match self
+            .decoder
+            .open(&self.path.to_string_lossy(), Arc::clone(&self.frame_ring))
+        {
+            Ok((ack, handle)) => {
+                self.duration_ms = Some(ack.duration_ms);
+                self.handle = Some(handle);
+                log::info!(
+                    "VideoPlayerApp: opened path={} handle={} duration_ms={}",
+                    self.path.display(),
+                    ack.handle_id,
+                    ack.duration_ms
+                );
+                true
+            }
+            Err(err) => {
+                let msg = format!("Unable to open video: {err}");
+                log::warn!("VideoPlayerApp: {} path={}", msg, self.path.display());
+                self.error = Some(msg);
+                false
+            }
+        }
+    }
+
+    fn set_playing(&mut self, playing: bool) {
+        if playing && !self.ensure_open() {
+            return;
+        }
+        if let Some(handle) = self.handle.as_mut() {
+            let state = if playing {
+                VideoState::Play
+            } else {
+                VideoState::Pause
+            };
+            if let Err(err) = handle.set_state(state) {
+                self.error = Some(format!("Playback control failed: {err}"));
+                return;
+            }
+        }
+        self.playing = playing;
+        self.pause_after_seek = false;
+        self.last_tick = Instant::now();
+    }
+
+    fn seek(&mut self, position_ms: u64) {
+        self.position_ms = self
+            .duration_ms
+            .map(|duration| position_ms.min(duration))
+            .unwrap_or(position_ms);
+        if let Some(handle) = self.handle.as_mut() {
+            if let Err(err) = handle.set_state(VideoState::Seek {
+                position_ms: self.position_ms,
+            }) {
+                self.error = Some(format!("Seek failed: {err}"));
+            } else if !self.playing {
+                self.pause_after_seek = true;
+            }
+        }
+        self.last_tick = Instant::now();
+    }
+
+    fn drain_frames(&mut self, ctx: &egui::Context) {
+        let Some(handle) = self.handle.as_ref() else {
+            return;
+        };
+        let size = [handle.width as usize, handle.height as usize];
+        while let Some(frame) = self.frame_ring.pop() {
+            if frame.len() != size[0].saturating_mul(size[1]).saturating_mul(4) {
+                log::warn!(
+                    "VideoPlayerApp: dropped malformed frame path={} bytes={} expected={}",
+                    self.path.display(),
+                    frame.len(),
+                    size[0].saturating_mul(size[1]).saturating_mul(4)
+                );
+                continue;
+            }
+            let image = egui::ColorImage::from_rgba_unmultiplied(size, &frame);
+            match &mut self.frame_texture {
+                Some(texture) => texture.set(image, egui::TextureOptions::LINEAR),
+                None => {
+                    self.frame_texture = Some(ctx.load_texture(
+                        format!("video-player:{}", self.path.display()),
+                        image,
+                        egui::TextureOptions::LINEAR,
+                    ));
+                }
+            }
+            self.frame_size = Some(size);
+        }
+    }
+
+    fn tick_position(&mut self) {
+        if !self.playing {
+            if self.pause_after_seek {
+                if let Some(handle) = self.handle.as_mut() {
+                    if let Err(err) = handle.set_state(VideoState::Pause) {
+                        self.error = Some(format!("Pause after seek failed: {err}"));
+                    }
+                }
+                self.pause_after_seek = false;
+            }
+            self.last_tick = Instant::now();
+            return;
+        }
+        let now = Instant::now();
+        let delta_ms = now.duration_since(self.last_tick).as_millis() as u64;
+        self.last_tick = now;
+        self.position_ms = self.position_ms.saturating_add(delta_ms);
+        if let Some(duration) = self.duration_ms {
+            if self.position_ms >= duration {
+                self.position_ms = duration;
+                self.set_playing(false);
+            }
+        }
+    }
+}
+
+impl App for VideoPlayerApp {
+    fn type_id(&self) -> &'static str {
+        "video-player"
+    }
+
+    fn display_name(&self) -> String {
+        format!("Video - {}", self.filename())
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, _ctx: &AppRenderContext<'_>) {
+        self.tick_position();
+        self.drain_frames(ui.ctx());
+        if self.playing {
+            ui.ctx().request_repaint();
+        }
+
+        ui.label(self.filename());
+        let available = ui.available_size();
+        let viewport_height = (available.y - 40.0).max(160.0);
+        let (rect, _) = ui.allocate_exact_size(
+            egui::vec2(available.x.max(1.0), viewport_height),
+            egui::Sense::hover(),
+        );
+        ui.painter().rect_filled(rect, 4.0, ui.visuals().extreme_bg_color);
+        if let (Some(texture), Some([w, h])) = (&self.frame_texture, self.frame_size) {
+            let tex_size = egui::vec2(w as f32, h as f32);
+            let scale = (rect.width() / tex_size.x)
+                .min(rect.height() / tex_size.y)
+                .max(0.01);
+            let draw_rect = egui::Rect::from_center_size(rect.center(), tex_size * scale);
+            ui.painter().image(
+                texture.id(),
+                draw_rect,
+                egui::Rect::from_min_max(egui::Pos2::ZERO, egui::pos2(1.0, 1.0)),
+                egui::Color32::WHITE,
+            );
+        } else {
+            ui.painter().text(
+                rect.center(),
+                egui::Align2::CENTER_CENTER,
+                if self.handle.is_some() {
+                    "Waiting for video frame"
+                } else {
+                    "Press Play"
+                },
+                egui::TextStyle::Body.resolve(ui.style()),
+                ui.visuals().weak_text_color(),
+            );
+        }
+        ui.add_space(8.0);
+        ui.horizontal(|ui| {
+            let label = if self.playing { "Pause" } else { "Play" };
+            if ui.button(label).clicked() {
+                self.set_playing(!self.playing);
+            }
+            let duration = self.duration_ms.unwrap_or(0).max(self.position_ms);
+            let mut pos = self.position_ms.min(duration);
+            let response = ui.add(egui::Slider::new(&mut pos, 0..=duration).show_value(false));
+            if response.changed() {
+                self.seek(pos);
+                if !self.playing {
+                    ui.ctx().request_repaint();
+                }
+            }
+            ui.label(format!(
+                "{} / {}",
+                format_time(self.position_ms),
+                self.duration_ms
+                    .map(format_time)
+                    .unwrap_or_else(|| "--:--".to_string())
+            ));
+        });
+        if let Some(error) = &self.error {
+            ui.label(error);
+        }
+    }
+
+    fn serialize_state(&self) -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "path": self.path.display().to_string(),
+            "position_ms": self.position_ms,
+            "duration_ms": self.duration_ms,
+        }))
+    }
+}
+
+fn format_time(ms: u64) -> String {
+    let total_seconds = ms / 1000;
+    let minutes = total_seconds / 60;
+    let seconds = total_seconds % 60;
+    format!("{minutes:02}:{seconds:02}")
+}

--- a/src/file_browser/helpers.rs
+++ b/src/file_browser/helpers.rs
@@ -11,6 +11,7 @@ const TEXT_PREVIEW_MAX_BYTES: u64 = 32 * 1024;
 /// (`open` / `xdg-open`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MediaKind {
+    Image,
     Video,
     Audio,
     Other,
@@ -28,6 +29,7 @@ impl MediaKind {
             return Self::Other;
         };
         match ext.as_str() {
+            "png" | "jpg" | "jpeg" | "gif" | "bmp" | "tiff" | "webp" => Self::Image,
             // Common video container formats. AVFoundation handles the
             // big three on macOS (#346); the rest still route to the
             // in-app player so it can surface a decoder error rather
@@ -46,6 +48,7 @@ impl MediaKind {
     /// means "fall through to the system default opener".
     pub(crate) fn player_app_id(self) -> Option<&'static str> {
         match self {
+            Self::Image => Some("image-viewer"),
             Self::Video => Some("video-player"),
             Self::Audio => Some("audio-player"),
             Self::Other => None,
@@ -557,6 +560,23 @@ mod media_bridge_tests {
     use std::path::PathBuf;
 
     #[test]
+    fn open_image_file_routes_to_image_viewer_app() {
+        for ext in &["png", "PNG", "jpg", "jpeg", "gif", "bmp", "tiff", "webp"] {
+            let p = PathBuf::from(format!("/tmp/photo.{ext}"));
+            assert_eq!(
+                MediaKind::for_path(&p),
+                MediaKind::Image,
+                "extension {ext} should classify as Image"
+            );
+            assert_eq!(
+                MediaKind::for_path(&p).player_app_id(),
+                Some("image-viewer"),
+                "image routes to image-viewer app"
+            );
+        }
+    }
+
+    #[test]
     fn open_video_file_routes_to_video_player_app() {
         for ext in &["mp4", "MP4", "mov", "mkv", "webm", "m4v", "avi"] {
             let p = PathBuf::from(format!("/tmp/clip.{ext}"));
@@ -594,7 +614,6 @@ mod media_bridge_tests {
     fn unrecognized_extension_falls_back_to_system_open() {
         for path in &[
             "/tmp/notes.txt",
-            "/tmp/photo.tiff",
             "/tmp/archive.zip",
             "/tmp/Makefile",
             "/tmp/.dotfile",

--- a/src/media/audio.rs
+++ b/src/media/audio.rs
@@ -150,6 +150,12 @@ impl PlaybackSession {
     pub fn set_volume(&self, v: f32) {
         self.player.set_volume(v);
     }
+    pub fn seek(&self, position: std::time::Duration) -> Result<(), String> {
+        self.player.try_seek(position).map_err(|e| e.to_string())
+    }
+    pub fn position(&self) -> std::time::Duration {
+        self.player.get_pos()
+    }
 }
 
 #[cfg(not(test))]
@@ -182,6 +188,17 @@ pub fn start_playback(request: PlaybackRequest) -> Result<PlaybackSession, Audio
     })
 }
 
+#[cfg(not(test))]
+pub fn source_duration_ms(source: &str) -> Option<u64> {
+    use rodio::Source;
+
+    let file = std::fs::File::open(source).ok()?;
+    let decoder = rodio::Decoder::try_from(file).ok()?;
+    decoder
+        .total_duration()
+        .map(|duration| duration.as_millis() as u64)
+}
+
 /// Test stub — playback is not exercised in unit tests; real hardware is not
 /// available in CI. The stub returns `Ok` unconditionally so routing tests
 /// can exercise the `AudioPlay` handler path without hardware.
@@ -195,6 +212,12 @@ impl PlaybackSession {
     pub fn pause(&self) {}
     pub fn resume(&self) {}
     pub fn set_volume(&self, _v: f32) {}
+    pub fn seek(&self, _position: std::time::Duration) -> Result<(), String> {
+        Ok(())
+    }
+    pub fn position(&self) -> std::time::Duration {
+        std::time::Duration::ZERO
+    }
 }
 
 #[cfg(test)]
@@ -212,6 +235,11 @@ pub fn start_playback(request: PlaybackRequest) -> Result<PlaybackSession, Audio
         request.volume
     );
     Ok(PlaybackSession { _phantom: () })
+}
+
+#[cfg(test)]
+pub fn source_duration_ms(_source: &str) -> Option<u64> {
+    None
 }
 
 // ─── Real-time output stream (WASM audio, G12) ────────────────────────────────

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -26,6 +26,24 @@ use std::path::{Path, PathBuf};
 /// `"terminal"` is intentionally absent — it is a PTY pane, not an `App`.
 pub(crate) fn builtin_factory(id: &str, cwd: &Path, args: &[String]) -> Option<Box<dyn App>> {
     match id {
+        "image-viewer" => {
+            let path = args.first().map(PathBuf::from)?;
+            Some(Box::new(crate::app::image_viewer_app::ImageViewerApp::new(
+                path,
+            )))
+        }
+        "video-player" => {
+            let path = args.first().map(PathBuf::from)?;
+            Some(Box::new(crate::app::video_player_app::VideoPlayerApp::new(
+                path,
+            )))
+        }
+        "audio-player" => {
+            let path = args.first().map(PathBuf::from)?;
+            Some(Box::new(crate::app::audio_player_app::AudioPlayerApp::new(
+                path,
+            )))
+        }
         "text-editor" => {
             // No explicit path → a fresh scratch note in the inbox. The file is
             // only created once content is typed (empty notes are deleted).
@@ -65,7 +83,7 @@ fn builtin_restore_args(
     app_state: Option<&serde_json::Value>,
 ) -> Option<Vec<String>> {
     match app_id {
-        "text-editor" => app_state
+        "text-editor" | "image-viewer" | "video-player" | "audio-player" => app_state
             .and_then(|state| state.get("path"))
             .and_then(|path| path.as_str())
             .map(|path| vec![path.to_string()]),
@@ -2014,6 +2032,25 @@ mod tests {
             cli_open_placement(Some("tab".to_string()), Some("overlay".to_string())),
             "tab"
         );
+    }
+
+    #[test]
+    fn builtin_factory_registers_native_media_viewers() {
+        let cwd = std::path::Path::new("/tmp");
+        for (id, path) in [
+            ("image-viewer", "/tmp/photo.png"),
+            ("video-player", "/tmp/clip.mp4"),
+            ("audio-player", "/tmp/song.mp3"),
+        ] {
+            let args = vec![path.to_string()];
+            let app = builtin_factory(id, cwd, &args).expect("media viewer builtin");
+            assert_eq!(app.type_id(), id);
+            assert!(
+                app.display_name()
+                    .contains(std::path::Path::new(path).file_name().unwrap().to_str().unwrap()),
+                "display name should include opened file"
+            );
+        }
     }
 
     fn write_sleeping_process_app(app_dir: &std::path::Path, id: &str) {


### PR DESCRIPTION
## Summary
- add native image, video, and audio viewer builtins and register them with media open routing
- route image extensions to image-viewer and force media viewer opens into split siblings
- add HostHarness coverage for native media routing plus close-return focus and selection behavior

## Stint
- 0349
- Linked GitHub issue: none

**Test evidence (attempt 1):**
- cargo test: 1514 passed, 0 failed, 1 ignored — filters: `media_files_route_to_native_viewer_apps`, `explorer_media_viewer_close_returns_focus_and_preserves_selection`, `open_image_file_routes_to_image_viewer_app`, `builtin_factory_registers_native_media_viewers`; full bin suite `cargo test --bin plexi`
- cargo build: passed — `cargo build`
- PlexiUiHarness render: not run — no committed scene for the new native viewer panes
- Codex review: 2 runs — findings for image fit, paused video seek, and audio repaint were addressed
- Conclusion: binary install required — visible native viewer UI, media playback, and File Explorer interaction need PR-build validation
- PR install: required via `just pr-install <PR>` from this feature worktree; validate with `plexi-pr-<PR>`, not `plexi` or `plexi-alpha`