### PR TITLE
feat(testing): expose native pane semantic state (stint 0363)

### DIFF
--- a/.agents/skills/drive-host/SKILL.md
+++ b/.agents/skills/drive-host/SKILL.md
@@ -77,12 +77,12 @@ env -u PLEXI_PANE_ID ... PLEXI_SOCKET=$HOME/.plexi-pr-<N>/notify.sock PLEXI_CHAN
 Ground truth comes from the host, never from what you expect to have happened:
 
 ```bash
-plexi-pr-<N> pane state <pane-id>     # app panes: JSON frame of the L1 UiNode tree; terminals: status
+plexi-pr-<N> pane state <pane-id>     # app panes: normalized semantic tree; terminals: status
 plexi-pr-<N> pane capture <pane-id> --lines 80
 tail -100 ~/.plexi-pr-<N>/plexi.log
 ```
 
-`pane state` is the L1 render tree for app panes — assert against it, not against a screenshot you eyeballed. `pane capture` returns terminal output as a JSON array; use `--from-cursor <n>` to read only lines written since a prior capture. The channel log (`~/.plexi-pr-<N>/plexi.log`) is the source for anything the drive commands can't surface — every feature ships an `info` trace, so grep it for the behavior you seeded.
+`pane state` exposes the last committed normalized semantic tree for process, native builtin, and WASM app panes — assert against `semantic.nodes`, not against a screenshot you eyeballed. Process panes also retain their compatible `frame` field. `pane capture` returns terminal output as a JSON array; use `--from-cursor <n>` to read only lines written since a prior capture. The channel log (`~/.plexi-pr-<N>/plexi.log`) is the source for anything the drive commands can't surface — every feature ships an `info` trace, so grep it for the behavior you seeded.
 
 ### 4. Teardown
 

--- a/.agents/skills/whats-next/WHATS_NEXT.md
+++ b/.agents/skills/whats-next/WHATS_NEXT.md
@@ -6,9 +6,9 @@
 
 ---
 
-## Current State (2026-07-10, money-path + explorer viewers landed)
+## Current State (2026-07-11, Assistant identity + shared scene verbs landed)
 
-`alpha` is at the `#2366` merge (`bf7cb0a4`). Six PRs landed this session — the full money-path buy-side/sell-side/legal bundle (0325/0339/0347/0245/0252/0355, detail in `docs/DEVLOG.md`) plus `0349` explorer native viewers (`#2366`, rebased onto post-money-path alpha, re-verified 1527/1527 tests green, manually exercised on `plexi-pr-2366` — image/video/audio launch, resolver routing, close-return-to-explorer focus, and OS fallthrough all confirmed correct via log trace).
+`alpha` is at `d610a776`: scoped Assistant settings (`0226`), backend-neutral scene verbs and symbolic pane handles (`0362`), and the Assistant agent registry/model-routing foundation (`0225`) are landed. Details live in `docs/DEVLOG.md`.
 
 **Free v1 finish line is now effectively complete.** The last tracked P1 gap (`0349`) is merged. Remaining gap: production hosted-registry install smoke after deploying alpha — not yet a stint task.
 
@@ -25,7 +25,7 @@ Other open PRs affecting priority reading:
 - `#2282` open: collapsible subcontexts (`0241`), failed build check.
 - `#1604` open: Windows port (external branch).
 
-Not real yet: first-party sales live (needs `0356` provisioning), production hosted-registry install smoke after alpha deploy, managed `ai.query` backend (`0323`), the entire third-party publisher economy (`0344`/`0352`/`0353`).
+Not real yet: native/WASM semantic state over live IPC (`0363`), the shared live scene backend (`0364`), complete Assistant conversation history (`0228`), skills and host-native Assistant tools (`0229`), first-party sales live (needs `0356` provisioning), production hosted-registry install smoke after alpha deploy, managed `ai.query` backend (`0323`), and the third-party publisher economy (`0344`/`0352`/`0353`).
 
 ---
 
@@ -44,10 +44,18 @@ A stranger installs, an agent builds an app first try, a free reviewed app insta
 
 The host Assistant becomes the workspace operator: typed host tools behind the permission broker, named agent personas, skills, app connectors.
 
-- `0225` agent registry + model routing
-- `0226` settings scopes (user/workspace/local/session)
+- Agent registry, model routing, and settings scopes are landed (`0225`, `0226`).
 - `0228` conversation persistence + history
-- `0229` skills + host tools (pane/app/terminal operations)
+  - `0229` skills + host tools (pane/app/terminal operations)
+    - `0359` Assistant E2E + local/cheap-model verification
+
+### Testing foundation: shared headless/live vocabulary
+
+Agents must be able to drive and verify every host surface through one scene language. Generic verbs and symbolic handles are landed (`0362`).
+
+- `0363` expose normalized Process, native, and WASM semantics through `plexi pane state`
+  - `0364` execute the shared TOML scene language against an installed host
+    - `0361` audit and close the remaining host-wide E2E gaps
 
 ### Epoch 3 — Commercial launch (Track B)
 
