### PR TITLE
feat(assistant): add agent registry and model routing (stint 0225)

### DIFF
--- a/justfile
+++ b/justfile
@@ -4,7 +4,9 @@
 PYTHON_VERSION := "3.12.13"
 PYTHON_PBS_DATE := "20260414"
 
-export RUSTFLAGS := "-D warnings"
+# Rust 1.97 warns on f64-to-f32 literal fallback throughout egui call sites.
+# Keep the global warning gate while upstream APIs transition to typed literals.
+export RUSTFLAGS := "-D warnings -A float-literal-f32-fallback"
 
 # Download the python-build-standalone runtime into assets/python/ for bundling.
 # Skips if the correct version is already present. macOS only.

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "plexi-sdk"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -34,14 +34,50 @@ use crate::broker::{
     TargetType,
 };
 use crate::host::app_timeline::{AppTimeline, EventDelivery};
-use crate::plexi_ai::broker::{AiBroker, AiBrokerRequest};
+use crate::plexi_ai::broker::{
+    AiBroker, AiBrokerRequest, ConcreteModelRoute, ReasoningEffort,
+};
 use crate::plexi_ai::tool_dispatch::ToolDispatcher;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Mutex};
 
 // ── Agent definition ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AgentSource {
+    BuiltIn,
+    User,
+    Workspace,
+}
+
+impl AgentSource {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::BuiltIn => "built-in",
+            Self::User => "user",
+            Self::Workspace => "workspace",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AgentModelRoutes {
+    pub low: Option<ConcreteModelRoute>,
+    pub medium: Option<ConcreteModelRoute>,
+    pub high: Option<ConcreteModelRoute>,
+}
+
+impl AgentModelRoutes {
+    pub fn for_tier(&self, tier: ModelTier) -> Option<&ConcreteModelRoute> {
+        match tier {
+            ModelTier::Low => self.low.as_ref(),
+            ModelTier::Medium => self.medium.as_ref(),
+            ModelTier::High => self.high.as_ref(),
+        }
+    }
+}
 
 /// One requested event subscription from `[[subscriptions]]` in
 /// `settings.toml`. A request, not a grant — `AgentHost::attach` only
@@ -68,6 +104,14 @@ pub struct AgentDefinition {
     /// `[permissions]` posture — actor-tier allow/ask/deny lists.
     pub posture: PermissionPosture,
     pub subscriptions: Vec<AgentSubscriptionRequest>,
+    pub source: AgentSource,
+    pub path: Option<PathBuf>,
+    pub description: String,
+    pub model_routes: AgentModelRoutes,
+    pub effort: Option<ReasoningEffort>,
+    pub tools: Vec<String>,
+    pub skills: Vec<String>,
+    pub hooks: Vec<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -75,6 +119,26 @@ struct SettingsToml {
     agent: AgentTable,
     #[serde(default)]
     subscriptions: Vec<SubscriptionTable>,
+    #[serde(default)]
+    models: BTreeMap<String, ModelRouteTable>,
+    #[serde(default)]
+    tools: NameList,
+    #[serde(default)]
+    skills: NameList,
+    #[serde(default)]
+    hooks: NameList,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct NameList {
+    #[serde(default)]
+    enabled: Vec<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ModelRouteTable {
+    provider: String,
+    model: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -82,6 +146,10 @@ struct AgentTable {
     id: String,
     display_name: String,
     default_tier: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    effort: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -142,7 +210,17 @@ impl AgentDefinition {
     /// Parse an agent from raw `AGENT.md` + `settings.toml` contents.
     /// Required fields fail fast with errors naming the field; nothing is
     /// silently defaulted.
+    #[cfg(test)]
     pub fn parse(prompt: &str, settings_toml: &str) -> Result<Self, String> {
+        Self::parse_from(prompt, settings_toml, AgentSource::Workspace, None)
+    }
+
+    fn parse_from(
+        prompt: &str,
+        settings_toml: &str,
+        source: AgentSource,
+        path: Option<PathBuf>,
+    ) -> Result<Self, String> {
         if prompt.trim().is_empty() {
             return Err("AGENT.md must be non-empty — it is the agent's system prompt".to_string());
         }
@@ -158,6 +236,30 @@ impl AgentDefinition {
             .map_err(|e| format!("settings.toml: [agent] {e}"))?;
         let posture = PermissionPosture::from_toml_str(settings_toml)
             .map_err(|e| format!("settings.toml: {e}"))?;
+        let effort = settings
+            .agent
+            .effort
+            .as_deref()
+            .map(ReasoningEffort::parse)
+            .transpose()
+            .map_err(|e| format!("settings.toml: [agent] {e}"))?;
+        let mut model_routes = AgentModelRoutes::default();
+        for (tier, route) in settings.models {
+            let parsed = ConcreteModelRoute {
+                provider: route.provider,
+                model: route.model,
+            };
+            if parsed.provider.trim().is_empty() || parsed.model.trim().is_empty() {
+                return Err(
+                    "settings.toml: [models] provider and model must be non-empty".to_string(),
+                );
+            }
+            match parse_tier(&tier).map_err(|e| format!("settings.toml: [models] {e}"))? {
+                ModelTier::Low => model_routes.low = Some(parsed),
+                ModelTier::Medium => model_routes.medium = Some(parsed),
+                ModelTier::High => model_routes.high = Some(parsed),
+            }
+        }
         let mut subscriptions = Vec::with_capacity(settings.subscriptions.len());
         for (i, sub) in settings.subscriptions.iter().enumerate() {
             let ctx = |e: String| format!("settings.toml: [[subscriptions]] #{}: {e}", i + 1);
@@ -182,6 +284,14 @@ impl AgentDefinition {
             prompt: prompt.to_string(),
             posture,
             subscriptions,
+            source,
+            path,
+            description: settings.agent.description,
+            model_routes,
+            effort,
+            tools: settings.tools.enabled,
+            skills: settings.skills.enabled,
+            hooks: settings.hooks.enabled,
         })
     }
 
@@ -193,8 +303,138 @@ impl AgentDefinition {
             .map_err(|e| format!("failed to read {}: {e}", prompt_path.display()))?;
         let settings = std::fs::read_to_string(&settings_path)
             .map_err(|e| format!("failed to read {}: {e}", settings_path.display()))?;
-        Self::parse(&prompt, &settings)
+        Self::parse_from(
+            &prompt,
+            &settings,
+            AgentSource::Workspace,
+            Some(dir.to_path_buf()),
+        )
     }
+
+    fn load_dir_from(dir: &Path, source: AgentSource) -> Result<Self, String> {
+        let mut definition = Self::load_dir(dir)?;
+        definition.source = source;
+        Ok(definition)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AgentRegistry {
+    active: BTreeMap<String, AgentDefinition>,
+    shadowed: BTreeMap<String, Vec<AgentDefinition>>,
+}
+
+impl AgentRegistry {
+    pub fn load(profile_dir: &Path, workspace_root: &Path) -> Self {
+        let default = AgentDefinition {
+            id: "default".to_string(),
+            display_name: "Plexi Assistant".to_string(),
+            default_tier: ModelTier::Medium,
+            prompt: crate::assistant::DEFAULT_AGENT_PROMPT.to_string(),
+            posture: PermissionPosture {
+                default_posture: Decision::Ask,
+                allow: Vec::new(),
+                ask: Vec::new(),
+                deny: Vec::new(),
+            },
+            subscriptions: Vec::new(),
+            source: AgentSource::BuiltIn,
+            path: None,
+            description: "General workspace assistant".to_string(),
+            model_routes: AgentModelRoutes::default(),
+            effort: None,
+            tools: Vec::new(),
+            skills: Vec::new(),
+            hooks: Vec::new(),
+        };
+        let user_dir = profile_dir.join("agents");
+        let workspace_dir = workspace_root
+            .join(crate::config::workspace_channel_dir())
+            .join("agents");
+        let user_agents = load_agents_dir(&user_dir, AgentSource::User);
+        let workspace_agents = load_agents_dir(&workspace_dir, AgentSource::Workspace);
+        log::info!(
+            "assistant: agent registry sources built-in=1 user={} workspace={}",
+            user_agents.len(),
+            workspace_agents.len()
+        );
+        let mut definitions = vec![default];
+        definitions.extend(user_agents);
+        definitions.extend(workspace_agents);
+        let mut active = BTreeMap::new();
+        let mut shadowed: BTreeMap<String, Vec<AgentDefinition>> = BTreeMap::new();
+        for definition in definitions {
+            if let Some(replaced) = active.insert(definition.id.clone(), definition) {
+                shadowed
+                    .entry(replaced.id.clone())
+                    .or_default()
+                    .push(replaced);
+            }
+        }
+        log::info!(
+            "assistant: agent registry loaded {} active, {} shadowed",
+            active.len(),
+            shadowed.values().map(Vec::len).sum::<usize>()
+        );
+        Self { active, shadowed }
+    }
+
+    pub fn active(&self, id: &str) -> Option<&AgentDefinition> {
+        self.active.get(id)
+    }
+
+    pub fn agents(&self) -> impl Iterator<Item = &AgentDefinition> {
+        self.active.values()
+    }
+    pub fn shadowed(&self, id: &str) -> &[AgentDefinition] {
+        self.shadowed.get(id).map(Vec::as_slice).unwrap_or(&[])
+    }
+}
+
+fn load_agents_dir(dir: &Path, source: AgentSource) -> Vec<AgentDefinition> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Vec::new(),
+        Err(error) => {
+            log::error!(
+                "assistant: failed to read {} agent directory {}: {error}",
+                source.label(),
+                dir.display()
+            );
+            return Vec::new();
+        }
+    };
+    let mut paths = Vec::new();
+    for entry in entries {
+        match entry {
+            Ok(entry) => {
+                let path = entry.path();
+                if path.is_dir() && path.join("settings.toml").is_file() {
+                    paths.push(path);
+                }
+            }
+            Err(error) => log::error!(
+                "assistant: failed to read entry in {} agent directory {}: {error}",
+                source.label(),
+                dir.display()
+            ),
+        }
+    }
+    paths.sort();
+    paths
+        .into_iter()
+        .filter_map(|path| match AgentDefinition::load_dir_from(&path, source) {
+            Ok(definition) => Some(definition),
+            Err(error) => {
+                log::error!(
+                    "assistant: agent registry skipped {} definition {}: {error}",
+                    source.label(),
+                    path.display()
+                );
+                None
+            }
+        })
+        .collect()
 }
 
 /// Load every agent under `<workspace>/<workspace_channel_dir>/agents/`.
@@ -208,8 +448,17 @@ pub fn load_workspace_agents(workspace_root: &Path) -> Vec<AgentDefinition> {
         return Vec::new();
     };
     let mut agents = Vec::new();
-    for entry in entries.flatten() {
-        let path = entry.path();
+    for entry in entries {
+        let path = match entry {
+            Ok(entry) => entry.path(),
+            Err(error) => {
+                log::error!(
+                    "agent: failed to read workspace agent directory entry in {}: {error}",
+                    agents_dir.display()
+                );
+                continue;
+            }
+        };
         if !path.is_dir() {
             continue;
         }
@@ -223,7 +472,7 @@ pub fn load_workspace_agents(workspace_root: &Path) -> Vec<AgentDefinition> {
             );
             continue;
         }
-        match AgentDefinition::load_dir(&path) {
+        match AgentDefinition::load_dir_from(&path, AgentSource::Workspace) {
             Ok(def) => {
                 log::info!(
                     "agent: loaded '{}' ({}) from {}",
@@ -598,6 +847,8 @@ impl AgentHost {
         let request = AiBrokerRequest {
             app_id: format!("agent:{}", agent.def.id),
             model_tier: agent.def.default_tier,
+            concrete_model: agent.def.model_routes.for_tier(agent.def.default_tier).cloned(),
+            reasoning_effort: agent.def.effort,
             system: agent.def.prompt.clone(),
             messages,
             tools: Vec::new(),
@@ -956,5 +1207,75 @@ default_tier = "low"
         // A user-caused event triggers a turn.
         host.handle_deliveries(0, vec![delivery(3, AppEventActor::User, "chess", None)]);
         assert_eq!(host.agents[0].in_flight, 1, "user event must trigger");
+    }
+
+    #[test]
+    fn registry_precedence_keeps_shadowed_definitions_visible() {
+        let profile = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let write_agent = |root: &Path, name: &str| {
+            let dir = root.join("agents").join("default");
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("AGENT.md"), format!("{name} prompt")).unwrap();
+            std::fs::write(
+                dir.join("settings.toml"),
+                format!(
+                    "[agent]\nid = \"default\"\ndisplay_name = \"{name}\"\ndefault_tier = \"medium\"\n\n[permissions]\ndefault_posture = \"ask\"\n"
+                ),
+            )
+            .unwrap();
+        };
+        write_agent(profile.path(), "User");
+        let workspace_channel = workspace.path().join(crate::config::workspace_channel_dir());
+        write_agent(&workspace_channel, "Workspace");
+
+        let registry = AgentRegistry::load(profile.path(), workspace.path());
+        assert_eq!(
+            registry.active("default").unwrap().display_name,
+            "Workspace"
+        );
+        assert_eq!(
+            registry.active("default").unwrap().source,
+            AgentSource::Workspace
+        );
+        assert_eq!(registry.shadowed("default").len(), 2);
+        assert_eq!(
+            registry.shadowed("default")[0].source,
+            AgentSource::BuiltIn
+        );
+        assert_eq!(registry.shadowed("default")[1].source, AgentSource::User);
+    }
+
+    #[test]
+    fn definition_parses_routes_effort_tools_skills_and_hooks() {
+        let settings = r#"
+[agent]
+id = "writer"
+display_name = "Writer"
+description = "Writes clearly"
+default_tier = "high"
+effort = "medium"
+[permissions]
+default_posture = "ask"
+[models.high]
+provider = "openrouter"
+model = "anthropic/claude-sonnet-4"
+[tools]
+enabled = ["docs.read"]
+[skills]
+enabled = ["human-writing"]
+[hooks]
+enabled = ["before-turn"]
+"#;
+        let definition = AgentDefinition::parse("Write.", settings).unwrap();
+        assert_eq!(definition.description, "Writes clearly");
+        assert_eq!(definition.effort, Some(ReasoningEffort::Medium));
+        assert_eq!(definition.tools, vec!["docs.read"]);
+        assert_eq!(definition.skills, vec!["human-writing"]);
+        assert_eq!(definition.hooks, vec!["before-turn"]);
+        assert_eq!(
+            definition.model_routes.high.unwrap().model,
+            "anthropic/claude-sonnet-4"
+        );
     }
 }

--- a/src/assistant/commands.rs
+++ b/src/assistant/commands.rs
@@ -42,6 +42,8 @@ pub const BUILT_IN_COMMANDS: &[(&str, &str)] = &[
         "Show or hide the model's reasoning for every turn.",
     ),
     ("model", "Show or change the model tier for this session."),
+    ("agent", "List, inspect, create, edit, or switch Assistant agents."),
+    ("effort", "Show or change reasoning effort for this session."),
     (
         "settings",
         "Show resolved Assistant settings and their sources.",

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -298,8 +298,19 @@ impl AssistantApp {
         // Load persisted session name (if any) so it survives restarts.
         model.session_name = store.active_session_name();
         model.show_thoughts = store.show_thoughts();
+        model.active_agent_id = store
+            .active_agent_id()
+            .unwrap_or_else(|| "default".to_string());
+        model.effort_override = store.effort_override();
         let settings_loader = SettingsLoader::new(profile_dir, &workspace_root);
         let agent_registry = AgentRegistry::load(profile_dir, &workspace_root);
+        if agent_registry.active(&model.active_agent_id).is_none() {
+            log::warn!(
+                "assistant: persisted agent '{}' is unavailable; using default",
+                model.active_agent_id
+            );
+            model.active_agent_id = "default".to_string();
+        }
         let session_overrides = SessionOverrides::default();
         let settings_report = settings_loader.load(&session_overrides);
         let (outcome_tx, outcome_rx) = std::sync::mpsc::channel();
@@ -692,6 +703,8 @@ impl AssistantApp {
         if let Err(e) = self.store.set_active_conversation(
             &self.model.conversation_id,
             self.model.session_name.as_deref(),
+            &self.model.active_agent_id,
+            self.model.effort_override,
         ) {
             log::error!("assistant: failed to persist active conversation: {e}");
         }
@@ -1516,23 +1529,34 @@ impl AssistantApp {
             self.execute_effects(effects);
             return;
         }
-        let dir = self.profile_dir.join("agents").join(id);
-        let result = std::fs::create_dir_all(&dir)
-            .and_then(|_| {
-                std::fs::write(
-                    dir.join("AGENT.md"),
-                    format!("You are {id}, a Plexi Assistant agent.\n"),
-                )
-            })
-            .and_then(|_| {
-                std::fs::write(
-                    dir.join("settings.toml"),
-                    format!(
-                        "[agent]\nid = \"{id}\"\ndisplay_name = \"{id}\"\ndefault_tier = \"medium\"\n\n[permissions]\ndefault_posture = \"ask\"\n"
-                    ),
-                )
-            });
+        let parent = self.profile_dir.join("agents");
+        let dir = parent.join(id);
+        let mut created_dir = false;
+        let result = (|| {
+            std::fs::create_dir_all(&parent)?;
+            std::fs::create_dir(&dir)?;
+            created_dir = true;
+            std::fs::write(
+                dir.join("AGENT.md"),
+                format!("You are {id}, a Plexi Assistant agent.\n"),
+            )?;
+            std::fs::write(
+                dir.join("settings.toml"),
+                format!(
+                    "[agent]\nid = \"{id}\"\ndisplay_name = \"{id}\"\ndefault_tier = \"medium\"\n\n[permissions]\ndefault_posture = \"ask\"\n"
+                ),
+            )
+        })();
         if let Err(error) = result {
+            if created_dir {
+                if let Err(cleanup_error) = std::fs::remove_dir_all(&dir) {
+                    log::error!(
+                        "assistant: failed to clean partial agent '{}' at {}: {cleanup_error}",
+                        id,
+                        dir.display()
+                    );
+                }
+            }
             log::error!(
                 "assistant: failed to create agent '{}' at {}: {error}",
                 id,
@@ -2172,6 +2196,25 @@ enabled = ["allowed.tool"]
             .unwrap()
             .text
             .contains("cannot be edited"));
+    }
+
+    #[test]
+    fn create_agent_refuses_to_overwrite_partial_definition() {
+        let ws = tempfile::tempdir().unwrap();
+        let dir = ws.path().join("agents").join("writer");
+        std::fs::create_dir_all(&dir).unwrap();
+        let prompt_path = dir.join("AGENT.md");
+        std::fs::write(&prompt_path, "Keep this prompt.\n").unwrap();
+        let mut app = test_app(ws.path());
+
+        app.cmd_create_agent("writer");
+
+        assert_eq!(
+            std::fs::read_to_string(prompt_path).unwrap(),
+            "Keep this prompt.\n"
+        );
+        assert!(!dir.join("settings.toml").exists());
+        assert_eq!(app.model.turns.last().unwrap().role, TurnRole::Error);
     }
 
     #[test]
@@ -3414,6 +3457,21 @@ enabled = ["allowed.tool"]
         drop(app);
         let reopened = AssistantApp::new(ws.path().to_path_buf(), MockBroker::ok("ok"), ws.path());
         assert_eq!(reopened.model.session_name.as_deref(), Some("My Session"));
+    }
+
+    #[test]
+    fn selected_agent_and_effort_persist_when_conversation_reopens() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = test_app(ws.path());
+        app.cmd_create_agent("writer");
+        app.cmd_switch_agent("writer");
+        app.set_session_effort(Some(ReasoningEffort::High));
+
+        drop(app);
+        let reopened = test_app(ws.path());
+
+        assert_eq!(reopened.model.active_agent_id, "writer");
+        assert_eq!(reopened.model.effort_override, Some(ReasoningEffort::High));
     }
 
     #[test]

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -21,12 +21,13 @@ use std::sync::{Arc, Mutex};
 
 use crate::app::app_trait::{App, AppRenderContext, KeyDisposition};
 use crate::app_protocol::{AiMessage, AiTool, ModelTier, PayloadMode, TriggerMode};
+use crate::agent::{AgentDefinition, AgentRegistry, AgentSource};
 use crate::broker::{
     ActorScope, ActorType, Decision, GrantDuration, GrantRecord, GrantSource, GrantStore,
     PermissionRequest, ResourceScope, TargetType,
 };
 use crate::host::app_timeline::AppTimeline;
-use crate::plexi_ai::broker::{AiBroker, AiBrokerRequest};
+use crate::plexi_ai::broker::{AiBroker, AiBrokerRequest, ReasoningEffort};
 use crate::plexi_ai::turn_loop::TurnDelta;
 use crate::plexi_ai::CancelToken;
 
@@ -47,7 +48,7 @@ use render::{AssistantRenderer, ComposerEvent, MarkdownTextCache};
 use settings::{AssistantSettings, SessionOverrides, SettingsLoadError, SettingsLoader};
 use store::AssistantStore;
 
-const ASSISTANT_SYSTEM_PROMPT: &str = "You are the Plexi Assistant, the workspace \
+pub(crate) const DEFAULT_AGENT_PROMPT: &str = "You are the Plexi Assistant, the workspace \
 operator inside the Plexi terminal environment. Answer concisely. Tools exposed \
 by running apps are available to you when listed; calls may pause for the user's \
 permission. You can subscribe to app event streams with the host tool \
@@ -103,6 +104,8 @@ enum ToolFlowEvent {
     Ask {
         tool: String,
         input_json: String,
+        actor_id: String,
+        actor_scope: ActorScope,
         reply: SyncSender<PermissionReply>,
     },
     /// A host tool call (`host.events.*`) for the pane to execute on the UI
@@ -126,6 +129,8 @@ struct AssistantToolHooks {
     /// Tools the user allowed with "remember" during this turn.
     session_allowed: Mutex<HashSet<String>>,
     flow_tx: Sender<ToolFlowEvent>,
+    actor_id: String,
+    actor_scope: ActorScope,
 }
 
 impl ToolCallHooks for AssistantToolHooks {
@@ -138,6 +143,8 @@ impl ToolCallHooks for AssistantToolHooks {
                 .send(ToolFlowEvent::Ask {
                     tool: name.to_string(),
                     input_json: input_json.to_string(),
+                    actor_id: self.actor_id.clone(),
+                    actor_scope: self.actor_scope,
                     reply: reply_tx,
                 })
                 .map_err(|_| "permission_denied: assistant pane closed".to_string())?;
@@ -197,6 +204,8 @@ pub struct AssistantApp {
     store: AssistantStore,
     broker: Arc<dyn AiBroker>,
     workspace_root: PathBuf,
+    profile_dir: PathBuf,
+    agent_registry: AgentRegistry,
     settings_loader: SettingsLoader,
     session_overrides: SessionOverrides,
     settings: AssistantSettings,
@@ -213,6 +222,7 @@ pub struct AssistantApp {
     flow_rx: Receiver<ToolFlowEvent>,
     /// Reply channel for the worker blocked on the pending permission sheet.
     pending_reply: Option<SyncSender<PermissionReply>>,
+    pending_connector_actor: Option<(String, ActorScope)>,
     /// Shared app event timeline (production: the global instance).
     timeline: Arc<Mutex<AppTimeline>>,
     /// Live event-stream subscriptions: `(target_id, subscription_id)` where
@@ -289,6 +299,7 @@ impl AssistantApp {
         model.session_name = store.active_session_name();
         model.show_thoughts = store.show_thoughts();
         let settings_loader = SettingsLoader::new(profile_dir, &workspace_root);
+        let agent_registry = AgentRegistry::load(profile_dir, &workspace_root);
         let session_overrides = SessionOverrides::default();
         let settings_report = settings_loader.load(&session_overrides);
         let (outcome_tx, outcome_rx) = std::sync::mpsc::channel();
@@ -298,6 +309,8 @@ impl AssistantApp {
             store,
             broker,
             workspace_root,
+            profile_dir: profile_dir.to_path_buf(),
+            agent_registry,
             settings_loader,
             session_overrides,
             settings: settings_report.settings,
@@ -310,6 +323,7 @@ impl AssistantApp {
             flow_tx,
             flow_rx,
             pending_reply: None,
+            pending_connector_actor: None,
             timeline,
             live_subs: Vec::new(),
             pending_subscribe: None,
@@ -436,6 +450,13 @@ impl AssistantApp {
                 AssistantEffect::ShowSettings => self.cmd_show_settings(),
                 AssistantEffect::ShowModelSetting => self.cmd_show_model_setting(),
                 AssistantEffect::SetSessionModel(tier) => self.set_session_model(tier),
+                AssistantEffect::ListAgents => self.cmd_list_agents(),
+                AssistantEffect::SwitchAgent(id) => self.cmd_switch_agent(&id),
+                AssistantEffect::InspectAgent(id) => self.cmd_inspect_agent(&id),
+                AssistantEffect::CreateAgent(id) => self.cmd_create_agent(&id),
+                AssistantEffect::EditAgent(id) => self.cmd_edit_agent(&id),
+                AssistantEffect::ShowEffort => self.cmd_show_effort(),
+                AssistantEffect::SetSessionEffort(effort) => self.set_session_effort(effort),
                 AssistantEffect::PersistShowThoughts(show) => {
                     if let Err(e) = self.store.set_show_thoughts(show) {
                         log::error!("assistant: failed to persist show_thoughts={show}: {e}");
@@ -459,6 +480,55 @@ impl AssistantApp {
         format!("app.{tool}")
     }
 
+    fn active_agent(&self) -> Option<&AgentDefinition> {
+        self.agent_registry
+            .active(&self.model.active_agent_id)
+            .or_else(|| self.agent_registry.active("default"))
+    }
+
+    fn connector_actor(&self) -> (String, ActorScope) {
+        self.active_agent()
+            .map(|agent| {
+                let scope = match agent.source {
+                    AgentSource::BuiltIn => ActorScope::BuiltIn,
+                    AgentSource::User => ActorScope::User,
+                    AgentSource::Workspace => ActorScope::Workspace,
+                };
+                (agent.id.clone(), scope)
+            })
+            .unwrap_or_else(|| (ASSISTANT_ACTOR_ID.to_string(), ActorScope::BuiltIn))
+    }
+
+    fn active_posture(&self) -> crate::broker::PermissionPosture {
+        let settings = self.settings.permissions.broker_posture();
+        let Some(agent) = self.active_agent().map(|agent| &agent.posture) else {
+            return settings;
+        };
+        let default_posture = if settings.default_posture == Decision::Deny
+            || agent.default_posture == Decision::Deny
+        {
+            Decision::Deny
+        } else if settings.default_posture == Decision::Ask
+            || agent.default_posture == Decision::Ask
+        {
+            Decision::Ask
+        } else {
+            Decision::Allow
+        };
+        let mut allow = settings.allow;
+        allow.extend(agent.allow.iter().cloned());
+        let mut ask = settings.ask;
+        ask.extend(agent.ask.iter().cloned());
+        let mut deny = settings.deny;
+        deny.extend(agent.deny.iter().cloned());
+        crate::broker::PermissionPosture {
+            default_posture,
+            allow,
+            ask,
+            deny,
+        }
+    }
+
     /// Evaluate one app connector tool for the assistant actor.
     fn tool_decision(&self, tool: &AiTool) -> Decision {
         if self.settings.permissions.posture.value == settings::AssistantPermissionPosture::Plan
@@ -466,14 +536,15 @@ impl AssistantApp {
         {
             return Decision::Deny;
         }
+        let (actor_id, _) = self.connector_actor();
         let req = PermissionRequest::new(
             ActorType::Agent,
-            ASSISTANT_ACTOR_ID,
+            &actor_id,
             TargetType::AppConnector,
             &Self::connector_target(&tool.name),
             Some(&self.workspace_root),
         );
-        let posture = self.settings.permissions.broker_posture();
+        let posture = self.active_posture();
         self.grant_store.evaluate(&req, Some(&posture))
     }
 
@@ -483,7 +554,7 @@ impl AssistantApp {
         } else {
             vec![event.to_string()]
         };
-        let posture = self.settings.permissions.broker_posture();
+        let posture = self.active_posture();
         crate::host::event_subscriptions::evaluate_subscription(
             &self.grant_store,
             Some(&posture),
@@ -501,14 +572,25 @@ impl AssistantApp {
     fn gated_dispatcher(&self) -> ToolDispatcher {
         let mut dispatcher = ToolDispatcher::from_registry(
             0,
-            format!("agent:{ASSISTANT_ACTOR_ID}"),
+            format!("agent:{}", self.connector_actor().0),
             self.workspace_root.clone(),
         );
         let mut allowed = HashSet::new();
         let mut ask_tools = HashSet::new();
         let mut denied = 0usize;
         let mut ro_auto = 0usize;
+        let declared_tools = self
+            .active_agent()
+            .map(|agent| agent.tools.as_slice())
+            .unwrap_or(&[]);
+        let settings_tools = &self.settings.tools.enabled.value;
         for tool in dispatcher.all_tools() {
+            if (!declared_tools.is_empty() && !declared_tools.contains(&tool.name))
+                || (!settings_tools.is_empty() && !settings_tools.contains(&tool.name))
+            {
+                denied += 1;
+                continue;
+            }
             match self.tool_decision(&tool) {
                 // Read-only tools skip the ask prompt (no permission sheet) but
                 // still respect explicit Deny grants — an admin deny wins.
@@ -539,10 +621,13 @@ impl AssistantApp {
             ask_tools.len(),
         );
         dispatcher.retain_allowed(&allowed);
+        let (actor_id, actor_scope) = self.connector_actor();
         dispatcher.set_hooks(Arc::new(AssistantToolHooks {
             ask_tools,
             session_allowed: Mutex::new(HashSet::new()),
             flow_tx: self.flow_tx.clone(),
+            actor_id,
+            actor_scope,
         }));
         // Host event tools: always visible; subscribing is ask-gated
         // per-stream inside the pane's host-call handler, not here.
@@ -749,10 +834,30 @@ impl AssistantApp {
         let cancel = CancelToken::new();
         self.turn_cancel = cancel.clone();
         let dispatcher = self.gated_dispatcher();
+        let Some(agent) = self.active_agent().cloned() else {
+            log::error!("assistant: no active or default agent available for dispatch");
+            let effects = self.model.finish_turn(
+                &conversation_id,
+                Err("Assistant agent registry has no default agent.".to_string()),
+            );
+            self.execute_effects(effects);
+            return;
+        };
+        let tier = self.session_overrides.model_tier.unwrap_or_else(|| {
+            if self.settings.model.tier.source.scope == settings::SettingsScope::Default {
+                agent.default_tier
+            } else {
+                self.settings.model.tier.value
+            }
+        });
+        let concrete_model = agent.model_routes.for_tier(tier).cloned();
+        let effort = self.model.effort_override.or(agent.effort);
         let request = AiBrokerRequest {
             app_id: "assistant".to_string(),
-            model_tier: self.settings.model.tier.value,
-            system: ASSISTANT_SYSTEM_PROMPT.to_string(),
+            model_tier: tier,
+            concrete_model,
+            reasoning_effort: effort,
+            system: agent.prompt,
             messages: self.history_messages(),
             tools: Vec::new(),
             workspace_root: Some(self.workspace_root.clone()),
@@ -761,8 +866,24 @@ impl AssistantApp {
             cancel,
         };
         log::info!(
-            "assistant[{conversation_id}]: dispatching turn ({} message(s))",
-            request.messages.len()
+            "assistant[{conversation_id}]: dispatching agent={} tier={} route={} effort={} messages={} tools={}",
+            agent.id,
+            settings::model_tier_name(request.model_tier),
+            request
+                .concrete_model
+                .as_ref()
+                .map(|route| format!("{}/{}", route.provider, route.model))
+                .unwrap_or_else(|| "tier-default".to_string()),
+            request
+                .reasoning_effort
+                .map(ReasoningEffort::label)
+                .unwrap_or("auto"),
+            request.messages.len(),
+            request
+                .tool_dispatcher
+                .as_ref()
+                .map(|dispatcher| dispatcher.all_tools().len())
+                .unwrap_or(0)
         );
         let broker = Arc::clone(&self.broker);
         let outcome_tx = self.outcome_tx.clone();
@@ -820,12 +941,15 @@ impl AssistantApp {
                 ToolFlowEvent::Ask {
                     tool,
                     input_json,
+                    actor_id,
+                    actor_scope,
                     reply,
                 } => {
                     log::info!("assistant: permission sheet shown for '{tool}'");
                     self.model
                         .permission_requested(&tool, &summarize_input(&input_json));
                     self.pending_reply = Some(reply);
+                    self.pending_connector_actor = Some((actor_id, actor_scope));
                 }
                 ToolFlowEvent::HostCall {
                     tool,
@@ -846,6 +970,7 @@ impl AssistantApp {
         while let Ok(outcome) = self.outcome_rx.try_recv() {
             self.delta_rx = None;
             self.pending_reply = None;
+            self.pending_connector_actor = None;
             let result = match (outcome.text, outcome.error) {
                 (Some(text), _) => Ok(text),
                 (None, Some(error)) => Err(error),
@@ -1002,6 +1127,7 @@ impl AssistantApp {
         if let Some(tx) = self.pending_reply.take() {
             let _ = tx.send(PermissionReply::Deny);
         }
+        self.pending_connector_actor = None;
         if let Some(pending) = self.pending_subscribe.take() {
             let _ = pending.reply.send(ToolCallResult {
                 output_json: None,
@@ -1027,7 +1153,7 @@ impl AssistantApp {
                 ("allow_once", PermissionReply::Allow { remember: false })
             }
             PermissionChoice::AllowSession => {
-                self.record_assistant_grant(
+                self.record_connector_grant(
                     TargetType::AppConnector,
                     &target,
                     GrantDuration::Session,
@@ -1036,7 +1162,7 @@ impl AssistantApp {
                 ("allow_session", PermissionReply::Allow { remember: true })
             }
             PermissionChoice::AllowAlways => {
-                self.record_assistant_grant(
+                self.record_connector_grant(
                     TargetType::AppConnector,
                     &target,
                     GrantDuration::Always,
@@ -1065,6 +1191,7 @@ impl AssistantApp {
                 pending.tool
             ),
         }
+        self.pending_connector_actor = None;
         let effects = self.model.permission_resolved(choice);
         self.execute_effects(effects);
     }
@@ -1136,9 +1263,49 @@ impl AssistantApp {
         self.execute_effects(effects);
     }
 
-    /// Record an Allow grant for the assistant actor on `target`.
+    fn record_connector_grant(
+        &mut self,
+        target_type: TargetType,
+        target: &str,
+        duration: GrantDuration,
+        source: GrantSource,
+    ) {
+        let (actor_id, actor_scope) = self
+            .pending_connector_actor
+            .clone()
+            .unwrap_or_else(|| self.connector_actor());
+        self.record_grant(
+            &actor_id,
+            actor_scope,
+            target_type,
+            target,
+            duration,
+            source,
+        );
+    }
+
+    /// Record an Allow grant for the shared Assistant event actor on `target`.
     fn record_assistant_grant(
         &mut self,
+        target_type: TargetType,
+        target: &str,
+        duration: GrantDuration,
+        source: GrantSource,
+    ) {
+        self.record_grant(
+            ASSISTANT_ACTOR_ID,
+            ActorScope::BuiltIn,
+            target_type,
+            target,
+            duration,
+            source,
+        );
+    }
+
+    fn record_grant(
+        &mut self,
+        actor_id: &str,
+        actor_scope: ActorScope,
         target_type: TargetType,
         target: &str,
         duration: GrantDuration,
@@ -1152,8 +1319,8 @@ impl AssistantApp {
             .unwrap_or_else(|_| self.workspace_root.clone());
         self.grant_store.record(GrantRecord {
             actor_type: ActorType::Agent,
-            actor_id: ASSISTANT_ACTOR_ID.to_string(),
-            actor_scope: ActorScope::BuiltIn,
+            actor_id: actor_id.to_string(),
+            actor_scope,
             workspace_root: Some(workspace_root),
             target_type,
             target_id: target.to_string(),
@@ -1176,6 +1343,268 @@ impl AssistantApp {
         self.settings_errors = report.errors;
     }
 
+    fn reload_agents(&mut self) {
+        self.agent_registry = AgentRegistry::load(&self.profile_dir, &self.workspace_root);
+        if self.agent_registry.active(&self.model.active_agent_id).is_none() {
+            self.model.active_agent_id = "default".to_string();
+        }
+    }
+
+    fn cmd_list_agents(&mut self) {
+        self.reload_agents();
+        let lines = self
+            .agent_registry
+            .agents()
+            .map(|agent| {
+                let marker = if agent.id == self.model.active_agent_id {
+                    " (active)"
+                } else {
+                    ""
+                };
+                let shadowed = self.agent_registry.shadowed(&agent.id);
+                let shadow_note = if shadowed.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        "; {} shadowed: {}",
+                        shadowed.len(),
+                        shadowed
+                            .iter()
+                            .map(|entry| entry.source.label())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                };
+                format!(
+                    "- `{}`: {} [{}]{}{}",
+                    agent.id,
+                    agent.display_name,
+                    agent.source.label(),
+                    marker,
+                    shadow_note
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let effects = self.model.push_info(format!("**Assistant agents**\n\n{lines}"));
+        self.execute_effects(effects);
+    }
+
+    fn cmd_switch_agent(&mut self, id: &str) {
+        self.reload_agents();
+        let Some(agent) = self.agent_registry.active(id) else {
+            let effects = self
+                .model
+                .push_error(format!("Unknown agent `{id}`. Run /agent to list agents."));
+            self.execute_effects(effects);
+            return;
+        };
+        self.model.active_agent_id = agent.id.clone();
+        self.model.effort_override = None;
+        log::info!(
+            "assistant: switched active agent to '{}' ({})",
+            agent.id,
+            agent.source.label()
+        );
+        let effects = self.model.push_info(format!(
+            "Active agent: `{}` ({}).",
+            agent.id, agent.display_name
+        ));
+        self.execute_effects(effects);
+    }
+
+    fn cmd_inspect_agent(&mut self, id: &str) {
+        self.reload_agents();
+        let Some(agent) = self.agent_registry.active(id) else {
+            let effects = self.model.push_error(format!("Unknown agent `{id}`."));
+            self.execute_effects(effects);
+            return;
+        };
+        let shadowed = self
+            .agent_registry
+            .shadowed(id)
+            .iter()
+            .map(|entry| entry.source.label())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let routes = [ModelTier::Low, ModelTier::Medium, ModelTier::High]
+            .into_iter()
+            .filter_map(|tier| {
+                agent.model_routes.for_tier(tier).map(|route| {
+                    format!(
+                        "{}={}/{}",
+                        settings::model_tier_name(tier),
+                        route.provider,
+                        route.model
+                    )
+                })
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let shadow_details = self
+            .agent_registry
+            .shadowed(id)
+            .iter()
+            .map(|entry| {
+                format!(
+                    "- {} [{}], tier={}, description={}, path={}, tools={}, skills={}, hooks={}",
+                    entry.display_name,
+                    entry.source.label(),
+                    settings::model_tier_name(entry.default_tier),
+                    if entry.description.is_empty() {
+                        "none"
+                    } else {
+                        &entry.description
+                    },
+                    entry
+                        .path
+                        .as_ref()
+                        .map(|path| path.display().to_string())
+                        .unwrap_or_else(|| "compiled".to_string()),
+                    format_setting_ids(&entry.tools),
+                    format_setting_ids(&entry.skills),
+                    format_setting_ids(&entry.hooks)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let text = format!(
+            "**Agent `{}`**\n\n- Name: {}\n- Source: {}\n- Description: {}\n- Default tier: {}\n- Routes: {}\n- Effort: {}\n- Tools: {}\n- Skills: {}\n- Hooks: {}\n- Shadowed sources: {}",
+            agent.id,
+            agent.display_name,
+            agent.source.label(),
+            if agent.description.is_empty() { "none" } else { &agent.description },
+            settings::model_tier_name(agent.default_tier),
+            if routes.is_empty() { "tier defaults" } else { &routes },
+            agent.effort.map(ReasoningEffort::label).unwrap_or("auto"),
+            format_setting_ids(&agent.tools),
+            format_setting_ids(&agent.skills),
+            format_setting_ids(&agent.hooks),
+            if shadowed.is_empty() { "none" } else { &shadowed }
+        );
+        let text = if shadow_details.is_empty() {
+            text
+        } else {
+            format!("{text}\n\n**Shadowed definitions**\n\n{shadow_details}")
+        };
+        let effects = self.model.push_info(text);
+        self.execute_effects(effects);
+    }
+
+    fn valid_agent_id(id: &str) -> bool {
+        !id.is_empty()
+            && id.chars().all(|ch| {
+                ch.is_ascii_lowercase()
+                    || ch.is_ascii_digit()
+                    || ch == '-'
+                    || ch == '_'
+            })
+    }
+
+    fn cmd_create_agent(&mut self, id: &str) {
+        self.reload_agents();
+        if !Self::valid_agent_id(id) {
+            let effects = self.model.push_error(
+                "Agent ids use lowercase letters, digits, hyphens, and underscores only."
+                    .to_string(),
+            );
+            self.execute_effects(effects);
+            return;
+        }
+        if self.agent_registry.active(id).is_some() {
+            let effects = self.model.push_error(format!("Agent `{id}` already exists."));
+            self.execute_effects(effects);
+            return;
+        }
+        let dir = self.profile_dir.join("agents").join(id);
+        let result = std::fs::create_dir_all(&dir)
+            .and_then(|_| {
+                std::fs::write(
+                    dir.join("AGENT.md"),
+                    format!("You are {id}, a Plexi Assistant agent.\n"),
+                )
+            })
+            .and_then(|_| {
+                std::fs::write(
+                    dir.join("settings.toml"),
+                    format!(
+                        "[agent]\nid = \"{id}\"\ndisplay_name = \"{id}\"\ndefault_tier = \"medium\"\n\n[permissions]\ndefault_posture = \"ask\"\n"
+                    ),
+                )
+            });
+        if let Err(error) = result {
+            log::error!(
+                "assistant: failed to create agent '{}' at {}: {error}",
+                id,
+                dir.display()
+            );
+            let effects = self.model.push_error(format!("Failed to create agent `{id}`: {error}"));
+            self.execute_effects(effects);
+            return;
+        }
+        self.reload_agents();
+        log::info!(
+            "assistant: created user agent '{}' at {}",
+            id,
+            dir.display()
+        );
+        let effects = self.model.push_info(format!("Created agent `{id}` at `{}`.", dir.display()));
+        self.execute_effects(effects);
+    }
+
+    fn cmd_edit_agent(&mut self, id: &str) {
+        self.reload_agents();
+        let Some(agent) = self.agent_registry.active(id) else {
+            let effects = self.model.push_error(format!("Unknown agent `{id}`."));
+            self.execute_effects(effects);
+            return;
+        };
+        if agent.source == AgentSource::BuiltIn {
+            let effects = self.model.push_error(
+                "Built-in agents cannot be edited. Create a user agent instead.".to_string(),
+            );
+            self.execute_effects(effects);
+            return;
+        }
+        let path = agent
+            .path
+            .clone()
+            .unwrap_or_else(|| self.profile_dir.join("agents").join(id));
+        log::info!("assistant: edit agent '{}' at {}", id, path.display());
+        let effects = self.model.push_info(format!("Edit agent `{id}` at `{}`.", path.display()));
+        self.execute_effects(effects);
+    }
+
+    fn cmd_show_effort(&mut self) {
+        let agent_effort = self.active_agent().and_then(|agent| agent.effort);
+        let effective = self.model.effort_override.or(agent_effort);
+        let source = if self.model.effort_override.is_some() {
+            "session"
+        } else if agent_effort.is_some() {
+            "agent"
+        } else {
+            "provider default"
+        };
+        let effects = self.model.push_info(format!(
+            "Reasoning effort: `{}` ({source}).",
+            effective.map(ReasoningEffort::label).unwrap_or("auto")
+        ));
+        self.execute_effects(effects);
+    }
+
+    fn set_session_effort(&mut self, effort: Option<ReasoningEffort>) {
+        self.model.effort_override = effort;
+        log::info!(
+            "assistant: session reasoning effort set to {}",
+            effort.map(ReasoningEffort::label).unwrap_or("auto")
+        );
+        let effects = self.model.push_info(format!(
+            "Reasoning effort set to `{}` for this session.",
+            effort.map(ReasoningEffort::label).unwrap_or("auto")
+        ));
+        self.execute_effects(effects);
+    }
+
     fn set_session_model(&mut self, tier: ModelTier) {
         self.session_overrides.model_tier = Some(tier);
         self.reload_settings();
@@ -1193,16 +1622,28 @@ impl AssistantApp {
 
     fn cmd_show_model_setting(&mut self) {
         self.reload_settings();
-        let tier = &self.settings.model.tier;
+        let configured = &self.settings.model.tier;
+        let (tier, source) = if self.session_overrides.model_tier.is_some()
+            || configured.source.scope != settings::SettingsScope::Default
+        {
+            (configured.value, configured.source.description())
+        } else if let Some(agent) = self.active_agent() {
+            (
+                agent.default_tier,
+                format!("agent `{}` [{}]", agent.id, agent.source.label()),
+            )
+        } else {
+            (configured.value, configured.source.description())
+        };
         log::info!(
             "assistant: /model showing {} from {}",
-            settings::model_tier_name(tier.value),
-            tier.source.description()
+            settings::model_tier_name(tier),
+            source
         );
         let effects = self.model.push_info(format!(
             "Model tier: `{}` ({}).",
-            settings::model_tier_name(tier.value),
-            tier.source.description()
+            settings::model_tier_name(tier),
+            source
         ));
         self.execute_effects(effects);
     }
@@ -1346,11 +1787,18 @@ impl AssistantApp {
 
     /// `/permissions`: persisted grants for the assistant actor.
     fn cmd_list_permissions(&mut self) {
+        let connector_actor_id = self.connector_actor().0;
         let lines: Vec<String> = self
             .grant_store
             .records()
             .iter()
-            .filter(|r| r.actor_type == ActorType::Agent && r.actor_id == ASSISTANT_ACTOR_ID)
+            .filter(|r| {
+                r.actor_type == ActorType::Agent
+                    && ((r.target_type == TargetType::AppConnector
+                        && r.actor_id == connector_actor_id)
+                        || (r.target_type == TargetType::AppEventStream
+                            && r.actor_id == ASSISTANT_ACTOR_ID))
+            })
             .map(|r| {
                 format!(
                     "{} = {} ({:?}, {:?})",
@@ -1380,9 +1828,14 @@ impl AssistantApp {
     /// `/revoke <target_id>`: remove persisted grants for one target. Event
     /// stream targets also lose their live timeline subscription.
     fn cmd_revoke(&mut self, target_id: &str) {
+        let actor_id = if target_id.starts_with("app.") {
+            self.connector_actor().0
+        } else {
+            ASSISTANT_ACTOR_ID.to_string()
+        };
         let removed = self
             .grant_store
-            .revoke(ActorType::Agent, ASSISTANT_ACTOR_ID, target_id);
+            .revoke(ActorType::Agent, &actor_id, target_id);
         let unsubscribed = self.unsubscribe_stream(target_id);
         let text = if removed == 0 && unsubscribed == 0 {
             format!("No grants found for '{target_id}'. See /permissions for target ids.")
@@ -1512,6 +1965,22 @@ mod tests {
         reply: Option<String>,
     }
 
+    #[derive(Default)]
+    struct CapturingBroker {
+        seen: Mutex<Vec<AiBrokerRequest>>,
+    }
+
+    impl AiBroker for CapturingBroker {
+        fn dispatch(
+            &self,
+            request: AiBrokerRequest,
+            _on_delta: &mut dyn FnMut(TurnDelta<'_>),
+        ) -> AiBrokerResponse {
+            self.seen.lock().unwrap().push(request);
+            AiBrokerResponse::ok("ok".to_string(), 0, 0)
+        }
+    }
+
     impl MockBroker {
         fn ok(reply: impl Into<String>) -> Arc<Self> {
             Arc::new(Self {
@@ -1585,6 +2054,184 @@ mod tests {
         assert_eq!(reopened.model.conversation_id, conversation_id);
         assert_eq!(reopened.model.turns.len(), 2);
         assert_eq!(reopened.model.turns[1].text, "echo: ok");
+    }
+
+    #[test]
+    fn scoped_and_session_model_tiers_route_active_agent_concretely() {
+        let ws = tempfile::tempdir().unwrap();
+        let assistant_settings_dir = ws
+            .path()
+            .join(crate::config::workspace_channel_dir())
+            .join("agents");
+        std::fs::create_dir_all(&assistant_settings_dir).unwrap();
+        std::fs::write(
+            assistant_settings_dir.join("settings.toml"),
+            "[model]\ntier = \"medium\"\n",
+        )
+        .unwrap();
+        let agent_dir = ws.path().join("agents").join("writer");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(agent_dir.join("AGENT.md"), "Writer system prompt").unwrap();
+        std::fs::write(
+            agent_dir.join("settings.toml"),
+            r#"
+[agent]
+id = "writer"
+display_name = "Writer"
+default_tier = "high"
+effort = "medium"
+[permissions]
+default_posture = "ask"
+[models.high]
+provider = "openrouter"
+model = "anthropic/test"
+[models.medium]
+provider = "openrouter"
+model = "anthropic/medium"
+[models.low]
+provider = "openrouter"
+model = "anthropic/low"
+[tools]
+enabled = ["allowed.tool"]
+"#,
+        )
+        .unwrap();
+        let broker = Arc::new(CapturingBroker::default());
+        let mut app = AssistantApp::new(ws.path().to_path_buf(), broker.clone(), ws.path());
+        register_echo_provider(
+            9199,
+            &["allowed.tool", "denied.tool"],
+            ws.path().to_path_buf(),
+        );
+
+        app.model.composer = "/agent writer".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        app.model.composer = "hello".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        wait_for_turn(&mut app);
+
+        app.model.composer = "/model low".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        app.model.composer = "hello again".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        wait_for_turn(&mut app);
+
+        let seen = broker.seen.lock().unwrap();
+        assert_eq!(seen.len(), 2);
+        assert_eq!(seen[0].system, "Writer system prompt");
+        assert_eq!(seen[0].model_tier, ModelTier::Medium);
+        assert_eq!(
+            seen[0].concrete_model.as_ref().unwrap().model,
+            "anthropic/medium"
+        );
+        assert_eq!(seen[1].model_tier, ModelTier::Low);
+        assert_eq!(
+            seen[1].concrete_model.as_ref().unwrap().model,
+            "anthropic/low"
+        );
+        assert_eq!(seen[1].reasoning_effort, Some(ReasoningEffort::Medium));
+        let tool_names = seen[1]
+            .tool_dispatcher
+            .as_ref()
+            .unwrap()
+            .all_tools()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect::<Vec<_>>();
+        assert!(tool_names.contains(&"allowed.tool".to_string()));
+        assert!(!tool_names.contains(&"denied.tool".to_string()));
+        tool_dispatch::unregister(9199);
+    }
+
+    #[test]
+    fn create_and_edit_agent_are_file_backed_and_builtin_is_read_only() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = test_app(ws.path());
+        app.cmd_create_agent("writer");
+        let dir = ws.path().join("agents").join("writer");
+        assert!(dir.join("AGENT.md").is_file());
+        assert!(dir.join("settings.toml").is_file());
+        app.cmd_edit_agent("writer");
+        assert!(app
+            .model
+            .turns
+            .last()
+            .unwrap()
+            .text
+            .contains(&dir.display().to_string()));
+        app.cmd_edit_agent("default");
+        assert_eq!(app.model.turns.last().unwrap().role, TurnRole::Error);
+        assert!(app
+            .model
+            .turns
+            .last()
+            .unwrap()
+            .text
+            .contains("cannot be edited"));
+    }
+
+    #[test]
+    fn named_agent_connector_permissions_use_agent_identity_and_scope() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = test_app(ws.path());
+        app.cmd_create_agent("writer");
+        app.cmd_switch_agent("writer");
+        app.record_connector_grant(
+            TargetType::AppConnector,
+            "app.docs.write",
+            GrantDuration::Session,
+            GrantSource::Session,
+        );
+
+        let record = app.grant_store.records().last().unwrap();
+        assert_eq!(record.actor_id, "writer");
+        assert_eq!(record.actor_scope, ActorScope::User);
+        let tool = AiTool {
+            name: "docs.write".to_string(),
+            description: "write docs".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+            timeout_ms: None,
+            read_only: false,
+        };
+        assert_eq!(app.tool_decision(&tool), Decision::Allow);
+    }
+
+    #[test]
+    fn agent_commands_expose_shadowed_definition_summaries() {
+        let ws = tempfile::tempdir().unwrap();
+        let write_agent = |dir: PathBuf, name: &str, description: &str| {
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("AGENT.md"), format!("{name} prompt")).unwrap();
+            std::fs::write(
+                dir.join("settings.toml"),
+                format!(
+                    "[agent]\nid = \"writer\"\ndisplay_name = \"{name}\"\ndescription = \"{description}\"\ndefault_tier = \"medium\"\n\n[permissions]\ndefault_posture = \"ask\"\n"
+                ),
+            )
+            .unwrap();
+        };
+        write_agent(ws.path().join("agents/writer"), "User Writer", "user copy");
+        write_agent(
+            ws.path()
+                .join(crate::config::workspace_channel_dir())
+                .join("agents/writer"),
+            "Workspace Writer",
+            "workspace copy",
+        );
+        let mut app = test_app(ws.path());
+
+        app.cmd_list_agents();
+        let list = &app.model.turns.last().unwrap().text;
+        assert!(list.contains("1 shadowed: user"), "{list}");
+        app.cmd_inspect_agent("writer");
+        let inspect = &app.model.turns.last().unwrap().text;
+        assert!(inspect.contains("Workspace Writer"), "{inspect}");
+        assert!(inspect.contains("User Writer [user]"), "{inspect}");
+        assert!(inspect.contains("description=user copy"), "{inspect}");
     }
 
     #[test]
@@ -1874,16 +2521,17 @@ mod tests {
         });
     }
 
-    /// Persist a grant for the assistant actor directly into the app's store.
+    /// Persist a grant for the active connector agent directly into the store.
     fn seed_grant(app: &mut AssistantApp, target: &str, decision: Decision) {
+        let (actor_id, actor_scope) = app.connector_actor();
         let workspace_root = app
             .workspace_root
             .canonicalize()
             .unwrap_or_else(|_| app.workspace_root.clone());
         app.grant_store.record(GrantRecord {
             actor_type: ActorType::Agent,
-            actor_id: ASSISTANT_ACTOR_ID.to_string(),
-            actor_scope: ActorScope::BuiltIn,
+            actor_id,
+            actor_scope,
             workspace_root: Some(workspace_root),
             target_type: TargetType::AppConnector,
             target_id: target.to_string(),

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -6,6 +6,7 @@
 
 use super::commands::{self, ParsedCommand};
 use crate::app_protocol::ModelTier;
+use crate::plexi_ai::broker::ReasoningEffort;
 
 /// Who produced a transcript row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -124,6 +125,13 @@ pub enum AssistantEffect {
     ShowModelSetting,
     /// `/model low|medium|high`: override the model tier for this session.
     SetSessionModel(ModelTier),
+    ListAgents,
+    SwitchAgent(String),
+    InspectAgent(String),
+    CreateAgent(String),
+    EditAgent(String),
+    ShowEffort,
+    SetSessionEffort(Option<ReasoningEffort>),
     /// `/thoughts`: persist the flipped show-thoughts preference.
     PersistShowThoughts(bool),
     /// `/clear` or `/new` ran while a turn was in flight: unblock any worker
@@ -165,6 +173,8 @@ pub struct AssistantModel {
     /// Show reasoning ("thoughts") sections in the transcript. Toggled by
     /// `/thoughts`, persisted in the assistant store's `state.toml`.
     pub show_thoughts: bool,
+    pub active_agent_id: String,
+    pub effort_override: Option<ReasoningEffort>,
     /// Shell-style composer history cursor over prior user turns. `None`
     /// means normal editing; `Some(0)` is the newest user message.
     history_cursor: Option<usize>,
@@ -185,6 +195,8 @@ impl AssistantModel {
             queued_user_turns: 0,
             turn_anchor: None,
             show_thoughts: false,
+            active_agent_id: "default".to_string(),
+            effort_override: None,
             history_cursor: None,
         }
     }
@@ -448,6 +460,50 @@ impl AssistantModel {
                     }
                 }
             }
+            "agent" if cmd.args.is_empty() => vec![AssistantEffect::ListAgents],
+            "agent" => {
+                let mut parts = cmd.args.split_whitespace();
+                let first = parts.next().unwrap_or("");
+                let second = parts.next();
+                match (first, second, parts.next()) {
+                    ("inspect", Some(id), None) => {
+                        vec![AssistantEffect::InspectAgent(id.to_string())]
+                    }
+                    ("create", Some(id), None) => {
+                        vec![AssistantEffect::CreateAgent(id.to_string())]
+                    }
+                    ("edit", Some(id), None) => vec![AssistantEffect::EditAgent(id.to_string())],
+                    (id, None, None) => vec![AssistantEffect::SwitchAgent(id.to_string())],
+                    _ => {
+                        self.turns.push(Turn::now(
+                            TurnRole::Error,
+                            "Usage: /agent [<id> | inspect <id> | create <id> | edit <id>].",
+                        ));
+                        vec![AssistantEffect::SessionWrite {
+                            conversation_id: self.conversation_id.clone(),
+                        }]
+                    }
+                }
+            }
+            "effort" if cmd.args.is_empty() => vec![AssistantEffect::ShowEffort],
+            "effort" => match cmd.args.as_str() {
+                "auto" => vec![AssistantEffect::SetSessionEffort(None)],
+                "low" => vec![AssistantEffect::SetSessionEffort(Some(ReasoningEffort::Low))],
+                "medium" => vec![AssistantEffect::SetSessionEffort(Some(ReasoningEffort::Medium))],
+                "high" => vec![AssistantEffect::SetSessionEffort(Some(ReasoningEffort::High))],
+                _ => {
+                    self.turns.push(Turn::now(
+                        TurnRole::Error,
+                        format!(
+                            "Invalid effort '{}'. Expected auto | low | medium | high.",
+                            cmd.args
+                        ),
+                    ));
+                    vec![AssistantEffect::SessionWrite {
+                        conversation_id: self.conversation_id.clone(),
+                    }]
+                }
+            },
             "revoke" => {
                 if cmd.args.is_empty() {
                     self.turns.push(Turn::now(
@@ -493,6 +549,13 @@ impl AssistantModel {
     /// persistence effect.
     pub fn push_info(&mut self, text: impl Into<String>) -> Vec<AssistantEffect> {
         self.turns.push(Turn::now(TurnRole::Assistant, text));
+        vec![AssistantEffect::SessionWrite {
+            conversation_id: self.conversation_id.clone(),
+        }]
+    }
+
+    pub fn push_error(&mut self, text: impl Into<String>) -> Vec<AssistantEffect> {
+        self.turns.push(Turn::now(TurnRole::Error, text));
         vec![AssistantEffect::SessionWrite {
             conversation_id: self.conversation_id.clone(),
         }]
@@ -901,6 +964,41 @@ mod tests {
 
         assert_eq!(settings_effects, config_effects);
         assert_eq!(settings_effects, vec![AssistantEffect::ShowSettings]);
+    }
+
+    #[test]
+    fn agent_and_effort_commands_emit_typed_effects() {
+        let mut model = AssistantModel::fresh();
+        assert_eq!(
+            submitted(&mut model, "/agent"),
+            vec![AssistantEffect::ListAgents]
+        );
+        assert_eq!(
+            submitted(&mut model, "/agent writer"),
+            vec![AssistantEffect::SwitchAgent("writer".to_string())]
+        );
+        assert_eq!(
+            submitted(&mut model, "/agent inspect writer"),
+            vec![AssistantEffect::InspectAgent("writer".to_string())]
+        );
+        assert_eq!(
+            submitted(&mut model, "/agent create writer"),
+            vec![AssistantEffect::CreateAgent("writer".to_string())]
+        );
+        assert_eq!(
+            submitted(&mut model, "/agent edit writer"),
+            vec![AssistantEffect::EditAgent("writer".to_string())]
+        );
+        assert_eq!(
+            submitted(&mut model, "/effort high"),
+            vec![AssistantEffect::SetSessionEffort(Some(
+                ReasoningEffort::High
+            ))]
+        );
+        assert_eq!(
+            submitted(&mut model, "/effort auto"),
+            vec![AssistantEffect::SetSessionEffort(None)]
+        );
     }
 
     #[test]

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -887,12 +887,16 @@ mod tests {
     #[test]
     fn clear_starts_fresh_conversation_with_new_id() {
         let mut m = AssistantModel::fresh();
+        m.active_agent_id = "writer".to_string();
+        m.effort_override = Some(ReasoningEffort::High);
         let old_id = m.conversation_id.clone();
         submitted(&mut m, "remember this");
         m.streaming = StreamingState::default();
         let effects = submitted(&mut m, "/clear");
         assert_ne!(m.conversation_id, old_id);
         assert!(m.turns.is_empty());
+        assert_eq!(m.active_agent_id, "writer");
+        assert_eq!(m.effort_override, Some(ReasoningEffort::High));
         assert!(
             matches!(&effects[0], AssistantEffect::SessionWrite { conversation_id }
             if *conversation_id == m.conversation_id)
@@ -902,11 +906,15 @@ mod tests {
     #[test]
     fn new_creates_named_conversation() {
         let mut m = AssistantModel::fresh();
+        m.active_agent_id = "writer".to_string();
+        m.effort_override = Some(ReasoningEffort::High);
         let old_id = m.conversation_id.clone();
         submitted(&mut m, "/new project notes");
         assert_ne!(m.conversation_id, old_id);
         assert_eq!(m.turns.len(), 1);
         assert!(m.turns[0].text.contains("project notes"));
+        assert_eq!(m.active_agent_id, "writer");
+        assert_eq!(m.effort_override, Some(ReasoningEffort::High));
     }
 
     #[test]

--- a/src/assistant/render.rs
+++ b/src/assistant/render.rs
@@ -209,19 +209,32 @@ impl AssistantRenderer {
             pip_color,
         );
 
-        let title = model
+        let session = model
             .session_name
             .clone()
             .unwrap_or_else(|| "Assistant".to_string());
-        // A real label (not painter text) so the title stays in the
-        // accessibility tree for UI-harness queries.
+        // Keep the session title and active agent as separate semantic labels.
+        // Scenes and assistive technology rely on the stable session label,
+        // while the adjacent agent label makes selection state observable.
         let mut bar_ui = ui.new_child(egui::UiBuilder::new().max_rect(bar_rect));
         bar_ui.centered_and_justified(|ui| {
-            ui.label(
-                RichText::new(title)
-                    .size(Self::HEADER_FONT_SIZE)
-                    .color(colors.text_dim),
-            );
+            ui.horizontal(|ui| {
+                ui.label(
+                    RichText::new(session)
+                        .size(Self::HEADER_FONT_SIZE)
+                        .color(colors.text_dim),
+                );
+                ui.label(
+                    RichText::new("·")
+                        .size(Self::HEADER_FONT_SIZE)
+                        .color(colors.text_dim),
+                );
+                ui.label(
+                    RichText::new(&model.active_agent_id)
+                        .size(Self::HEADER_FONT_SIZE)
+                        .color(colors.text_dim),
+                );
+            });
         });
     }
 

--- a/src/assistant/store.rs
+++ b/src/assistant/store.rs
@@ -16,8 +16,9 @@
 use std::path::{Path, PathBuf};
 
 use super::model::Turn;
+use crate::plexi_ai::broker::ReasoningEffort;
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Default, serde::Serialize, serde::Deserialize)]
 struct StateToml {
     active_conversation: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -25,6 +26,10 @@ struct StateToml {
     /// `/thoughts` toggle: show reasoning sections in the transcript.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     show_thoughts: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    active_agent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    effort_override: Option<ReasoningEffort>,
 }
 
 /// Handle to the on-disk Assistant store for one workspace.
@@ -84,20 +89,28 @@ impl AssistantStore {
         &self,
         id: &str,
         session_name: Option<&str>,
+        active_agent_id: &str,
+        effort_override: Option<ReasoningEffort>,
     ) -> Result<(), String> {
-        let mut state = self.read_state().unwrap_or(StateToml {
-            active_conversation: String::new(),
-            session_name: None,
-            show_thoughts: None,
-        });
+        let mut state = self.read_state().unwrap_or_default();
         state.active_conversation = id.to_string();
         state.session_name = session_name.map(str::to_string);
+        state.active_agent_id = Some(active_agent_id.to_string());
+        state.effort_override = effort_override;
         self.write_state(&state)
     }
 
     /// The persisted session name for the active conversation, if any.
     pub fn active_session_name(&self) -> Option<String> {
         self.read_state()?.session_name
+    }
+
+    pub fn active_agent_id(&self) -> Option<String> {
+        self.read_state()?.active_agent_id
+    }
+
+    pub fn effort_override(&self) -> Option<ReasoningEffort> {
+        self.read_state()?.effort_override
     }
 
     /// The persisted `/thoughts` toggle. Default: hidden.
@@ -109,11 +122,7 @@ impl AssistantStore {
 
     /// Persist the `/thoughts` toggle, preserving the rest of the state.
     pub fn set_show_thoughts(&self, show: bool) -> Result<(), String> {
-        let mut state = self.read_state().unwrap_or(StateToml {
-            active_conversation: String::new(),
-            session_name: None,
-            show_thoughts: None,
-        });
+        let mut state = self.read_state().unwrap_or_default();
         state.show_thoughts = Some(show);
         self.write_state(&state)
     }
@@ -181,7 +190,9 @@ mod tests {
         assert_eq!(store.active_conversation(), None);
 
         let id = "conv-test-1";
-        store.set_active_conversation(id, None).unwrap();
+        store
+            .set_active_conversation(id, None, "default", None)
+            .unwrap();
         store
             .write_turns(
                 id,
@@ -215,7 +226,9 @@ mod tests {
     fn store_path_is_channel_aware() {
         let ws = tempfile::tempdir().unwrap();
         let store = AssistantStore::new(ws.path());
-        store.set_active_conversation("c1", None).unwrap();
+        store
+            .set_active_conversation("c1", None, "default", None)
+            .unwrap();
         let expected = ws
             .path()
             .join(crate::config::workspace_channel_dir())
@@ -234,7 +247,9 @@ mod tests {
         assert!(store.show_thoughts());
 
         // Switching conversations must not clobber the preference.
-        store.set_active_conversation("c2", Some("notes")).unwrap();
+        store
+            .set_active_conversation("c2", Some("notes"), "default", None)
+            .unwrap();
         assert!(store.show_thoughts());
         assert_eq!(store.active_conversation().as_deref(), Some("c2"));
         assert_eq!(store.active_session_name().as_deref(), Some("notes"));

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -847,6 +847,8 @@ impl WasmPane {
                     AiBrokerRequest {
                         app_id,
                         model_tier,
+                        concrete_model: None,
+                        reasoning_effort: None,
                         system: req.system,
                         messages,
                         tools: Vec::new(),

--- a/src/plexi_ai/backend/mod.rs
+++ b/src/plexi_ai/backend/mod.rs
@@ -14,6 +14,42 @@ use std::sync::{mpsc, Arc};
 
 use crate::app_protocol::ModelTier;
 
+/// Provider-neutral concrete model route selected by an Assistant agent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConcreteModelRoute {
+    pub provider: String,
+    pub model: String,
+}
+
+/// Provider-neutral reasoning effort selected by an Assistant agent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReasoningEffort {
+    Low,
+    Medium,
+    High,
+}
+
+impl ReasoningEffort {
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        match raw {
+            "low" => Ok(Self::Low),
+            "medium" => Ok(Self::Medium),
+            "high" => Ok(Self::High),
+            other => Err(format!(
+                "invalid effort '{other}' (expected low | medium | high)"
+            )),
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+        }
+    }
+}
+
 /// Whether the backend is billed per-token or via a flat subscription.
 /// Drives the cost ledger.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -90,6 +126,8 @@ pub struct AiBackendRequest {
     /// Model tier from the broker request. Used by backends to apply
     /// tier-specific request parameters (e.g. disabling reasoning for Low).
     pub model_tier: Option<ModelTier>,
+    /// Provider-neutral reasoning effort requested by an Assistant agent.
+    pub reasoning_effort: Option<ReasoningEffort>,
     /// Cooperative cancellation handle. The streaming read loop checks this
     /// each chunk and aborts (drops `tx`) when tripped, so an interrupted turn
     /// stops consuming the network stream instead of running to completion.

--- a/src/plexi_ai/backend/mod.rs
+++ b/src/plexi_ai/backend/mod.rs
@@ -22,7 +22,8 @@ pub struct ConcreteModelRoute {
 }
 
 /// Provider-neutral reasoning effort selected by an Assistant agent.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
     Low,
     Medium,

--- a/src/plexi_ai/backend/openrouter.rs
+++ b/src/plexi_ai/backend/openrouter.rs
@@ -140,11 +140,7 @@ fn stream_openrouter(
         body["tools"] = serde_json::Value::Array(tools_json);
     }
 
-    // Disable reasoning for Low-tier queries — speed matters more than depth
-    // at this tier, and leaving it on adds latency and cost (Gemini Flash Lite).
-    if request.model_tier == Some(ModelTier::Low) {
-        body["reasoning"] = serde_json::json!({ "enabled": false });
-    }
+    apply_reasoning_config(&mut body, request.model_tier, request.reasoning_effort);
 
     let body_str = match serde_json::to_string(&body) {
         Ok(s) => s,
@@ -349,9 +345,32 @@ fn stream_openrouter(
     }
 }
 
+fn apply_reasoning_config(
+    body: &mut serde_json::Value,
+    tier: Option<ModelTier>,
+    effort: Option<super::ReasoningEffort>,
+) {
+    if let Some(effort) = effort {
+        body["reasoning"] = serde_json::json!({ "effort": effort.label() });
+    } else if tier == Some(ModelTier::Low) {
+        body["reasoning"] = serde_json::json!({ "enabled": false });
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn explicit_reasoning_effort_is_encoded_in_payload() {
+        let mut body = serde_json::json!({});
+        apply_reasoning_config(
+            &mut body,
+            Some(ModelTier::Low),
+            Some(crate::plexi_ai::backend::ReasoningEffort::High),
+        );
+        assert_eq!(body["reasoning"], serde_json::json!({"effort": "high"}));
+    }
 
     /// Verify that the system prompt is injected as a leading messages-array
     /// entry (OpenAI format), not as a top-level "system" field (Anthropic).

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -23,6 +23,7 @@ use crate::host::event_log::{self, HostEvent};
 use crate::plexi_ai::backend::ollama::OllamaBackend;
 use crate::plexi_ai::backend::openrouter::OpenRouterBackend;
 use crate::plexi_ai::backend::{AiBackend, AiBackendRequest, BillingModel};
+pub use crate::plexi_ai::backend::{ConcreteModelRoute, ReasoningEffort};
 use crate::plexi_ai::ledger::{self, LedgerRow};
 use crate::plexi_ai::tool_dispatch::ToolDispatcher;
 use crate::plexi_ai::turn_loop::{self, TurnError};
@@ -69,6 +70,11 @@ pub fn get_pane_snapshot() -> Arc<Vec<PaneContext>> {
 pub struct AiBrokerRequest {
     pub app_id: String,
     pub model_tier: ModelTier,
+    /// Optional agent-selected provider/model route. Ordinary app callers
+    /// leave this unset and retain configured tier routing.
+    pub concrete_model: Option<ConcreteModelRoute>,
+    /// Optional agent-selected reasoning effort.
+    pub reasoning_effort: Option<ReasoningEffort>,
     pub system: String,
     pub messages: Vec<AiMessage>,
     pub tools: Vec<AiTool>,
@@ -182,11 +188,17 @@ impl AiBroker for LiveAiBroker {
             return AiBrokerResponse::err(format!("budget_exceeded: {reason}"));
         }
 
-        let backend_name = ai_config.backend.as_deref().unwrap_or("openrouter");
+        let backend_name = request
+            .concrete_model
+            .as_ref()
+            .map(|route| route.provider.clone())
+            .or_else(|| ai_config.backend.clone())
+            .unwrap_or_else(|| "openrouter".to_string());
 
-        match backend_name {
+        match backend_name.as_str() {
             "ollama" => dispatch_ollama(request, ai_config, on_delta),
-            _ => dispatch_openrouter(request, ai_config, on_delta),
+            "openrouter" => dispatch_openrouter(request, ai_config, on_delta),
+            other => AiBrokerResponse::err(format!("unsupported_model_provider: {other}")),
         }
     }
 }
@@ -206,7 +218,18 @@ fn dispatch_openrouter(
         }
     };
 
-    let model_id = resolve_model_tier(&request.model_tier, or_config);
+    if let Some(route) = request
+        .concrete_model
+        .as_ref()
+        .filter(|route| route.provider != "openrouter")
+    {
+        return AiBrokerResponse::err(format!("unsupported_model_provider: {}", route.provider));
+    }
+    let model_id = request
+        .concrete_model
+        .as_ref()
+        .map(|route| route.model.clone())
+        .or_else(|| resolve_model_tier(&request.model_tier, or_config));
     let model_id = match model_id {
         Some(m) => m,
         None => {
@@ -373,7 +396,18 @@ fn dispatch_ollama(
         }
     };
 
-    let model_id = resolve_ollama_model_tier(&request.model_tier, ollama_config);
+    if let Some(route) = request
+        .concrete_model
+        .as_ref()
+        .filter(|route| route.provider != "ollama")
+    {
+        return AiBrokerResponse::err(format!("unsupported_model_provider: {}", route.provider));
+    }
+    let model_id = request
+        .concrete_model
+        .as_ref()
+        .map(|route| route.model.clone())
+        .or_else(|| resolve_ollama_model_tier(&request.model_tier, ollama_config));
     let model_id = match model_id {
         Some(m) => m,
         None => {
@@ -536,6 +570,7 @@ fn run_turn_and_respond(
             system: Arc::clone(&system),
             tools: Arc::clone(&all_tools),
             model_tier: Some(request.model_tier),
+            reasoning_effort: request.reasoning_effort,
             cancel: request.cancel.clone(),
         };
 
@@ -1002,6 +1037,8 @@ mod tests {
             AiBrokerRequest {
                 app_id: "test".to_string(),
                 model_tier: ModelTier::Low,
+                concrete_model: None,
+                reasoning_effort: None,
                 system: "be helpful".to_string(),
                 messages: messages.clone(),
                 tools: vec![],
@@ -1035,6 +1072,8 @@ mod tests {
             AiBrokerRequest {
                 app_id: "test".to_string(),
                 model_tier: ModelTier::Low,
+                concrete_model: None,
+                reasoning_effort: None,
                 system: String::new(),
                 messages: vec![AiMessage {
                     role: "user".to_string(),
@@ -1226,6 +1265,8 @@ mod tests {
             AiBrokerRequest {
                 app_id: "test".to_string(),
                 model_tier: ModelTier::Low,
+                concrete_model: None,
+                reasoning_effort: None,
                 system: String::new(),
                 messages: vec![AiMessage {
                     role: "user".to_string(),
@@ -1261,6 +1302,8 @@ mod tests {
             AiBrokerRequest {
                 app_id: "test".to_string(),
                 model_tier: ModelTier::Low,
+                concrete_model: None,
+                reasoning_effort: None,
                 system: String::new(),
                 messages: vec![AiMessage {
                     role: "user".to_string(),
@@ -1373,6 +1416,8 @@ mod tests {
         let request = AiBrokerRequest {
             app_id: "test".to_string(),
             model_tier: crate::app_protocol::ModelTier::Low,
+            concrete_model: None,
+            reasoning_effort: None,
             system: "sys".to_string(),
             messages: vec![crate::app_protocol::AiMessage {
                 role: "user".to_string(),
@@ -1467,6 +1512,8 @@ mod tests {
         let request = AiBrokerRequest {
             app_id: "test".to_string(),
             model_tier: ModelTier::Low,
+            concrete_model: None,
+            reasoning_effort: None,
             system: "sys".to_string(),
             messages: vec![AiMessage {
                 role: "user".to_string(),
@@ -1546,6 +1593,8 @@ mod tests {
         let request = AiBrokerRequest {
             app_id: "test".to_string(),
             model_tier: ModelTier::Low,
+            concrete_model: None,
+            reasoning_effort: None,
             system: "sys".to_string(),
             messages: vec![AiMessage {
                 role: "user".to_string(),

--- a/src/process_app/prompts.rs
+++ b/src/process_app/prompts.rs
@@ -424,6 +424,8 @@ pub(crate) fn show_prompt_modal(
                                         AiBrokerRequest {
                                             app_id,
                                             model_tier: q.model_tier,
+                                            concrete_model: None,
+                                            reasoning_effort: None,
                                             system: q.system,
                                             messages: q.messages,
                                             tools: q.tools,

--- a/src/process_app/routing.rs
+++ b/src/process_app/routing.rs
@@ -1225,6 +1225,8 @@ impl ProcessApp {
                             AiBrokerRequest {
                                 app_id,
                                 model_tier,
+                                concrete_model: None,
+                                reasoning_effort: None,
                                 system,
                                 messages,
                                 tools,

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1440,6 +1440,7 @@ mod tests {
         h.run_steps(2);
 
         assert!(h.pane_has_label(assistant, "Assistant"));
+        assert!(h.pane_has_label(assistant, "default"));
         assert!(!h.pane_has_label(files, "Assistant"));
     }
 


### PR DESCRIPTION
Stint task 0225

No linked GitHub issue.

## Summary

- Loads built-in, user, and workspace Assistant agents with deterministic precedence and visible shadowed definitions.
- Adds /agent list, switch, inspect, create, and edit plus session /effort controls.
- Applies the active agent prompt, model tier and concrete route, reasoning effort, connector allowlist, permission posture, and per-agent permission identity to Assistant dispatches.
- Keeps skills and hooks typed and inspectable for 0229 without executing them here.
- Preserves existing tier routing for non-Assistant broker callers and exposes the active agent as a separate semantic header label.

## Test evidence

- Targeted Assistant tests: 101 passed, 0 failed.
- Targeted agent tests: 11 passed, 0 failed.
- Targeted broker tests: 14 passed, 0 failed.
- Targeted OpenRouter tests: 8 passed, 0 failed.
- Full cargo test --bin plexi: 1,575 passed, 0 failed, 1 parameterized scene entry ignored.
- Scene suite: passed, including native Assistant settings/model scene.
- cargo build: passed without warnings.
- git diff --check: passed.
- Manual review found and fixed stable semantic-label regression before push.

## Validation

**Validate attempt 1:** PASS
**Test date:** 2026-07-11