### PR TITLE
website: legal surface — ToS, privacy, refund, DMCA (stint 0347)

### DIFF
--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -15,4 +15,26 @@ import Logo from './Logo.astro';
       <a href="/rss.xml">RSS</a>
     </div>
   </div>
+  <div class="wrap legal-row">
+    <a href="/legal/terms">Terms</a>
+    <a href="/legal/privacy">Privacy</a>
+    <a href="/legal/refunds">Refunds</a>
+    <a href="/legal/dmca">DMCA & Abuse</a>
+  </div>
 </footer>
+
+<style>
+  footer .legal-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0;
+  }
+  footer .legal-row a { color: var(--fg-4); transition: color 150ms; }
+  footer .legal-row a:hover { color: var(--fg-2); }
+</style>

--- a/website/src/layouts/LegalLayout.astro
+++ b/website/src/layouts/LegalLayout.astro
@@ -1,0 +1,92 @@
+---
+import Layout from './Layout.astro';
+
+interface Props {
+  title: string;
+  description?: string;
+  lastReviewed: string;
+}
+
+const { title, description = '', lastReviewed } = Astro.props;
+
+const legalPages = [
+  { href: '/legal/terms', label: 'Terms' },
+  { href: '/legal/privacy', label: 'Privacy' },
+  { href: '/legal/refunds', label: 'Refunds' },
+  { href: '/legal/dmca', label: 'DMCA & Abuse' },
+];
+
+const currentPath = Astro.url.pathname.replace(/\/$/, '');
+---
+<Layout title={`${title} — Plexi`} description={description}>
+  <article class="legal-article">
+    <div class="wrap">
+      <header class="legal-header">
+        <h1>{title}</h1>
+        <p class="reviewed">Last reviewed: {lastReviewed}</p>
+        <nav class="legal-nav" aria-label="Legal pages">
+          {legalPages.map(p => (
+            <a href={p.href} class:list={['legal-nav-link', { active: currentPath === p.href }]}>{p.label}</a>
+          ))}
+        </nav>
+      </header>
+
+      <div class="legal-note">
+        These are plain-language drafts written by the Plexi team, not a lawyer.
+        They are under professional legal review before commercial launch. If
+        anything here conflicts with what a signed agreement or applicable law
+        requires, the law wins.
+      </div>
+
+      <div class="prose">
+        <slot />
+      </div>
+    </div>
+  </article>
+</Layout>
+
+<style>
+  .legal-article { padding: 112px 0 80px; }
+  .legal-article .wrap { max-width: 760px; }
+
+  .legal-header { margin-bottom: 40px; }
+  .legal-header h1 { font-size: 40px; font-weight: 650; letter-spacing: 0; line-height: 1.1; margin-bottom: 12px; }
+  .legal-header .reviewed { color: var(--fg-4); font-size: 13px; letter-spacing: 0.04em; margin-bottom: 24px; }
+
+  .legal-nav { display: flex; flex-wrap: wrap; gap: 8px; }
+  .legal-nav-link {
+    font-size: 12px; letter-spacing: 0.02em;
+    padding: 6px 12px; border-radius: 6px;
+    color: var(--fg-3); border: 1px solid var(--border);
+    background: var(--bg-2); transition: color 150ms, background 150ms, border-color 150ms;
+  }
+  .legal-nav-link:hover { color: var(--fg); border-color: var(--border-2); }
+  .legal-nav-link.active { color: var(--accent-light); border-color: var(--accent); background: var(--accent-dim); }
+
+  .legal-note {
+    border: 1px solid var(--border-2); border-left: 2px solid var(--accent);
+    background: var(--bg-2); border-radius: 8px;
+    padding: 16px 18px; margin-bottom: 40px;
+    color: var(--fg-3); font-size: 13px; line-height: 1.7;
+  }
+
+  .prose { color: var(--fg); font-size: 14px; line-height: 1.8; }
+  .prose :global(h2) { font-size: 22px; letter-spacing: 0; font-weight: 600; margin: 44px 0 16px; color: var(--fg); }
+  .prose :global(h3) { font-size: 16px; font-weight: 600; margin: 30px 0 12px; color: var(--fg); }
+  .prose :global(p) { margin-bottom: 18px; color: var(--fg-2); }
+  .prose :global(a) { color: var(--accent-light); border-bottom: 1px solid rgba(147, 51, 234, 0.35); transition: color 150ms, border-color 150ms; }
+  .prose :global(a:hover) { color: var(--fg); border-bottom-color: var(--fg); }
+  .prose :global(ul), .prose :global(ol) { margin: 0 0 18px 22px; color: var(--fg-2); }
+  .prose :global(li) { margin-bottom: 8px; }
+  .prose :global(strong) { color: var(--fg); font-weight: 600; }
+  .prose :global(hr) { border: none; border-top: 1px solid var(--border); margin: 40px 0; }
+  .prose :global(code) { background: var(--bg-3); padding: 2px 6px; border-radius: 4px; font-size: 12.5px; color: var(--accent-light); border: 1px solid var(--border); }
+
+  @media (max-width: 980px) {
+    .legal-article { padding: 88px 0 60px; }
+    .legal-header h1 { font-size: 30px; }
+  }
+  @media (max-width: 480px) {
+    .legal-header h1 { font-size: 26px; }
+  }
+</style>