@@ -89,11 +97,11 @@ Maintenance (input debt, hygiene, polish) deliberately does not appear here — 
 ## Priority Stack (flat view)
 
 P0: none.
-P1: `0356` (ops: go-live provisioning), `0241` (open PR needs fixing), `0285` (draft PR), `0322` (paid-download host gating), `0344`, `0341`*.
-P2 and below: `0354` (subscription active-gating), `0352`, `0353`, `0323`, `0317`, `0295`, `0297`, `0357` (P3, sudo-noise investigation), plus the backlog in `stint list`.
+P1: `0361`*, `0359`*, `0356` (ops: go-live provisioning), `0241` (open PR needs fixing), `0285` (draft PR), `0322` (paid-download host gating), `0344`, `0341`*.
+P2 and below: `0363`, `0364`*, `0228`, `0229`, `0354` (subscription active-gating), `0352`, `0353`, `0323`, `0317`, `0295`, `0297`, `0360` (P3, deactivate noise), `0357` (P3, sudo noise), plus the backlog in `stint list`.
 (* = blocked; see the Arc for what unblocks them.)
 
-**Next recommended task:** free v1's last coding gap (`0349`) is merged — the finish line is real pending only a post-deploy registry smoke. The top remaining item is **`0356`**: ops-only, provision Polar production + the private bucket and flip `SALES_ENABLED` — that's the entire distance between merged code and live revenue. For coding work, `0322` (host paid-download gating) + `0354` (subscription active-gating) extend the money path host-side; `0344` (publisher pipeline) is ready but its third-party product creation stays blocked on `0352`.
+**Next recommended task:** `0363`, the observation layer required before a live scene backend can verify native and WASM panes.
 
 ---
 

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -6,6 +6,10 @@ or `/merge-pr` trims the orientation file; do not rewrite old entries.
 
 ---
 
+## 2026-07-11: Assistant identity and shared scene verbs landed
+
+`0226` (#2375) added scoped Assistant settings. `0362` (#2376) replaced feature-specific scene actions with generic open, text, key, context, symbolic-handle, assertion, and report primitives. `0225` (#2377) added the file-backed agent registry, model-tier routing, `/agent`, and `/effort`; validation also made agent and effort choices survive reopen, rejected partial agent-definition overwrites, and kept PR installs compatible with Rust 1.97's new float-literal warning.
+
 ## 2026-07-10 — Explorer native media viewers landed
 
 `0349` (#2366) completed the explorer-as-window-manager loop: image, video, and audio files opened from File Explorer now land in native Rust viewer panes (`image-viewer` fit/zoom/pan, `video-player` and `audio-player` play/pause/seek) instead of bouncing to the macOS opener, and closing a viewer returns focus to the explorer with its selection intact. The branch was 15 commits stale (predated the money-path merge run); rebased cleanly onto alpha with one expected touch-point in `pane_ops/create.rs` (shared with `0245`'s bug bundle) resolving without conflict, re-verified 1527/1527 `cargo test --bin plexi` green post-rebase. Manually exercised on `plexi-pr-2366`: log trace confirmed correct `launch_app_by_id_with_layout` routing for all three viewer types, `close_tile` returning focus to the file_browser tile on both audio closes, and unsupported types (`.json`, `.pdf`) still falling through to the OS opener. This was the last tracked P1 gap in the Epoch 1 (free v1) finish line.

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1410,12 +1410,20 @@ impl PlexiApp {
                                 .runtime
                                 .frame_json()
                                 .unwrap_or(serde_json::Value::Array(vec![]));
+                            let semantic = app_pane.semantic_state();
+                            log::info!(
+                                "pane_ipc: get_pane_state: pane_id={pane_id} runtime={} schema_version={} node_count={}",
+                                app_pane.runtime.runtime_kind(),
+                                semantic.schema_version,
+                                semantic.nodes.len(),
+                            );
                             serde_json::json!({
                                 "pane_id": pane_id,
                                 "type": "app",
                                 "title": app_pane.name,
                                 "manifest_id": app_pane.manifest_id,
                                 "frame": frame,
+                                "semantic": semantic,
                             })
                             .to_string()
                         } else if let Some(term) = pane.as_terminal() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -422,6 +422,7 @@ pub struct PlexiApp {
 #[cfg(test)]
 fn configure_egui_ctx(ctx: &egui::Context, colors: &Colors) {
     theme::setup_fonts(ctx);
+    ctx.enable_accesskit();
     ctx.set_visuals(egui::Visuals::dark());
     ctx.options_mut(|o| o.zoom_with_keyboard = false);
     theme::setup_style(ctx, colors, true);
@@ -898,6 +899,7 @@ impl PlexiApp {
         log::info!(target: "plexi::frame_diag", "frame diagnostics active; summary every 10s");
 
         theme::setup_fonts(&cc.egui_ctx);
+        cc.egui_ctx.enable_accesskit();
         cc.egui_ctx.set_visuals(egui::Visuals::dark());
         cc.egui_ctx.options_mut(|o| o.zoom_with_keyboard = false);
 
@@ -1118,6 +1120,7 @@ impl PlexiApp {
                                         hidden: false,
                                         agent: None,
                                         slots: std::collections::HashMap::new(),
+                                        semantic_state: Default::default(),
                                     })));
                             }
                         }
