### PR TITLE
fix: host bug bundle (FooterKeys wrap, symlink check, event identity, cli-renderer cleanup) (stint 0245)

### DIFF
--- a/src/app/canvas_bindings.rs
+++ b/src/app/canvas_bindings.rs
@@ -299,9 +299,13 @@ impl PlexiApp {
         // already removed (race between close and dispatch), so we allow through
         // rather than silently dropping a legitimate late-arriving command.
         //
-        // Note: validation is lexical (normalize_path collapses ".." without I/O).
-        // Symlinks inside the workspace root that point outside are treated as
-        // trusted, consistent with OS-level file permission semantics.
+        // Two gates, both must pass:
+        //   1. Lexical (normalize_path collapses ".." without I/O) — a cheap
+        //      first reject for obvious `../` traversal.
+        //   2. Canonical (resolves symlinks via the filesystem) — a symlink that
+        //      lives inside the workspace but points outside passes the lexical
+        //      check, so `open` would follow it out of the sandbox (#2242). The
+        //      canonical gate rejects targets whose *real* path escapes the root.
         if let Some(ref root) = workspace_root {
             let p = std::path::Path::new(&path);
             let absolute = if p.is_absolute() {
@@ -314,6 +318,13 @@ impl PlexiApp {
                 log::warn!(
                     "OpenArtifact: pane {sender_pane_id} rejected — path {path:?} outside \
                      workspace {root:?}"
+                );
+                return;
+            }
+            if !canonical_within_workspace(root, &absolute) {
+                log::warn!(
+                    "OpenArtifact: pane {sender_pane_id} rejected — real path of {path:?} \
+                     escapes workspace {root:?} (symlink)"
                 );
                 return;
             }
@@ -554,6 +565,32 @@ fn shell_open(path: &str, reveal: bool) {
     }
 }
 
+/// True when the *real* (symlink-resolved) path of `absolute` stays inside the
+/// canonicalized `workspace_root`. Complements the lexical `normalize_path`
+/// check: a symlink inside the workspace pointing outside it passes the lexical
+/// gate but fails here (#2242).
+fn canonical_within_workspace(root: &std::path::Path, absolute: &std::path::Path) -> bool {
+    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    canonicalize_existing_prefix(absolute).starts_with(&canonical_root)
+}
+
+/// Canonicalize the deepest existing ancestor of `path` (resolving any symlinks
+/// on the way) and re-append the not-yet-existing tail. Symlinks can only live
+/// on the existing prefix, so this catches a workspace-internal symlink that
+/// redirects outside the sandbox even when the final target does not exist yet.
+/// Falls back to the lexical normalization when nothing on the chain exists.
+fn canonicalize_existing_prefix(path: &std::path::Path) -> std::path::PathBuf {
+    for ancestor in path.ancestors() {
+        if let Ok(canonical) = ancestor.canonicalize() {
+            return match path.strip_prefix(ancestor) {
+                Ok(rest) => canonical.join(rest),
+                Err(_) => canonical,
+            };
+        }
+    }
+    normalize_path(path)
+}
+
 fn normalize_path(path: &std::path::Path) -> std::path::PathBuf {
     use std::path::Component;
     let mut result = std::path::PathBuf::new();
@@ -571,8 +608,49 @@ fn normalize_path(path: &std::path::Path) -> std::path::PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_path, quote_for_shell};
+    use super::{canonical_within_workspace, normalize_path, quote_for_shell};
     use std::path::PathBuf;
+
+    /// A symlink that lives inside the workspace but points outside it passes the
+    /// lexical check yet must be rejected by the canonical containment gate
+    /// (#2242). Regression for the OpenArtifact sandbox escape.
+    #[test]
+    #[cfg(unix)]
+    fn canonical_check_rejects_workspace_internal_symlink_to_outside() {
+        let tmp = std::env::temp_dir().join(format!("plexi-artifact-{}", uuid::Uuid::new_v4()));
+        let workspace = tmp.join("workspace");
+        let outside = tmp.join("outside");
+        std::fs::create_dir_all(&workspace).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        let secret = outside.join("secret.txt");
+        std::fs::write(&secret, b"top secret").unwrap();
+
+        // `workspace/link` -> `../outside` (a symlink inside the workspace).
+        let link = workspace.join("link");
+        std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+        // Lexically, `workspace/link/secret.txt` is under the workspace root.
+        let via_symlink = link.join("secret.txt");
+        assert!(
+            normalize_path(&via_symlink).starts_with(&workspace),
+            "lexical check should pass (that is the bug)"
+        );
+        // Canonically, its real path escapes the workspace and must be rejected.
+        assert!(
+            !canonical_within_workspace(&workspace, &via_symlink),
+            "canonical check must reject a symlink escaping the workspace"
+        );
+
+        // A genuine in-workspace file is still accepted.
+        let inside = workspace.join("ok.txt");
+        std::fs::write(&inside, b"fine").unwrap();
+        assert!(
+            canonical_within_workspace(&workspace, &inside),
+            "canonical check must accept a real in-workspace file"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 
     #[test]
     fn normalize_path_collapses_parent_dirs() {

--- a/src/app/host_mcp.rs
+++ b/src/app/host_mcp.rs
@@ -323,6 +323,12 @@ fn tool_subscribe_and_wait(
         .clamp(1, MAX_WAIT_SECS);
 
     // Route the broker-checked subscribe through the UI thread.
+    //
+    // Identity is split (#2290): the broker actor stays the stable `mcp:host`
+    // so one "Always" grant covers every host-MCP connection, while the delivery
+    // routing key is minted unique per call so two concurrent waiters never
+    // cross-talk or tear each other down.
+    let delivery_id = format!("{MCP_SUBSCRIBER_ID}:{}", uuid::Uuid::new_v4());
     let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel::<HostSubscribeReply>(1);
     let req = HostSubscribeRequest {
         publisher_app_id: app_id.clone(),
@@ -331,7 +337,8 @@ fn tool_subscribe_and_wait(
         trigger_mode: crate::app_protocol::TriggerMode::Conversation,
         resource_id: None,
         from_pane_id: None,
-        subscriber_override: Some(MCP_SUBSCRIBER_ID.to_string()),
+        subscriber_override: Some(delivery_id),
+        broker_actor_override: Some(MCP_SUBSCRIBER_ID.to_string()),
         reply: reply_tx,
     };
     subscribe_tx

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -598,6 +598,9 @@ fn handle_events_subscribe(
         resource_id,
         from_pane_id,
         subscriber_override: None,
+        // CLI identity (`pane:N`) is already stable and unique per pane, so the
+        // broker actor is the routing id itself — no decoupling needed.
+        broker_actor_override: None,
         reply: reply_tx,
     };
     if subscribe_tx.send(req).is_err() {

--- a/src/host/event_subscriptions.rs
+++ b/src/host/event_subscriptions.rs
@@ -246,10 +246,18 @@ pub struct HostSubscribeRequest {
     /// Pane id stamped by the host PTY env (`PLEXI_PANE_ID`), forwarded by the
     /// transport. Host-trusted: the CLI cannot pass a subscriber identity flag.
     pub from_pane_id: Option<u64>,
-    /// Transport-supplied subscriber id, used instead of the pane-derived one.
-    /// Set only by trusted host transport code (e.g. the host MCP server uses
-    /// `mcp:host`), never sourced from an untrusted client argument.
+    /// Transport-supplied subscriber id — the *delivery routing key*: where this
+    /// specific in-flight wait's events are queued and torn down. Must be unique
+    /// per concurrent waiter (e.g. the host MCP server mints `mcp:host:<uuid>`),
+    /// never sourced from an untrusted client argument.
     pub subscriber_override: Option<String>,
+    /// Transport-supplied *authorization identity*: the stable actor id the
+    /// broker checks grants against, decoupled from the per-call routing key
+    /// above (#2290). When `None`, the broker actor is the routing id itself
+    /// (the CLI case, where `pane:N` is already both stable and unique). The
+    /// host MCP server sets this to the stable `mcp:host` so one "Always" grant
+    /// covers every concurrent connection.
+    pub broker_actor_override: Option<String>,
     pub reply: SyncSender<HostSubscribeReply>,
 }
 
@@ -263,7 +271,13 @@ pub struct HostSubscribeRequest {
 /// taken from the user's click.
 pub struct PendingEventConsent {
     pub subscriber_type: ActorType,
+    /// Delivery routing key — unique per waiter; the recorded subscription and
+    /// its teardown key on this.
     pub subscriber_id: String,
+    /// Authorization identity — stable actor the broker grant is persisted
+    /// against on `AllowAlways` (#2290). Equals `subscriber_id` unless the
+    /// transport decoupled them (host MCP: `mcp:host`).
+    pub broker_actor_id: String,
     /// App-id namespace the streams live under.
     pub app_id: String,
     /// Stream names touched (empty = all of the app's declared streams). Drives
@@ -461,6 +475,13 @@ impl HostSubscriptionService {
             Some(id) => (ActorType::Agent, id.clone()),
             None => Self::resolve_cli_subscriber(req.from_pane_id),
         };
+        // Authorization identity: the stable actor the broker grants are keyed
+        // to. Defaults to the routing id (CLI: `pane:N` is both), overridden by
+        // the host MCP server to `mcp:host` so grants outlive any one connection.
+        let broker_actor_id = req
+            .broker_actor_override
+            .clone()
+            .unwrap_or_else(|| subscriber_id.clone());
         // Reject undeclared streams before involving the broker so the client
         // gets a precise error instead of a generic permission denial.
         let undeclared: Vec<String> = req
@@ -485,7 +506,7 @@ impl HostSubscriptionService {
             &self.workspace_root,
             &req.publisher_app_id,
             subscriber_type,
-            &subscriber_id,
+            &broker_actor_id,
             &req.event_names,
         );
         match decision {
@@ -523,6 +544,7 @@ impl HostSubscriptionService {
                 Some(PendingEventConsent {
                     subscriber_type,
                     subscriber_id,
+                    broker_actor_id,
                     app_id: req.publisher_app_id,
                     event_names: req.event_names,
                     action: ConsentAction::Subscribe {
@@ -551,6 +573,7 @@ impl HostSubscriptionService {
         let PendingEventConsent {
             subscriber_type,
             subscriber_id,
+            broker_actor_id,
             app_id,
             event_names,
             action,
@@ -566,7 +589,13 @@ impl HostSubscriptionService {
                 ConsentAction::Subscribe { .. } => subscription_targets(&app_id, &event_names),
                 ConsentAction::Publish { .. } => publish_targets(&app_id, &event_names),
             };
-            self.persist_always_grants(subscriber_type, &subscriber_id, &app_id, &targets, config_dir);
+            self.persist_always_grants(
+                subscriber_type,
+                &broker_actor_id,
+                &app_id,
+                &targets,
+                config_dir,
+            );
         }
         let scope = if choice == ConsentChoice::AllowAlways {
             "always"
@@ -782,6 +811,9 @@ impl HostSubscriptionService {
                 );
                 Some(PendingEventConsent {
                     subscriber_type: actor_type,
+                    // Publish is one-shot with no long-poll, so routing and
+                    // authorization identity are the same emitter id.
+                    broker_actor_id: actor_id.clone(),
                     subscriber_id: actor_id,
                     app_id: req.app_id,
                     event_names,
@@ -947,9 +979,81 @@ mod tests {
             resource_id: None,
             from_pane_id: Some(7),
             subscriber_override: override_id.map(String::from),
+            broker_actor_override: None,
             reply: tx,
         };
         (req, rx)
+    }
+
+    /// A subscribe request that decouples the delivery routing key from the
+    /// broker actor id (the host-MCP shape): grants are checked against
+    /// `broker_actor`, deliveries route to the unique `delivery_id` (#2290).
+    fn subscribe_request_decoupled(
+        delivery_id: &str,
+        broker_actor: &str,
+    ) -> (HostSubscribeRequest, std::sync::mpsc::Receiver<HostSubscribeReply>) {
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        let req = HostSubscribeRequest {
+            publisher_app_id: "event-probe".to_string(),
+            event_names: vec!["probe.tick".to_string()],
+            payload_mode: PayloadMode::Full,
+            trigger_mode: TriggerMode::Conversation,
+            resource_id: None,
+            from_pane_id: None,
+            subscriber_override: Some(delivery_id.to_string()),
+            broker_actor_override: Some(broker_actor.to_string()),
+            reply: tx,
+        };
+        (req, rx)
+    }
+
+    /// Two concurrent host-MCP waiters share the stable broker actor `mcp:host`
+    /// but mint distinct delivery keys. Each must receive its own delivery, and
+    /// tearing one down must leave the other live (#2290).
+    #[test]
+    fn concurrent_mcp_subscribers_do_not_collide() {
+        let timeline = timeline_with_stream();
+        let svc = granted_service(Arc::clone(&timeline));
+
+        let (req_a, rx_a) = subscribe_request_decoupled("mcp:host:aaaa", "mcp:host");
+        let (req_b, rx_b) = subscribe_request_decoupled("mcp:host:bbbb", "mcp:host");
+        assert!(svc.classify_subscribe_request(req_a).is_none());
+        assert!(svc.classify_subscribe_request(req_b).is_none());
+        let (ta, sa) = match rx_a.recv().unwrap() {
+            HostSubscribeReply::Ok { subscriber_type, subscriber_id, .. } => {
+                (subscriber_type, subscriber_id)
+            }
+            HostSubscribeReply::Err { message } => panic!("subscribe A failed: {message}"),
+        };
+        let (tb, sb) = match rx_b.recv().unwrap() {
+            HostSubscribeReply::Ok { subscriber_type, subscriber_id, .. } => {
+                (subscriber_type, subscriber_id)
+            }
+            HostSubscribeReply::Err { message } => panic!("subscribe B failed: {message}"),
+        };
+        // The reply echoes the unique routing key, not the shared broker actor.
+        assert_eq!(sa, "mcp:host:aaaa");
+        assert_eq!(sb, "mcp:host:bbbb");
+        assert_eq!(timeline.lock().unwrap().subscriptions().len(), 2);
+
+        // One emitted event fans out to both independent subscriptions.
+        timeline
+            .lock()
+            .unwrap()
+            .record_event("event-probe", 7, probe_event(1))
+            .expect("emit should record");
+
+        // Tear down A. B's subscription and its queued delivery must survive.
+        let (subs, _drops) = timeline.lock().unwrap().clear_subscriber(ta, &sa);
+        assert_eq!(subs, 1, "clearing A removes exactly A's subscription");
+        assert_eq!(
+            timeline.lock().unwrap().subscriptions().len(),
+            1,
+            "B's subscription must remain after A is cleared"
+        );
+        let deliveries_b = timeline.lock().unwrap().take_deliveries_for(tb, &sb);
+        assert_eq!(deliveries_b.len(), 1, "B still receives its own delivery");
+        assert_eq!(deliveries_b[0].event, "probe.tick");
     }
 
     fn probe_event(count: u64) -> EmittedEvent {

--- a/src/render/app_chrome.rs
+++ b/src/render/app_chrome.rs
@@ -182,7 +182,16 @@ impl<'a> AppChrome<'a> {
 
     pub(crate) fn paint_footer_keys(&self, ui: &mut Ui, entries: &[FooterKeyEntry], divider: bool) {
         let chip_row_h = chip_row_height(ui);
-        let total_h = footer_keys_height(ui, divider);
+        let row_h = chip_row_h + 4.0;
+        let chip_font = FontId::monospace(style::TEXT_HINT);
+        let desc_font = FontId::proportional(style::TEXT_HINT);
+
+        // Measure against the width the height pass used, so allocation and paint
+        // agree on the wrapped row count.
+        let avail_w = footer_keys_available_width(ui);
+        let rows = footer_keys_rows(ui, entries, &chip_font, &desc_font, avail_w);
+        let total_h = footer_keys_height(ui, entries, divider);
+
         let (rect, _) = ui.allocate_exact_size(
             egui::vec2(ui.available_width(), total_h),
             egui::Sense::hover(),
@@ -204,11 +213,25 @@ impl<'a> AppChrome<'a> {
             );
         }
 
-        let chip_font = FontId::monospace(style::TEXT_HINT);
-        let desc_font = FontId::proportional(style::TEXT_HINT);
-        let content_w = footer_keys_content_width(ui, entries, &chip_font, &desc_font, self.colors);
-        let content_rect = footer_keys_content_rect(full_rect, content_w, chip_row_h, divider);
-        paint_footer_keys_row(ui, content_rect, entries, chip_font, desc_font, self.colors);
+        // Each row is centered horizontally (preserving the single-line centering
+        // of #2111) and stacked top-to-bottom inside the band.
+        let content_top = full_rect.min.y + if divider { 1.0 } else { 0.0 } + style::SPACE_SM;
+        for (idx, (start, end, row_w)) in rows.iter().enumerate() {
+            let row_top = content_top + idx as f32 * (row_h + style::SPACE_XS);
+            let row_band = egui::Rect::from_min_size(
+                egui::pos2(full_rect.min.x, row_top),
+                egui::vec2(full_rect.width(), row_h),
+            );
+            let content_rect = footer_keys_content_rect(row_band, *row_w, chip_row_h, false);
+            paint_footer_keys_row(
+                ui,
+                content_rect,
+                &entries[*start..*end],
+                chip_font.clone(),
+                desc_font.clone(),
+                self.colors,
+            );
+        }
     }
 
     pub(crate) fn paint_action_bar_background(&self, ui: &Ui, rect: egui::Rect) {
@@ -572,13 +595,95 @@ pub(crate) fn chip_row_height(ui: &egui::Ui) -> f32 {
     text_h + style::KEYCHIP_PAD_V * 2.0
 }
 
-pub(crate) fn footer_keys_height(ui: &egui::Ui, divider: bool) -> f32 {
+/// Height of the footer-keys band, accounting for wrapping: in a pane too
+/// narrow to hold every entry on one line, entries flow onto additional rows and
+/// the band grows to fit (#2240). `ui.available_width()` is the same width the
+/// paint pass lays out against, so the host-measured height the `Column` /
+/// bottom-pin allocator reserves always matches what gets painted.
+pub(crate) fn footer_keys_height(ui: &egui::Ui, entries: &[FooterKeyEntry], divider: bool) -> f32 {
+    let chip_font = FontId::monospace(style::TEXT_HINT);
+    let desc_font = FontId::proportional(style::TEXT_HINT);
+    let avail_w = footer_keys_available_width(ui);
+    let rows = footer_keys_rows(ui, entries, &chip_font, &desc_font, avail_w);
+    let n = rows.len().max(1) as f32;
     let row_h = chip_row_height(ui) + 4.0;
+    let base = style::SPACE_SM + n * row_h + (n - 1.0) * style::SPACE_XS + style::SPACE_SM;
     if divider {
-        1.0 + style::SPACE_SM + row_h + style::SPACE_SM
+        1.0 + base
     } else {
-        style::SPACE_SM + row_h + style::SPACE_SM
+        base
     }
+}
+
+/// Usable content width for footer-key rows: the available width minus the
+/// left/right band insets [`footer_keys_content_rect`] applies.
+fn footer_keys_available_width(ui: &egui::Ui) -> f32 {
+    (ui.available_width() - style::SPACE_MD * 2.0).max(0.0)
+}
+
+/// Width of a single footer entry (its key chips + gaps + description) as an
+/// atomic, un-wrappable unit. Color does not affect glyph advance, so a fixed
+/// color is used — this lets the free-function height path measure without a
+/// `Colors` handle.
+fn footer_entry_width(
+    ui: &Ui,
+    entry: &FooterKeyEntry,
+    chip_font: &FontId,
+    desc_font: &FontId,
+) -> f32 {
+    let chip_row_h = chip_row_height(ui);
+    let mut w: f32 = 0.0;
+    for (ki, key) in entry.keys.iter().enumerate() {
+        if ki > 0 {
+            w += style::KEYCHIP_GAP;
+        }
+        let tw = ui.fonts(|f| {
+            f.layout_no_wrap(key.clone(), chip_font.clone(), Color32::WHITE)
+                .size()
+                .x
+        });
+        w += (tw + style::KEYCHIP_PAD_H * 2.0)
+            .max(chip_row_h)
+            .max(style::KEYCHIP_MIN_W);
+    }
+    w += 4.0;
+    w += ui.fonts(|f| {
+        f.layout_no_wrap(entry.description.clone(), desc_font.clone(), Color32::WHITE)
+            .size()
+            .x
+    });
+    w
+}
+
+/// Greedily pack footer entries into rows no wider than `avail_w`. Each row is
+/// `(start, end, row_width)` over `entries[start..end]`. An entry that alone
+/// exceeds `avail_w` still occupies its own row (never dropped). The height and
+/// paint passes both call this so their row counts always agree.
+fn footer_keys_rows(
+    ui: &Ui,
+    entries: &[FooterKeyEntry],
+    chip_font: &FontId,
+    desc_font: &FontId,
+    avail_w: f32,
+) -> Vec<(usize, usize, f32)> {
+    let mut rows = Vec::new();
+    let mut i = 0;
+    while i < entries.len() {
+        let start = i;
+        let mut row_w = 0.0;
+        while i < entries.len() {
+            let ew = footer_entry_width(ui, &entries[i], chip_font, desc_font);
+            let sep = if i > start { style::SPACE_MD } else { 0.0 };
+            // Always keep at least one entry per row, even if it overflows alone.
+            if i > start && row_w + sep + ew > avail_w {
+                break;
+            }
+            row_w += sep + ew;
+            i += 1;
+        }
+        rows.push((start, i, row_w));
+    }
+    rows
 }
 
 pub(crate) fn footer_keys_content_rect(
@@ -600,46 +705,6 @@ pub(crate) fn footer_keys_content_rect(
     let chrome_h = (full_rect.max.y - chrome_top).max(0.0);
     let top = chrome_top + (chrome_h - chip_row_h).max(0.0) / 2.0;
     egui::Rect::from_min_size(egui::pos2(left, top), egui::vec2(width, chip_row_h))
-}
-
-fn footer_keys_content_width(
-    ui: &Ui,
-    entries: &[FooterKeyEntry],
-    chip_font: &FontId,
-    desc_font: &FontId,
-    colors: &Colors,
-) -> f32 {
-    let chip_row_h = chip_row_height(ui);
-    let mut content_w: f32 = 0.0;
-    for (ei, entry) in entries.iter().enumerate() {
-        for (ki, key) in entry.keys.iter().enumerate() {
-            if ki > 0 {
-                content_w += style::KEYCHIP_GAP;
-            }
-            let tw = ui.fonts(|f| {
-                f.layout_no_wrap(key.clone(), chip_font.clone(), colors.text_primary)
-                    .size()
-                    .x
-            });
-            content_w += (tw + style::KEYCHIP_PAD_H * 2.0)
-                .max(chip_row_h)
-                .max(style::KEYCHIP_MIN_W);
-        }
-        content_w += 4.0;
-        content_w += ui.fonts(|f| {
-            f.layout_no_wrap(
-                entry.description.clone(),
-                desc_font.clone(),
-                colors.text_dim,
-            )
-            .size()
-            .x
-        });
-        if ei + 1 < entries.len() {
-            content_w += style::SPACE_MD;
-        }
-    }
-    content_w
 }
 
 fn paint_footer_keys_row(
@@ -740,6 +805,47 @@ mod tests {
         assert_eq!(chrome.text_color("", "accent"), colors.accent);
         assert_eq!(chrome.text_color("accent", ""), colors.accent);
         assert_eq!(chrome.text_color("neutral", ""), colors.bg_active);
+    }
+
+    /// #2240: footer keys pack onto one row when they fit and wrap onto
+    /// additional rows in a narrow band, and the measured height grows with the
+    /// wrapped row count so `Column`/bottom-pin reserves enough space.
+    #[test]
+    fn footer_keys_wrap_in_narrow_band() {
+        let entries: Vec<FooterKeyEntry> = (0..6)
+            .map(|i| FooterKeyEntry {
+                keys: vec![format!("^{i}")],
+                description: format!("action {i}"),
+            })
+            .collect();
+        let chip_font = FontId::monospace(style::TEXT_HINT);
+        let desc_font = FontId::proportional(style::TEXT_HINT);
+
+        let ctx = egui::Context::default();
+        ctx.begin_pass(egui::RawInput::default());
+        egui::CentralPanel::default().show(&ctx, |ui| {
+            // Wide band: everything fits on a single row.
+            let wide = footer_keys_rows(ui, &entries, &chip_font, &desc_font, 10_000.0);
+            assert_eq!(wide.len(), 1, "all entries fit on one row when wide");
+            assert_eq!(wide[0], (0, entries.len(), wide[0].2));
+
+            // Narrow band: entries wrap onto multiple rows, none dropped.
+            let narrow = footer_keys_rows(ui, &entries, &chip_font, &desc_font, 90.0);
+            assert!(narrow.len() > 1, "entries must wrap in a narrow band");
+            let covered: usize = narrow.iter().map(|(s, e, _)| e - s).sum();
+            assert_eq!(covered, entries.len(), "every entry appears exactly once");
+            for w in narrow.windows(2) {
+                assert_eq!(w[0].1, w[1].0, "rows are contiguous");
+            }
+
+            // Height reflects the wrapped row count: taller than a single row.
+            let one_row = style::SPACE_SM + (chip_row_height(ui) + 4.0) + style::SPACE_SM;
+            assert!(
+                footer_keys_height(ui, &entries, false) >= one_row,
+                "wrapped footer height must be at least one row tall"
+            );
+        });
+        let _ = ctx.end_pass();
     }
 
     #[test]

--- a/src/render/cli_renderer_app.rs
+++ b/src/render/cli_renderer_app.rs
@@ -62,8 +62,17 @@ pub struct CliRendererApp {
     last_selected: usize,
     /// Per-flag form values, keyed by flag name.
     field_values: HashMap<String, String>,
+    /// Path the descriptor was read from. Owned so the per-pane temp descriptor
+    /// (`$TMPDIR/plexi-descriptor-<uuid>.json`) is deleted on pane close via
+    /// `Drop`, instead of leaking one file per CLI open (#2246).
+    descriptor_path: String,
     /// Linked terminal pane id (0 = not yet linked).
     terminal_pane_id: u64,
+    /// Set when the terminal-link handshake returns pane id 0 (host could not
+    /// spawn the linked terminal). Distinguishes a hard failure from the normal
+    /// "still connecting" state so the renderer surfaces a visible error instead
+    /// of a stuck "(connecting terminal…)" label (#2246).
+    terminal_link_failed: bool,
     /// Pending AppCommands to drain each frame.
     pending_commands: Vec<AppCommand>,
     /// Last command string that was run (shown as a hint).
@@ -119,7 +128,9 @@ impl CliRendererApp {
             selected: 0,
             last_selected: 0,
             field_values: HashMap::new(),
+            descriptor_path,
             terminal_pane_id: 0,
+            terminal_link_failed: false,
             pending_commands: vec![],
             last_run: String::new(),
             terminal_requested: false,
@@ -534,7 +545,9 @@ impl CliRendererApp {
         // Run button
         ui.horizontal(|ui| {
             ui.add_space(style::SPACE_MD);
-            let run_text = if self.terminal_pane_id == 0 {
+            let run_text = if self.terminal_link_failed {
+                "▶  Run  (terminal unavailable)"
+            } else if self.terminal_pane_id == 0 {
                 "▶  Run  (connecting terminal…)"
             } else {
                 "▶  Run"
@@ -543,6 +556,20 @@ impl CliRendererApp {
                 self.execute();
             }
         });
+
+        // Surface a visible error when the terminal link hard-failed, so the Run
+        // affordance is not silently inert (#2246).
+        if self.terminal_link_failed {
+            ui.add_space(style::SPACE_SM);
+            ui.horizontal(|ui| {
+                ui.add_space(style::SPACE_MD);
+                ui.label(
+                    RichText::new("Could not open a linked terminal — reopen this tool to retry.")
+                        .size(style::TEXT_CAPTION)
+                        .color(colors.danger),
+                );
+            });
+        }
 
         // Last run hint
         if !self.last_run.is_empty() {
@@ -660,6 +687,33 @@ impl CliRendererApp {
             });
         });
         took_focus
+    }
+}
+
+impl Drop for CliRendererApp {
+    /// Delete the per-pane temp descriptor on close (#2246). Guarded to the
+    /// host-minted `$TMPDIR/plexi-descriptor-*.json` pattern so a caller-supplied
+    /// or test-fixture path is never touched.
+    fn drop(&mut self) {
+        let path = std::path::Path::new(&self.descriptor_path);
+        let in_temp_dir = path.parent() == Some(std::env::temp_dir().as_path());
+        let is_descriptor = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("plexi-descriptor-") && n.ends_with(".json"));
+        if in_temp_dir && is_descriptor {
+            match std::fs::remove_file(path) {
+                Ok(()) => log::info!(
+                    "CliRendererApp: cleaned up temp descriptor {}",
+                    self.descriptor_path
+                ),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => log::warn!(
+                    "CliRendererApp: failed to remove temp descriptor {}: {e}",
+                    self.descriptor_path
+                ),
+            }
+        }
     }
 }
 
@@ -801,10 +855,21 @@ impl App for CliRendererApp {
         {
             if request_id == &self.terminal_request_id {
                 self.terminal_pane_id = *terminal_pane_id;
-                log::info!(
-                    "CliRendererApp: linked terminal ready, pane_id={}",
-                    terminal_pane_id
-                );
+                if *terminal_pane_id == 0 {
+                    // Handshake completed but the host could not spawn a linked
+                    // terminal — surface it instead of a stuck "connecting" state.
+                    self.terminal_link_failed = true;
+                    log::warn!(
+                        "CliRendererApp: linked terminal request {request_id} returned pane id 0 \
+                         — terminal link failed"
+                    );
+                } else {
+                    self.terminal_link_failed = false;
+                    log::info!(
+                        "CliRendererApp: linked terminal ready, pane_id={}",
+                        terminal_pane_id
+                    );
+                }
             }
         }
     }
@@ -1054,5 +1119,56 @@ mod tests {
         let app = CliRendererApp::new("/nonexistent/descriptor/path.json".into());
         assert!(matches!(app.view, View::Error(_)));
         assert!(app.descriptor.is_none());
+    }
+
+    /// Dropping the renderer deletes its host-minted temp descriptor (#2246), so
+    /// `$TMPDIR/plexi-descriptor-*.json` files do not accumulate per CLI open.
+    #[test]
+    fn drop_removes_temp_descriptor_file() {
+        let path = std::env::temp_dir().join(format!(
+            "plexi-descriptor-{}.json",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&path, FIXTURE).expect("write temp descriptor");
+        assert!(path.exists());
+        {
+            let _app = CliRendererApp::new(path.to_string_lossy().into_owned());
+        }
+        assert!(
+            !path.exists(),
+            "temp descriptor must be removed when the renderer pane closes"
+        );
+    }
+
+    /// A non-temp descriptor path (e.g. a test fixture) is never deleted on drop.
+    #[test]
+    fn drop_leaves_non_temp_descriptor_file() {
+        let (app, dir) = app_from_fixture();
+        let path = dir.path().join("descriptor.json");
+        assert!(path.exists());
+        drop(app);
+        assert!(
+            path.exists(),
+            "a fixture descriptor outside the temp pattern must survive drop"
+        );
+    }
+
+    /// A `LinkedTerminalReady` handshake that returns pane id 0 is a hard failure,
+    /// not the normal "still connecting" state — the renderer flags it so a
+    /// visible error replaces the stuck "connecting terminal…" label (#2246).
+    #[test]
+    fn zero_terminal_pane_id_flags_link_failure() {
+        let (mut app, _dir) = app_from_fixture();
+        assert!(!app.terminal_link_failed);
+        let request_id = app.terminal_request_id.clone();
+        app.queue_outbound_event(crate::app_protocol::PlexiEvent::LinkedTerminalReady {
+            request_id,
+            terminal_pane_id: 0,
+        });
+        assert!(
+            app.terminal_link_failed,
+            "pane id 0 must mark the terminal link as failed"
+        );
+        assert_eq!(app.terminal_pane_id, 0);
     }
 }

--- a/src/render/components.rs
+++ b/src/render/components.rs
@@ -2081,7 +2081,9 @@ fn text_edit_should_submit(
 /// if the height cannot be determined without rendering.
 fn bottom_pin_height(ui: &egui::Ui, node: &UiNode) -> Option<f32> {
     match node {
-        UiNode::FooterKeys { divider, .. } => Some(app_chrome::footer_keys_height(ui, *divider)),
+        UiNode::FooterKeys { entries, divider } => {
+            Some(app_chrome::footer_keys_height(ui, entries, *divider))
+        }
         UiNode::Footer { .. } => Some(app_chrome::footer_height()),
         _ => None,
     }


### PR DESCRIPTION
Implements stint task **0245** (no linked GitHub issue). Four independent host bugs, each reproduced and fixed at the root, with regression tests. Former issue refs: #2240, #2242, #2290, #2246.

## Fixes

**1. FooterKeys overflows instead of wrapping in narrow panes (#2240)** — `src/render/app_chrome.rs`, `src/render/components.rs`
`UiNode::FooterKeys` pre-measured content as a single centered line and clipped on overflow. Added greedy row-packing (`footer_keys_rows`) shared by the height and paint passes: entries wrap onto additional rows in a band too narrow to hold them, each row stays horizontally centered (preserves #2111), and `footer_keys_height` now grows with the wrapped row count so the bottom-pin allocator reserves the right height. Single-row behavior (and the existing height for ≤1 row) is unchanged.

**2. OpenArtifact lexical path check does not resolve symlinks (#2242)** — `src/app/canvas_bindings.rs`
The containment check was purely lexical, so a workspace-internal symlink pointing outside the sandbox passed and `open` followed it out. Added a canonical containment gate (`canonical_within_workspace`) after the cheap lexical pre-check: it canonicalizes the deepest existing ancestor (resolving symlinks) and rejects targets whose real path escapes `workspace_root`.

**3. Host MCP event subscribers collide on a single shared identity (#2290)** — `src/host/event_subscriptions.rs`, `src/app/host_mcp.rs`, `src/app/mod.rs`
`mcp:host` was used as both the broker authorization identity and the delivery-routing key, so two concurrent host-MCP waiters cross-talked and one's teardown cleared the other's subscription. Split the two: `HostSubscribeRequest` now carries a stable `broker_actor_override` (grant matching) distinct from the per-call `subscriber_override` (delivery routing). The host MCP server keeps `mcp:host` as the broker actor so one "Always" grant still covers every connection, and mints a unique `mcp:host:<uuid>` routing key per `subscribe_and_wait`. CLI identity (`pane:N`) is untouched.

**4. Silent degraded-ready + uncleaned descriptor temp files in cli-renderer (#2246)** — `src/render/cli_renderer_app.rs`
- A `LinkedTerminalReady { terminal_pane_id: 0 }` handshake left the Run button stuck at "(connecting terminal…)" forever. It now flags `terminal_link_failed` and surfaces a visible in-pane error.
- `$TMPDIR/plexi-descriptor-<uuid>.json` was written per CLI open and never removed. `Drop` now deletes it on pane close, guarded to the host-minted temp pattern so fixtures/caller paths are never touched.

## Tests
All observable/return-value invariants covered by Rust `#[test]`s:
- `footer_keys_wrap_in_narrow_band` — wraps in a narrow band, one row when wide, every entry covered once, height grows.
- `canonical_check_rejects_workspace_internal_symlink_to_outside` — symlink escape rejected, real in-workspace file accepted.
- `concurrent_mcp_subscribers_do_not_collide` — two waiters (shared broker actor, distinct routing keys) each get their own delivery; clearing one leaves the other live.
- `drop_removes_temp_descriptor_file`, `drop_leaves_non_temp_descriptor_file`, `zero_terminal_pane_id_flags_link_failure`.

`cargo test --bin plexi`: **1522 passed, 0 failed, 1 ignored**. `cargo build` clean (no warnings).

## Validation
Bugs 1 and 4 have user-visible UI surfaces (footer wrapping, cli-renderer error/Run button). Recommend installing the PR build with `just pr-install <N>` from this worktree and driving a narrow-pane L1 app footer + a `plexi open <cli>` renderer to confirm visually. Bugs 2 and 3 are fully covered by the harness tests above (install skippable for those two).