--- a/website/src/pages/auth/verify.astro
+++ b/website/src/pages/auth/verify.astro
@@ -141,6 +141,12 @@ const body =
           <button class="btn lg" type="submit">
             {CONFIRM[view.purpose].button} <span class="arrow">→</span>
           </button>
+          {view.purpose !== 'account_delete' && (
+            <p class="legal-consent">
+              By continuing you agree to the <a href="/legal/terms">Terms of Service</a>
+              and <a href="/legal/privacy">Privacy Policy</a>.
+            </p>
+          )}
         </form>
       )}
       {view.mode === 'result' && view.outcome.kind === 'error' && (
@@ -155,6 +161,9 @@ const body =
   .verify-page h1 { font-size: 48px; font-weight: 700; letter-spacing: 0; margin-bottom: 16px; }
   .verify-page .lead { color: var(--fg-2); font-size: 17px; line-height: 1.6; max-width: 540px; margin-bottom: 32px; }
   .verify-page button.btn { font: inherit; cursor: pointer; border: none; }
+  .verify-page .legal-consent { margin-top: 20px; color: var(--fg-4); font-size: 13px; line-height: 1.6; max-width: 400px; }
+  .verify-page .legal-consent a { color: var(--fg-3); border-bottom: 1px solid var(--border-2); transition: color 150ms; }
+  .verify-page .legal-consent a:hover { color: var(--fg); }
 
   @media (max-width: 980px) {
     .verify-page { padding: 88px 0 60px; }

--- a/website/src/pages/legal/dmca.astro
+++ b/website/src/pages/legal/dmca.astro
@@ -1,0 +1,60 @@
+---
+import LegalLayout from '../../layouts/LegalLayout.astro';
+const CONTACT = 'adhdisntreal@gmail.com';
+---
+<LegalLayout
+  title="DMCA & Abuse"
+  description="How to report copyright infringement, malware, or abuse in the Plexi marketplace."
+  lastReviewed="July 9, 2026"
+>
+  <p>
+    If an app in the Plexi marketplace infringes your copyright, ships
+    malware, or abuses the platform, report it and we will act. Send every
+    report to <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
+  </p>
+
+  <h2>Reporting copyright infringement</h2>
+  <p>
+    If you own the rights to something an app copied without permission, send a
+    notice that includes:
+  </p>
+  <ul>
+    <li>your name and contact details;</li>
+    <li>what work was infringed, and where the original lives;</li>
+    <li>which app or listing is infringing, with enough detail for us to find it;</li>
+    <li>a statement that you believe in good faith the use was not authorized by the rights holder or the law;</li>
+    <li>a statement, under penalty of perjury, that your notice is accurate and you are the rights holder or authorized to act for them;</li>
+    <li>your signature (a typed name is fine).</li>
+  </ul>
+
+  <h2>What we do with a valid notice</h2>
+  <p>
+    We review it and, if it holds up, we delist the app so it stops selling
+    and we notify the publisher. Existing installs on people's machines keep
+    working, because we do not reach into anyone's computer to remove files.
+  </p>
+
+  <h2>Counter-notice</h2>
+  <p>
+    If your app was taken down and you believe that was a mistake, send a
+    counter-notice to <a href={`mailto:${CONTACT}`}>{CONTACT}</a> with your
+    contact details, the app that was removed, and a statement, under penalty
+    of perjury, that you believe it was removed by mistake or misidentification.
+    We will pass it to the party who filed the original notice and restore the
+    listing if that is the right outcome.
+  </p>
+
+  <h2>Reporting malware or abuse</h2>
+  <p>
+    If an app does something harmful or something it never disclosed, tell us
+    and describe what you saw. When we confirm an app is malware, we stop its
+    downloads and notify affected users. Even then we never uninstall anything
+    from anyone's machine; we make sure people know so they can decide what to
+    do.
+  </p>
+
+  <h2>Contact</h2>
+  <p>
+    All notices and reports: <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
+  </p>
+</LegalLayout>

--- a/website/src/pages/legal/privacy.astro
+++ b/website/src/pages/legal/privacy.astro
@@ -1,0 +1,74 @@
+---
+import LegalLayout from '../../layouts/LegalLayout.astro';
+const CONTACT = 'adhdisntreal@gmail.com';
+---
+<LegalLayout
+  title="Privacy Policy"
+  description="What Plexi stores, what it never stores, and how your data is handled."
+  lastReviewed="July 9, 2026"
+>
+  <p>
+    Plexi stores as little about you as it can. This page says exactly what we
+    keep, what we never keep, and who else touches your data.
+  </p>
+
+  <h2>What we store</h2>
+  <ul>
+    <li><strong>Your email address</strong>, so you can sign in and we can send magic links and receipts.</li>
+    <li><strong>Your purchases and entitlements</strong> — which apps your account owns.</li>
+    <li><strong>Your subscription status</strong>, if you subscribe to Plexi AI.</li>
+    <li><strong>Sign-in tokens</strong>, stored hashed, never in plain text.</li>
+  </ul>
+  <p>
+    That is the whole list. We do not build advertising profiles, and we do
+    not sell your data.
+  </p>
+
+  <h2>What we never store</h2>
+  <p>
+    We never store your payment details. Card numbers are entered on
+    <strong>Polar's</strong> checkout in your browser. Polar is the merchant
+    of record and holds the payment data; it never reaches Plexi's systems. We
+    only receive confirmation from Polar that a purchase happened.
+  </p>
+
+  <h2>No tracking cookies, no consent banner</h2>
+  <p>
+    Plexi does not use tracking or advertising cookies, so there is nothing to
+    consent to and no cookie banner to click through. The website sets one
+    session cookie, and only after you sign in, so that you stay signed in.
+    That is it.
+  </p>
+
+  <h2>Using free apps stays private</h2>
+  <p>
+    Browsing the marketplace and installing free apps needs no account, so we
+    have nothing to collect when you do. An account only comes into it when
+    you publish, buy, or use the AI subscription.
+  </p>
+
+  <h2>Who else touches your data</h2>
+  <ul>
+    <li><strong>Resend</strong> sends the magic-link and receipt emails, so it processes your email address.</li>
+    <li><strong>Polar</strong> handles checkout and payments, so it holds your payment details and billing information.</li>
+    <li><strong>Railway</strong> hosts plexiapp.com and its database.</li>
+  </ul>
+  <p>
+    Each of these has its own terms and privacy policy covering the data it
+    handles on our behalf.
+  </p>
+
+  <h2>Your data, your call</h2>
+  <p>
+    You can ask us to delete your account and the data tied to it at any time.
+    Deleting your account removes your email and account record. Apps you
+    already installed stay on your disk and keep working, because that code
+    lives on your machine, not ours.
+  </p>
+
+  <h2>Contact</h2>
+  <p>
+    To delete your data or ask a privacy question, email
+    <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
+  </p>
+</LegalLayout>

--- a/website/src/pages/legal/refunds.astro
+++ b/website/src/pages/legal/refunds.astro
@@ -1,0 +1,47 @@
+---
+import LegalLayout from '../../layouts/LegalLayout.astro';
+const CONTACT = 'adhdisntreal@gmail.com';
+---
+<LegalLayout
+  title="Refund Policy"
+  description="Plexi's 14-day, no-questions-asked refund policy for paid apps and subscriptions."
+  lastReviewed="July 9, 2026"
+>
+  <p>
+    If a paid app is not what you wanted, you have 14 days to get your money
+    back. No questions asked.
+  </p>
+
+  <h2>How to get a refund</h2>
+  <p>
+    Request a refund within 14 days of buying the app. Email
+    <a href={`mailto:${CONTACT}`}>{CONTACT}</a> with the account email you used
+    and the app you bought, and we will process it through Polar. Because Polar
+    is the merchant of record, the refund is issued to the same card you paid
+    with.
+  </p>
+
+  <h2>What happens when you refund</h2>
+  <ul>
+    <li>Polar reverses the charge.</li>
+    <li>The record that your account owns the app is deleted.</li>
+    <li>
+      The app you already installed keeps working. A refund does not reach
+      into your machine and remove anything. What you lose is future access:
+      the app no longer re-downloads or pulls updates from the marketplace.
+    </li>
+  </ul>
+
+  <h2>Subscriptions</h2>
+  <p>
+    You can cancel the Plexi AI subscription at any time. Cancelling stops it
+    from renewing; you keep Pro access through the end of the billing period
+    you already paid for. If something went wrong with a charge, email us and
+    we will make it right.
+  </p>
+
+  <h2>Contact</h2>
+  <p>
+    Refund questions: <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
+  </p>
+</LegalLayout>

--- a/website/src/pages/legal/terms.astro
+++ b/website/src/pages/legal/terms.astro
@@ -1,0 +1,144 @@
+---
+import LegalLayout from '../../layouts/LegalLayout.astro';
+const CONTACT = 'adhdisntreal@gmail.com';
+---
+<LegalLayout
+  title="Terms of Service"
+  description="The terms for using Plexi, plexiapp.com, and the app marketplace, including publisher terms."
+  lastReviewed="July 9, 2026"
+>
+  <p>
+    These terms cover your use of Plexi: the macOS app, the website at
+    plexiapp.com, and the app marketplace. Using any of them means you accept
+    what is written here. If you do not, do not use them.
+  </p>
+
+  <h2>The software is yours to run</h2>
+  <p>
+    Plexi is open-source software you install and run on your own Mac. The
+    code you install and the files you create live on your disk. Nothing we
+    do on our end can reach in and delete or disable what you have already
+    installed. That is a design choice, not a promise we might revoke later.
+  </p>
+  <p>
+    You can use Plexi for anything legal. You are responsible for what you
+    run inside it and for the agents, commands, and apps you choose to
+    execute.
+  </p>
+
+  <h2>Accounts</h2>
+  <p>
+    You only need an account to publish an app, buy a paid app, or use the
+    Plexi AI subscription. Browsing and installing free apps needs no account.
+  </p>
+  <p>
+    Accounts are email only. You sign in with a magic link sent to your
+    address, so there is no password to lose. Keep access to that email
+    secure, because anyone who can read it can sign in as you. Tell us at
+    <a href={`mailto:${CONTACT}`}>{CONTACT}</a> if you think your account has
+    been used without your permission.
+  </p>
+
+  <h2>Acceptable use</h2>
+  <p>Do not use Plexi or plexiapp.com to:</p>
+  <ul>
+    <li>break the law or help someone else break it;</li>
+    <li>distribute malware, or ship an app that does something it does not disclose;</li>
+    <li>infringe someone else's copyright, trademark, or other rights;</li>
+    <li>attack, overload, or try to break into our systems or other people's.</li>
+  </ul>
+
+  <h2>Buying apps</h2>
+  <p>
+    A purchase is a fact recorded on our server: this account owns this app.
+    Once you buy an app, the files are yours the way a book is yours. The app
+    keeps working whether or not you stay subscribed to anything, and whether
+    or not the app stays listed in the marketplace.
+  </p>
+  <p>
+    Refunds run 14 days, no questions asked. See the
+    <a href="/legal/refunds">Refund Policy</a> for exactly what happens when
+    you request one.
+  </p>
+
+  <h2>Payments</h2>
+  <p>
+    Payments go through <strong>Polar</strong>, which acts as the merchant of
+    record. Polar owns the checkout page and handles your card, sales tax and
+    VAT, and chargebacks. Card details are entered in your browser on Polar's
+    checkout and never touch Plexi's systems. Your use of checkout is also
+    subject to
+    <a href="https://polar.sh/legal/terms" target="_blank" rel="noopener noreferrer">Polar's terms</a>.
+  </p>
+
+  <h2>Publisher terms</h2>
+  <p>
+    These apply if you publish an app to the Plexi marketplace.
+  </p>
+  <ul>
+    <li>
+      <strong>Revenue share is 85/15.</strong> You keep 85% of the net
+      revenue on your paid apps, after Polar's payment fees. Plexi keeps 15%.
+      Payouts are made on a monthly cycle to the payout details you provide
+      during onboarding.
+    </li>
+    <li>
+      <strong>Every app is reviewed before it lists.</strong> There is no way
+      onto the marketplace except through human review. We can ask for
+      changes, or reject a submission, before it goes live.
+    </li>
+    <li>
+      <strong>We can review, delist, and take down.</strong> We can remove an
+      app from the catalog to stop new sales, for example if it breaks these
+      terms, infringes someone's rights, or turns out to be malware.
+    </li>
+    <li>
+      <strong>Existing installs keep working.</strong> Delisting an app stops
+      new sales but does not touch copies people already installed. People who
+      already bought it keep their downloads and updates. The one exception is
+      a malware takedown: there we stop downloads and notify affected users,
+      but we still never uninstall anything from their machines.
+    </li>
+    <li>
+      You are responsible for what your app does and for having the rights to
+      everything you ship in it. You must not publish an app that is malware,
+      infringes someone else's rights, or does something it does not disclose
+      to the people who install it.
+    </li>
+  </ul>
+
+  <h2>The Plexi AI subscription</h2>
+  <p>
+    The AI subscription gives you 50 free requests each month. After that,
+    Pro is $10/month. When you hit your limit the request stops with a clear
+    message; you are never quietly billed extra or charged a surprise
+    overage.
+  </p>
+
+  <h2>No warranty</h2>
+  <p>
+    Plexi is provided as is. We do our best to make it reliable, but we do not
+    guarantee it will be error-free, uninterrupted, or fit for a particular
+    purpose. You run it, your agents, and third-party apps at your own risk.
+  </p>
+
+  <h2>Limitation of liability</h2>
+  <p>
+    To the extent the law allows, Plexi and its maintainers are not liable for
+    indirect, incidental, or consequential damages arising from your use of
+    the software, the website, or the marketplace. Nothing here limits
+    liability that cannot be limited by law.
+  </p>
+
+  <h2>Changes to these terms</h2>
+  <p>
+    We may update these terms as Plexi grows. When we make a meaningful
+    change, we update the last-reviewed date at the top of this page. Your
+    continued use after a change means you accept the updated terms.
+  </p>
+
+  <h2>Contact</h2>
+  <p>
+    Questions about these terms: <a href={`mailto:${CONTACT}`}>{CONTACT}</a>.
+  </p>
+</LegalLayout>


### PR DESCRIPTION
Implements stint **0347** — the legal surface that gates switching paid sales on (0338 accounts / 0339 Polar). No linked GitHub issue; stint is authoritative.

## What shipped
Four plain-language legal pages on plexiapp.com, each marked with a last-reviewed date and a standing note that they are drafts pending professional legal review:

- `/legal/terms` — Terms of Service, including the **publisher terms** section: 85/15 revenue share on net after Polar fees, mandatory pre-listing review, delist/takedown rights, and the "existing installs keep working" rule (delist stops new sales; malware takedown stops downloads + notifies, never uninstalls).
- `/legal/privacy` — what we store (email, purchases, subscription, hashed tokens), what we never store (payment data — Polar is merchant of record), and an explicit "no tracking cookies, no consent banner" statement per the non-scope.
- `/legal/refunds` — 14 days, no questions asked; refund deletes the purchase row, installed app keeps working but stops updating.
- `/legal/dmca` — copyright notice + counter-notice flow and malware/abuse reporting, all routed to the public contact email.

## Wiring
- `LegalLayout.astro` wraps the standard site shell, renders the last-reviewed date and a cross-link nav across the four pages.
- Footer gains a site-wide legal-links row, so every page links to all four (Astro `Footer.astro` is shared).
- `auth/verify.astro` account-confirm form now shows a "By continuing you agree to Terms / Privacy" consent line (skipped on the account-delete flow).

## Content sourcing
Copy drafted from `docs/marketplace-monetization.md` (revenue share, refund window, protection levers, data boundaries) and `docs/marketplace-hosted.md` §1 (free apps install with no account). Written to a human, non-legalese tone via the `human-writing` skill.

## Verification
`npm run build` (astro build) is green; all four `/legal/*` routes prerender, footer legal links appear on the homepage, and no `plexiapp.dev` / `plexi.app` strings exist in the diff.