### PR TITLE
feat(testing): unify scene actions (stint 0362)

### DIFF
--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -24,6 +24,7 @@
 //! Assertions are structured keys (typed matchers), never expression strings.
 //! New verbs require a scene that needs them.
 
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -33,7 +34,7 @@ use crate::host::pane::{AppRuntime, Pane};
 use crate::spatial::tiling::PaneId;
 use crate::ui_tests::PlexiUiHarness;
 
-pub const SCENE_REPORT_SCHEMA_VERSION: u32 = 1;
+pub const SCENE_REPORT_SCHEMA_VERSION: u32 = 2;
 
 // ─── Scene file format ───────────────────────────────────────────────────────
 
@@ -62,59 +63,122 @@ fn default_true() -> bool {
 #[derive(Deserialize, Debug)]
 #[serde(untagged)]
 pub enum Step {
-    /// Launch a real PGAP app process from a repo-relative app dir.
-    /// `args` are forwarded in `PlexiEvent::Init` and surface as `ctx.args` —
-    /// pass JSON state for deterministic scenes.
-    OpenApp {
-        open_app: String,
-        #[serde(default)]
-        args: Vec<String>,
-    },
-    /// Open the built-in file browser at a repo-relative (or absolute) dir.
-    OpenFileBrowser { open_file_browser: String },
-    /// Launch a sandboxed WASM component app from a repo-relative `.wasm` file.
-    /// `args` are forwarded to the guest's `init` as its argv.
-    OpenWasm {
-        open_wasm: String,
-        #[serde(default)]
-        args: Vec<String>,
-    },
-    /// Press a key combo, e.g. "cmd+b", "enter", "ctrl+shift+p".
-    Key { key: String },
+    /// Open one process, WASM, or builtin app and bind its pane id to a handle.
+    Open { open: OpenSpec },
+    /// Insert text through egui's normal text-input event path.
+    Text { text: TextSpec },
+    /// Press a key combo against a pane handle or the whole host.
+    Key { key: KeySpec },
     /// Toggle the host sidebar.
     Sidebar { sidebar: bool },
     /// Switch to the context at this router index.
     SwitchContext { switch_context: usize },
     /// Push the focused pane into a new subcontext with this name.
     PushToSubcontext { push_to_subcontext: String },
-    /// Block until the last-opened app commits its first real frame.
+    /// Block until a process app handle commits its first real frame.
     WaitAppFrame { wait_app_frame: WaitSpec },
     /// Advance N harness frames.
     RunSteps { run_steps: usize },
     /// Structured assertions — every present key must match.
     Assert { assert: AssertSpec },
+    /// Assert that the headless host accessibility tree contains an exact label.
+    AssertLabel { assert_label: AssertLabelSpec },
     /// Save a headless screenshot to `<out_dir>/<name>`.
     Shot { shot: String },
+}
+
+/// One generic app-opening request. `kind` determines which production launch
+/// path runs; `as` binds the resulting pane id for later steps.
+#[derive(Deserialize, Debug)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum OpenSpec {
+    /// Launch a real PGAP process from an app directory.
+    Process {
+        path: String,
+        #[serde(rename = "as")]
+        handle: String,
+        #[serde(default)]
+        args: Vec<String>,
+    },
+    /// Launch a reviewed raw WASM component.
+    Wasm {
+        path: String,
+        #[serde(rename = "as")]
+        handle: String,
+        #[serde(default)]
+        args: Vec<String>,
+    },
+    /// Open a compiled-in app by its production builtin id.
+    Builtin {
+        id: String,
+        #[serde(rename = "as")]
+        handle: String,
+        cwd: Option<String>,
+        #[serde(default)]
+        args: Vec<String>,
+    },
+}
+
+impl OpenSpec {
+    fn handle(&self) -> &str {
+        match self {
+            Self::Process { handle, .. }
+            | Self::Wasm { handle, .. }
+            | Self::Builtin { handle, .. } => handle,
+        }
+    }
+
+    fn target_kind(&self) -> &'static str {
+        match self {
+            Self::Process { .. } => "process",
+            Self::Wasm { .. } => "wasm",
+            Self::Builtin { .. } => "builtin",
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct TextSpec {
+    pub target: String,
+    pub value: String,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct KeySpec {
+    pub target: String,
+    pub value: String,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct AssertLabelSpec {
+    pub target: String,
+    pub label: String,
 }
 
 #[derive(Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct WaitSpec {
+    pub target: String,
     pub timeout_s: f32,
 }
 
 #[derive(Deserialize, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct AssertSpec {
+    /// Pane handle used by app lifecycle and tree assertions.
+    pub target: Option<String>,
     pub pane_count: Option<usize>,
     pub window_count: Option<usize>,
     pub context_count: Option<usize>,
     /// Portal panes across all windows.
     pub portal_count: Option<usize>,
     pub sidebar: Option<bool>,
-    /// Lifecycle of the last-opened app pane, lowercase (e.g. "running").
+    /// Lifecycle of the target app pane, lowercase (e.g. "running").
     pub lifecycle: Option<String>,
-    /// Substring match against the last-opened app's serialized L1 tree.
+    /// Substring match against the target app's serialized L1 tree.
     pub tree_contains: Option<String>,
 }
 
@@ -127,6 +191,8 @@ pub struct SceneReport {
     pub passed: bool,
     pub steps: Vec<StepResult>,
     pub shots: Vec<String>,
+    /// Symbolic pane handles resolved during this run.
+    pub handles: BTreeMap<String, PaneId>,
     pub host: HostState,
     /// Last-opened app pane state, when a scene opened one.
     pub app: Option<AppState>,
@@ -138,7 +204,52 @@ pub struct StepResult {
     pub step: String,
     pub ok: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub detail: Option<String>,
+    pub detail: Option<StepDetail>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<SceneError>,
+}
+
+#[derive(Serialize, Debug)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum StepDetail {
+    Opened {
+        target_kind: String,
+        handle: String,
+        pane_id: PaneId,
+    },
+    TextInput {
+        target: String,
+        pane_id: Option<PaneId>,
+        length: usize,
+    },
+    KeyInput {
+        target: String,
+        pane_id: Option<PaneId>,
+        value: String,
+    },
+    LabelMatched {
+        target: String,
+        pane_id: Option<PaneId>,
+        label: String,
+    },
+    Message {
+        message: String,
+    },
+}
+
+#[derive(Serialize, Debug, Clone, PartialEq, Eq)]
+pub struct SceneError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl SceneError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
 }
 
 #[derive(Serialize, Debug)]
@@ -162,9 +273,75 @@ pub struct AppState {
 
 // ─── Runner ──────────────────────────────────────────────────────────────────
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InputTarget {
+    Host,
+    Pane(PaneId),
+}
+
+#[derive(Default)]
+struct PaneHandles {
+    by_name: HashMap<String, PaneId>,
+}
+
+impl PaneHandles {
+    fn ensure_available(&self, handle: &str) -> Result<(), SceneError> {
+        if handle.trim().is_empty() {
+            return Err(SceneError::new(
+                "invalid_handle",
+                "open: symbolic handle cannot be empty",
+            ));
+        }
+        if handle == "host" {
+            return Err(SceneError::new(
+                "reserved_handle",
+                "open: 'host' is reserved for whole-host input",
+            ));
+        }
+        if self.by_name.contains_key(handle) {
+            return Err(SceneError::new(
+                "duplicate_handle",
+                format!("open: symbolic handle '{handle}' is already bound"),
+            ));
+        }
+        Ok(())
+    }
+
+    fn bind(&mut self, handle: &str, pane_id: PaneId) -> Result<(), SceneError> {
+        self.ensure_available(handle)?;
+        self.by_name.insert(handle.to_string(), pane_id);
+        Ok(())
+    }
+
+    fn resolve(&self, target: &str) -> Result<PaneId, SceneError> {
+        self.by_name.get(target).copied().ok_or_else(|| {
+            SceneError::new(
+                "missing_target",
+                format!("target '{target}' has not been opened in this scene"),
+            )
+        })
+    }
+
+    fn resolve_input(&self, target: &str) -> Result<InputTarget, SceneError> {
+        if target == "host" {
+            Ok(InputTarget::Host)
+        } else {
+            self.resolve(target).map(InputTarget::Pane)
+        }
+    }
+
+    fn report(&self) -> BTreeMap<String, PaneId> {
+        self.by_name
+            .iter()
+            .map(|(name, pane_id)| (name.clone(), *pane_id))
+            .collect()
+    }
+}
+
 pub struct SceneRunner {
     h: PlexiUiHarness,
     last_app_pane: Option<PaneId>,
+    handles: PaneHandles,
     out_dir: PathBuf,
     no_shots: bool,
 }
@@ -181,13 +358,22 @@ pub fn run_scene(scene_path: &Path, out_dir: &Path, no_shots: bool) -> SceneRepo
     let raw = match std::fs::read_to_string(scene_path) {
         Ok(r) => r,
         Err(e) => {
-            return failed_report(scene_name, format!("read {}: {e}", scene_path.display()));
+            return failed_report(
+                scene_name,
+                SceneError::new("scene_read", format!("read {}: {e}", scene_path.display())),
+            );
         }
     };
     let scene: Scene = match toml::from_str(&raw) {
         Ok(s) => s,
         Err(e) => {
-            return failed_report(scene_name, format!("parse {}: {e}", scene_path.display()));
+            return failed_report(
+                scene_name,
+                SceneError::new(
+                    "scene_parse",
+                    format!("parse {}: {e}", scene_path.display()),
+                ),
+            );
         }
     };
 
@@ -198,6 +384,7 @@ pub fn run_scene(scene_path: &Path, out_dir: &Path, no_shots: bool) -> SceneRepo
     let mut runner = SceneRunner {
         h,
         last_app_pane: None,
+        handles: PaneHandles::default(),
         out_dir: out_dir.to_path_buf(),
         no_shots,
     };
@@ -213,13 +400,15 @@ pub fn run_scene(scene_path: &Path, out_dir: &Path, no_shots: bool) -> SceneRepo
                 step: label,
                 ok: true,
                 detail,
+                error: None,
             }),
             Err(e) => {
                 steps.push(StepResult {
                     index,
                     step: label,
                     ok: false,
-                    detail: Some(e),
+                    detail: None,
+                    error: Some(e),
                 });
                 passed = false;
                 break;
@@ -233,6 +422,7 @@ pub fn run_scene(scene_path: &Path, out_dir: &Path, no_shots: bool) -> SceneRepo
         passed,
         steps,
         shots,
+        handles: runner.handles.report(),
         host: runner.host_state(),
         app: runner.app_state(),
     };