@@ -1895,6 +1898,7 @@ impl PlexiApp {
             hidden: false,
             agent: None,
             slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
         };
 
         let win = &mut self.windows[win_idx];

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -1263,6 +1263,7 @@ fn test_app_pane(pane_id: u64) -> crate::host::pane::Pane {
         hidden: false,
         agent: None,
         slots: std::collections::HashMap::new(),
+        semantic_state: Default::default(),
     }))
 }
 

--- a/src/app/tests/navigation_tests.rs
+++ b/src/app/tests/navigation_tests.rs
@@ -160,6 +160,7 @@ fn send_to_pane_searches_all_windows() {
             hidden: false,
             agent: None,
             slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
         }
     };
     win1.panes.insert(
@@ -235,6 +236,7 @@ fn pane_list_excludes_orphaned_panes_and_navigate_succeeds() {
         hidden: false,
         agent: None,
         slots: std::collections::HashMap::new(),
+        semantic_state: Default::default(),
     }));
     h.app.windows[0].panes.insert(orphan_id, orphan_pane);
     assert!(
@@ -397,6 +399,7 @@ fn overlay_panes_preserve_replaced_pane_agent_state() {
             hidden: false,
             agent: None,
             slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
         })),
     );
 
@@ -907,6 +910,7 @@ fn on_launch_focus_existing_reveals_instance_behind_overlay() {
             hidden: false,
             agent: None,
             slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
         }))
     };
     h.app.windows[0].panes.insert(slot, overlay_pane);

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1043,9 +1043,9 @@ pub enum PaneCmd {
     },
     /// Return the current UI state of a pane as JSON.
     ///
