### PR TITLE
v1 polish: app-reported pip status SDK effect + UI gallery smoke (stint 0252)

### DIFF
--- a/sdk/python/plexi_sdk/_v3_runtime.py
+++ b/sdk/python/plexi_sdk/_v3_runtime.py
@@ -376,6 +376,8 @@ class V3AppRuntime:
                 _emit({"type": "status_summary", "text": effect.text})
             elif isinstance(effect, effects.SetTitle):
                 _emit({"type": "set_title", "title": effect.title})
+            elif isinstance(effect, effects.SetPipStatus):
+                _emit({"type": "set_pip_status", "status": effect.status})
             elif isinstance(effect, effects.SetTimer):
                 _emit({
                     "type": "set_timer",

--- a/sdk/python/plexi_sdk/effects.py
+++ b/sdk/python/plexi_sdk/effects.py
@@ -10,7 +10,10 @@ same meaning.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Literal, Optional
+
+PipStatus = Literal["green", "yellow", "red"]
+"""Traffic-light health an app reports for its own activity dot."""
 
 
 @dataclass
@@ -143,6 +146,18 @@ class SetStatus:
     """Set the pane status text shown by Plexi chrome."""
 
     text: str
+
+
+@dataclass
+class SetPipStatus:
+    """Report this app's own pip status — a red/yellow/green activity dot.
+
+    Takes priority over the host's derived activity until the app reports a
+    new status. The host stamps the pane id, so an app can only ever set its
+    own pip. ``status`` must be ``"green"``, ``"yellow"``, or ``"red"``.
+    """
+
+    status: PipStatus
 
 
 @dataclass

--- a/sdk/python/tests/test_v3_runtime_regression.py
+++ b/sdk/python/tests/test_v3_runtime_regression.py
@@ -154,6 +154,16 @@ class TestEffects:
         finally:
             proc.kill()
 
+    def test_set_pip_status(self, tmp_path):
+        app = self._app_with_init_effects(tmp_path, 'SetPipStatus("yellow")')
+        proc = _spawn_v3_app(app)
+        try:
+            events = _init_and_render(proc)
+            pips = _find_events(events, "set_pip_status")
+            assert any(p.get("status") == "yellow" for p in pips)
+        finally:
+            proc.kill()
+
     def test_set_timer(self, tmp_path):
         app = self._app_with_init_effects(tmp_path, 'SetTimer(id=42, delay_ms=1000, repeat=True)')
         proc = _spawn_v3_app(app)
@@ -603,7 +613,7 @@ class TestFrameTiming:
         finally:
             proc.kill()
 
-    def test_balls_physics_progresses(self, tmp_path):
+    def test_balls_physics_progresses(self):
         """The balls app physics must actually advance between frames."""
         from plexi_sdk.testing import AppHarness
         balls_path = REPO_ROOT / "apps" / "dev" / "balls" / "balls.py"

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -913,6 +913,24 @@ mod tests {
     }
 
     #[test]
+    fn ui_gallery_overlay_smoke() {
+        let mut h = PlexiUiHarness::new_sized(900.0, 640.0);
+        h.step();
+        h.with_app_mut(|app| {
+            app.show_ui_gallery = true;
+        });
+        // Two steps: egui Areas spend their first frame on an invisible sizing
+        // pass; the modal is visible from the second frame.
+        h.run_steps(2);
+
+        // Modal title and the first section header are real ui.label widgets.
+        h.harness().get_by_label("Host UI Gallery");
+        h.harness().get_by_label("Chrome primitives");
+        h.save_screenshot("/tmp/plexi_ui_gallery.png")
+            .expect("render failed");
+    }
+
+    #[test]
     fn parked_sidebar_dropdown_uses_shared_list_header() {
         let mut h = PlexiUiHarness::new_sized(900.0, 620.0);
         h.with_app_mut(|app| {

--- a/website/src/content/docs/sdk.md
+++ b/website/src/content/docs/sdk.md
@@ -114,6 +114,14 @@ Set the pane title shown by Plexi chrome.
 
 Set the pane status text shown by Plexi chrome.
 
+### `SetPipStatus`
+
+Report this app's own pip status — a red/yellow/green activity dot.
+
+Takes priority over the host's derived activity until the app reports a
+new status. The host stamps the pane id, so an app can only ever set its
+own pip. ``status`` must be ``"green"``, ``"yellow"``, or ``"red"``.
+
 ### `CloseSelf`
 
 Ask the host to close this app pane.


### PR DESCRIPTION
Stint task **0252** (v1 polish bundle). No linked GitHub issue — stint is authoritative.

## Summary

Of the 5 bundled polish items, 3 already landed on alpha via prior PRs; this PR completes the remaining 2.

**Already done on alpha (verified, skipped):**
- Command palette aliases — `search_text` synonyms (shell/console/vsplit/hsplit) + `palette_command_aliases_match_starter_synonyms`.
- Precomputed lowercase search haystack — cached `search_text` on every `PaletteEntry`, `.contains` match + `palette_searchable_text_is_cached_lowercase`.
- `PLEXI_CONTEXT_ROOT` stale after `context set-root` — landed via PR #2250 (sidebar/overlay refresh + CLI tip).

**Implemented here:**
- **App-reported pip status (red/yellow/green).** Host side (`PipStatus`, `SetPipStatus` routing, `Pane::set_pip_status`) already existed; the missing piece was the Python SDK surface. Added the `SetPipStatus` effect dataclass (`effects.py`), its dispatch to `{"type":"set_pip_status"}` (`_v3_runtime.py`), and a regression test.
- **Host UI gallery visual smoke coverage.** Added `ui_gallery_overlay_smoke` (`src/ui_tests.rs`) — opens the gallery via `PlexiUiHarness`, asserts "Host UI Gallery" / "Chrome primitives" render, saves a screenshot.
- Removed an unused `tmp_path` fixture param in `test_v3_runtime_regression.py`.

## Test evidence
- `cargo test --bin plexi`: **1517 passed, 0 failed** (incl. new `ui_gallery_overlay_smoke`).
- `cargo build`: green.
- `uv run pytest -k set_pip_status`: **passed**; `pyright` clean on the changed SDK source.