### PR TITLE
feat: scoped Assistant settings (stint 0226)

### DIFF
--- a/src/assistant/commands.rs
+++ b/src/assistant/commands.rs
@@ -41,6 +41,12 @@ pub const BUILT_IN_COMMANDS: &[(&str, &str)] = &[
         "thoughts",
         "Show or hide the model's reasoning for every turn.",
     ),
+    ("model", "Show or change the model tier for this session."),
+    (
+        "settings",
+        "Show resolved Assistant settings and their sources.",
+    ),
+    ("config", "Show Assistant settings (alias for /settings)."),
 ];
 
 /// Parse `input` as a slash command. Returns `None` when the input is not a
@@ -172,11 +178,31 @@ mod tests {
     fn help_lists_every_builtin_and_marks_none_unimplemented() {
         let help = help_text();
         for (name, _) in BUILT_IN_COMMANDS {
-            assert!(help.contains(&format!("/{name}")), "{name} missing from /help");
+            assert!(
+                help.contains(&format!("/{name}")),
+                "{name} missing from /help"
+            );
         }
         assert!(
             !help.contains("not yet implemented"),
             "no built-in should advertise itself as unimplemented"
+        );
+    }
+
+    #[test]
+    fn settings_and_model_handlers_are_exposed_in_help_and_picker() {
+        let names: Vec<&str> = BUILT_IN_COMMANDS.iter().map(|(name, _)| *name).collect();
+
+        assert!(names.contains(&"model"));
+        assert!(names.contains(&"settings"));
+        assert!(names.contains(&"config"));
+        assert!(help_text().contains("/model"));
+        assert_eq!(
+            filter_commands("config")
+                .into_iter()
+                .map(|(name, _)| name)
+                .collect::<Vec<_>>(),
+            vec!["config"]
         );
     }
 }

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -291,16 +291,6 @@ impl AssistantApp {
         let settings_loader = SettingsLoader::new(profile_dir, &workspace_root);
         let session_overrides = SessionOverrides::default();
         let settings_report = settings_loader.load(&session_overrides);
-        for error in &settings_report.errors {
-            let text = format!("Assistant settings error: {error}");
-            if !model
-                .turns
-                .iter()
-                .any(|turn| turn.role == TurnRole::Error && turn.text == text)
-            {
-                model.turns.push(model::Turn::now(TurnRole::Error, text));
-            }
-        }
         let (outcome_tx, outcome_rx) = std::sync::mpsc::channel();
         let (flow_tx, flow_rx) = std::sync::mpsc::channel();
         let mut app = Self {
@@ -2824,6 +2814,24 @@ mod tests {
     }
 
     #[test]
+    fn settings_load_errors_do_not_persist_as_conversation_turns() {
+        let ws = tempfile::tempdir().unwrap();
+        let settings_path = ws.path().join("agents/settings.toml");
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(&settings_path, "unknown = true\n").unwrap();
+
+        let app = test_app(ws.path());
+        assert_eq!(app.settings_errors.len(), 1);
+        assert!(app.model.turns.is_empty());
+        drop(app);
+
+        std::fs::write(&settings_path, "[model]\ntier = \"low\"\n").unwrap();
+        let reopened = test_app(ws.path());
+        assert!(reopened.settings_errors.is_empty());
+        assert!(reopened.model.turns.is_empty());
+    }
+
+    #[test]
     fn model_without_args_shows_the_resolved_tier_and_source() {
         let ws = tempfile::tempdir().unwrap();
         let settings_path = ws.path().join("agents/settings.toml");
@@ -2888,21 +2896,23 @@ mod tests {
         std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
         std::fs::write(&settings_path, "[model\ntier = nope").unwrap();
 
-        let app = test_app(ws.path());
+        let mut app = test_app(ws.path());
+        assert_eq!(app.settings_errors.len(), 1);
 
-        let error = app
+        app.model.composer = "/settings".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        assert!(app
             .model
             .turns
-            .iter()
-            .find(|turn| turn.role == TurnRole::Error)
-            .expect("settings parse error must be visible in the transcript");
-        assert!(error
+            .last()
+            .unwrap()
             .text
             .contains(settings_path.to_string_lossy().as_ref()));
     }
 
     #[test]
-    fn reopening_with_the_same_settings_error_does_not_duplicate_the_row() {
+    fn reopening_with_the_same_settings_error_keeps_one_active_error() {
         let ws = tempfile::tempdir().unwrap();
         let settings_path = ws.path().join("agents/settings.toml");
         std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
@@ -2910,17 +2920,8 @@ mod tests {
 
         drop(test_app(ws.path()));
         let reopened = test_app(ws.path());
-        let matching_errors = reopened
-            .model
-            .turns
-            .iter()
-            .filter(|turn| {
-                turn.role == TurnRole::Error
-                    && turn.text.contains(settings_path.to_string_lossy().as_ref())
-            })
-            .count();
-
-        assert_eq!(matching_errors, 1);
+        assert_eq!(reopened.settings_errors.len(), 1);
+        assert!(reopened.model.turns.is_empty());
     }
 
     #[test]
@@ -2929,15 +2930,17 @@ mod tests {
         let settings_path = ws.path().join("agents/settings.toml");
         std::fs::create_dir_all(&settings_path).unwrap();
 
-        let app = test_app(ws.path());
+        let mut app = test_app(ws.path());
+        assert_eq!(app.settings_errors.len(), 1);
 
-        let error = app
+        app.model.composer = "/settings".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        assert!(app
             .model
             .turns
-            .iter()
-            .find(|turn| turn.role == TurnRole::Error)
-            .expect("settings read error must be visible in the transcript");
-        assert!(error
+            .last()
+            .unwrap()
             .text
             .contains(settings_path.to_string_lossy().as_ref()));
     }

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -11,6 +11,7 @@ pub mod audit;
 pub mod commands;
 pub mod model;
 pub mod render;
+pub mod settings;
 pub mod store;
 
 use std::collections::HashSet;
@@ -43,6 +44,7 @@ use crate::plexi_ai::tool_dispatch::{
 use audit::{AuditEvent, AuditLog};
 use model::{AssistantEffect, AssistantModel, PermissionChoice, TurnRole};
 use render::{AssistantRenderer, ComposerEvent, MarkdownTextCache};
+use settings::{AssistantSettings, SessionOverrides, SettingsLoadError, SettingsLoader};
 use store::AssistantStore;
 
 const ASSISTANT_SYSTEM_PROMPT: &str = "You are the Plexi Assistant, the workspace \
@@ -178,12 +180,27 @@ fn summarize_input(input_json: &str) -> String {
     }
 }
 
+fn format_setting_ids(ids: &[String]) -> String {
+    if ids.is_empty() {
+        "none".to_string()
+    } else {
+        ids.iter()
+            .map(|id| format!("`{id}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
 /// The host Assistant pane: model + store + broker + grant wiring.
 pub struct AssistantApp {
     pub(crate) model: AssistantModel,
     store: AssistantStore,
     broker: Arc<dyn AiBroker>,
     workspace_root: PathBuf,
+    settings_loader: SettingsLoader,
+    session_overrides: SessionOverrides,
+    settings: AssistantSettings,
+    settings_errors: Vec<SettingsLoadError>,
     /// Unified broker grants (same `grants.toml` shape as `AgentHost`).
     /// Session grants are recorded in memory only; "always" grants are saved.
     grant_store: GrantStore,
@@ -271,6 +288,19 @@ impl AssistantApp {
         // Load persisted session name (if any) so it survives restarts.
         model.session_name = store.active_session_name();
         model.show_thoughts = store.show_thoughts();
+        let settings_loader = SettingsLoader::new(profile_dir, &workspace_root);
+        let session_overrides = SessionOverrides::default();
+        let settings_report = settings_loader.load(&session_overrides);
+        for error in &settings_report.errors {
+            let text = format!("Assistant settings error: {error}");
+            if !model
+                .turns
+                .iter()
+                .any(|turn| turn.role == TurnRole::Error && turn.text == text)
+            {
+                model.turns.push(model::Turn::now(TurnRole::Error, text));
+            }
+        }
         let (outcome_tx, outcome_rx) = std::sync::mpsc::channel();
         let (flow_tx, flow_rx) = std::sync::mpsc::channel();
         let mut app = Self {
@@ -278,6 +308,10 @@ impl AssistantApp {
             store,
             broker,
             workspace_root,
+            settings_loader,
+            session_overrides,
+            settings: settings_report.settings,
+            settings_errors: settings_report.errors,
             grant_store: GrantStore::load_or_default(profile_dir),
             audit: AuditLog::new(profile_dir.join("audit.jsonl")),
             outcome_tx,
@@ -333,6 +367,12 @@ impl AssistantApp {
                 continue;
             };
             let (app, event) = (app.to_string(), event.to_string());
+            if self.event_stream_decision(&app, &event) != Decision::Allow {
+                log::info!(
+                    "assistant: persisted subscription '{target}' withheld by permission posture"
+                );
+                continue;
+            }
             self.subscribe_stream(&app, &event);
         }
         log::info!(
@@ -349,7 +389,11 @@ impl AssistantApp {
             log::info!("assistant: already subscribed to '{target}'");
             return;
         }
-        let event_names = if event == "*" { Vec::new() } else { vec![event.to_string()] };
+        let event_names = if event == "*" {
+            Vec::new()
+        } else {
+            vec![event.to_string()]
+        };
         let subscription_id = crate::host::event_subscriptions::record_subscription(
             &self.timeline,
             app,
@@ -399,6 +443,9 @@ impl AssistantApp {
                 AssistantEffect::ListPermissions => self.cmd_list_permissions(),
                 AssistantEffect::RevokeGrant { target_id } => self.cmd_revoke(&target_id),
                 AssistantEffect::ShowAudit => self.cmd_show_audit(),
+                AssistantEffect::ShowSettings => self.cmd_show_settings(),
+                AssistantEffect::ShowModelSetting => self.cmd_show_model_setting(),
+                AssistantEffect::SetSessionModel(tier) => self.set_session_model(tier),
                 AssistantEffect::PersistShowThoughts(show) => {
                     if let Err(e) = self.store.set_show_thoughts(show) {
                         log::error!("assistant: failed to persist show_thoughts={show}: {e}");
@@ -423,15 +470,39 @@ impl AssistantApp {
     }
 
     /// Evaluate one app connector tool for the assistant actor.
-    fn tool_decision(&self, tool: &str) -> Decision {
+    fn tool_decision(&self, tool: &AiTool) -> Decision {
+        if self.settings.permissions.posture.value == settings::AssistantPermissionPosture::Plan
+            && !tool.read_only
+        {
+            return Decision::Deny;
+        }
         let req = PermissionRequest::new(
             ActorType::Agent,
             ASSISTANT_ACTOR_ID,
             TargetType::AppConnector,
-            &Self::connector_target(tool),
+            &Self::connector_target(&tool.name),
             Some(&self.workspace_root),
         );
-        self.grant_store.evaluate(&req, None)
+        let posture = self.settings.permissions.broker_posture();
+        self.grant_store.evaluate(&req, Some(&posture))
+    }
+
+    fn event_stream_decision(&self, app: &str, event: &str) -> Decision {
+        let event_names = if event == "*" {
+            Vec::new()
+        } else {
+            vec![event.to_string()]
+        };
+        let posture = self.settings.permissions.broker_posture();
+        crate::host::event_subscriptions::evaluate_subscription(
+            &self.grant_store,
+            Some(&posture),
+            &self.workspace_root,
+            app,
+            ActorType::Agent,
+            ASSISTANT_ACTOR_ID,
+            &event_names,
+        )
     }
 
     /// Build the broker-gated dispatcher for one turn: denied tools are
@@ -448,7 +519,7 @@ impl AssistantApp {
         let mut denied = 0usize;
         let mut ro_auto = 0usize;
         for tool in dispatcher.all_tools() {
-            match self.tool_decision(&tool.name) {
+            match self.tool_decision(&tool) {
                 // Read-only tools skip the ask prompt (no permission sheet) but
                 // still respect explicit Deny grants — an admin deny wins.
                 Decision::Allow | Decision::Ask if tool.read_only => {
@@ -631,16 +702,7 @@ impl AssistantApp {
                     let _ = reply.send(ok(format!("already subscribed to {target}")));
                     return;
                 }
-                let event_names = if event == "*" { Vec::new() } else { vec![event.clone()] };
-                match crate::host::event_subscriptions::evaluate_subscription(
-                    &self.grant_store,
-                    None,
-                    &self.workspace_root,
-                    &app,
-                    ActorType::Agent,
-                    ASSISTANT_ACTOR_ID,
-                    &event_names,
-                ) {
+                match self.event_stream_decision(&app, &event) {
                     Decision::Allow => {
                         self.subscribe_stream(&app, &event);
                         self.audit
@@ -699,7 +761,7 @@ impl AssistantApp {
         let dispatcher = self.gated_dispatcher();
         let request = AiBrokerRequest {
             app_id: "assistant".to_string(),
-            model_tier: ModelTier::Medium,
+            model_tier: self.settings.model.tier.value,
             system: ASSISTANT_SYSTEM_PROMPT.to_string(),
             messages: self.history_messages(),
             tools: Vec::new(),
@@ -1118,6 +1180,95 @@ impl AssistantApp {
         });
     }
 
+    fn reload_settings(&mut self) {
+        let report = self.settings_loader.load(&self.session_overrides);
+        self.settings = report.settings;
+        self.settings_errors = report.errors;
+    }
+
+    fn set_session_model(&mut self, tier: ModelTier) {
+        self.session_overrides.model_tier = Some(tier);
+        self.reload_settings();
+        log::info!(
+            "assistant[{}]: session model tier changed to {}",
+            self.model.conversation_id,
+            settings::model_tier_name(tier)
+        );
+        let effects = self.model.push_info(format!(
+            "Model tier set to `{}` for this session.",
+            settings::model_tier_name(tier)
+        ));
+        self.execute_effects(effects);
+    }
+
+    fn cmd_show_model_setting(&mut self) {
+        self.reload_settings();
+        let tier = &self.settings.model.tier;
+        log::info!(
+            "assistant: /model showing {} from {}",
+            settings::model_tier_name(tier.value),
+            tier.source.description()
+        );
+        let effects = self.model.push_info(format!(
+            "Model tier: `{}` ({}).",
+            settings::model_tier_name(tier.value),
+            tier.source.description()
+        ));
+        self.execute_effects(effects);
+    }
+
+    fn cmd_show_settings(&mut self) {
+        self.reload_settings();
+        let tier = &self.settings.model.tier;
+        let mut text = format!(
+            "**Assistant settings**\n\n- Model tier: `{}` ({})\n\
+             - Permission posture: `{}` ({})\n\
+             - Enabled tools: {} ({})\n\
+             - Memory: {} ({})\n\
+             - Enabled hooks: {} ({})\n",
+            settings::model_tier_name(tier.value),
+            tier.source.description(),
+            self.settings.permissions.posture.value.as_str(),
+            self.settings.permissions.posture.source.description(),
+            format_setting_ids(&self.settings.tools.enabled.value),
+            self.settings.tools.enabled.source.description(),
+            if self.settings.memory.enabled.value {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            self.settings.memory.enabled.source.description(),
+            format_setting_ids(&self.settings.hooks.enabled.value),
+            self.settings.hooks.enabled.source.description()
+        );
+        if self.settings.permissions.rules.is_empty() {
+            text.push_str("- Permission rules: none\n");
+        } else {
+            text.push_str("- Permission rules:\n");
+            for rule in &self.settings.permissions.rules {
+                text.push_str(&format!(
+                    "  - `{}`: {} ({})\n",
+                    rule.rule,
+                    rule.decision.as_str(),
+                    rule.source.description()
+                ));
+            }
+        }
+        if !self.settings_errors.is_empty() {
+            text.push_str("\n**Load errors**\n\n");
+            for error in &self.settings_errors {
+                text.push_str(&format!("- {error}\n"));
+            }
+        }
+        log::info!(
+            "assistant: /settings showing {} permission rule(s), {} load error(s)",
+            self.settings.permissions.rules.len(),
+            self.settings_errors.len()
+        );
+        let effects = self.model.push_info(text);
+        self.execute_effects(effects);
+    }
+
     /// `/tools`: discovered app connector tools with their broker decisions.
     fn cmd_list_tools(&mut self) {
         let dispatcher = ToolDispatcher::from_registry(
@@ -1141,7 +1292,7 @@ impl AssistantApp {
                 out.push_str(&format!(
                     "{} — {}\n",
                     Self::connector_target(&tool.name),
-                    self.tool_decision(&tool.name).as_str()
+                    self.tool_decision(&tool).as_str()
                 ));
             }
             out
@@ -1152,14 +1303,7 @@ impl AssistantApp {
             text.push_str("\nApp event streams (host.events.subscribe / unsubscribe):\n");
             for (app, event) in streams {
                 let target = format!("{app}::{event}");
-                let req = PermissionRequest::new(
-                    ActorType::Agent,
-                    ASSISTANT_ACTOR_ID,
-                    TargetType::AppEventStream,
-                    &target,
-                    Some(&self.workspace_root),
-                );
-                let decision = self.grant_store.evaluate(&req, None);
+                let decision = self.event_stream_decision(&app, &event);
                 let subscribed = self.live_subs.iter().any(|(t, _)| *t == target);
                 text.push_str(&format!(
                     "{target} — {}{}\n",
@@ -1194,7 +1338,7 @@ impl AssistantApp {
                     tools.len()
                 ));
                 for tool in &tools {
-                    let decision = self.tool_decision(&tool.name);
+                    let decision = self.tool_decision(tool);
                     let kind = if tool.read_only { "read" } else { "mutate" };
                     out.push_str(&format!(
                         "  {} [{}] — {}\n",
@@ -1526,6 +1670,87 @@ mod tests {
     }
 
     #[test]
+    fn resolved_settings_deny_is_enforced_by_the_permission_broker() {
+        let ws = tempfile::tempdir().unwrap();
+        let settings_path = ws.path().join("agents/settings.toml");
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            settings_path,
+            "[permissions]\ndeny = [\"app.csv.read_range\"]\n",
+        )
+        .unwrap();
+        let app = test_app(ws.path());
+        let (tx, _rx) = std::sync::mpsc::channel();
+        tool_dispatch::register(
+            9206,
+            "csv".to_string(),
+            vec![crate::app_protocol::AiTool {
+                name: "csv.read_range".to_string(),
+                description: "read cells".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+                timeout_ms: None,
+                read_only: true,
+            }],
+            AppEventSender { tx },
+            ws.path().to_path_buf(),
+        );
+
+        let visible: Vec<String> = app
+            .gated_dispatcher()
+            .all_tools()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+
+        assert!(!visible.contains(&"csv.read_range".to_string()));
+        tool_dispatch::unregister(9206);
+    }
+
+    #[test]
+    fn plan_posture_hides_mutating_connector_despite_allow_grant_but_keeps_reads() {
+        let ws = tempfile::tempdir().unwrap();
+        let settings_path = ws.path().join("agents/settings.toml");
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(settings_path, "[permissions]\ndefault_posture = \"plan\"\n").unwrap();
+        let mut app = test_app(ws.path());
+        let (tx, _rx) = std::sync::mpsc::channel();
+        tool_dispatch::register(
+            9207,
+            "csv".to_string(),
+            vec![
+                crate::app_protocol::AiTool {
+                    name: "csv.read_range".to_string(),
+                    description: "read cells".to_string(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                    timeout_ms: None,
+                    read_only: true,
+                },
+                crate::app_protocol::AiTool {
+                    name: "csv.write_cell".to_string(),
+                    description: "write a cell".to_string(),
+                    input_schema: serde_json::json!({"type": "object"}),
+                    timeout_ms: None,
+                    read_only: false,
+                },
+            ],
+            AppEventSender { tx },
+            ws.path().to_path_buf(),
+        );
+        seed_grant(&mut app, "app.csv.write_cell", Decision::Allow);
+
+        let visible: HashSet<String> = app
+            .gated_dispatcher()
+            .all_tools()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect();
+
+        assert!(visible.contains("csv.read_range"));
+        assert!(!visible.contains("csv.write_cell"));
+        tool_dispatch::unregister(9207);
+    }
+
+    #[test]
     fn apps_command_lists_running_app_connectors() {
         let ws = tempfile::tempdir().unwrap();
         let mut app = test_app(ws.path());
@@ -1628,7 +1853,13 @@ mod tests {
                 read_only: false,
             })
             .collect();
-        tool_dispatch::register(pane_id, "test-app".to_string(), tools, AppEventSender { tx }, ws);
+        tool_dispatch::register(
+            pane_id,
+            "test-app".to_string(),
+            tools,
+            AppEventSender { tx },
+            ws,
+        );
         std::thread::spawn(move || {
             while let Ok(item) = rx.recv() {
                 let crate::process_app::StdinItem::Event(json) = item else {
@@ -2419,6 +2650,89 @@ mod tests {
     }
 
     #[test]
+    fn resolved_settings_deny_blocks_event_subscription() {
+        let ws = tempfile::tempdir().unwrap();
+        let settings_path = ws.path().join("agents/settings.toml");
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            settings_path,
+            "[permissions]\ndeny = [\"chess::move.played\"]\n",
+        )
+        .unwrap();
+        let timeline = chess_timeline();
+        let mut app = test_app_with_timeline(ws.path(), timeline.clone());
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+
+        app.handle_host_call(
+            HOST_TOOL_SUBSCRIBE,
+            r#"{"app": "chess", "event": "move.played"}"#,
+            tx,
+        );
+
+        let result = rx.try_recv().expect("settings deny replies synchronously");
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("permission_denied"));
+        assert!(app.live_subs.is_empty());
+        assert!(timeline.lock().unwrap().subscriptions().is_empty());
+    }
+
+    #[test]
+    fn plan_posture_allows_read_only_event_subscription_when_rule_allows() {
+        let ws = tempfile::tempdir().unwrap();
+        let settings_path = ws.path().join("agents/settings.toml");
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            settings_path,
+            "[permissions]\ndefault_posture = \"plan\"\nallow = [\"chess::move.played\"]\n",
+        )
+        .unwrap();
+        let timeline = chess_timeline();
+        let mut app = test_app_with_timeline(ws.path(), timeline.clone());
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+
+        app.handle_host_call(
+            HOST_TOOL_SUBSCRIBE,
+            r#"{"app": "chess", "event": "move.played"}"#,
+            tx,
+        );
+
+        let result = rx
+            .try_recv()
+            .expect("an allowed subscription replies synchronously");
+        assert!(result.error.is_none(), "{:?}", result.error);
+        assert_eq!(app.live_subs.len(), 1);
+        assert_eq!(timeline.lock().unwrap().subscriptions().len(), 1);
+    }
+
+    #[test]
+    fn tools_view_reports_resolved_event_stream_decision() {
+        let ws = tempfile::tempdir().unwrap();
+        let settings_path = ws.path().join("agents/settings.toml");
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            settings_path,
+            "[permissions]\ndeny = [\"chess::move.played\"]\n",
+        )
+        .unwrap();
+        let mut app = test_app_with_timeline(ws.path(), chess_timeline());
+
+        app.model.composer = "/tools".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+
+        assert!(app
+            .model
+            .turns
+            .last()
+            .unwrap()
+            .text
+            .contains("chess::move.played — deny"));
+    }
+
+    #[test]
     fn host_unsubscribe_removes_live_subscription() {
         let ws = tempfile::tempdir().unwrap();
         let timeline = chess_timeline();
@@ -2473,5 +2787,158 @@ mod tests {
         app.execute_effects(effects);
         wait_for_turn(&mut app);
         assert_eq!(app.model.turns.last().unwrap().role, TurnRole::Error);
+    }
+
+    #[test]
+    fn model_command_changes_session_scope_without_writing_settings_files() {
+        let ws = tempfile::tempdir().unwrap();
+        let user_path = ws.path().join("agents/settings.toml");
+        let workspace_agents = ws
+            .path()
+            .join(crate::config::workspace_channel_dir())
+            .join("agents");
+        let workspace_path = workspace_agents.join("settings.toml");
+        let local_path = workspace_agents.join("settings.local.toml");
+        let mut app = test_app(ws.path());
+
+        app.model.composer = "/model high".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+
+        assert_eq!(app.session_overrides.model_tier, Some(ModelTier::High));
+        assert_eq!(app.settings.model.tier.value, ModelTier::High);
+        assert_eq!(
+            app.settings.model.tier.source.scope,
+            settings::SettingsScope::Session
+        );
+        assert!(app
+            .model
+            .turns
+            .last()
+            .unwrap()
+            .text
+            .contains("this session"));
+        assert!(!user_path.is_file());
+        assert!(!workspace_path.is_file());
+        assert!(!local_path.is_file());
+    }
+
+    #[test]
+    fn model_without_args_shows_the_resolved_tier_and_source() {
+        let ws = tempfile::tempdir().unwrap();
+        let settings_path = ws.path().join("agents/settings.toml");
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(&settings_path, "[model]\ntier = \"low\"\n").unwrap();
+        let mut app = test_app(ws.path());
+
+        app.model.composer = "/model".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+
+        let output = &app.model.turns.last().unwrap().text;
+        assert!(output.contains("`low`") && output.contains("user"));
+    }
+
+    #[test]
+    fn settings_and_config_commands_show_the_same_resolved_view() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = test_app(ws.path());
+
+        app.model.composer = "/settings".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        let settings_output = app.model.turns.last().unwrap().text.clone();
+
+        app.model.composer = "/config".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        let config_output = &app.model.turns.last().unwrap().text;
+
+        assert_eq!(config_output, &settings_output);
+    }
+
+    #[test]
+    fn settings_command_shows_tools_memory_and_hooks_with_sources() {
+        let ws = tempfile::tempdir().unwrap();
+        let settings_path = ws.path().join("agents/settings.toml");
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &settings_path,
+            "[tools]\nenabled = [\"host.panes.read\"]\n\
+             [memory]\nenabled = true\n\
+             [hooks]\nenabled = [\"turn.finished\"]\n",
+        )
+        .unwrap();
+        let mut app = test_app(ws.path());
+
+        app.model.composer = "/settings".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+
+        let output = &app.model.turns.last().unwrap().text;
+        assert!(output.contains("Enabled tools: `host.panes.read` (user"));
+        assert!(output.contains("Memory: enabled (user"));
+        assert!(output.contains("Enabled hooks: `turn.finished` (user"));
+    }
+
+    #[test]
+    fn invalid_settings_toml_is_visible_without_preventing_startup() {
+        let ws = tempfile::tempdir().unwrap();
+        let settings_path = ws.path().join("agents/settings.toml");
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(&settings_path, "[model\ntier = nope").unwrap();
+
+        let app = test_app(ws.path());
+
+        let error = app
+            .model
+            .turns
+            .iter()
+            .find(|turn| turn.role == TurnRole::Error)
+            .expect("settings parse error must be visible in the transcript");
+        assert!(error
+            .text
+            .contains(settings_path.to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn reopening_with_the_same_settings_error_does_not_duplicate_the_row() {
+        let ws = tempfile::tempdir().unwrap();
+        let settings_path = ws.path().join("agents/settings.toml");
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(&settings_path, "[model\ntier = nope").unwrap();
+
+        drop(test_app(ws.path()));
+        let reopened = test_app(ws.path());
+        let matching_errors = reopened
+            .model
+            .turns
+            .iter()
+            .filter(|turn| {
+                turn.role == TurnRole::Error
+                    && turn.text.contains(settings_path.to_string_lossy().as_ref())
+            })
+            .count();
+
+        assert_eq!(matching_errors, 1);
+    }
+
+    #[test]
+    fn settings_read_error_is_visible_without_preventing_startup() {
+        let ws = tempfile::tempdir().unwrap();
+        let settings_path = ws.path().join("agents/settings.toml");
+        std::fs::create_dir_all(&settings_path).unwrap();
+
+        let app = test_app(ws.path());
+
+        let error = app
+            .model
+            .turns
+            .iter()
+            .find(|turn| turn.role == TurnRole::Error)
+            .expect("settings read error must be visible in the transcript");
+        assert!(error
+            .text
+            .contains(settings_path.to_string_lossy().as_ref()));
     }
 }

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -5,6 +5,7 @@
 //! shell (`AssistantApp`) executes them.
 
 use super::commands::{self, ParsedCommand};
+use crate::app_protocol::ModelTier;
 
 /// Who produced a transcript row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -117,6 +118,12 @@ pub enum AssistantEffect {
     RevokeGrant { target_id: String },
     /// `/audit`: show recent audit events.
     ShowAudit,
+    /// `/settings` and `/config`: show the resolved Assistant settings.
+    ShowSettings,
+    /// `/model`: show the resolved model tier and its source.
+    ShowModelSetting,
+    /// `/model low|medium|high`: override the model tier for this session.
+    SetSessionModel(ModelTier),
     /// `/thoughts`: persist the flipped show-thoughts preference.
     PersistShowThoughts(bool),
     /// `/clear` or `/new` ran while a turn was in flight: unblock any worker
@@ -416,6 +423,31 @@ impl AssistantModel {
             "apps" => vec![AssistantEffect::ListApps],
             "permissions" => vec![AssistantEffect::ListPermissions],
             "audit" => vec![AssistantEffect::ShowAudit],
+            "settings" | "config" => vec![AssistantEffect::ShowSettings],
+            "model" if cmd.args.is_empty() => vec![AssistantEffect::ShowModelSetting],
+            "model" => {
+                let tier = match cmd.args.as_str() {
+                    "low" => Some(ModelTier::Low),
+                    "medium" => Some(ModelTier::Medium),
+                    "high" => Some(ModelTier::High),
+                    _ => None,
+                };
+                match tier {
+                    Some(tier) => vec![AssistantEffect::SetSessionModel(tier)],
+                    None => {
+                        self.turns.push(Turn::now(
+                            TurnRole::Error,
+                            format!(
+                                "Invalid model tier '{}'. Expected low | medium | high.",
+                                cmd.args
+                            ),
+                        ));
+                        vec![AssistantEffect::SessionWrite {
+                            conversation_id: self.conversation_id.clone(),
+                        }]
+                    }
+                }
+            }
             "revoke" => {
                 if cmd.args.is_empty() {
                     self.turns.push(Turn::now(
@@ -857,6 +889,62 @@ mod tests {
         let effects = submitted(&mut m, "/revoke");
         assert!(matches!(&effects[0], AssistantEffect::SessionWrite { .. }));
         assert_eq!(m.turns.last().unwrap().role, TurnRole::Error);
+    }
+
+    #[test]
+    fn settings_and_config_commands_are_equivalent() {
+        let mut settings_model = AssistantModel::fresh();
+        let mut config_model = AssistantModel::fresh();
+
+        let settings_effects = submitted(&mut settings_model, "/settings");
+        let config_effects = submitted(&mut config_model, "/config");
+
+        assert_eq!(settings_effects, config_effects);
+        assert_eq!(settings_effects, vec![AssistantEffect::ShowSettings]);
+    }
+
+    #[test]
+    fn model_without_args_requests_the_resolved_setting() {
+        let mut model = AssistantModel::fresh();
+
+        let effects = submitted(&mut model, "/model");
+
+        assert_eq!(effects, vec![AssistantEffect::ShowModelSetting]);
+    }
+
+    #[test]
+    fn model_with_valid_tier_requests_a_session_override() {
+        let mut model = AssistantModel::fresh();
+
+        let effects = submitted(&mut model, "/model high");
+
+        assert_eq!(
+            effects,
+            vec![AssistantEffect::SetSessionModel(
+                crate::app_protocol::ModelTier::High
+            )]
+        );
+    }
+
+    #[test]
+    fn model_rejects_invalid_tier_without_requesting_a_mutation() {
+        let mut model = AssistantModel::fresh();
+
+        let effects = submitted(&mut model, "/model turbo");
+
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, AssistantEffect::SetSessionModel(_))),
+            "invalid tier must not request a settings mutation: {effects:?}"
+        );
+        assert_eq!(model.turns.last().unwrap().role, TurnRole::Error);
+        assert!(model
+            .turns
+            .last()
+            .unwrap()
+            .text
+            .contains("low | medium | high"));
     }
 
     #[test]

--- a/src/assistant/settings.rs
+++ b/src/assistant/settings.rs
@@ -1,0 +1,895 @@
+//! Typed, layered settings for the host Assistant.
+
+use std::path::{Path, PathBuf};
+
+use crate::app_protocol::ModelTier;
+use crate::broker::Decision;
+
+pub fn model_tier_name(tier: ModelTier) -> &'static str {
+    match tier {
+        ModelTier::Low => "low",
+        ModelTier::Medium => "medium",
+        ModelTier::High => "high",
+    }
+}
+
+/// One Assistant settings layer, in increasing precedence order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsScope {
+    Default,
+    User,
+    Workspace,
+    Local,
+    Session,
+}
+
+impl std::fmt::Display for SettingsScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Default => "default",
+            Self::User => "user",
+            Self::Workspace => "workspace",
+            Self::Local => "local",
+            Self::Session => "session",
+        })
+    }
+}
+
+/// Where one resolved setting came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingSource {
+    pub scope: SettingsScope,
+    pub path: Option<PathBuf>,
+}
+
+impl SettingSource {
+    fn defaults() -> Self {
+        Self {
+            scope: SettingsScope::Default,
+            path: None,
+        }
+    }
+
+    pub fn description(&self) -> String {
+        match &self.path {
+            Some(path) => format!("{} ({})", self.scope, path.display()),
+            None => self.scope.to_string(),
+        }
+    }
+}
+
+/// A resolved value together with the scope that supplied it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Sourced<T> {
+    pub value: T,
+    pub source: SettingSource,
+}
+
+/// Model settings after all active scopes have been applied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModelSettings {
+    pub tier: Sourced<ModelTier>,
+}
+
+/// Tool ids enabled by the active settings scope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolsSettings {
+    pub enabled: Sourced<Vec<String>>,
+}
+
+/// Whether Assistant memory is enabled by the active settings scope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MemorySettings {
+    pub enabled: Sourced<bool>,
+}
+
+/// Hook ids enabled by the active settings scope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HooksSettings {
+    pub enabled: Sourced<Vec<String>>,
+}
+
+/// Product-level default posture for Assistant permissions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssistantPermissionPosture {
+    Review,
+    Plan,
+    Work,
+    Locked,
+}
+
+impl AssistantPermissionPosture {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Review => "review",
+            Self::Plan => "plan",
+            Self::Work => "work",
+            Self::Locked => "locked",
+        }
+    }
+
+    fn broker_default(self) -> Decision {
+        match self {
+            Self::Review | Self::Plan | Self::Work => Decision::Ask,
+            Self::Locked => Decision::Deny,
+        }
+    }
+}
+
+fn decision_precedence(decision: Decision) -> u8 {
+    match decision {
+        Decision::Allow => 0,
+        Decision::Ask => 1,
+        Decision::Deny => 2,
+    }
+}
+
+/// One deduplicated permission rule after scope and decision merging.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedPermissionRule {
+    pub rule: String,
+    pub decision: Decision,
+    pub source: SettingSource,
+}
+
+/// Permission rules after all active scopes have been merged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PermissionSettings {
+    pub posture: Sourced<AssistantPermissionPosture>,
+    pub rules: Vec<ResolvedPermissionRule>,
+}
+
+impl Default for PermissionSettings {
+    fn default() -> Self {
+        Self {
+            posture: Sourced {
+                value: AssistantPermissionPosture::Review,
+                source: SettingSource::defaults(),
+            },
+            rules: Vec::new(),
+        }
+    }
+}
+
+impl PermissionSettings {
+    pub fn broker_posture(&self) -> crate::broker::PermissionPosture {
+        let mut posture = crate::broker::PermissionPosture {
+            default_posture: self.posture.value.broker_default(),
+            allow: Vec::new(),
+            ask: Vec::new(),
+            deny: Vec::new(),
+        };
+        for rule in &self.rules {
+            match rule.decision {
+                Decision::Allow => posture.allow.push(rule.rule.clone()),
+                Decision::Ask => posture.ask.push(rule.rule.clone()),
+                Decision::Deny => posture.deny.push(rule.rule.clone()),
+            }
+        }
+        posture
+    }
+
+    fn merge(&mut self, overrides: &PermissionRuleOverrides, source: &SettingSource) {
+        if let Some(default_posture) = overrides.default_posture {
+            self.posture = Sourced {
+                value: default_posture,
+                source: source.clone(),
+            };
+        }
+        self.merge_rules(&overrides.allow, Decision::Allow, source);
+        self.merge_rules(&overrides.ask, Decision::Ask, source);
+        self.merge_rules(&overrides.deny, Decision::Deny, source);
+    }
+
+    fn merge_rules(&mut self, rules: &[String], decision: Decision, source: &SettingSource) {
+        for rule in rules {
+            if let Some(existing) = self.rules.iter_mut().find(|entry| entry.rule == *rule) {
+                if decision_precedence(decision) > decision_precedence(existing.decision) {
+                    existing.decision = decision;
+                    existing.source = source.clone();
+                } else if decision == existing.decision {
+                    existing.source = source.clone();
+                }
+            } else {
+                self.rules.push(ResolvedPermissionRule {
+                    rule: rule.clone(),
+                    decision,
+                    source: source.clone(),
+                });
+            }
+        }
+    }
+}
+
+/// Assistant settings after all active scopes have been applied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssistantSettings {
+    pub model: ModelSettings,
+    pub tools: ToolsSettings,
+    pub memory: MemorySettings,
+    pub hooks: HooksSettings,
+    pub permissions: PermissionSettings,
+}
+
+impl Default for AssistantSettings {
+    fn default() -> Self {
+        Self {
+            model: ModelSettings {
+                tier: Sourced {
+                    value: ModelTier::Medium,
+                    source: SettingSource::defaults(),
+                },
+            },
+            tools: ToolsSettings {
+                enabled: Sourced {
+                    value: Vec::new(),
+                    source: SettingSource::defaults(),
+                },
+            },
+            memory: MemorySettings {
+                enabled: Sourced {
+                    value: false,
+                    source: SettingSource::defaults(),
+                },
+            },
+            hooks: HooksSettings {
+                enabled: Sourced {
+                    value: Vec::new(),
+                    source: SettingSource::defaults(),
+                },
+            },
+            permissions: PermissionSettings::default(),
+        }
+    }
+}
+
+/// Allow, ask, and deny rules contributed by one settings scope.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PermissionRuleOverrides {
+    #[serde(default)]
+    pub default_posture: Option<AssistantPermissionPosture>,
+    #[serde(default)]
+    pub allow: Vec<String>,
+    #[serde(default)]
+    pub ask: Vec<String>,
+    #[serde(default)]
+    pub deny: Vec<String>,
+}
+
+impl PermissionRuleOverrides {
+    fn is_empty(&self) -> bool {
+        self.default_posture.is_none()
+            && self.allow.is_empty()
+            && self.ask.is_empty()
+            && self.deny.is_empty()
+    }
+}
+
+/// Temporary settings owned by one Assistant pane session.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SessionOverrides {
+    pub model_tier: Option<ModelTier>,
+    pub permissions: PermissionRuleOverrides,
+}
+
+/// One settings file that could not be read or parsed.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SettingsLoadError {
+    #[error("failed to read {scope} Assistant settings at {}: {cause}", path.display())]
+    Read {
+        scope: SettingsScope,
+        path: PathBuf,
+        cause: String,
+    },
+    #[error("failed to parse {scope} Assistant settings at {}: {cause}", path.display())]
+    Parse {
+        scope: SettingsScope,
+        path: PathBuf,
+        cause: String,
+    },
+}
+
+/// Resolved settings plus every recoverable layer error encountered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsLoadReport {
+    pub settings: AssistantSettings,
+    pub errors: Vec<SettingsLoadError>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SettingsFile {
+    #[serde(default)]
+    model: ModelFile,
+    #[serde(default)]
+    tools: ToolsFile,
+    #[serde(default)]
+    memory: MemoryFile,
+    #[serde(default)]
+    hooks: HooksFile,
+    #[serde(default)]
+    permissions: PermissionRuleOverrides,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ModelFile {
+    tier: Option<ModelTier>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ToolsFile {
+    enabled: Option<Vec<String>>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MemoryFile {
+    enabled: Option<bool>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HooksFile {
+    enabled: Option<Vec<String>>,
+}
+
+/// Resolves channel-scoped user, workspace, local, and session settings.
+pub struct SettingsLoader {
+    user_path: PathBuf,
+    workspace_path: PathBuf,
+    local_path: PathBuf,
+}
+
+impl SettingsLoader {
+    pub fn new(profile_dir: &Path, workspace_root: &Path) -> Self {
+        let workspace_agents_dir = workspace_root
+            .join(crate::config::workspace_channel_dir())
+            .join("agents");
+        Self {
+            user_path: profile_dir.join("agents/settings.toml"),
+            workspace_path: workspace_agents_dir.join("settings.toml"),
+            local_path: workspace_agents_dir.join("settings.local.toml"),
+        }
+    }
+
+    pub fn load(&self, session: &SessionOverrides) -> SettingsLoadReport {
+        let mut settings = AssistantSettings::default();
+        let mut errors = Vec::new();
+        Self::apply_scope(
+            &mut settings,
+            &mut errors,
+            SettingsScope::User,
+            &self.user_path,
+        );
+        Self::apply_scope(
+            &mut settings,
+            &mut errors,
+            SettingsScope::Workspace,
+            &self.workspace_path,
+        );
+        Self::apply_scope(
+            &mut settings,
+            &mut errors,
+            SettingsScope::Local,
+            &self.local_path,
+        );
+        if let Some(tier) = session.model_tier {
+            settings.model.tier = Sourced {
+                value: tier,
+                source: SettingSource {
+                    scope: SettingsScope::Session,
+                    path: None,
+                },
+            };
+            log::info!(
+                "assistant settings: applied session model tier {}",
+                model_tier_name(tier)
+            );
+        }
+        if !session.permissions.is_empty() {
+            settings.permissions.merge(
+                &session.permissions,
+                &SettingSource {
+                    scope: SettingsScope::Session,
+                    path: None,
+                },
+            );
+            log::info!("assistant settings: applied session permission rules");
+        }
+        SettingsLoadReport { settings, errors }
+    }
+
+    fn apply_scope(
+        settings: &mut AssistantSettings,
+        errors: &mut Vec<SettingsLoadError>,
+        scope: SettingsScope,
+        path: &Path,
+    ) {
+        match Self::load_file(scope, path) {
+            Ok(Some(file)) => {
+                Self::apply_file(
+                    settings,
+                    file,
+                    SettingSource {
+                        scope,
+                        path: Some(path.to_path_buf()),
+                    },
+                );
+                log::info!(
+                    "assistant settings: loaded {scope} scope from {}",
+                    path.display()
+                );
+            }
+            Ok(None) => {}
+            Err(error) => {
+                log::error!("assistant settings: {error}");
+                errors.push(error);
+            }
+        }
+    }
+
+    fn load_file(
+        scope: SettingsScope,
+        path: &Path,
+    ) -> Result<Option<SettingsFile>, SettingsLoadError> {
+        let raw = match std::fs::read_to_string(path) {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(SettingsLoadError::Read {
+                    scope,
+                    path: path.to_path_buf(),
+                    cause: error.to_string(),
+                });
+            }
+        };
+        toml::from_str(&raw)
+            .map(Some)
+            .map_err(|error| SettingsLoadError::Parse {
+                scope,
+                path: path.to_path_buf(),
+                cause: error.to_string(),
+            })
+    }
+
+    fn apply_file(settings: &mut AssistantSettings, file: SettingsFile, source: SettingSource) {
+        if let Some(tier) = file.model.tier {
+            settings.model.tier = Sourced {
+                value: tier,
+                source: source.clone(),
+            };
+        }
+        if let Some(enabled) = file.tools.enabled {
+            settings.tools.enabled = Sourced {
+                value: enabled,
+                source: source.clone(),
+            };
+        }
+        if let Some(enabled) = file.memory.enabled {
+            settings.memory.enabled = Sourced {
+                value: enabled,
+                source: source.clone(),
+            };
+        }
+        if let Some(enabled) = file.hooks.enabled {
+            settings.hooks.enabled = Sourced {
+                value: enabled,
+                source: source.clone(),
+            };
+        }
+        settings.permissions.merge(&file.permissions, &source);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_settings(path: &std::path::Path, raw: &str) {
+        std::fs::create_dir_all(path.parent().expect("settings path has a parent")).unwrap();
+        std::fs::write(path, raw).unwrap();
+    }
+
+    #[test]
+    fn defaults_use_medium_model_tier_with_default_source() {
+        let settings = AssistantSettings::default();
+
+        assert_eq!(
+            settings.model.tier.value,
+            crate::app_protocol::ModelTier::Medium
+        );
+        assert_eq!(settings.model.tier.source.scope, SettingsScope::Default);
+        assert_eq!(settings.tools.enabled.value, Vec::<String>::new());
+        assert_eq!(settings.tools.enabled.source.scope, SettingsScope::Default);
+        assert!(!settings.memory.enabled.value);
+        assert_eq!(settings.memory.enabled.source.scope, SettingsScope::Default);
+        assert_eq!(settings.hooks.enabled.value, Vec::<String>::new());
+        assert_eq!(settings.hooks.enabled.source.scope, SettingsScope::Default);
+        assert_eq!(
+            settings.permissions.posture,
+            Sourced {
+                value: AssistantPermissionPosture::Review,
+                source: SettingSource {
+                    scope: SettingsScope::Default,
+                    path: None,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn default_permission_posture_is_review_and_maps_to_broker_ask() {
+        let settings = AssistantSettings::default();
+
+        assert_eq!(
+            settings.permissions.posture.value,
+            AssistantPermissionPosture::Review
+        );
+        assert_eq!(
+            settings.permissions.broker_posture().default_posture,
+            crate::broker::Decision::Ask
+        );
+    }
+
+    #[test]
+    fn permission_postures_map_to_unified_broker_defaults() {
+        let cases = [
+            (AssistantPermissionPosture::Review, Decision::Ask),
+            (AssistantPermissionPosture::Plan, Decision::Ask),
+            (AssistantPermissionPosture::Work, Decision::Ask),
+            (AssistantPermissionPosture::Locked, Decision::Deny),
+        ];
+
+        for (value, expected) in cases {
+            let permissions = PermissionSettings {
+                posture: Sourced {
+                    value,
+                    source: SettingSource::defaults(),
+                },
+                rules: Vec::new(),
+            };
+            assert_eq!(permissions.broker_posture().default_posture, expected);
+        }
+    }
+
+    #[test]
+    fn user_model_tier_overrides_default_and_records_its_path() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let loader = SettingsLoader::new(profile.path(), workspace.path());
+        write_settings(&loader.user_path, "[model]\ntier = \"low\"\n");
+
+        let report = loader.load(&SessionOverrides::default());
+
+        assert_eq!(report.settings.model.tier.value, ModelTier::Low);
+        assert_eq!(
+            report.settings.model.tier.source,
+            SettingSource {
+                scope: SettingsScope::User,
+                path: Some(loader.user_path.clone()),
+            }
+        );
+    }
+
+    #[test]
+    fn workspace_model_tier_overrides_user_scope() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let loader = SettingsLoader::new(profile.path(), workspace.path());
+        let workspace_path = workspace
+            .path()
+            .join(crate::config::workspace_channel_dir())
+            .join("agents/settings.toml");
+        write_settings(&loader.user_path, "[model]\ntier = \"low\"\n");
+        write_settings(&workspace_path, "[model]\ntier = \"high\"\n");
+
+        let report = loader.load(&SessionOverrides::default());
+
+        assert_eq!(
+            report.settings.model.tier,
+            Sourced {
+                value: ModelTier::High,
+                source: SettingSource {
+                    scope: SettingsScope::Workspace,
+                    path: Some(workspace_path),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn local_model_tier_overrides_workspace_scope() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let loader = SettingsLoader::new(profile.path(), workspace.path());
+        let agents_dir = workspace
+            .path()
+            .join(crate::config::workspace_channel_dir())
+            .join("agents");
+        let workspace_path = agents_dir.join("settings.toml");
+        let local_path = agents_dir.join("settings.local.toml");
+        write_settings(&workspace_path, "[model]\ntier = \"low\"\n");
+        write_settings(&local_path, "[model]\ntier = \"high\"\n");
+
+        let report = loader.load(&SessionOverrides::default());
+
+        assert_eq!(
+            report.settings.model.tier,
+            Sourced {
+                value: ModelTier::High,
+                source: SettingSource {
+                    scope: SettingsScope::Local,
+                    path: Some(local_path),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn local_enabled_tools_replace_workspace_and_user_tools_with_their_source() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let loader = SettingsLoader::new(profile.path(), workspace.path());
+        write_settings(
+            &loader.user_path,
+            "[tools]\nenabled = [\"host.panes.read\"]\n",
+        );
+        write_settings(
+            &loader.workspace_path,
+            "[tools]\nenabled = [\"app.csv.describe\", \"app.csv.read\"]\n",
+        );
+        write_settings(
+            &loader.local_path,
+            "[tools]\nenabled = [\"host.files.read\"]\n",
+        );
+
+        let report = loader.load(&SessionOverrides::default());
+
+        assert_eq!(
+            report.settings.tools.enabled,
+            Sourced {
+                value: vec!["host.files.read".to_string()],
+                source: SettingSource {
+                    scope: SettingsScope::Local,
+                    path: Some(loader.local_path.clone()),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn local_memory_setting_replaces_workspace_and_user_values_with_its_source() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let loader = SettingsLoader::new(profile.path(), workspace.path());
+        write_settings(&loader.user_path, "[memory]\nenabled = true\n");
+        write_settings(&loader.workspace_path, "[memory]\nenabled = false\n");
+        write_settings(&loader.local_path, "[memory]\nenabled = true\n");
+
+        let report = loader.load(&SessionOverrides::default());
+
+        assert_eq!(
+            report.settings.memory.enabled,
+            Sourced {
+                value: true,
+                source: SettingSource {
+                    scope: SettingsScope::Local,
+                    path: Some(loader.local_path.clone()),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn local_enabled_hooks_replace_workspace_and_user_hooks_with_their_source() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let loader = SettingsLoader::new(profile.path(), workspace.path());
+        write_settings(&loader.user_path, "[hooks]\nenabled = [\"turn.started\"]\n");
+        write_settings(
+            &loader.workspace_path,
+            "[hooks]\nenabled = [\"turn.finished\"]\n",
+        );
+        write_settings(
+            &loader.local_path,
+            "[hooks]\nenabled = [\"permission.requested\"]\n",
+        );
+
+        let report = loader.load(&SessionOverrides::default());
+
+        assert_eq!(
+            report.settings.hooks.enabled,
+            Sourced {
+                value: vec!["permission.requested".to_string()],
+                source: SettingSource {
+                    scope: SettingsScope::Local,
+                    path: Some(loader.local_path.clone()),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn session_model_tier_overrides_local_scope() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let loader = SettingsLoader::new(profile.path(), workspace.path());
+        write_settings(&loader.local_path, "[model]\ntier = \"low\"\n");
+        let session = SessionOverrides {
+            model_tier: Some(ModelTier::High),
+            ..SessionOverrides::default()
+        };
+
+        let report = loader.load(&session);
+
+        assert_eq!(
+            report.settings.model.tier,
+            Sourced {
+                value: ModelTier::High,
+                source: SettingSource {
+                    scope: SettingsScope::Session,
+                    path: None,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn invalid_toml_reports_its_scope_and_path_without_blocking_valid_layers() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let loader = SettingsLoader::new(profile.path(), workspace.path());
+        write_settings(&loader.user_path, "[model\ntier = nope");
+        write_settings(&loader.workspace_path, "[model]\ntier = \"high\"\n");
+
+        let report = loader.load(&SessionOverrides::default());
+
+        assert_eq!(report.settings.model.tier.value, ModelTier::High);
+        assert!(matches!(
+            report.errors.as_slice(),
+            [SettingsLoadError::Parse {
+                scope: SettingsScope::User,
+                path,
+                ..
+            }] if *path == loader.user_path
+        ));
+    }
+
+    #[test]
+    fn unsupported_settings_groups_are_reported_instead_of_silently_ignored() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let loader = SettingsLoader::new(profile.path(), workspace.path());
+        write_settings(&loader.user_path, "[quantum]\nenabled = true\n");
+
+        let report = loader.load(&SessionOverrides::default());
+
+        assert!(matches!(
+            report.errors.as_slice(),
+            [SettingsLoadError::Parse {
+                scope: SettingsScope::User,
+                path,
+                ..
+            }] if *path == loader.user_path
+        ));
+    }
+
+    #[test]
+    fn permission_rules_merge_across_scopes_and_dedupe() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let loader = SettingsLoader::new(profile.path(), workspace.path());
+        write_settings(
+            &loader.user_path,
+            "[permissions]\nallow = [\"host.panes.read\", \"app.csv.read\"]\n",
+        );
+        write_settings(
+            &loader.workspace_path,
+            "[permissions]\nallow = [\"app.csv.read\", \"app.csv.describe\"]\n",
+        );
+
+        let report = loader.load(&SessionOverrides::default());
+        let rules: Vec<(&str, Decision, SettingsScope)> = report
+            .settings
+            .permissions
+            .rules
+            .iter()
+            .map(|rule| (rule.rule.as_str(), rule.decision, rule.source.scope))
+            .collect();
+
+        assert_eq!(
+            rules,
+            vec![
+                ("host.panes.read", Decision::Allow, SettingsScope::User,),
+                ("app.csv.read", Decision::Allow, SettingsScope::Workspace,),
+                (
+                    "app.csv.describe",
+                    Decision::Allow,
+                    SettingsScope::Workspace,
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn default_permission_posture_uses_normal_scope_precedence() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let loader = SettingsLoader::new(profile.path(), workspace.path());
+        write_settings(
+            &loader.user_path,
+            "[permissions]\ndefault_posture = \"locked\"\n",
+        );
+        write_settings(
+            &loader.workspace_path,
+            "[permissions]\ndefault_posture = \"work\"\n",
+        );
+        let session = SessionOverrides {
+            permissions: PermissionRuleOverrides {
+                default_posture: Some(AssistantPermissionPosture::Plan),
+                ..PermissionRuleOverrides::default()
+            },
+            ..SessionOverrides::default()
+        };
+
+        let report = loader.load(&session);
+
+        assert_eq!(
+            report.settings.permissions.posture,
+            Sourced {
+                value: AssistantPermissionPosture::Plan,
+                source: SettingSource {
+                    scope: SettingsScope::Session,
+                    path: None,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn permission_rules_enforce_deny_then_ask_precedence_across_scopes() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let loader = SettingsLoader::new(profile.path(), workspace.path());
+        write_settings(
+            &loader.user_path,
+            "[permissions]\ndeny = [\"host.secrets.read\"]\nask = [\"app.csv.write\"]\n",
+        );
+        write_settings(
+            &loader.workspace_path,
+            "[permissions]\nask = [\"host.secrets.read\"]\nallow = [\"app.csv.write\"]\n",
+        );
+        write_settings(
+            &loader.local_path,
+            "[permissions]\nallow = [\"host.secrets.read\", \"app.csv.write\"]\n",
+        );
+        let session = SessionOverrides {
+            model_tier: None,
+            permissions: PermissionRuleOverrides {
+                allow: vec!["host.secrets.read".to_string(), "app.csv.write".to_string()],
+                ..PermissionRuleOverrides::default()
+            },
+        };
+
+        let report = loader.load(&session);
+        let rules: Vec<(&str, Decision, SettingsScope)> = report
+            .settings
+            .permissions
+            .rules
+            .iter()
+            .map(|rule| (rule.rule.as_str(), rule.decision, rule.source.scope))
+            .collect();
+
+        assert_eq!(
+            rules,
+            vec![
+                ("app.csv.write", Decision::Ask, SettingsScope::User,),
+                ("host.secrets.read", Decision::Deny, SettingsScope::User,),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Stint tasks 0226

No linked GitHub issue.

## Summary

- Loads typed Assistant settings from user, workspace, local workspace, and session scopes.
- Adds sourced model, tools, memory, hooks, and permission posture values with merged permission rules.
- Adds real `/settings`, `/config`, and session-only `/model` commands, then applies the resolved tier and permission posture at dispatch.

## Test evidence

- `cargo test --bin plexi assistant::settings`: 15 passed, 0 failed.
- `cargo test --bin plexi assistant`: 100 passed, 0 failed.
- `cargo test --bin plexi`: 1,559 passed, 0 failed, 1 PTY-only ignored.
- `cargo build`: passed.
- Conclusion: binary install required because acceptance includes real composer input, channel-scoped file loading, and installed-host logging.