-    /// For app panes: returns a JSON object with a `frame` array of RenderCommands
-    /// representing the last-rendered L1 UiNode tree. Agents can use this to inspect
-    /// what an app is currently displaying.
+    /// For app panes: returns a versioned, runtime-neutral `semantic` tree. Process
+    /// apps also retain the compatible `frame` RenderCommand array. Agents can use
+    /// the semantic nodes to inspect what any app runtime is currently displaying.
     ///
     /// For terminal panes: returns a simple status object (type, title, pane_id).
     ///

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -771,7 +771,8 @@ pub fn pane_capture_cli(
 /// `plexi pane state <id>`
 ///
 /// Sends a `get_pane_state` command to PLEXI_SOCKET. For app panes, the host
-/// writes a JSON object containing the last-rendered frame (RenderCommand array).
+/// writes a JSON object containing a versioned normalized `semantic` tree.
+/// Process apps also retain the compatible `frame` RenderCommand array.
 /// For terminal panes, returns a simple status object. Returns 0 on success, 1 on error.
 pub fn pane_state_cli(pane_id: u64) -> i32 {
     let id = uuid::Uuid::new_v4();

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -6,6 +6,247 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::mpsc::Sender;
 
+pub(crate) const SEMANTIC_PANE_STATE_SCHEMA_VERSION: u32 = 1;
+
+/// Runtime-neutral, read-only representation returned by `plexi pane state`.
+#[derive(Clone, Debug, serde::Serialize)]
+pub(crate) struct SemanticPaneState {
+    pub schema_version: u32,
+    pub runtime_kind: String,
+    pub roots: Vec<String>,
+    pub nodes: Vec<SemanticPaneNode>,
+}
+
+impl Default for SemanticPaneState {
+    fn default() -> Self {
+        Self::empty("builtin")
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+pub(crate) struct SemanticPaneNode {
+    pub id: String,
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bounds: Option<[f64; 4]>,
+}
+
+impl SemanticPaneState {
+    pub(crate) fn empty(runtime_kind: &str) -> Self {
+        Self {
+            schema_version: SEMANTIC_PANE_STATE_SCHEMA_VERSION,
+            runtime_kind: runtime_kind.to_string(),
+            roots: Vec::new(),
+            nodes: Vec::new(),
+        }
+    }
+
+    pub(crate) fn from_process_frame(frame: &serde_json::Value) -> Self {
+        let mut nodes = Vec::new();
+        let roots = collect_process_semantics(frame, "frame", &mut nodes);
+        Self {
+            schema_version: SEMANTIC_PANE_STATE_SCHEMA_VERSION,
+            runtime_kind: "process".to_string(),
+            roots,
+            nodes,
+        }
+    }
+
+    pub(crate) fn from_accesskit(
+        nodes: &egui::IdMap<egui::accesskit::Node>,
+        pane_rect: egui::Rect,
+    ) -> Self {
+        let mut nodes: Vec<SemanticPaneNode> = nodes
+            .iter()
+            .filter_map(|(id, node)| {
+                let bounds = node.bounds()?;
+                let center = egui::pos2(
+                    ((bounds.x0 + bounds.x1) / 2.0) as f32,
+                    ((bounds.y0 + bounds.y1) / 2.0) as f32,
+                );
+                pane_rect.contains(center).then(|| SemanticPaneNode {
+                    id: id.value().to_string(),
+                    role: format!("{:?}", node.role()).to_ascii_lowercase(),
+                    label: node.label().map(str::to_string),
+                    value: node.value().map(str::to_string),
+                    children: node.children().iter().map(|id| id.0.to_string()).collect(),
+                    bounds: Some([bounds.x0, bounds.y0, bounds.x1, bounds.y1]),
+                })
+            })
+            .collect();
+        let retained_ids: std::collections::HashSet<String> =
+            nodes.iter().map(|node| node.id.clone()).collect();
+        for node in &mut nodes {
+            node.children.retain(|child| retained_ids.contains(child));
+        }
+        let child_ids: std::collections::HashSet<&str> = nodes
+            .iter()
+            .flat_map(|node| node.children.iter().map(String::as_str))
+            .collect();
+        let roots = nodes
+            .iter()
+            .filter(|node| !child_ids.contains(node.id.as_str()))
+            .map(|node| node.id.clone())
+            .collect();
+        Self {
+            schema_version: SEMANTIC_PANE_STATE_SCHEMA_VERSION,
+            runtime_kind: "builtin".to_string(),
+            roots,
+            nodes,
+        }
+    }
+
+    pub(crate) fn from_wasm_tree(tree: &crate::host::wasm_app::UiTree) -> Self {
+        use crate::host::wasm_app::UiNodeData;
+
+        let nodes = tree
+            .nodes
+            .iter()
+            .map(|node| {
+                let (role, label, value, children) = match &node.data {
+                    UiNodeData::Empty => ("empty", None, None, Vec::new()),
+                    UiNodeData::Text(text) => {
+                        ("text", Some(text.text.clone()), None, Vec::new())
+                    }
+                    UiNodeData::Button(button) => {
+                        ("button", Some(button.label.clone()), None, Vec::new())
+                    }
+                    UiNodeData::TextInput(input) => (
+                        "text_input",
+                        Some(input.placeholder.clone()),
+                        (!input.password).then(|| input.value.clone()),
+                        Vec::new(),
+                    ),
+                    UiNodeData::Row(row) => (
+                        "row",
+                        None,
+                        None,
+                        row.children.iter().map(u32::to_string).collect(),
+                    ),
+                    UiNodeData::Column(column) => (
+                        "column",
+                        None,
+                        None,
+                        column.children.iter().map(u32::to_string).collect(),
+                    ),
+                    UiNodeData::ProgressBar(progress) => (
+                        "progress_bar",
+                        progress.label.clone(),
+                        Some(progress.value.to_string()),
+                        Vec::new(),
+                    ),
+                    UiNodeData::Badge(badge) => {
+                        ("badge", Some(badge.text.clone()), None, Vec::new())
+                    }
+                    UiNodeData::ListView(list) => (
+                        "list_view",
+                        None,
+                        list.selected.map(|selected| selected.to_string()),
+                        list.items.iter().map(u32::to_string).collect(),
+                    ),
+                    UiNodeData::Scroll(scroll) => {
+                        ("scroll", None, None, vec![scroll.child.to_string()])
+                    }
+                    UiNodeData::Padding(padding) => {
+                        ("padding", None, None, vec![padding.child.to_string()])
+                    }
+                    UiNodeData::Divider => ("divider", None, None, Vec::new()),
+                    UiNodeData::Space(space) => {
+                        ("space", None, Some(space.to_string()), Vec::new())
+                    }
+                    UiNodeData::Surface(surface) => (
+                        "surface",
+                        None,
+                        Some(format!("{}x{}", surface.width, surface.height)),
+                        Vec::new(),
+                    ),
+                };
+                SemanticPaneNode {
+                    id: node.id.to_string(),
+                    role: role.to_string(),
+                    label,
+                    value,
+                    children,
+                    bounds: None,
+                }
+            })
+            .collect();
+        Self {
+            schema_version: SEMANTIC_PANE_STATE_SCHEMA_VERSION,
+            runtime_kind: "wasm".to_string(),
+            roots: vec![tree.root.to_string()],
+            nodes,
+        }
+    }
+}
+
+fn collect_process_semantics(
+    value: &serde_json::Value,
+    path: &str,
+    nodes: &mut Vec<SemanticPaneNode>,
+) -> Vec<String> {
+    match value {
+        serde_json::Value::Array(values) => values
+            .iter()
+            .enumerate()
+            .flat_map(|(index, value)| {
+                collect_process_semantics(value, &format!("{path}.{index}"), nodes)
+            })
+            .collect(),
+        serde_json::Value::Object(object) => {
+            let children: Vec<String> = object
+                .iter()
+                .flat_map(|(key, value)| {
+                    collect_process_semantics(value, &format!("{path}.{key}"), nodes)
+                })
+                .collect();
+            let Some(role) = object.get("type").and_then(serde_json::Value::as_str) else {
+                return children;
+            };
+            let label = object
+                .get("text")
+                .or_else(|| object.get("label"))
+                .or_else(|| object.get("title"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string);
+            let value = object.get("value").and_then(|value| match value {
+                serde_json::Value::String(value) => Some(value.clone()),
+                serde_json::Value::Number(value) => Some(value.to_string()),
+                _ => None,
+            });
+            nodes.push(SemanticPaneNode {
+                id: path.to_string(),
+                role: role.to_string(),
+                label,
+                value,
+                children,
+                bounds: process_command_bounds(object),
+            });
+            vec![path.to_string()]
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn process_command_bounds(
+    object: &serde_json::Map<String, serde_json::Value>,
+) -> Option<[f64; 4]> {
+    let x = object.get("x")?.as_f64()?;
+    let y = object.get("y")?.as_f64()?;
+    let width = object.get("w").and_then(serde_json::Value::as_f64).unwrap_or(0.0);
+    let height = object
+        .get("h")
+        .and_then(serde_json::Value::as_f64)
+        .unwrap_or(0.0);
+    Some([x, y, x + width, y + height])
+}
+
 // ---------------------------------------------------------------------------
 // Pane ADT (spec §2) — Terminal | App | Portal.
 // Issue #1374 added the Portal variant (formerly SubContext).
@@ -451,6 +692,14 @@ impl AppRuntime {
             AppRuntime::Wasm(_) => None,
         }
     }
+
+    pub(crate) fn runtime_kind(&self) -> &'static str {
+        match self {
+            AppRuntime::Process(_) => "process",
+            AppRuntime::Builtin(_) => "builtin",
+            AppRuntime::Wasm(_) => "wasm",
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -476,4 +725,92 @@ pub struct AppPane {
     /// activity for the activity dot. `None` = fall back to agent()/host-observed.
     pub pip_status: Option<crate::app_protocol::PipStatus>,
     pub slots: HashMap<String, PathBuf>,
+    /// Last semantics committed by the production render path for native apps.
+    pub(crate) semantic_state: SemanticPaneState,
+}
+
+impl AppPane {
+    pub(crate) fn semantic_state(&self) -> SemanticPaneState {
+        match &self.runtime {
+            AppRuntime::Process(_) => self
+                .runtime
+                .frame_json()
+                .as_ref()
+                .map(SemanticPaneState::from_process_frame)
+                .unwrap_or_else(|| SemanticPaneState::empty("process")),
+            AppRuntime::Builtin(_) => self.semantic_state.clone(),
+            AppRuntime::Wasm(app) => app.semantic_state().clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod semantic_state_tests {
+    use super::*;
+
+    #[test]
+    fn process_frame_normalization_preserves_text_and_runtime_kind() {
+        let frame = serde_json::json!([
+            {"type": "text", "text": "process label", "x": 1.0, "y": 2.0},
+            {"type": "rect", "hit_region": "open-settings"}
+        ]);
+
+        let state = SemanticPaneState::from_process_frame(&frame);
+
+        assert_eq!(state.schema_version, SEMANTIC_PANE_STATE_SCHEMA_VERSION);
+        assert_eq!(state.runtime_kind, "process");
+        assert!(state.nodes.iter().any(|node| {
+            node.role == "text" && node.label.as_deref() == Some("process label")
+        }));
+    }
+
+    #[test]
+    fn default_builtin_state_has_valid_versioned_metadata() {
+        let state = SemanticPaneState::default();
+
+        assert_eq!(state.schema_version, SEMANTIC_PANE_STATE_SCHEMA_VERSION);
+        assert_eq!(state.runtime_kind, "builtin");
+    }
+
+    #[test]
+    fn accesskit_normalization_removes_children_outside_pane() {
+        let parent_id = egui::Id::new("parent");
+        let inside_id = egui::Id::new("inside");
+        let outside_id = egui::Id::new("outside");
+        let mut parent = egui::accesskit::Node::new(egui::accesskit::Role::Group);
+        parent.set_bounds(egui::accesskit::Rect {
+            x0: 0.0,
+            y0: 0.0,
+            x1: 100.0,
+            y1: 100.0,
+        });
+        parent.push_child(inside_id.value().into());
+        parent.push_child(outside_id.value().into());
+        let node_at = |x0, x1| {
+            let mut node = egui::accesskit::Node::new(egui::accesskit::Role::Label);
+            node.set_bounds(egui::accesskit::Rect {
+                x0,
+                y0: 10.0,
+                x1,
+                y1: 20.0,
+            });
+            node
+        };
+        let mut nodes = egui::IdMap::default();
+        nodes.insert(parent_id, parent);
+        nodes.insert(inside_id, node_at(10.0, 20.0));
+        nodes.insert(outside_id, node_at(200.0, 220.0));
+
+        let state = SemanticPaneState::from_accesskit(
+            &nodes,
+            egui::Rect::from_min_max(egui::Pos2::ZERO, egui::pos2(100.0, 100.0)),
+        );
+        let parent = state
+            .nodes
+            .iter()
+            .find(|node| node.id == parent_id.value().to_string())
+            .expect("parent retained");
+
+        assert_eq!(parent.children, vec![inside_id.value().to_string()]);
+    }
 }

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -1086,6 +1086,8 @@ pub struct LiveWasmPane {
     /// Concatenated text of the last rendered view tree. Lets the headless
     /// scene runner assert on rendered content without re-entering the guest.
     last_text: String,
+    /// Runtime-neutral semantics retained from the last committed guest tree.
+    semantic_state: crate::host::pane::SemanticPaneState,
     /// egui texture id of the guest surface, registered once into the host's
     /// shared renderer and sampled live (zero-copy). `None` until first present
     /// or when no shared device exists (headless).
@@ -1124,6 +1126,7 @@ impl LiveWasmPane {
             pending_init: Some(snapshot),
             error: None,
             last_text: String::new(),
+            semantic_state: crate::host::pane::SemanticPaneState::empty("wasm"),
             surface_id: None,
             surface_dims: None,
             fallback_tex: None,
@@ -1168,6 +1171,10 @@ impl LiveWasmPane {
         self.title
             .clone()
             .unwrap_or_else(|| self.spawn_name.clone())
+    }
+
+    pub(crate) fn semantic_state(&self) -> &crate::host::pane::SemanticPaneState {
+        &self.semantic_state
     }
 
     pub fn has_pending_capability_prompt(&self) -> bool {
@@ -1309,6 +1316,7 @@ impl LiveWasmPane {
             }
         };
         self.last_text = collect_tree_text(&tree);
+        self.semantic_state = crate::host::pane::SemanticPaneState::from_wasm_tree(&tree);
         // Composite the guest's GPU render zero-copy: register its surface
         // texture into the host's shared egui renderer once and sample it live.
         // The guest re-renders into the same texture every frame, so the
@@ -1364,7 +1372,11 @@ impl LiveWasmPane {
         match self.inner.apply_render_result(result, now) {
             Ok(true) => {
                 match self.inner.view() {
-                    Ok(t) => self.last_text = collect_tree_text(&t),
+                    Ok(t) => {
+                        self.last_text = collect_tree_text(&t);
+                        self.semantic_state =
+                            crate::host::pane::SemanticPaneState::from_wasm_tree(&t);
+                    }
                     Err(e) => {
                         self.fail("view after input", e);
                         return;
@@ -2204,6 +2216,21 @@ mod tests {
 
         let text = tree_text(&harness.state_mut().view()?);
         assert!(text.contains("Count: 1"), "guest view after click:\n{text}");
+        Ok(())
+    }
+
+    #[test]
+    fn wasm_view_normalizes_committed_semantics() -> wasmtime::Result<()> {
+        let mut p = counter_pane();
+        p.init(&StateSnapshot { entries: vec![] }, (400.0, 300.0), 0, &[])?;
+
+        let state = crate::host::pane::SemanticPaneState::from_wasm_tree(&p.view()?);
+
+        assert_eq!(state.runtime_kind, "wasm");
+        assert!(state
+            .nodes
+            .iter()
+            .any(|node| node.label.as_deref() == Some("Increment")));
         Ok(())
     }
 

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -1719,6 +1719,7 @@ mod tests {
                 hidden: false,
                 agent: None,
                 slots: std::collections::HashMap::new(),
+                semantic_state: Default::default(),
             }))
         };
 

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -418,6 +418,7 @@ mod tests {
             hidden: false,
             agent: None,
             slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
         };
 
         app.windows[0]

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -123,6 +123,7 @@ pub(crate) fn restore_builtin_app_pane(
         hidden: false,
         agent: None,
         slots: std::collections::HashMap::new(),
+        semantic_state: Default::default(),
     })))
 }
 
@@ -163,6 +164,7 @@ pub(crate) fn restore_assistant_pane(
         hidden: false,
         agent: None,
         slots: std::collections::HashMap::new(),
+        semantic_state: Default::default(),
     }))
 }
 
@@ -283,6 +285,7 @@ impl PlexiApp {
                 hidden: false,
                 agent: None,
                 slots: std::collections::HashMap::new(),
+                semantic_state: Default::default(),
             }))
         };
 
@@ -428,6 +431,7 @@ impl PlexiApp {
                 hidden: false,
                 agent: None,
                 slots: std::collections::HashMap::new(),
+                semantic_state: Default::default(),
             })),
         );
         if self.windows[active].focused_pane.is_none() {
@@ -609,6 +613,7 @@ impl PlexiApp {
                 hidden: false,
                 agent: None,
                 slots: std::collections::HashMap::new(),
+                semantic_state: Default::default(),
             })),
         );
         crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
