### PR TITLE
polish: agent pips flash yellow when working, solid green when idle

### DIFF
--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -541,13 +541,13 @@ pub enum PipStatus {
 impl PipStatus {
     /// Map the app-reported status onto the host activity-dot vocabulary so the
     /// dot renders the app's intended color. The pip palette (`src/ui/theme.rs`)
-    /// is green=Working, yellow=Idle, red=Blocked, so the color-faithful mapping
-    /// is green→Working, yellow→Idle, red→Blocked. (Green maps to Working, which
-    /// pulses — a "healthy + active" dot.)
+    /// is yellow=Working, green=Idle, red=Blocked, so the color-faithful mapping
+    /// is yellow→Working, green→Idle, red→Blocked. (Yellow maps to Working, which
+    /// pulses — an "attention + active" dot.)
     pub fn as_agent_state(self) -> &'static AgentState {
         match self {
-            PipStatus::Green => &AgentState::Working,
-            PipStatus::Yellow => &AgentState::Idle,
+            PipStatus::Green => &AgentState::Idle,
+            PipStatus::Yellow => &AgentState::Working,
             PipStatus::Red => &AgentState::Blocked,
         }
     }
@@ -4187,10 +4187,10 @@ mod pip_status_tests {
 
     #[test]
     fn pip_status_maps_color_faithfully_to_agent_state() {
-        // The pip palette (src/ui/theme.rs) is green=Working, yellow=Idle,
+        // The pip palette (src/ui/theme.rs) is yellow=Working, green=Idle,
         // red=Blocked, so the dot renders the app's intended color.
-        assert_eq!(PipStatus::Green.as_agent_state(), &AgentState::Working);
-        assert_eq!(PipStatus::Yellow.as_agent_state(), &AgentState::Idle);
+        assert_eq!(PipStatus::Green.as_agent_state(), &AgentState::Idle);
+        assert_eq!(PipStatus::Yellow.as_agent_state(), &AgentState::Working);
         assert_eq!(PipStatus::Red.as_agent_state(), &AgentState::Blocked);
     }
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -3457,14 +3457,14 @@ fn set_pip_status_drives_activity_dot_and_overrides_agent() {
         );
     }
 
-    // Pip status wins over hook agent state: set an Idle agent, then report green.
+    // Pip status wins over hook agent state: set a Working agent, then report green.
     h.app.windows[0]
         .panes
         .get_mut(&pane)
         .unwrap()
         .set_agent(Some(PaneAgentState {
             pane_id: pane,
-            state: AgentState::Idle,
+            state: AgentState::Working,
             agent: "test".to_string(),
             detail: None,
             session_id: None,
@@ -3480,7 +3480,7 @@ fn set_pip_status_drives_activity_dot_and_overrides_agent() {
     let p = h.app.windows[0].panes.get(&pane).unwrap();
     assert_eq!(
         p.effective_activity(),
-        Some(&AgentState::Working),
-        "green pip -> Working (green dot), overriding the Idle agent state"
+        Some(&AgentState::Idle),
+        "green pip -> Idle (green dot), overriding the Working agent state"
     );
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -135,11 +135,11 @@ impl Colors {
             warning: parse_hex_or(&cfg.yellow, Color32::from_rgb(0xf9, 0xe2, 0xaf)),
             pip_working: parse_hex_or(
                 &cfg.pip_working,
-                parse_hex_or(&cfg.green, Color32::from_rgb(0xa6, 0xe3, 0xa1)),
+                parse_hex_or(&cfg.yellow, Color32::from_rgb(0xf9, 0xe2, 0xaf)),
             ),
             pip_idle: parse_hex_or(
                 &cfg.pip_idle,
-                parse_hex_or(&cfg.yellow, Color32::from_rgb(0xf9, 0xe2, 0xaf)),
+                parse_hex_or(&cfg.green, Color32::from_rgb(0xa6, 0xe3, 0xa1)),
             ),
             pip_blocked: parse_hex_or(
                 &cfg.pip_blocked,
@@ -1116,14 +1116,14 @@ mod tests {
     use super::*;
     use crate::config::ThemeConfig;
 
-    /// pip_working/idle/blocked fall back to success/warning/danger when not set,
+    /// pip_working/idle/blocked fall back to warning/success/danger when not set,
     /// and use the override color when set. pip_dim defaults to 0.45.
     #[test]
     fn pip_colors_fall_back_to_semantic_and_accept_overrides() {
         let default_cfg = ThemeConfig::default();
         let colors = Colors::from_config(&default_cfg);
-        assert_eq!(colors.pip_working, colors.success);
-        assert_eq!(colors.pip_idle, colors.warning);
+        assert_eq!(colors.pip_working, colors.warning);
+        assert_eq!(colors.pip_idle, colors.success);
         assert_eq!(colors.pip_blocked, colors.danger);
         assert!((colors.pip_dim - 0.45).abs() < f32::EPSILON);
 


### PR DESCRIPTION
Stint task 0350. P0 UI polish, no linked GitHub issue.

## Summary

- Swapped the default pip color fallback: working now falls back to yellow, idle now falls back to green (`src/ui/theme.rs`).
- Existing `[theme]` overrides for `pip_working` / `pip_idle` still take priority unchanged.
- Swapped `PipStatus::as_agent_state()` so app-reported green/yellow pips stay color-faithful under the new default palette (green -> Idle, yellow -> Working).
- Updated the theme default-fallback test, the pip-status mapping test, and the harness test that exercises pip-status overriding hook agent state.

## Done When

- Working agents flash yellow; idle agents show solid green, by default.
- Explicit `[theme]` pip_working/pip_idle overrides still work exactly as before.
- `PipStatus::as_agent_state()` maps green -> Idle and yellow -> Working so app-reported pip colors remain faithful.
- `cargo test --bin plexi` is green.