### PR TITLE
fix: pane key drives native app keyboard handlers (stint 0351)

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1237,7 +1237,7 @@ impl PlexiApp {
                 response_file,
             } => {
                 log::info!("pane_ipc: kind=key_pane pane_id={pane_id} key={key:?}");
-                let result = match self
+                let result: Result<serde_json::Value, String> = match self
                     .windows
                     .iter_mut()
                     .find_map(|win| win.panes.get_mut(pane_id))
@@ -1251,17 +1251,48 @@ impl PlexiApp {
                             let bytes = super::key_str_to_pty_bytes(key);
                             term.backend
                                 .process_command(egui_term::BackendCommand::Write(bytes));
-                            Ok(())
+                            Ok(serde_json::json!({"ok": true}))
                         } else if let Some(app_pane) = pane.as_app_mut() {
-                            let (key_str, modifiers) = super::parse_key_str_to_event(key);
-                            app_pane.runtime.queue_outbound_event(
-                                crate::app_protocol::PlexiEvent::Key {
-                                    key: key_str,
-                                    modifiers,
-                                    pressed: true,
+                            match &mut app_pane.runtime {
+                                crate::host::pane::AppRuntime::Process(_) => {
+                                    let (key_str, modifiers) = super::parse_key_str_to_event(key);
+                                    app_pane.runtime.queue_outbound_event(
+                                        crate::app_protocol::PlexiEvent::Key {
+                                            key: key_str,
+                                            modifiers,
+                                            pressed: true,
+                                        },
+                                    );
+                                    Ok(serde_json::json!({"ok": true}))
+                                }
+                                // Native (builtin/WASM) apps read keys from egui
+                                // InputState, not the PGAP event queue — drive
+                                // their real `handle_key` handler.
+                                runtime => match super::drive_native_pane_key(runtime, key) {
+                                    Ok(disposition) => {
+                                        let disposition = match disposition {
+                                            crate::app::app_trait::KeyDisposition::Consumed => {
+                                                "consumed"
+                                            }
+                                            crate::app::app_trait::KeyDisposition::Passthrough => {
+                                                "passthrough"
+                                            }
+                                        };
+                                        log::info!(
+                                            "pane_ipc: key_pane: native app pane_id={pane_id} \
+                                             key={key:?} disposition={disposition}"
+                                        );
+                                        Ok(serde_json::json!({
+                                            "ok": true,
+                                            "disposition": disposition,
+                                        }))
+                                    }
+                                    Err(e) => {
+                                        log::warn!("pane_ipc: key_pane: {e}");
+                                        Err(e)
+                                    }
                                 },
-                            );
-                            Ok(())
+                            }
                         } else {
                             Err(format!("pane {pane_id}: unknown pane type"))
                         }
@@ -1269,7 +1300,7 @@ impl PlexiApp {
                 };
                 if let Some(rf) = response_file {
                     let json = match &result {
-                        Ok(()) => serde_json::json!({"ok": true}).to_string(),
+                        Ok(v) => v.to_string(),
                         Err(msg) => serde_json::json!({"error": msg}).to_string(),
                     };
                     if let Err(e) = std::fs::write(rf, &json) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4082,6 +4082,118 @@ fn parse_key_str_to_event(key: &str) -> (String, crate::app_protocol::Modifiers)
     (key_str, modifiers)
 }
 
+/// Translate a key string (same vocabulary as `key_str_to_pty_bytes`) into a
+/// synthesized `egui::RawInput` for native app panes. Native (builtin/WASM)
+/// apps read keys from `egui::InputState` via `App::handle_key`, not the PGAP
+/// event queue, so CLI key injection must produce egui events. Returns `None`
+/// for key strings that don't map to an `egui::Key`.
+pub(crate) fn key_str_to_egui_raw_input(key: &str) -> Option<egui::RawInput> {
+    let mut parts: Vec<&str> = key.split('+').collect();
+    let key_part = parts.pop().unwrap_or(key);
+    let mut modifiers = egui::Modifiers::default();
+    for m in &parts {
+        match m.to_lowercase().as_str() {
+            "ctrl" | "control" => {
+                modifiers.ctrl = true;
+                if !cfg!(target_os = "macos") {
+                    modifiers.command = true;
+                }
+            }
+            "shift" => modifiers.shift = true,
+            "alt" => modifiers.alt = true,
+            "cmd" | "command" | "meta" => {
+                modifiers.mac_cmd = cfg!(target_os = "macos");
+                modifiers.command = true;
+            }
+            _ => {}
+        }
+    }
+    let lower = key_part.to_lowercase();
+    // Named keys use egui's `Key::from_name` vocabulary; single printable
+    // chars ("a", "/", "1") and F-keys ("f5") pass through — `from_name`
+    // accepts lowercase letters and punctuation chars directly.
+    let name: String = match lower.as_str() {
+        "enter" | "return" => "Enter".into(),
+        "escape" | "esc" => "Escape".into(),
+        "space" => "Space".into(),
+        "backspace" => "Backspace".into(),
+        "tab" => "Tab".into(),
+        "delete" => "Delete".into(),
+        "home" => "Home".into(),
+        "end" => "End".into(),
+        "pageup" => "PageUp".into(),
+        "pagedown" => "PageDown".into(),
+        "up" | "arrowup" => "ArrowUp".into(),
+        "down" | "arrowdown" => "ArrowDown".into(),
+        "left" | "arrowleft" => "ArrowLeft".into(),
+        "right" | "arrowright" => "ArrowRight".into(),
+        "plus" => "Plus".into(),
+        "minus" => "Minus".into(),
+        "equals" => "Equals".into(),
+        "slash" => "Slash".into(),
+        f if f.starts_with('f') && f.len() > 1 && f[1..].chars().all(|c| c.is_ascii_digit()) => {
+            f.to_uppercase()
+        }
+        other => other.into(),
+    };
+    let egui_key = egui::Key::from_name(&name)?;
+    let mut events = vec![egui::Event::Key {
+        key: egui_key,
+        physical_key: None,
+        pressed: true,
+        repeat: false,
+        modifiers,
+    }];
+    // Real keyboard input also emits an `Event::Text` for printable chars
+    // (search fields and text inputs read Text, not Key). Mirror that unless
+    // a chord modifier is held.
+    if !modifiers.ctrl && !modifiers.command && !modifiers.mac_cmd && !modifiers.alt {
+        let text = if lower == "space" {
+            Some(" ".to_string())
+        } else {
+            let mut chars = key_part.chars();
+            match (chars.next(), chars.next()) {
+                (Some(ch), None) if !ch.is_control() => Some(if modifiers.shift {
+                    ch.to_uppercase().to_string()
+                } else {
+                    ch.to_string()
+                }),
+                _ => None,
+            }
+        };
+        if let Some(t) = text {
+            events.push(egui::Event::Text(t));
+        }
+    }
+    Some(egui::RawInput {
+        events,
+        modifiers,
+        ..Default::default()
+    })
+}
+
+/// Drive a native (builtin or WASM) app pane's `App::handle_key` with a
+/// synthesized key — the same handler a real keystroke reaches through
+/// `dispatch_app_key_events`. Never bypass this into app internals: `pane key`
+/// must exercise the app's real keyboard path so live validation observes
+/// production behavior.
+fn drive_native_pane_key(
+    runtime: &mut crate::host::pane::AppRuntime,
+    key: &str,
+) -> Result<app_trait::KeyDisposition, String> {
+    let raw = key_str_to_egui_raw_input(key)
+        .ok_or_else(|| format!("key {key:?} does not map to a native app key event"))?;
+    // Throwaway context: the cheapest way to build a well-formed InputState.
+    // handle_key only reads input — it never paints — so no fonts/render
+    // setup is needed.
+    let ctx = egui::Context::default();
+    let mut disposition = app_trait::KeyDisposition::Passthrough;
+    let _ = ctx.run(raw, |ctx| {
+        ctx.input(|i| disposition = runtime.handle_key(i));
+    });
+    Ok(disposition)
+}
+
 /// process-app registry to register against (terminals — should never reach
 /// this path; logged at the call site).
 fn register_directed_pipe_on_target(pane: &mut crate::host::pane::Pane, pipe_id: &str) -> bool {

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -28,6 +28,70 @@ fn parse_key_str_to_event_preserves_modifiers() {
 }
 
 #[test]
+fn key_str_to_egui_raw_input_maps_named_keys_without_text() {
+    let raw = key_str_to_egui_raw_input("enter").expect("enter must map");
+    assert_eq!(raw.events.len(), 1, "named keys emit no Text event");
+    assert!(matches!(
+        raw.events[0],
+        egui::Event::Key {
+            key: egui::Key::Enter,
+            pressed: true,
+            repeat: false,
+            ..
+        }
+    ));
+
+    let raw = key_str_to_egui_raw_input("ArrowDown").expect("ArrowDown must map");
+    assert!(matches!(
+        raw.events[0],
+        egui::Event::Key {
+            key: egui::Key::ArrowDown,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn key_str_to_egui_raw_input_emits_text_for_printable_chars() {
+    let raw = key_str_to_egui_raw_input("a").expect("a must map");
+    assert!(matches!(
+        raw.events[0],
+        egui::Event::Key {
+            key: egui::Key::A,
+            ..
+        }
+    ));
+    assert!(
+        matches!(&raw.events[1], egui::Event::Text(t) if t == "a"),
+        "printable chars must also emit Text for search fields; got {:?}",
+        raw.events
+    );
+
+    let raw = key_str_to_egui_raw_input("space").expect("space must map");
+    assert!(matches!(&raw.events[1], egui::Event::Text(t) if t == " "));
+}
+
+#[test]
+fn key_str_to_egui_raw_input_chords_set_modifiers_and_suppress_text() {
+    let raw = key_str_to_egui_raw_input("ctrl+c").expect("ctrl+c must map");
+    assert!(raw.modifiers.ctrl);
+    assert_eq!(
+        raw.events.len(),
+        1,
+        "chord keys must not emit Text; got {:?}",
+        raw.events
+    );
+
+    let raw = key_str_to_egui_raw_input("cmd+enter").expect("cmd+enter must map");
+    assert!(raw.modifiers.command);
+}
+
+#[test]
+fn key_str_to_egui_raw_input_rejects_unmappable_strings() {
+    assert!(key_str_to_egui_raw_input("notakey").is_none());
+}
+
+#[test]
 fn test_spawn_pane_targets_correct_window_with_from_pane_id() {
     let ctx = egui::Context::default();
     let ft = crate::platform::logging::new_frame_tick();

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -644,6 +644,17 @@ pub fn pane_key_cli(pane_id: u64, key: &str) -> i32 {
                     let _ = std::fs::remove_file(&response_path);
                     if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
                         if v.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
+                            // Native app panes report whether the app's key
+                            // handler consumed the key — surface a miss so
+                            // driving agents don't assume the key acted.
+                            if let Some(d) = v.get("disposition").and_then(|v| v.as_str()) {
+                                if d != "consumed" {
+                                    eprintln!(
+                                        "note: key delivered but not consumed by the app \
+                                         (disposition: {d})"
+                                    );
+                                }
+                            }
                             return 0;
                         }
                         if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -2976,6 +2976,38 @@ mod tests {
         );
     }
 
+    /// Regression for stint 0351: `plexi pane key <id> enter` must drive the
+    /// same `handle_key` → `open_file` path a physical Enter press takes. In
+    /// prod, `open_file` hands the path to the host's `OpenArtifact` resolver
+    /// (`open_file_in_app`, #2283) — that resolver has its own coverage; this
+    /// test proves the CLI key-string vocabulary reaches it for a selected
+    /// media file.
+    #[test]
+    fn cli_key_string_enter_opens_selected_media_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("clip.mp4"), b"not a real video").expect("write");
+        let mut app = FileBrowserApp::new(dir.path().to_path_buf());
+        assert!(!app.entries[0].is_dir, "fixture must select the media file");
+
+        let raw = crate::app::key_str_to_egui_raw_input("enter")
+            .expect("CLI key string 'enter' must map to an egui event");
+        let ctx = egui::Context::default();
+        let mut consumed = false;
+        let _ = ctx.run(raw, |ctx| {
+            ctx.input(|i| {
+                consumed = app.handle_key(i) == crate::app::app_trait::KeyDisposition::Consumed;
+            });
+        });
+
+        assert!(consumed, "injected Enter must be consumed by the app");
+        assert_eq!(
+            app.opened_files.len(),
+            1,
+            "injected Enter must reach open_file for the selected media file"
+        );
+        assert!(app.opened_files[0].ends_with("clip.mp4"));
+    }
+
     #[test]
     fn l_key_on_file_opens_file() {
         let (mut app, _dir) = make_file_only_dir_app();

--- a/src/testing/AGENTS.md
+++ b/src/testing/AGENTS.md
@@ -21,6 +21,7 @@ Test infrastructure for the Plexi host. `HostHarness` (headless egui test harnes
 
 ## Traps
 
+- **`plexi pane key` must exercise real key handlers, never a parallel resolver path.** The host `KeyPane` handler routes by pane type: terminals get PTY bytes, process/PGAP apps get `PlexiEvent::Key`, and native (builtin/WASM) apps get a synthesized `egui::InputState` driven through `App::handle_key` (`drive_native_pane_key` in `src/app/mod.rs`) — the same handler a physical keystroke reaches. When adding pane-driving capabilities, extend these paths; never add a hidden CLI that bypasses an app's own keyboard flow. Native panes report `disposition` (consumed/passthrough) in the response file so drive-host validation can detect ignored keys.
 - **`cargo test --lib` silently misses host tests.** `--lib` only runs the `app_protocol` lib target (~47 tests). Host tests — app_registry, HostHarness, process_app, workspace_secrets — live in the binary target. Always use `cargo test --bin plexi`.
 - **`HostHarness::add_test_pane()` inserts a `ProcessApp` pane, not a Terminal.** Terminal-count assertions must not assume the initial pane is a Terminal; offset accordingly.
 - **Test constructor sync.** When adding a field to any struct that has a `new_for_test()` constructor, update that constructor in the same commit. Run `cargo test --bin plexi` on the base branch first to distinguish pre-existing failures from regressions.

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -361,6 +361,64 @@ mod tests {
         })
     }
 
+    /// Regression for stint 0351: `AppRequest::KeyPane` (the `plexi pane key`
+    /// socket path) must drive a native app pane through its real
+    /// `App::handle_key` — not the PGAP event queue, which native apps never
+    /// read. Enter on the File Explorer's selected directory must run the
+    /// app's own Activate flow (navigate_into), and the response file must
+    /// report the disposition so driving agents can detect ignored keys.
+    #[test]
+    fn pane_key_ipc_drives_native_file_browser_handle_key() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(dir.path().join("inner")).expect("mkdir");
+
+        let mut h = PlexiUiHarness::new();
+        h.open_file_browser(dir.path().to_path_buf());
+        h.step();
+
+        let pane_id = h.with_app(|app| {
+            app.windows[app.active_window]
+                .panes
+                .iter()
+                .find_map(|(id, p)| p.as_app().map(|_| *id))
+                .expect("file browser pane must exist after open_file_browser")
+        });
+
+        let rf_dir = tempfile::tempdir().expect("tempdir");
+        let rf = rf_dir.path().join("key-response.json");
+        h.with_app_mut(|app| {
+            app.handle_pane_ipc_request(crate::app_protocol::AppRequest::KeyPane {
+                pane_id,
+                key: "enter".to_string(),
+                response_file: Some(rf.to_string_lossy().into_owned()),
+            })
+        });
+
+        let content = std::fs::read_to_string(&rf).expect("KeyPane must write a response file");
+        let v: serde_json::Value = serde_json::from_str(&content).expect("response must be JSON");
+        assert_eq!(v["ok"], true, "response must be ok; got {content}");
+        assert_eq!(
+            v["disposition"], "consumed",
+            "File Explorer must consume Enter; got {content}"
+        );
+
+        // Enter on the selected directory (dirs sort first, selected=0) runs
+        // the app's real Activate flow — cwd must now be the subdirectory.
+        let cwd = h.with_app(|app| {
+            app.windows[app.active_window]
+                .panes
+                .get(&pane_id)
+                .and_then(|p| p.as_app())
+                .and_then(|a| a.runtime.serialize_state())
+                .and_then(|s| s["cwd"].as_str().map(str::to_string))
+                .expect("file browser must serialize cwd")
+        });
+        assert!(
+            cwd.ends_with("inner"),
+            "Enter must navigate into the selected directory; cwd={cwd}"
+        );
+    }
+
     /// Stint 0207: render the four new canvas styling primitives (rect gradient,
     /// rect glow + stroke, circle glow + stroke, arc_ring) directly through
     /// `render_draw_commands` and save a PNG for visual inspection.


### PR DESCRIPTION
Stint task 0351 (no linked GitHub issue). P0: blocked hands-off PR validation for any native-app pane.

## Summary

- `plexi pane key` on a native (builtin/WASM) app pane was a silent no-op: the host queued `PlexiEvent::Key`, but native apps read keys from egui `InputState` via `App::handle_key` and never see the PGAP event queue.
- The `KeyPane` handler now routes by runtime: terminals keep PTY bytes, process/PGAP apps keep `PlexiEvent::Key`, native apps get a synthesized `egui::InputState` (`key_str_to_egui_raw_input` + `drive_native_pane_key`) driven through their real `handle_key` — the same handler a physical keystroke reaches via `dispatch_app_key_events`. Printable keys also emit `Event::Text` so search fields behave like real typing.
- Native-pane responses now include `disposition: consumed|passthrough`; the CLI prints a note when a key is delivered but not consumed, so drive-host agents can detect ignored input. Trap documented in `src/testing/AGENTS.md`.

## Done When

- [x] `plexi pane key <file-browser-pane> enter` reaches `FileBrowserApp::handle_key` and its existing Activate → `open_file` → `OpenArtifact` flow
- [x] Process-app/PGAP `PlexiEvent::Key` delivery unchanged; terminal PTY bytes unchanged
- [x] Regression coverage: `cli_key_string_enter_opens_selected_media_file` (media file, app layer) and `pane_key_ipc_drives_native_file_browser_handle_key` (KeyPane socket request end-to-end in PlexiUiHarness, asserts disposition + navigation)
- [x] Trap documented in `src/testing/AGENTS.md`

**Test evidence (attempt 1):**
- cargo test: 1516 passed, 0 failed — full bin suite (targeted filters: `key_str_to_egui`, `cli_key_string_enter_opens_selected_media_file`, `pane_key_ipc_drives_native_file_browser_handle_key`)
- No visual change — no screenshot; PlexiUiHarness state test covers KeyPane → native `handle_key` → navigate headlessly
- Codex review vs alpha: clean (no correctness issues)
- Live-driven on the PR build (host start/pane key/host stop): Enter on File Explorer's selected directory logged `disposition=consumed` and navigated; an unbound key (f9) logged `disposition=passthrough` with a CLI note; an unmappable key string errored cleanly
- Conclusion: binary install required — the CLI to `PLEXI_SOCKET` to host transport only exists in a running host

**Validate attempt 1:** PASS
**Test date:** 2026-07-08