@@ -921,6 +926,7 @@ impl PlexiApp {
                 hidden: false,
                 agent: None,
                 slots: std::collections::HashMap::new(),
+                semantic_state: Default::default(),
             }))
         };
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -2005,6 +2005,7 @@ mod restore_overlay_replacement_tests {
             hidden: false,
             agent: None,
             slots: HashMap::new(),
+            semantic_state: Default::default(),
         }))
     }
 
@@ -2066,6 +2067,7 @@ mod move_to_adjacent_window_tests {
             hidden: false,
             agent: None,
             slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
         }))
     }
 
@@ -2203,6 +2205,7 @@ mod pop_pane_to_new_window_tests {
             hidden: false,
             agent: None,
             slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
         }))
     }
 
@@ -2388,6 +2391,7 @@ mod move_to_row_boundary_tests {
             hidden: false,
             agent: None,
             slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
         }))
     }
 
@@ -2597,6 +2601,7 @@ mod context_root_cwd_tests {
             hidden: false,
             agent: None,
             slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
         };
         let tile = app.windows[0].tree.tiles.insert_pane(pane_id);
         app.windows[0].tree.root = Some(tile);
@@ -2727,6 +2732,7 @@ mod navigate_boundary_tests {
             hidden: false,
             agent: None,
             slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
         }))
     }
 

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -948,7 +948,8 @@ pub enum AppRequest {
     },
 
     /// Query the last-rendered UI state of a pane. Sent by `plexi pane state`.