@@ -251,7 +441,7 @@ pub fn run_scene(scene_path: &Path, out_dir: &Path, no_shots: bool) -> SceneRepo
     report
 }
 
-fn failed_report(scene: String, error: String) -> SceneReport {
+fn failed_report(scene: String, error: SceneError) -> SceneReport {
     SceneReport {
         schema_version: SCENE_REPORT_SCHEMA_VERSION,
         scene,
@@ -260,9 +450,11 @@ fn failed_report(scene: String, error: String) -> SceneReport {
             index: 0,
             step: "load".to_string(),
             ok: false,
-            detail: Some(error),
+            detail: None,
+            error: Some(error),
         }],
         shots: Vec::new(),
+        handles: BTreeMap::new(),
         host: HostState {
             context_count: 0,
             window_count: 0,
@@ -276,28 +468,32 @@ fn failed_report(scene: String, error: String) -> SceneReport {
 
 fn step_label(step: &Step) -> String {
     match step {
-        Step::OpenApp { open_app, .. } => format!("open_app {open_app}"),
-        Step::OpenFileBrowser { open_file_browser } => {
-            format!("open_file_browser {open_file_browser}")
-        }
-        Step::OpenWasm { open_wasm, args } => {
-            if args.is_empty() {
-                format!("open_wasm {open_wasm}")
-            } else {
-                format!("open_wasm {open_wasm} -- {}", args.join(" "))
-            }
-        }
-        Step::Key { key } => format!("key {key}"),
+        Step::Open { open } => format!("open {} as {}", open.target_kind(), open.handle()),
+        Step::Text { text } => format!(
+            "text {} ({} chars)",
+            text.target,
+            text.value.chars().count()
+        ),
+        Step::Key { key } => format!("key {} {}", key.target, key.value),
         Step::Sidebar { sidebar } => format!("sidebar {sidebar}"),
         Step::SwitchContext { switch_context } => format!("switch_context {switch_context}"),
         Step::PushToSubcontext { push_to_subcontext } => {
             format!("push_to_subcontext {push_to_subcontext}")
         }
         Step::WaitAppFrame { wait_app_frame } => {
-            format!("wait_app_frame {}s", wait_app_frame.timeout_s)
+            format!(
+                "wait_app_frame {} {}s",
+                wait_app_frame.target, wait_app_frame.timeout_s
+            )
         }
         Step::RunSteps { run_steps } => format!("run_steps {run_steps}"),
         Step::Assert { .. } => "assert".to_string(),
+        Step::AssertLabel { assert_label } => {
+            format!(
+                "assert_label {} {:?}",
+                assert_label.target, assert_label.label
+            )
+        }
         Step::Shot { shot } => format!("shot {shot}"),
     }
 }
@@ -342,28 +538,82 @@ fn preapprove_wasm_scene_grants(wasm_path: &Path) -> Result<(), String> {
 }
 
 impl SceneRunner {
-    fn exec(&mut self, step: &Step, shots: &mut Vec<String>) -> Result<Option<String>, String> {
+    fn exec(
+        &mut self,
+        step: &Step,
+        shots: &mut Vec<String>,
+    ) -> Result<Option<StepDetail>, SceneError> {
         match step {
-            Step::OpenApp { open_app, args } => {
-                let pane_id = self.h.open_app_at(&resolve(open_app), args)?;
+            Step::Open { open } => {
+                let handle = open.handle();
+                self.handles.ensure_available(handle)?;
+                let pane_id = match open {
+                    OpenSpec::Process { path, args, .. } => {
+                        let path = resolve(path);
+                        self.h
+                            .open_target(crate::ui_tests::HarnessOpenTarget::Process {
+                                path: &path,
+                                args,
+                            })
+                    }
+                    OpenSpec::Wasm { path, args, .. } => {
+                        let path = resolve(path);
+                        preapprove_wasm_scene_grants(&path).map_err(|message| {
+                            SceneError::new("wasm_preapproval_failed", message)
+                        })?;
+                        self.h
+                            .open_target(crate::ui_tests::HarnessOpenTarget::Wasm {
+                                path: &path,
+                                args,
+                            })
+                    }
+                    OpenSpec::Builtin { id, cwd, args, .. } => {
+                        let cwd = cwd
+                            .as_deref()
+                            .map(resolve)
+                            .unwrap_or_else(|| self.h.workspace_root().to_path_buf());
+                        self.h
+                            .open_target(crate::ui_tests::HarnessOpenTarget::Builtin {
+                                id,
+                                cwd: &cwd,
+                                args,
+                            })
+                    }
+                }
+                .map_err(|message| SceneError::new("open_failed", message))?;
+                self.handles.bind(handle, pane_id)?;
                 self.last_app_pane = Some(pane_id);
                 self.h.step();
-                Ok(Some(format!("pane {pane_id}")))
+                log::info!(
+                    "scene: open kind={} handle={} pane_id={pane_id}",
+                    open.target_kind(),
+                    handle
+                );
+                Ok(Some(StepDetail::Opened {
+                    target_kind: open.target_kind().to_string(),
+                    handle: handle.to_string(),
+                    pane_id,
+                }))
             }
-            Step::OpenFileBrowser { open_file_browser } => {
-                self.h.open_file_browser(resolve(open_file_browser));
+            Step::Text { text } => {
+                let target = self.handles.resolve_input(&text.target)?;
+                let pane_id = self.focus_target(target)?;
+                self.h
+                    .harness()
+                    .input_mut()
+                    .events
+                    .push(egui::Event::Text(text.value.clone()));
                 self.h.step();
-                Ok(None)
-            }
-            Step::OpenWasm { open_wasm, args } => {
-                let wasm_path = resolve(open_wasm);
-                preapprove_wasm_scene_grants(&wasm_path)?;
-                let pane_id = self
-                    .h
-                    .open_wasm_at_with_args(&wasm_path, args.clone())?;
-                self.last_app_pane = Some(pane_id);
-                self.h.step();
-                Ok(Some(format!("pane {pane_id}")))
+                let length = text.value.chars().count();
+                log::info!(
+                    "scene: text target={} pane_id={pane_id:?} length={length}",
+                    text.target
+                );
+                Ok(Some(StepDetail::TextInput {
+                    target: text.target.clone(),
+                    pane_id,
+                    length,
+                }))
             }
             Step::Key { key } => {
                 // Bare printable character — not a named key or modifier chord.
@@ -377,21 +627,35 @@ impl SceneRunner {
                 // named keys ("enter", "left") and chords ("ctrl+z") are always
                 // multi-character. No `+`-prefix check needed — a literal `+`
                 // key has len == 1 and must take the Event::Text path.
-                let mut key_chars = key.chars();
-                let is_bare_printable =
-                    key_chars.next().is_some_and(|c| !c.is_control()) && key_chars.next().is_none();
+                let target = self.handles.resolve_input(&key.target)?;
+                let pane_id = self.focus_target(target)?;
+                let mut key_chars = key.value.chars();
+                let is_bare_printable = key_chars
+                    .next()
+                    .is_some_and(|character| !character.is_control())
+                    && key_chars.next().is_none();
                 if is_bare_printable {
                     self.h
                         .harness()
                         .input_mut()
                         .events
-                        .push(egui::Event::Text(key.to_string()));
+                        .push(egui::Event::Text(key.value.clone()));
                 } else {
-                    let (modifiers, k) = parse_key(key)?;
+                    let (modifiers, k) = parse_key(&key.value)
+                        .map_err(|message| SceneError::new("invalid_key", message))?;
                     self.h.harness().press_key_modifiers(modifiers, k);
                 }
                 self.h.step();
-                Ok(None)
+                log::info!(
+                    "scene: key target={} pane_id={pane_id:?} value={}",
+                    key.target,
+                    key.value
+                );
+                Ok(Some(StepDetail::KeyInput {
+                    target: key.target.clone(),
+                    pane_id,
+                    value: key.value.clone(),
+                }))
             }
             Step::Sidebar { sidebar } => {
                 let v = *sidebar;
@@ -403,7 +667,10 @@ impl SceneRunner {
                 let idx = *switch_context;
                 let len = self.h.with_app(|app| app.router.len());
                 if idx >= len {
-                    return Err(format!("switch_context {idx}: only {len} contexts exist"));
+                    return Err(SceneError::new(
+                        "invalid_context",
+                        format!("switch_context {idx}: only {len} contexts exist"),
+                    ));
                 }
                 self.h.with_app_mut(|app| app.switch_workspace(idx));
                 self.h.step();
@@ -416,13 +683,10 @@ impl SceneRunner {
                 Ok(None)
             }
             Step::WaitAppFrame { wait_app_frame } => {
-                let pane_id = self
-                    .last_app_pane
-                    .ok_or("wait_app_frame: no app opened yet")?;
-                self.h.wait_for_app_frame(
-                    pane_id,
-                    Duration::from_secs_f32(wait_app_frame.timeout_s),
-                )?;
+                let pane_id = self.handles.resolve(&wait_app_frame.target)?;
+                self.h
+                    .wait_for_app_frame(pane_id, Duration::from_secs_f32(wait_app_frame.timeout_s))
+                    .map_err(|message| SceneError::new("wait_app_frame_failed", message))?;
                 Ok(None)
             }
             Step::RunSteps { run_steps } => {
@@ -430,21 +694,62 @@ impl SceneRunner {
                 Ok(None)
             }
             Step::Assert { assert } => self.check(assert).map(|()| None),
+            Step::AssertLabel { assert_label } => {
+                let target = self.handles.resolve_input(&assert_label.target)?;
+                let pane_id = self.focus_target(target)?;
+                let matched = match pane_id {
+                    Some(pane_id) => self.h.pane_has_label(pane_id, &assert_label.label),
+                    None => self.h.host_has_label(&assert_label.label),
+                };
+                if !matched {
+                    return Err(SceneError::new(
+                        "label_not_found",
+                        format!(
+                            "assert_label: {:?} not found after focusing target '{}'",
+                            assert_label.label, assert_label.target
+                        ),
+                    ));
+                }
+                Ok(Some(StepDetail::LabelMatched {
+                    target: assert_label.target.clone(),
+                    pane_id,
+                    label: assert_label.label.clone(),
+                }))
+            }
             Step::Shot { shot } => {
                 if self.no_shots {
-                    return Ok(Some("skipped (no-shots)".to_string()));
+                    return Ok(Some(StepDetail::Message {
+                        message: "skipped (no-shots)".to_string(),
+                    }));
                 }
                 let path = self.out_dir.join(shot);
                 self.h
                     .save_screenshot(&path.to_string_lossy())
-                    .map_err(|e| format!("shot {shot}: {e}"))?;
+                    .map_err(|error| {
+                        SceneError::new("screenshot_failed", format!("shot {shot}: {error}"))
+                    })?;
                 shots.push(path.display().to_string());
-                Ok(Some(path.display().to_string()))
+                Ok(Some(StepDetail::Message {
+                    message: path.display().to_string(),
+                }))
             }
         }
     }
 
-    fn check(&mut self, spec: &AssertSpec) -> Result<(), String> {
+    fn focus_target(&mut self, target: InputTarget) -> Result<Option<PaneId>, SceneError> {
+        match target {
+            InputTarget::Host => Ok(None),
+            InputTarget::Pane(pane_id) => {
+                self.h
+                    .focus_pane(pane_id)
+                    .map_err(|message| SceneError::new("target_unavailable", message))?;
+                self.h.step();
+                Ok(Some(pane_id))
+            }
+        }
+    }
+
+    fn check(&mut self, spec: &AssertSpec) -> Result<(), SceneError> {
         let host = self.host_state();
         let mut failures = Vec::new();
         let mut expect = |name: &str, expected: String, actual: String| {
@@ -472,9 +777,21 @@ impl SceneRunner {
             expect("sidebar", v.to_string(), host.sidebar.to_string());
         }
         if spec.lifecycle.is_some() || spec.tree_contains.is_some() {
-            let app = self
-                .app_state()
-                .ok_or("assert lifecycle/tree_contains: no app opened yet")?;
+            let target = spec.target.as_deref().ok_or_else(|| {
+                SceneError::new(
+                    "missing_assert_target",
+                    "assert lifecycle/tree_contains requires target = '<handle>'",
+                )
+            })?;
+            let pane_id = self.handles.resolve(target)?;
+            let app = self.app_state_for(pane_id).ok_or_else(|| {
+                SceneError::new(
+                    "app_state_unavailable",
+                    format!(
+                        "assert target '{target}' has no process or WASM app state; use assert_label for native UI"
+                    ),
+                )
+            })?;
             if let Some(v) = &spec.lifecycle {
                 expect("lifecycle", v.clone(), app.lifecycle.clone());
             }
@@ -488,7 +805,7 @@ impl SceneRunner {
         if failures.is_empty() {
             Ok(())
         } else {
-            Err(failures.join("; "))
+            Err(SceneError::new("assertion_failed", failures.join("; ")))
         }
     }
 
@@ -509,6 +826,10 @@ impl SceneRunner {
 
     fn app_state(&self) -> Option<AppState> {
         let pane_id = self.last_app_pane?;
+        self.app_state_for(pane_id)
+    }
+
+    fn app_state_for(&self, pane_id: PaneId) -> Option<AppState> {
         self.h.with_app(|app| {
             for win in &app.windows {
                 if let Some(Pane::App(app_pane)) = win.panes.get(&pane_id) {
@@ -656,5 +977,88 @@ mod tests {
         assert_eq!(k, egui::Key::Enter);
         assert!(parse_key("cmd+").is_err());
         assert!(parse_key("cmd+bogus").is_err());
+    }
+
+    #[test]
+    fn generic_scene_steps_parse_with_typed_targets() {
+        let raw = r#"
+            [[steps]]
+            open = { kind = "builtin", id = "assistant", cwd = ".", as = "assistant" }
+
+            [[steps]]
+            text = { target = "assistant", value = "/settings" }
+
+            [[steps]]
+            key = { target = "assistant", value = "enter" }
+
+            [[steps]]
+            assert_label = { target = "assistant", label = "Assistant settings" }
+        "#;
+
+        let scene: Scene = toml::from_str(raw).expect("generic scene should parse");
+
+        assert!(matches!(
+            &scene.steps[..],
+            [
+                Step::Open {
+                    open: OpenSpec::Builtin { handle, .. }
+                },
+                Step::Text { text: TextSpec { target: text_target, .. } },
+                Step::Key { key: KeySpec { target: key_target, .. } },
+                Step::AssertLabel {
+                    assert_label: AssertLabelSpec { target: label_target, .. }
+                }
+            ] if handle == "assistant"
+                && text_target == "assistant"
+                && key_target == "assistant"
+                && label_target == "assistant"
+        ));
+    }
+
+    #[test]
+    fn generic_open_rejects_fields_from_another_target_kind() {
+        let raw = r#"
+            [[steps]]
+            open = { kind = "builtin", id = "assistant", path = "apps/dev/balls", as = "assistant" }
+        "#;
+
+        assert!(toml::from_str::<Scene>(raw).is_err());
+    }
+
+    #[test]
+    fn pane_handles_reject_duplicate_names() {
+        let mut handles = PaneHandles::default();
+        handles.bind("assistant", 41).expect("first bind");
+
+        let error = handles.bind("assistant", 42).unwrap_err();
+
+        assert_eq!(error.code, "duplicate_handle");
+    }
+
+    #[test]
+    fn pane_handles_reject_missing_targets() {
+        let handles = PaneHandles::default();
+
+        let error = handles.resolve("missing").unwrap_err();
+
+        assert_eq!(error.code, "missing_target");
+    }
+
+    #[test]
+    fn pane_handles_reserve_host_target() {
+        let mut handles = PaneHandles::default();
+
+        let error = handles.bind("host", 41).unwrap_err();
+
+        assert_eq!(error.code, "reserved_handle");
+    }
+
+    #[test]
+    fn pane_handles_resolve_host_only_as_an_input_target() {
+        let handles = PaneHandles::default();
+
+        let target = handles.resolve_input("host").expect("host input target");
+
+        assert_eq!(target, InputTarget::Host);
     }
 }

--- a/src/testing/TESTING.md
+++ b/src/testing/TESTING.md
@@ -25,14 +25,13 @@ suite = false               # optional, default true. false = excluded from
                             # processes); run them via `just scene`.
 
 [[steps]]
-open_app = "apps/dev/balls"                     # real Python process, production launch path
-args = ["--state", '{"balls": 3}']          # optional; surfaces as ctx.args in the SDK
+open = { kind = "process", path = "apps/dev/balls", as = "balls", args = ["--state", '{"balls": 3}'] }
 
 [[steps]]
-wait_app_frame = { timeout_s = 15.0 }       # block until first committed frame
+wait_app_frame = { target = "balls", timeout_s = 15.0 }
 
 [[steps]]
-assert = { pane_count = 1, lifecycle = "running", tree_contains = "balls" }
+assert = { target = "balls", pane_count = 1, lifecycle = "running", tree_contains = "balls" }
 
 [[steps]]
 shot = "balls.png"                          # optional; written to the out dir
@@ -42,22 +41,25 @@ shot = "balls.png"                          # optional; written to the out dir
 
 | Verb | Effect |
 |---|---|
-| `open_app = "<dir>"` (+ optional `args = [...]`) | Spawn a real PGAP app process from an app dir (relative paths resolve from the repo root). Args surface as `ctx.args`. |
-| `open_file_browser = "<dir>"` | Open the built-in file browser host app at a dir. |
-| `key = "cmd+b"` | Press a key combo (`cmd`/`ctrl`/`alt`/`shift` + key name). |
+| `open = { kind = "process", path = "<dir>", as = "<handle>", args = [...] }` | Spawn a real PGAP app process from an app dir. Relative paths resolve from the repo root. Args surface as `ctx.args`. |
+| `open = { kind = "wasm", path = "<file.wasm>", as = "<handle>", args = [...] }` | Open a reviewed raw WASM component. |
+| `open = { kind = "builtin", id = "<id>", as = "<handle>", cwd = "<dir>" }` | Open a compiled-in host app by id. `cwd` is optional and defaults to a fresh harness-owned directory. |
+| `text = { target = "<handle>", value = "hello" }` | Focus a pane and insert text through egui's normal text-input path. The report records the character count, not the text. |
+| `key = { target = "<handle>", value = "enter" }` | Focus a pane and press a key combo (`cmd`/`ctrl`/`alt`/`shift` plus a key name). Use `target = "host"` for a whole-host shortcut. |
 | `sidebar = true` | Show/hide the host sidebar. |
 | `switch_context = 0` | Switch to the context at this router index. |
 | `push_to_subcontext = "Name"` | Push the focused pane into a new subcontext (creates a portal). |
-| `wait_app_frame = { timeout_s = N }` | Wait for the last-opened app's first committed frame. Fails with the app's stderr on crash/timeout. |
+| `wait_app_frame = { target = "<handle>", timeout_s = N }` | Wait for a process app's first committed frame. Fails with the app's stderr on crash or timeout. |
 | `run_steps = N` | Advance N harness frames. |
 | `assert = { ... }` | Structured assertions — see below. |
+| `assert_label = { target = "<handle>", label = "Settings" }` | Focus a pane and require an exact semantic label inside that pane's rendered rectangle. Use `target = "host"` for the whole accessibility tree. |
 | `shot = "name.png"` | Headless screenshot to the out dir. |
 
-New verbs require a scene that needs them — no speculative DSL growth. Assertions are structured keys, never expression strings.
+Every `open` step binds one unique symbolic handle. Later pane steps reject missing handles, duplicate handles fail before an app opens, and `host` is reserved for explicit whole-host input. New verbs require a scene that needs them. Assertions are structured keys, never expression strings. `tests/scenes/assistant-settings.toml` exercises `open`, `text`, pane-targeted `key`, and `assert_label` against the native Assistant without starting an AI turn.
 
 ### Assertions
 
-`pane_count`, `window_count`, `context_count`, `portal_count` (across all windows), `sidebar`, `lifecycle` (last-opened app, lowercase, e.g. `"running"`), `tree_contains` (substring match against the app's serialized L1 render tree). Every present key must match.
+`pane_count`, `window_count`, `context_count`, `portal_count` (across all windows), and `sidebar` assert host state. `lifecycle` and `tree_contains` require `target = "<handle>"`; they inspect that process or WASM app's serialized L1 state. Native builtins use `assert_label`. Every present key must match.
 
 ### Running
 
@@ -71,11 +73,11 @@ cargo test --bin plexi scene_suite           # all committed suite scenes
 
 ### SceneReport
 
-Every run writes `<out>/<scene>.json` (`schema_version: 1`): pass/fail per step, host state snapshot (context/window/pane/portal counts, sidebar), and the last-opened app's `lifecycle` plus its full committed L1 render tree as JSON. **Prefer asserting on state over comparing pixels** — the tree is the app's UI state; screenshots are an artifact for human review.
+Every run writes `<out>/<scene>.json` (`schema_version: 2`). It includes pass/fail per step, resolved handles, host state, and the last-opened process or WASM app's committed state. Successful action details and failures are structured objects; failures carry stable `code` and `message` fields. Prefer state and semantic-label assertions over pixel comparisons. Screenshots remain a human review artifact.
 
 ## Real App Processes in Tests
 
-`open_app` (and `PlexiUiHarness::open_app_at`) uses the production path: manifest load → `ProcessApp::launch` → real child process, IPC threads, L1 render pipeline. Outside an installed bundle the repo SDK is exported via `PLEXI_SDK_PATH=sdk/python` automatically. Python resolution comes from `src/app/python_env.rs`: per-app `.venv` → bundled python → system `python3`, with Python >=3.11 required.
+`open = { kind = "process", ... }` uses the production path: manifest load, `ProcessApp::launch`, real child process, IPC threads, and the L1 render pipeline. Outside an installed bundle the repo SDK is exported through `PLEXI_SDK_PATH=sdk/python` automatically. Python resolution comes from `src/app/python_env.rs`: per-app `.venv`, bundled python, then system `python3`, with Python 3.11 or newer required.
 
 ## Pre-Push Evidence
 

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -40,28 +40,81 @@ use crate::spatial::tiling::PaneId;
 
 // ─── PlexiUiHarness ──────────────────────────────────────────────────────────
 
+/// Generic app target used by the scene runner. Builtin ids resolve through
+/// the production factory plus the test-only registry below.
+pub(crate) enum HarnessOpenTarget<'a> {
+    Process {
+        path: &'a Path,
+        args: &'a [String],
+    },
+    Wasm {
+        path: &'a Path,
+        args: &'a [String],
+    },
+    Builtin {
+        id: &'a str,
+        cwd: &'a Path,
+        args: &'a [String],
+    },
+}
+
+type HarnessBuiltinFactory = fn(&Path, &[String]) -> Box<dyn crate::app::app_trait::App>;
+
+fn assistant_harness_factory(
+    workspace_root: &Path,
+    _args: &[String],
+) -> Box<dyn crate::app::app_trait::App> {
+    let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
+        std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
+    Box::new(crate::assistant::AssistantApp::new(
+        workspace_root.to_path_buf(),
+        broker,
+        workspace_root,
+    ))
+}
+
+const HARNESS_BUILTIN_FACTORIES: &[(&str, HarnessBuiltinFactory)] =
+    &[("assistant", assistant_harness_factory)];
+
+fn harness_builtin_factory(
+    id: &str,
+    cwd: &Path,
+    args: &[String],
+) -> Option<Box<dyn crate::app::app_trait::App>> {
+    HARNESS_BUILTIN_FACTORIES
+        .iter()
+        .find(|(candidate, _)| *candidate == id)
+        .map(|(_, factory)| factory(cwd, args))
+}
+
 /// Semantic UI test harness. Wraps egui_kittest's `Harness<PlexiApp>` using the
 /// `new_eframe` constructor so PlexiApp gets the kittest-managed egui::Context
 /// at construction time — no shared-state gymnastics needed.
 pub struct PlexiUiHarness {
     inner: egui_kittest::Harness<'static, PlexiApp>,
+    workspace: tempfile::TempDir,
 }
 
 impl PlexiUiHarness {
     /// Create a harness with a fresh, isolated PlexiApp.
     pub fn new() -> Self {
+        let workspace = tempfile::tempdir().expect("create UI harness workspace");
         let frame_tick = Arc::new(AtomicU64::new(0));
         let harness = egui_kittest::Harness::new_eframe(move |cc| {
             let (app, _ipc_tx) = PlexiApp::new_for_test(cc.egui_ctx.clone(), frame_tick);
             app
         });
-        Self { inner: harness }
+        Self {
+            inner: harness,
+            workspace,
+        }
     }
 
     /// Create a harness with an explicit surface size. Use for screenshot
     /// tests — the default kittest surface is too small for pane chrome and
     /// app content to be legible in the saved PNG.
     pub fn new_sized(width: f32, height: f32) -> Self {
+        let workspace = tempfile::tempdir().expect("create UI harness workspace");
         let frame_tick = Arc::new(AtomicU64::new(0));
         let harness = egui_kittest::Harness::builder()
             .with_size(egui::Vec2::new(width, height))
@@ -69,7 +122,10 @@ impl PlexiUiHarness {
                 let (app, _ipc_tx) = PlexiApp::new_for_test(cc.egui_ctx.clone(), frame_tick);
                 app
             });
-        Self { inner: harness }
+        Self {
+            inner: harness,
+            workspace,
+        }
     }
 
     /// Advance one frame. Uses `step()` — PlexiApp continuously requests
@@ -133,7 +189,127 @@ impl PlexiUiHarness {
         f(self.inner.state())
     }
 
+    /// Fresh directory owned by this harness. Scenes use it when an open step
+    /// omits `cwd`, keeping native app state out of the developer's workspace.
+    pub fn workspace_root(&self) -> &Path {
+        self.workspace.path()
+    }
+
     // ── Real app / host app / portal drivers ─────────────────────────────────
+
+    /// Open any supported scene target through its normal pane-opening path.
+    pub fn open_target(&mut self, target: HarnessOpenTarget<'_>) -> Result<PaneId, String> {
+        match target {
+            HarnessOpenTarget::Process { path, args } => self.open_app_at(path, args),
+            HarnessOpenTarget::Wasm { path, args } => {
+                self.open_wasm_at_with_args(path, args.to_vec())
+            }
+            HarnessOpenTarget::Builtin { id, cwd, args } => self.open_builtin_by_id(id, cwd, args),
+        }
+    }
+
+    fn open_builtin_by_id(
+        &mut self,
+        id: &str,
+        cwd: &Path,
+        args: &[String],
+    ) -> Result<PaneId, String> {
+        let before: std::collections::HashSet<PaneId> = self.with_app(|app| {
+            app.windows
+                .iter()
+                .flat_map(|window| window.panes.keys())
+                .copied()
+                .collect()
+        });
+        if let Some(app) = harness_builtin_factory(id, cwd, args) {
+            self.with_app_mut(|host| {
+                host.open_builtin_app_pane(
+                    app,
+                    crate::app::permissions::AppPermissions::builtin(),
+                    cwd.to_path_buf(),
+                    None,
+                    Some("split_v"),
+                    None,
+                );
+            });
+        } else {
+            self.with_app_mut(|host| {
+                host.launch_app_by_id_with_layout(
+                    id,
+                    Some("split_v".to_string()),
+                    args,
+                    Some(cwd.to_path_buf()),
+                )
+            })?;
+        }
+        let pane_id = self.with_app(|host| {
+            host.windows
+                .iter()
+                .flat_map(|window| window.panes.keys())
+                .find(|pane_id| !before.contains(pane_id))
+                .copied()
+                .ok_or_else(|| format!("no new pane appeared after opening builtin '{id}'"))
+        })?;
+        let is_builtin = self.with_app(|host| {
+            host.windows.iter().any(|window| {
+                matches!(
+                    window.panes.get(&pane_id),
+                    Some(Pane::App(app)) if matches!(app.runtime, AppRuntime::Builtin(_))
+                )
+            })
+        });
+        if !is_builtin {
+            return Err(format!("app id '{id}' did not resolve to a builtin"));
+        }
+        Ok(pane_id)
+    }
+
+    /// Focus a pane through the same navigation path used by host commands.
+    pub fn focus_pane(&mut self, pane_id: PaneId) -> Result<(), String> {
+        if self.with_app_mut(|app| app.pane_navigate(pane_id)) {
+            Ok(())
+        } else {
+            Err(format!("pane {pane_id} no longer exists"))
+        }
+    }
+
+    /// Exact semantic-label lookup scoped to one rendered pane rectangle.
+    pub fn pane_has_label(&mut self, pane_id: PaneId, label: &str) -> bool {
+        use egui_kittest::kittest::Queryable;
+
+        let pane_rect = self.with_app(|host| {
+            host.windows.iter().find_map(|window| {
+                if !window.panes.contains_key(&pane_id) {
+                    return None;
+                }
+                let tile_id = window.tree.tiles.iter().find_map(|(tile_id, tile)| {
+                    matches!(tile, egui_tiles::Tile::Pane(id) if *id == pane_id)
+                        .then_some(tile_id)
+                })?;
+                window.tree.tiles.rect(*tile_id)
+            })
+        });
+        let Some(pane_rect) = pane_rect else {
+            return false;
+        };
+
+        self.inner.query_all_by_label(label).any(|node| {
+            node.raw_bounds().is_some_and(|bounds| {
+                let center = egui::pos2(
+                    ((bounds.x0 + bounds.x1) / 2.0) as f32,
+                    ((bounds.y0 + bounds.y1) / 2.0) as f32,
+                );
+                pane_rect.contains(center)
+            })
+        })
+    }
+
+    /// Exact semantic-label lookup against the whole headless host tree.
+    pub fn host_has_label(&mut self, label: &str) -> bool {
+        use egui_kittest::kittest::Queryable;
+
+        self.inner.query_all_by_label(label).next().is_some()
+    }
 
     /// Launch a real PGAP app process from `app_dir` (a directory containing
     /// `manifest.toml`) — the same production path as `plexi app open <path>`.
@@ -1240,6 +1416,31 @@ mod tests {
         h.save_screenshot("/tmp/plexi_assistant_pane.png")
             .expect("render failed");
         println!("Screenshot saved to /tmp/plexi_assistant_pane.png");
+    }
+
+    #[test]
+    fn semantic_label_lookup_is_scoped_to_the_target_pane() {
+        let mut h = PlexiUiHarness::new_sized(1000.0, 720.0);
+        let workspace = h.workspace_root().to_path_buf();
+        let assistant = h
+            .open_target(HarnessOpenTarget::Builtin {
+                id: "assistant",
+                cwd: &workspace,
+                args: &[],
+            })
+            .expect("open Assistant");
+        h.step();
+        let files = h
+            .open_target(HarnessOpenTarget::Builtin {
+                id: "file_browser",
+                cwd: &workspace,
+                args: &[],
+            })
+            .expect("open File Browser");
+        h.run_steps(2);
+
+        assert!(h.pane_has_label(assistant, "Assistant"));
+        assert!(!h.pane_has_label(files, "Assistant"));
     }
 
     /// Assistant pane with a pending permission sheet renders (Phase D2).

--- a/tests/scenes/assistant-idle.toml
+++ b/tests/scenes/assistant-idle.toml
@@ -5,17 +5,16 @@ size = [1280.0, 800.0]
 suite = false
 
 [[steps]]
-open_app = "apps/dev/assistant-pgap"
-args = ["--demo-state", '{"messages": [{"role": "user", "content": "What is the difference between a git worktree and a branch?"}, {"role": "assistant", "content": "A **branch** is a pointer to a commit. A **worktree** is a separate working directory checked out to a branch, so you can have multiple branches checked out at once.", "thinking": "The user wants a concise comparison.", "thinking_secs": 2.3}, {"role": "user", "content": "And if the network is down?"}, {"role": "error", "content": "ai_query failed: openrouter io error: connection refused"}], "model_tier": "medium"}']
+open = { kind = "process", path = "apps/dev/assistant-pgap", as = "assistant", args = ["--demo-state", '{"messages": [{"role": "user", "content": "What is the difference between a git worktree and a branch?"}, {"role": "assistant", "content": "A **branch** is a pointer to a commit. A **worktree** is a separate working directory checked out to a branch, so you can have multiple branches checked out at once.", "thinking": "The user wants a concise comparison.", "thinking_secs": 2.3}, {"role": "user", "content": "And if the network is down?"}, {"role": "error", "content": "ai_query failed: openrouter io error: connection refused"}], "model_tier": "medium"}'] }
 
 [[steps]]
-wait_app_frame = { timeout_s = 15.0 }
+wait_app_frame = { target = "assistant", timeout_s = 15.0 }
 
 [[steps]]
 run_steps = 5
 
 [[steps]]
-assert = { pane_count = 1, lifecycle = "running", tree_contains = "Assistant PGAP" }
+assert = { target = "assistant", pane_count = 1, lifecycle = "running", tree_contains = "Assistant PGAP" }
 
 [[steps]]
 shot = "assistant-idle.png"

--- a/tests/scenes/assistant-settings.toml
+++ b/tests/scenes/assistant-settings.toml
@@ -1,0 +1,39 @@
+# Native Assistant command scene. It drives the real composer through egui
+# input and checks semantic labels without dispatching an AI turn.
+size = [1280.0, 800.0]
+
+[[steps]]
+open = { kind = "builtin", id = "assistant", as = "assistant" }
+
+[[steps]]
+run_steps = 2
+
+[[steps]]
+assert_label = { target = "assistant", label = "Assistant" }
+
+[[steps]]
+text = { target = "assistant", value = "/settings" }
+
+[[steps]]
+key = { target = "assistant", value = "enter" }
+
+[[steps]]
+run_steps = 3
+
+[[steps]]
+assert_label = { target = "assistant", label = "Assistant settings" }
+
+[[steps]]
+text = { target = "assistant", value = "/model" }
+
+[[steps]]
+key = { target = "assistant", value = "enter" }
+
+[[steps]]
+run_steps = 3
+
+[[steps]]
+assert_label = { target = "assistant", label = "Model tier: " }
+
+[[steps]]
+shot = "assistant-settings.png"

--- a/tests/scenes/assistant.toml
+++ b/tests/scenes/assistant.toml
@@ -6,17 +6,16 @@ size = [1280.0, 800.0]
 suite = false
 
 [[steps]]
-open_app = "apps/dev/assistant-pgap"
-args = ["--demo-state", '{"messages": [{"role": "user", "content": "What is the difference between a git worktree and a branch?"}, {"role": "assistant", "content": "A **branch** is a pointer to a commit. A **worktree** is a separate working directory checked out to a branch, so you can have multiple branches checked out at once.", "thinking": "The user wants a concise comparison.", "thinking_secs": 2.3}, {"role": "user", "content": "Show me how to create one.\nKeep it short."}], "is_streaming": true, "thinking_text": "They want the wtp command. I should show `wtp add -b <branch>` and mention the worktrees/ directory convention, keeping it to two lines as requested.", "model_tier": "low"}']
+open = { kind = "process", path = "apps/dev/assistant-pgap", as = "assistant", args = ["--demo-state", '{"messages": [{"role": "user", "content": "What is the difference between a git worktree and a branch?"}, {"role": "assistant", "content": "A **branch** is a pointer to a commit. A **worktree** is a separate working directory checked out to a branch, so you can have multiple branches checked out at once.", "thinking": "The user wants a concise comparison.", "thinking_secs": 2.3}, {"role": "user", "content": "Show me how to create one.\nKeep it short."}], "is_streaming": true, "thinking_text": "They want the wtp command. I should show `wtp add -b <branch>` and mention the worktrees/ directory convention, keeping it to two lines as requested.", "model_tier": "low"}'] }
 
 [[steps]]
-wait_app_frame = { timeout_s = 15.0 }
+wait_app_frame = { target = "assistant", timeout_s = 15.0 }
 
 [[steps]]
 run_steps = 5
 
 [[steps]]
-assert = { pane_count = 1, lifecycle = "running", tree_contains = "Assistant PGAP" }
+assert = { target = "assistant", pane_count = 1, lifecycle = "running", tree_contains = "Assistant PGAP" }
 
 [[steps]]
 shot = "assistant.png"

--- a/tests/scenes/balls.toml
+++ b/tests/scenes/balls.toml
@@ -5,16 +5,16 @@ size = [1280.0, 800.0]
 suite = false
 
 [[steps]]
-open_app = "apps/dev/balls"
+open = { kind = "process", path = "apps/dev/balls", as = "balls" }
 
 [[steps]]
-wait_app_frame = { timeout_s = 15.0 }
+wait_app_frame = { target = "balls", timeout_s = 15.0 }
 
 [[steps]]
 run_steps = 5
 
 [[steps]]
-assert = { pane_count = 1, lifecycle = "running", tree_contains = "balls" }
+assert = { target = "balls", pane_count = 1, lifecycle = "running", tree_contains = "balls" }
 
 [[steps]]
 shot = "balls.png"

--- a/tests/scenes/file-browser-middle.toml
+++ b/tests/scenes/file-browser-middle.toml
@@ -4,7 +4,7 @@
 size = [680.0, 600.0]
 
 [[steps]]
-open_file_browser = "."
+open = { kind = "builtin", id = "file_browser", cwd = ".", as = "files" }
 
 [[steps]]
 run_steps = 3

--- a/tests/scenes/file-browser-narrow.toml
+++ b/tests/scenes/file-browser-narrow.toml
@@ -2,7 +2,7 @@
 size = [520.0, 400.0]
 
 [[steps]]
-open_file_browser = "."
+open = { kind = "builtin", id = "file_browser", cwd = ".", as = "files" }
 
 [[steps]]
 run_steps = 3

--- a/tests/scenes/file-browser-sidebar.toml
+++ b/tests/scenes/file-browser-sidebar.toml
@@ -2,7 +2,7 @@
 size = [1280.0, 800.0]
 
 [[steps]]
-open_file_browser = "."
+open = { kind = "builtin", id = "file_browser", cwd = ".", as = "files" }
 
 [[steps]]
 sidebar = true

--- a/tests/scenes/file-browser-tiny.toml
+++ b/tests/scenes/file-browser-tiny.toml
@@ -2,7 +2,7 @@
 size = [360.0, 280.0]
 
 [[steps]]
-open_file_browser = "."
+open = { kind = "builtin", id = "file_browser", cwd = ".", as = "files" }
 
 [[steps]]
 run_steps = 3

--- a/tests/scenes/file-browser.toml
+++ b/tests/scenes/file-browser.toml
@@ -2,7 +2,7 @@
 size = [1280.0, 800.0]
 
 [[steps]]
-open_file_browser = "."
+open = { kind = "builtin", id = "file_browser", cwd = ".", as = "files" }
 
 [[steps]]
 run_steps = 3

--- a/tests/scenes/footer-small-pane.toml
+++ b/tests/scenes/footer-small-pane.toml
@@ -8,17 +8,17 @@ size = [280.0, 480.0]
 suite = false
 
 [[steps]]
-open_app = "apps/dev/ui-gallery"
+open = { kind = "process", path = "apps/dev/ui-gallery", as = "gallery" }
 
 [[steps]]
-wait_app_frame = { timeout_s = 15.0 }
+wait_app_frame = { target = "gallery", timeout_s = 15.0 }
 
 [[steps]]
 run_steps = 10
 
 # The app survives the narrow pane and keeps rendering its tree (footer included).
 [[steps]]
-assert = { pane_count = 1, lifecycle = "running", tree_contains = "Footer" }
+assert = { target = "gallery", pane_count = 1, lifecycle = "running", tree_contains = "Footer" }
 
 [[steps]]
 shot = "footer-small-pane.png"

--- a/tests/scenes/keymap-probe.toml
+++ b/tests/scenes/keymap-probe.toml
@@ -7,25 +7,25 @@ size = [640.0, 480.0]
 suite = false
 
 [[steps]]
-open_app = "apps/dev/keymap-probe"
+open = { kind = "process", path = "apps/dev/keymap-probe", as = "probe" }
 
 [[steps]]
-wait_app_frame = { timeout_s = 15.0 }
+wait_app_frame = { target = "probe", timeout_s = 15.0 }
 
 [[steps]]
 run_steps = 5
 
 [[steps]]
-assert = { pane_count = 1, lifecycle = "running", tree_contains = "last_action=none" }
+assert = { target = "probe", pane_count = 1, lifecycle = "running", tree_contains = "last_action=none" }
 
 [[steps]]
-key = "z"
+key = { target = "probe", value = "z" }
 
 [[steps]]
 run_steps = 30
 
 [[steps]]
-assert = { tree_contains = "bare-z" }
+assert = { target = "probe", tree_contains = "bare-z" }
 
 [[steps]]
 shot = "keymap-probe.png"

--- a/tests/scenes/scaffold-renders-frame1.toml
+++ b/tests/scenes/scaffold-renders-frame1.toml
@@ -7,27 +7,27 @@ size = [1280.0, 800.0]
 suite = false
 
 [[steps]]
-open_app = "apps/dev/counter"
+open = { kind = "process", path = "apps/dev/counter", as = "counter" }
 
 [[steps]]
-wait_app_frame = { timeout_s = 15.0 }
+wait_app_frame = { target = "counter", timeout_s = 15.0 }
 
 [[steps]]
 run_steps = 8
 
 # First frame renders the scaffold's AppBar title.
 [[steps]]
-assert = { pane_count = 1, lifecycle = "running", tree_contains = "Counter" }
+assert = { target = "counter", pane_count = 1, lifecycle = "running", tree_contains = "Counter" }
 
 # A keystroke reaches the on_key handler; the app keeps running (no crash).
 [[steps]]
-key = "plus"
+key = { target = "counter", value = "plus" }
 
 [[steps]]
 run_steps = 8
 
 [[steps]]
-assert = { pane_count = 1, lifecycle = "running", tree_contains = "Counter" }
+assert = { target = "counter", pane_count = 1, lifecycle = "running", tree_contains = "Counter" }
 
 [[steps]]
 shot = "scaffold-renders-frame1.png"

--- a/tests/scenes/subcontext-portal.toml
+++ b/tests/scenes/subcontext-portal.toml
@@ -3,7 +3,7 @@
 size = [1280.0, 800.0]
 
 [[steps]]
-open_file_browser = "."
+open = { kind = "builtin", id = "file_browser", cwd = ".", as = "files" }
 
 [[steps]]
 run_steps = 2

--- a/tests/scenes/wasm-sysmon.toml
+++ b/tests/scenes/wasm-sysmon.toml
@@ -8,19 +8,19 @@ size = [900.0, 640.0]
 suite = true
 
 [[steps]]
-open_wasm = "tests/wasm-fixtures/sysmon.wasm"
+open = { kind = "wasm", path = "tests/wasm-fixtures/sysmon.wasm", as = "sysmon" }
 
 [[steps]]
 run_steps = 3
 
 [[steps]]
-assert = { pane_count = 1, lifecycle = "running", tree_contains = "System Monitor" }
+assert = { target = "sysmon", pane_count = 1, lifecycle = "running", tree_contains = "System Monitor" }
 
 [[steps]]
-assert = { tree_contains = "CPU" }
+assert = { target = "sysmon", tree_contains = "CPU" }
 
 [[steps]]
-assert = { tree_contains = "Mem" }
+assert = { target = "sysmon", tree_contains = "Mem" }
 
 [[steps]]
 shot = "wasm-sysmon.png"


### PR DESCRIPTION
Stint tasks 0362

No linked GitHub issue.

## Summary

- Replaces feature-specific scene open verbs with one typed open action and symbolic pane handles.
- Adds pane-targeted text, key, and semantic-label actions with structured report details and errors.
- Migrates all scene fixtures and adds a native Assistant scene for /settings and /model.

## Test evidence

- `cargo test --bin plexi scenes::tests`: 8 passed, 0 failed, 1 parameterized scene entry ignored.
- `cargo test --bin plexi scene_suite`: 1 passed, 0 failed.
- `cargo test --bin plexi`: 1,567 passed, 0 failed, 1 parameterized scene entry ignored.
- `cargo build`: passed.
- PlexiUiHarness render: `${TMPDIR}plexi-scenes/assistant-settings.png` shows native Assistant output for `/settings` and `/model` with an empty composer and no AI turn.
- Manual review fixed pane-scoping so a matching label in another pane cannot satisfy `assert_label`.
- Conclusion: install skippable - full coverage. The changed Rust modules are test-only and the committed scene exercises the full user-visible behavior headlessly.