-    /// For app panes: host writes a JSON object with a `frame` array of RenderCommands.
+    /// For app panes: host writes a versioned `semantic` tree for every runtime.
+    /// Process panes also retain the compatible `frame` RenderCommand array.
     /// For terminal panes: host writes a simple status object.
     /// Host writes `{"error":"..."}` if the pane is not found.
     GetPaneState { pane_id: u64, response_file: String },

--- a/src/render/app_pane.rs
+++ b/src/render/app_pane.rs
@@ -134,7 +134,24 @@ pub fn render(
     // guaranteed by the allocate_exact_size calls above. Apps read ui.available_height() /
     // available_size() and always see the post-chrome budget with no guesswork.
     let ctx = AppRenderContext { colors, is_focused };
+    let content_rect = ui.available_rect_before_wrap();
     app_pane.runtime.ui(ui, &ctx);
+    if matches!(app_pane.runtime, crate::host::pane::AppRuntime::Builtin(_)) {
+        if let Some(state) = ui.ctx().viewport(|viewport| {
+            viewport
+                .this_pass
+                .accesskit_state
+                .as_ref()
+                .map(|accesskit| {
+                    crate::host::pane::SemanticPaneState::from_accesskit(
+                        &accesskit.nodes,
+                        content_rect,
+                    )
+                })
+        }) {
+            app_pane.semantic_state = state;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -367,6 +367,49 @@ fn read_json_response(path: &str) -> serde_json::Value {
     serde_json::from_str(&content).expect("response must be valid JSON")
 }
 
+#[test]
+fn get_pane_state_preserves_process_frame_and_adds_normalized_semantics() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    let pane_id = h.add_test_pane();
+    let Some(Pane::App(app_pane)) = h.app.windows[0].panes.get_mut(&pane_id) else {
+        panic!("expected app pane");
+    };
+    let AppRuntime::Process(process) = &mut app_pane.runtime else {
+        panic!("expected process runtime");
+    };
+    process.frame.push(crate::app_protocol::RenderCommand::Text {
+        x: 4.0,
+        y: 8.0,
+        text: "process state label".to_string(),
+        size: 14.0,
+        color: "#ffffff".to_string(),
+        monospace: false,
+        bold: false,
+        align: Default::default(),
+        max_width: None,
+        elide: false,
+        selectable: false,
+        max_lines: None,
+        hit_region: None,
+    });
+    let response_file = temp_response(tmp.path(), "pane-state");
+
+    h.inject_ipc(AppRequest::GetPaneState {
+        pane_id,
+        response_file: response_file.clone(),
+    });
+    h.run_frames(1);
+    let response = read_json_response(&response_file);
+
+    assert_eq!(response["frame"][0]["text"], "process state label");
+    assert_eq!(response["semantic"]["schema_version"], 1);
+    assert_eq!(response["semantic"]["runtime_kind"], "process");
+    assert!(response["semantic"]["nodes"]
+        .as_array()
+        .is_some_and(|nodes| !nodes.is_empty()));
+}
+
 // -- Pane file slots ------------------------------------------------------
 
 #[test]
@@ -3264,6 +3307,7 @@ fn add_app_pane_to_window(h: &mut HostHarness, window_id: u64, pane_id: u64) {
         hidden: false,
         agent: None,
         slots: HashMap::new(),
+        semantic_state: Default::default(),
     };
     let win = h
         .app

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -132,6 +132,7 @@ impl HostHarness {
             hidden: false,
             agent: None,
             slots: HashMap::new(),
+            semantic_state: Default::default(),
         };
 
         let win = &mut self.app.windows[0];

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -525,6 +525,7 @@ mod tests {
                 hidden: false,
                 agent: None,
                 slots: std::collections::HashMap::new(),
+                semantic_state: Default::default(),
             };
             let win = &mut app.windows[app.active_window];
             win.panes.insert(pane_id, Pane::App(Box::new(app_pane)));
@@ -877,6 +878,7 @@ mod tests {
                 hidden: false,
                 agent: None,
                 slots: std::collections::HashMap::new(),
+                semantic_state: Default::default(),
             };
             let mut child_panes = std::collections::HashMap::new();
             child_panes.insert(editor_pane_id, Pane::App(Box::new(editor)));
@@ -1027,6 +1029,7 @@ mod tests {
                 hidden: false,
                 agent: None,
                 slots: std::collections::HashMap::new(),
+                semantic_state: Default::default(),
             };
             let win = &mut app.windows[app.active_window];
             win.panes.insert(pane_id, Pane::App(Box::new(app_pane)));
@@ -1444,6 +1447,46 @@ mod tests {
         assert!(!h.pane_has_label(files, "Assistant"));
     }
 
+    #[test]
+    fn native_builtin_pane_state_retains_committed_semantics() {
+        let mut h = PlexiUiHarness::new_sized(1000.0, 720.0);
+        let workspace = h.workspace_root().to_path_buf();
+        let assistant = h
+            .open_target(HarnessOpenTarget::Builtin {
+                id: "assistant",
+                cwd: &workspace,
+                args: &[],
+            })
+            .expect("open Assistant");
+        let files = h
+            .open_target(HarnessOpenTarget::Builtin {
+                id: "file_browser",
+                cwd: &workspace,
+                args: &[],
+            })
+            .expect("open File Browser");
+        h.run_steps(2);
+
+        let (assistant_state, files_state) = h.with_app(|host| {
+            let state = |pane_id| {
+                host.windows
+                    .iter()
+                    .find_map(|window| window.panes.get(&pane_id))
+                    .and_then(Pane::as_app)
+                    .map(|pane| pane.semantic_state())
+                    .expect("builtin pane state")
+            };
+            (state(assistant), state(files))
+        });
+
+        assert_eq!(assistant_state.runtime_kind, "builtin");
+        assert!(assistant_state.nodes.iter().any(|node| {
+            node.label.as_deref() == Some("Assistant") || node.value.as_deref() == Some("Assistant")
+        }));
+        assert_eq!(files_state.runtime_kind, "builtin");
+        assert!(!files_state.nodes.is_empty());
+    }
+
     /// Assistant pane with a pending permission sheet renders (Phase D2).
     #[test]
     fn assistant_permission_sheet_renders() {
@@ -1581,6 +1624,7 @@ mod tests {
                 hidden: true,
                 agent: None,
                 slots: std::collections::HashMap::new(),
+                semantic_state: Default::default(),
             };
             let win = &mut app.windows[app.active_window];
             win.panes
@@ -1922,6 +1966,7 @@ mod tests {
                     hidden: false,
                     agent: None,
                     slots: std::collections::HashMap::new(),
+                    semantic_state: Default::default(),
                 };
                 let win = &mut app.windows[app.active_window];
                 win.panes.insert(pane_id, Pane::App(Box::new(app_pane)));

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -793,7 +793,7 @@ Example: plexi pane command 42 "git status" --enter
 
 Return the current UI state of a pane as JSON.
 
-For app panes: returns a JSON object with a `frame` array of RenderCommands representing the last-rendered L1 UiNode tree. Agents can use this to inspect what an app is currently displaying.
+For app panes: returns a versioned, runtime-neutral `semantic` tree. Process apps also retain the compatible `frame` RenderCommand array. Agents can use the semantic nodes to inspect what any app runtime is currently displaying.
 
 For terminal panes: returns a simple status object (type, title, pane_id).
 


### PR DESCRIPTION
Stint task 0363

No linked GitHub issue.

## Summary

- Adds one versioned semantic pane-state envelope across Process, native builtin, and WASM runtimes.
- Preserves the existing Process `frame` response while `plexi pane state` gains normalized `semantic.nodes`.
- Captures native AccessKit semantics from the committed production render pass and retains committed WASM trees without per-app serializers.
- Logs runtime/schema/node counts without logging semantic content and updates drive-host guidance.

## Done When

- `pane state` returns known Assistant, another builtin, Process, and WASM semantics.
- Process frame consumers remain compatible.
- Reads stay same-user and read-only.
- Logs include pane id, runtime kind, schema version, and node count without user text.

## Test evidence

- Targeted semantic tests: 18 passed, 0 failed.
- Full `cargo test --bin plexi`: 1,584 passed, 0 failed.
- `cargo build`: passed.
- Assistant settings scene: passed; `/tmp/plexi-0363-scenes/assistant-settings.png` inspected and shows Assistant settings plus model-tier output.
- Codex review: clean after two review rounds.
- Conclusion: binary install required because acceptance includes an installed-host `plexi pane state` proof for native Assistant and WASM.