### PR TITLE
assistant: add conversation history and rewind

### DIFF
--- a/src/assistant/commands.rs
+++ b/src/assistant/commands.rs
@@ -42,13 +42,33 @@ pub const BUILT_IN_COMMANDS: &[(&str, &str)] = &[
         "Show or hide the model's reasoning for every turn.",
     ),
     ("model", "Show or change the model tier for this session."),
-    ("agent", "List, inspect, create, edit, or switch Assistant agents."),
-    ("effort", "Show or change reasoning effort for this session."),
+    (
+        "agent",
+        "List, inspect, create, edit, or switch Assistant agents.",
+    ),
+    (
+        "effort",
+        "Show or change reasoning effort for this session.",
+    ),
     (
         "settings",
         "Show resolved Assistant settings and their sources.",
     ),
     ("config", "Show Assistant settings (alias for /settings)."),
+    ("resume", "List or resume a prior workspace conversation."),
+    (
+        "history",
+        "Show turns, checkpoints, compactions, and interruptions.",
+    ),
+    (
+        "rewind",
+        "Rewind conversation context to an explicit turn or checkpoint.",
+    ),
+    (
+        "compact",
+        "Compact older context while preserving raw history.",
+    ),
+    ("export", "Export the transcript and Assistant audit log."),
 ];
 
 /// Parse `input` as a slash command. Returns `None` when the input is not a
@@ -206,5 +226,14 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["config"]
         );
+    }
+
+    #[test]
+    fn conversation_history_commands_are_discoverable() {
+        let names: Vec<&str> = BUILT_IN_COMMANDS.iter().map(|(name, _)| *name).collect();
+        for expected in ["resume", "history", "rewind", "compact", "export"] {
+            assert!(names.contains(&expected), "missing /{expected}");
+            assert!(help_text().contains(&format!("/{expected}")));
+        }
     }
 }

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -19,9 +19,9 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc::{Receiver, Sender, SyncSender};
 use std::sync::{Arc, Mutex};
 
+use crate::agent::{AgentDefinition, AgentRegistry, AgentSource};
 use crate::app::app_trait::{App, AppRenderContext, KeyDisposition};
 use crate::app_protocol::{AiMessage, AiTool, ModelTier, PayloadMode, TriggerMode};
-use crate::agent::{AgentDefinition, AgentRegistry, AgentSource};
 use crate::broker::{
     ActorScope, ActorType, Decision, GrantDuration, GrantRecord, GrantSource, GrantStore,
     PermissionRequest, ResourceScope, TargetType,
@@ -198,6 +198,60 @@ fn format_setting_ids(ids: &[String]) -> String {
     }
 }
 
+fn bounded_head_tail(text: &str, budget: usize) -> String {
+    let flat = text.replace('\n', " ");
+    let chars = flat.chars().collect::<Vec<_>>();
+    if chars.len() <= budget {
+        return flat;
+    }
+    if budget < 12 {
+        return chars.into_iter().take(budget).collect();
+    }
+
+    let mut keep = budget;
+    for _ in 0..2 {
+        let omitted = chars.len().saturating_sub(keep);
+        let marker_len = format!(" [{omitted} chars omitted] ").chars().count();
+        keep = budget.saturating_sub(marker_len);
+    }
+    let head = keep.div_ceil(2);
+    let tail = keep.saturating_sub(head);
+    let omitted = chars.len().saturating_sub(head + tail);
+    let marker = format!(" [{omitted} chars omitted] ");
+    let mut out = chars.iter().take(head).collect::<String>();
+    out.push_str(&marker);
+    out.extend(chars.iter().skip(chars.len() - tail));
+    out.chars().take(budget).collect()
+}
+
+fn deterministic_context_summary(turns: &[model::Turn], budget: usize) -> String {
+    let mut out = String::new();
+    for (index, turn) in turns.iter().enumerate() {
+        let remaining = budget.saturating_sub(out.chars().count());
+        let turns_left = turns.len() - index;
+        let label = format!("- {:?}: ", turn.role);
+        let fair_share = (remaining / turns_left).min(640);
+        if fair_share <= label.chars().count() + 1 {
+            let omitted = turns.len() - index;
+            let marker = format!("- [{omitted} older turn(s) omitted; see raw checkpoint]");
+            let available = budget.saturating_sub(out.chars().count());
+            out.push_str(&bounded_head_tail(&marker, available));
+            break;
+        }
+        let content_budget = fair_share - label.chars().count() - 1;
+        out.push_str(&label);
+        out.push_str(&bounded_head_tail(&turn.text, content_budget));
+        out.push('\n');
+    }
+    out.truncate(
+        out.char_indices()
+            .nth(budget)
+            .map(|(index, _)| index)
+            .unwrap_or(out.len()),
+    );
+    out
+}
+
 /// The host Assistant pane: model + store + broker + grant wiring.
 pub struct AssistantApp {
     pub(crate) model: AssistantModel,
@@ -302,6 +356,23 @@ impl AssistantApp {
             .active_agent_id()
             .unwrap_or_else(|| "default".to_string());
         model.effort_override = store.effort_override();
+        match store.recover_interrupted_turn(&model.conversation_id) {
+            Ok(true) => {
+                model.turns.push(model::Turn::now(
+                    TurnRole::Error,
+                    "The previous model/tool turn was interrupted when Plexi stopped.",
+                ));
+                log::info!(
+                    "assistant[{}]: recovered interrupted turn",
+                    model.conversation_id
+                );
+            }
+            Ok(false) => {}
+            Err(e) => log::error!(
+                "assistant[{}]: failed to recover interrupted turn: {e}",
+                model.conversation_id
+            ),
+        }
         let settings_loader = SettingsLoader::new(profile_dir, &workspace_root);
         let agent_registry = AgentRegistry::load(profile_dir, &workspace_root);
         if agent_registry.active(&model.active_agent_id).is_none() {
@@ -468,6 +539,16 @@ impl AssistantApp {
                 AssistantEffect::EditAgent(id) => self.cmd_edit_agent(&id),
                 AssistantEffect::ShowEffort => self.cmd_show_effort(),
                 AssistantEffect::SetSessionEffort(effort) => self.set_session_effort(effort),
+                AssistantEffect::ListConversations => self.cmd_list_conversations(),
+                AssistantEffect::ResumeConversation(selector) => {
+                    self.cmd_resume_conversation(&selector)
+                }
+                AssistantEffect::ShowHistory => self.cmd_show_history(),
+                AssistantEffect::RewindConversation(selector) => {
+                    self.cmd_rewind_conversation(&selector)
+                }
+                AssistantEffect::CompactConversation => self.cmd_compact_conversation(),
+                AssistantEffect::ExportConversation => self.cmd_export_conversation(),
                 AssistantEffect::PersistShowThoughts(show) => {
                     if let Err(e) = self.store.set_show_thoughts(show) {
                         log::error!("assistant: failed to persist show_thoughts={show}: {e}");
@@ -714,6 +795,15 @@ impl AssistantApp {
         {
             log::error!(
                 "assistant[{}]: failed to persist transcript: {e}",
+                self.model.conversation_id
+            );
+        }
+        if let Err(e) = self
+            .store
+            .set_turn_in_flight(self.model.streaming.in_flight)
+        {
+            log::error!(
+                "assistant[{}]: failed to persist in-flight state: {e}",
                 self.model.conversation_id
             );
         }
@@ -1358,7 +1448,11 @@ impl AssistantApp {
 
     fn reload_agents(&mut self) {
         self.agent_registry = AgentRegistry::load(&self.profile_dir, &self.workspace_root);
-        if self.agent_registry.active(&self.model.active_agent_id).is_none() {
+        if self
+            .agent_registry
+            .active(&self.model.active_agent_id)
+            .is_none()
+        {
             self.model.active_agent_id = "default".to_string();
         }
     }
@@ -1399,7 +1493,9 @@ impl AssistantApp {
             })
             .collect::<Vec<_>>()
             .join("\n");
-        let effects = self.model.push_info(format!("**Assistant agents**\n\n{lines}"));
+        let effects = self
+            .model
+            .push_info(format!("**Assistant agents**\n\n{lines}"));
         self.execute_effects(effects);
     }
 
@@ -1506,12 +1602,9 @@ impl AssistantApp {
 
     fn valid_agent_id(id: &str) -> bool {
         !id.is_empty()
-            && id.chars().all(|ch| {
-                ch.is_ascii_lowercase()
-                    || ch.is_ascii_digit()
-                    || ch == '-'
-                    || ch == '_'
-            })
+            && id
+                .chars()
+                .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-' || ch == '_')
     }
 
     fn cmd_create_agent(&mut self, id: &str) {
@@ -1525,7 +1618,9 @@ impl AssistantApp {
             return;
         }
         if self.agent_registry.active(id).is_some() {
-            let effects = self.model.push_error(format!("Agent `{id}` already exists."));
+            let effects = self
+                .model
+                .push_error(format!("Agent `{id}` already exists."));
             self.execute_effects(effects);
             return;
         }
@@ -1562,7 +1657,9 @@ impl AssistantApp {
                 id,
                 dir.display()
             );
-            let effects = self.model.push_error(format!("Failed to create agent `{id}`: {error}"));
+            let effects = self
+                .model
+                .push_error(format!("Failed to create agent `{id}`: {error}"));
             self.execute_effects(effects);
             return;
         }
@@ -1572,7 +1669,9 @@ impl AssistantApp {
             id,
             dir.display()
         );
-        let effects = self.model.push_info(format!("Created agent `{id}` at `{}`.", dir.display()));
+        let effects = self
+            .model
+            .push_info(format!("Created agent `{id}` at `{}`.", dir.display()));
         self.execute_effects(effects);
     }
 
@@ -1595,7 +1694,9 @@ impl AssistantApp {
             .clone()
             .unwrap_or_else(|| self.profile_dir.join("agents").join(id));
         log::info!("assistant: edit agent '{}' at {}", id, path.display());
-        let effects = self.model.push_info(format!("Edit agent `{id}` at `{}`.", path.display()));
+        let effects = self
+            .model
+            .push_info(format!("Edit agent `{id}` at `{}`.", path.display()));
         self.execute_effects(effects);
     }
 
@@ -1627,6 +1728,308 @@ impl AssistantApp {
             effort.map(ReasoningEffort::label).unwrap_or("auto")
         ));
         self.execute_effects(effects);
+    }
+
+    fn cmd_list_conversations(&mut self) {
+        match self.store.list_conversations() {
+            Ok(items) => {
+                log::info!("assistant: /resume listed {} conversation(s)", items.len());
+                let body = if items.is_empty() {
+                    "No saved conversations in this workspace.".to_string()
+                } else {
+                    let rows = items
+                        .iter()
+                        .enumerate()
+                        .map(|(index, item)| {
+                            format!(
+                                "{}. {} `{}`: {} turn(s){}",
+                                index + 1,
+                                item.title,
+                                item.id,
+                                item.turn_count,
+                                if item.active { " (active)" } else { "" }
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    format!("**Workspace conversations**\n\n{rows}\n\nUse `/resume <index-or-id>`.")
+                };
+                let effects = self.model.push_info(body);
+                self.execute_effects(effects);
+            }
+            Err(e) => {
+                log::error!("assistant: /resume failed to list conversations: {e}");
+                let effects = self
+                    .model
+                    .push_error(format!("Could not list conversations: {e}"));
+                self.execute_effects(effects);
+            }
+        }
+    }
+
+    fn resolve_conversation(&self, selector: &str) -> Result<String, String> {
+        let items = self.store.list_conversations()?;
+        if let Ok(index) = selector.parse::<usize>() {
+            return items
+                .get(index.saturating_sub(1))
+                .map(|item| item.id.clone())
+                .ok_or_else(|| format!("No conversation at index {index}."));
+        }
+        let matches = items
+            .iter()
+            .filter(|item| item.id == selector || item.id.starts_with(selector))
+            .collect::<Vec<_>>();
+        match matches.as_slice() {
+            [item] => Ok(item.id.clone()),
+            [] => Err(format!("No conversation matches `{selector}`.")),
+            _ => Err(format!("Conversation selector `{selector}` is ambiguous.")),
+        }
+    }
+
+    fn cmd_resume_conversation(&mut self, selector: &str) {
+        let id = match self.resolve_conversation(selector) {
+            Ok(id) => id,
+            Err(e) => {
+                let effects = self.model.push_error(e);
+                self.execute_effects(effects);
+                return;
+            }
+        };
+        let turns = self.store.load_turns(&id);
+        let session_name = match self.store.load_history(&id) {
+            Ok(history) => history.name,
+            Err(e) => {
+                log::error!("assistant[{id}]: /resume failed to read metadata: {e}");
+                let effects = self
+                    .model
+                    .push_error(format!("Could not resume conversation metadata: {e}"));
+                self.execute_effects(effects);
+                return;
+            }
+        };
+        let turn_count = turns.len();
+        let cancel = self.model.switch_conversation(id.clone(), turns);
+        self.model.session_name = session_name;
+        self.execute_effects(cancel);
+        log::info!("assistant[{id}]: resumed conversation ({turn_count} turn(s))");
+        let effects = self.model.push_info(format!(
+            "Resumed `{id}` with {turn_count} turn(s). Agent, effort, and thought settings were preserved."
+        ));
+        self.execute_effects(effects);
+    }
+
+    fn cmd_show_history(&mut self) {
+        let id = self.model.conversation_id.clone();
+        match self.store.load_history(&id) {
+            Ok(history) => {
+                let mut rows = self
+                    .model
+                    .turns
+                    .iter()
+                    .enumerate()
+                    .map(|(index, turn)| {
+                        let preview: String =
+                            turn.text.replace('\n', " ").chars().take(80).collect();
+                        format!(
+                            "- turn:{} | {:?} | {} | {}",
+                            index + 1,
+                            turn.role,
+                            turn.created_at,
+                            preview
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                rows.extend(history.checkpoints.iter().map(|checkpoint| {
+                    format!(
+                        "- checkpoint:{} | {} | {} turn(s) | {}",
+                        checkpoint.id,
+                        checkpoint.label,
+                        checkpoint.turn_count,
+                        checkpoint.created_at
+                    )
+                }));
+                rows.extend(history.compactions.iter().map(|boundary| {
+                    format!(
+                        "- compaction | {} older turn(s) | raw checkpoint:{} | {}",
+                        boundary.compacted_turns, boundary.checkpoint_id, boundary.created_at
+                    )
+                }));
+                rows.extend(
+                    history
+                        .interruptions
+                        .iter()
+                        .map(|at| format!("- interrupted | {at}")),
+                );
+                log::info!(
+                    "assistant[{id}]: /history turns={} checkpoints={} compactions={} interruptions={}",
+                    self.model.turns.len(),
+                    history.checkpoints.len(),
+                    history.compactions.len(),
+                    history.interruptions.len()
+                );
+                let effects = self.model.push_info(format!(
+                    "**Conversation history**\n\n{}",
+                    if rows.is_empty() {
+                        "No history yet.".to_string()
+                    } else {
+                        rows.join("\n")
+                    }
+                ));
+                self.execute_effects(effects);
+            }
+            Err(e) => {
+                log::error!("assistant[{id}]: /history failed: {e}");
+                let effects = self
+                    .model
+                    .push_error(format!("Could not read history: {e}"));
+                self.execute_effects(effects);
+            }
+        }
+    }
+
+    fn cmd_rewind_conversation(&mut self, selector: &str) {
+        let target = if let Some(raw) = selector.strip_prefix("turn:") {
+            match raw.parse::<usize>() {
+                Ok(count) if count <= self.model.turns.len() => {
+                    Ok(self.model.turns[..count].to_vec())
+                }
+                _ => Err(format!("Invalid turn selector `{selector}`.")),
+            }
+        } else if let Some(checkpoint) = selector.strip_prefix("checkpoint:") {
+            self.store
+                .load_checkpoint(&self.model.conversation_id, checkpoint)
+        } else {
+            Err("Use `/rewind turn:N` or `/rewind checkpoint:ID`.".to_string())
+        };
+        let target = match target {
+            Ok(target) => target,
+            Err(e) => {
+                let effects = self.model.push_error(e);
+                self.execute_effects(effects);
+                return;
+            }
+        };
+        let id = self.model.conversation_id.clone();
+        let checkpoint = match self
+            .store
+            .write_checkpoint(&id, "rewind-safety", &self.model.turns)
+        {
+            Ok(checkpoint) => checkpoint,
+            Err(e) => {
+                log::error!("assistant[{id}]: /rewind safety checkpoint failed: {e}");
+                let effects = self.model.push_error(format!(
+                    "Rewind stopped: could not write safety checkpoint: {e}"
+                ));
+                self.execute_effects(effects);
+                return;
+            }
+        };
+        let cancel = self.model.switch_conversation(id.clone(), target);
+        self.execute_effects(cancel);
+        log::info!(
+            "assistant[{id}]: rewound conversation context safety_checkpoint={}",
+            checkpoint.id
+        );
+        let effects = self.model.push_info(format!(
+            "Conversation context rewound to `{selector}`. Safety checkpoint: `{}`. Files and apps were untouched.",
+            checkpoint.id
+        ));
+        self.execute_effects(effects);
+    }
+
+    fn cmd_compact_conversation(&mut self) {
+        const RETAIN_RECENT: usize = 6;
+        const SUMMARY_BUDGET_CHARS: usize = 4_096;
+        if self.model.turns.len() <= RETAIN_RECENT {
+            let effects = self
+                .model
+                .push_info("Nothing to compact yet; fewer than seven turns are active.");
+            self.execute_effects(effects);
+            return;
+        }
+        let id = self.model.conversation_id.clone();
+        let compacted = self.model.turns.len() - RETAIN_RECENT;
+        let checkpoint =
+            match self
+                .store
+                .write_checkpoint(&id, "pre-compaction-raw-history", &self.model.turns)
+            {
+                Ok(checkpoint) => checkpoint,
+                Err(e) => {
+                    log::error!("assistant[{id}]: /compact checkpoint failed: {e}");
+                    let effects = self.model.push_error(format!(
+                        "Compaction stopped: could not preserve raw history: {e}"
+                    ));
+                    self.execute_effects(effects);
+                    return;
+                }
+            };
+        let summary =
+            deterministic_context_summary(&self.model.turns[..compacted], SUMMARY_BUDGET_CHARS);
+        let recent = self.model.turns[compacted..].to_vec();
+        let mut compacted_turns = vec![model::Turn::now(
+            TurnRole::Assistant,
+            format!(
+                "Compacted context ({compacted} turn(s)); raw history checkpoint `{}`:\n{excerpts}",
+                checkpoint.id,
+                excerpts = summary
+            ),
+        )];
+        compacted_turns.extend(recent);
+        if let Err(e) = self.store.record_compaction(&id, &checkpoint.id, compacted) {
+            log::error!("assistant[{id}]: failed to record compaction boundary: {e}");
+            let effects = self.model.push_error(format!(
+                "Raw checkpoint written, but compaction stopped because boundary metadata failed: {e}"
+            ));
+            self.execute_effects(effects);
+            return;
+        }
+        let cancel = self.model.switch_conversation(id.clone(), compacted_turns);
+        self.execute_effects(cancel);
+        log::info!(
+            "assistant[{id}]: compacted {compacted} turn(s) checkpoint={}",
+            checkpoint.id
+        );
+        self.session_write();
+    }
+
+    fn cmd_export_conversation(&mut self) {
+        let audit_path = self.profile_dir.join("audit.jsonl");
+        let audit = match std::fs::read_to_string(&audit_path) {
+            Ok(raw) => raw,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(e) => {
+                log::error!("assistant: /export read {}: {e}", audit_path.display());
+                let effects = self.model.push_error(format!(
+                    "Export failed reading {}: {e}",
+                    audit_path.display()
+                ));
+                self.execute_effects(effects);
+                return;
+            }
+        };
+        let id = self.model.conversation_id.clone();
+        match self
+            .store
+            .export_conversation(&id, &self.model.turns, &audit)
+        {
+            Ok(path) => {
+                log::info!(
+                    "assistant[{id}]: exported transcript and audit to {}",
+                    path.display()
+                );
+                let effects = self.model.push_info(format!(
+                    "Exported transcript and tool/audit log to `{}`.",
+                    path.display()
+                ));
+                self.execute_effects(effects);
+            }
+            Err(e) => {
+                log::error!("assistant[{id}]: /export failed: {e}");
+                let effects = self.model.push_error(format!("Export failed: {e}"));
+                self.execute_effects(effects);
+            }
+        }
     }
 
     fn set_session_model(&mut self, tier: ModelTier) {
@@ -2504,6 +2907,128 @@ enabled = ["allowed.tool"]
         assert_eq!(
             app.store.active_conversation().as_deref(),
             Some(second_id.as_str())
+        );
+    }
+
+    #[test]
+    fn resume_history_rewind_compact_and_export_are_observable() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = test_app(ws.path());
+        let first_id = app.model.conversation_id.clone();
+        for index in 0..4 {
+            let question = if index == 0 {
+                format!("beginning-intent {} ending-intent", "q".repeat(2_000))
+            } else {
+                format!("question {index}")
+            };
+            app.model
+                .turns
+                .push(model::Turn::now(TurnRole::User, question));
+            app.model.turns.push(model::Turn::now(
+                TurnRole::Assistant,
+                format!("answer {index}"),
+            ));
+        }
+        app.session_write();
+
+        app.model.composer = "/new second".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        let second_id = app.model.conversation_id.clone();
+
+        app.model.composer = "/resume".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        assert!(app.model.turns.last().unwrap().text.contains(&first_id));
+        assert!(app.model.turns.last().unwrap().text.contains(&second_id));
+
+        app.model.composer = format!("/resume {first_id}");
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        assert_eq!(app.model.conversation_id, first_id);
+        assert!(app.model.turns.last().unwrap().text.contains("Resumed"));
+
+        let pre_compaction = app.model.turns.clone();
+        let pre_compaction_chars = pre_compaction
+            .iter()
+            .map(|turn| turn.text.chars().count())
+            .sum::<usize>();
+        app.model.composer = "/compact".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        assert!(app.model.turns[0].text.contains("Compacted context"));
+        assert!(app.model.turns[0].text.contains("beginning-intent"));
+        assert!(app.model.turns[0].text.contains("ending-intent"));
+        assert!(app.model.turns[0].text.contains("chars omitted"));
+        let history = app.store.load_history(&first_id).unwrap();
+        assert_eq!(history.compactions.len(), 1);
+        let raw = app
+            .store
+            .load_checkpoint(&first_id, &history.compactions[0].checkpoint_id)
+            .unwrap();
+        assert_eq!(raw, pre_compaction, "raw checkpoint is exact");
+        let compacted_chars = app
+            .model
+            .turns
+            .iter()
+            .map(|turn| turn.text.chars().count())
+            .sum::<usize>();
+        assert!(
+            compacted_chars < pre_compaction_chars / 2,
+            "active context must be materially smaller"
+        );
+
+        app.model.composer = "/rewind turn:2".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        assert_eq!(app.model.turns.len(), 3, "two turns plus rewind notice");
+        assert!(app
+            .model
+            .turns
+            .last()
+            .unwrap()
+            .text
+            .contains("Files and apps were untouched"));
+
+        app.model.composer = "/history".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        let history_row = app.model.turns.last().unwrap();
+        assert!(history_row.text.contains("checkpoint:"));
+        assert!(history_row.text.contains("compaction"));
+
+        app.model.composer = "/export".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        let export_row = app.model.turns.last().unwrap();
+        assert!(export_row.text.contains("/exports/"));
+    }
+
+    #[test]
+    fn restart_marks_persisted_in_flight_turn_interrupted() {
+        let ws = tempfile::tempdir().unwrap();
+        let id = {
+            let mut app = test_app(ws.path());
+            app.model.streaming.in_flight = true;
+            app.session_write();
+            app.model.conversation_id.clone()
+        };
+
+        let reopened = test_app(ws.path());
+        assert_eq!(reopened.model.conversation_id, id);
+        assert!(reopened
+            .model
+            .turns
+            .iter()
+            .any(|turn| turn.text.contains("was interrupted")));
+        assert_eq!(
+            reopened
+                .store
+                .load_history(&id)
+                .unwrap()
+                .interruptions
+                .len(),
+            1
         );
     }
 

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -108,7 +108,9 @@ pub enum AssistantEffect {
         prompt: String,
     },
     /// Persist unwritten turns and the active conversation id to disk.
-    SessionWrite { conversation_id: String },
+    SessionWrite {
+        conversation_id: String,
+    },
     /// `/tools`: list discovered app connector tools with broker decisions.
     ListTools,
     /// `/apps`: list running apps and their exposed connectors.
@@ -116,7 +118,9 @@ pub enum AssistantEffect {
     /// `/permissions`: list persisted grants for the assistant actor.
     ListPermissions,
     /// `/revoke <target_id>`: remove persisted grants for one target.
-    RevokeGrant { target_id: String },
+    RevokeGrant {
+        target_id: String,
+    },
     /// `/audit`: show recent audit events.
     ShowAudit,
     /// `/settings` and `/config`: show the resolved Assistant settings.
@@ -132,6 +136,12 @@ pub enum AssistantEffect {
     EditAgent(String),
     ShowEffort,
     SetSessionEffort(Option<ReasoningEffort>),
+    ListConversations,
+    ResumeConversation(String),
+    ShowHistory,
+    RewindConversation(String),
+    CompactConversation,
+    ExportConversation,
     /// `/thoughts`: persist the flipped show-thoughts preference.
     PersistShowThoughts(bool),
     /// `/clear` or `/new` ran while a turn was in flight: unblock any worker
@@ -338,6 +348,20 @@ impl AssistantModel {
         vec![AssistantEffect::CancelTurn]
     }
 
+    pub(crate) fn switch_conversation(
+        &mut self,
+        conversation_id: String,
+        turns: Vec<Turn>,
+    ) -> Vec<AssistantEffect> {
+        let effects = self.interrupt_turn();
+        self.conversation_id = conversation_id;
+        self.turns = turns;
+        self.composer.clear();
+        self.history_cursor = None;
+        self.picker_selected = 0;
+        effects
+    }
+
     /// Insert a row that belongs to the in-flight turn at the turn anchor,
     /// keeping it above anything appended mid-turn (slash-view output,
     /// queued messages). Falls back to a plain append when no turn is in
@@ -357,10 +381,10 @@ impl AssistantModel {
     /// below; unknown names answer with an error row.
     fn execute_command(&mut self, cmd: &ParsedCommand) -> Vec<AssistantEffect> {
         log::info!(
-            "assistant[{}]: command /{} args='{}'",
+            "assistant[{}]: command /{} args_len={}",
             self.conversation_id,
             cmd.name,
-            cmd.args
+            cmd.args.len()
         );
         match cmd.name.as_str() {
             // Fresh context in a new conversation; the prior transcript
@@ -369,6 +393,7 @@ impl AssistantModel {
                 let mut effects = self.interrupt_turn();
                 let prior = self.conversation_id.clone();
                 self.conversation_id = new_conversation_id();
+                self.session_name = None;
                 self.turns.clear();
                 log::info!(
                     "assistant: /clear — new conversation {} (prior {prior} resumable)",
@@ -384,6 +409,7 @@ impl AssistantModel {
                 let mut effects = self.interrupt_turn();
                 self.conversation_id = new_conversation_id();
                 self.turns.clear();
+                self.set_session_name(&cmd.args);
                 if !cmd.args.is_empty() {
                     self.turns.push(Turn::now(
                         TurnRole::Assistant,
@@ -436,6 +462,21 @@ impl AssistantModel {
             "permissions" => vec![AssistantEffect::ListPermissions],
             "audit" => vec![AssistantEffect::ShowAudit],
             "settings" | "config" => vec![AssistantEffect::ShowSettings],
+            "resume" if cmd.args.is_empty() => vec![AssistantEffect::ListConversations],
+            "resume" => vec![AssistantEffect::ResumeConversation(cmd.args.clone())],
+            "history" => vec![AssistantEffect::ShowHistory],
+            "rewind" if cmd.args.is_empty() => {
+                self.turns.push(Turn::now(
+                    TurnRole::Error,
+                    "Usage: /rewind <turn:N | checkpoint:ID>. Conversation context only; files and apps are untouched.",
+                ));
+                vec![AssistantEffect::SessionWrite {
+                    conversation_id: self.conversation_id.clone(),
+                }]
+            }
+            "rewind" => vec![AssistantEffect::RewindConversation(cmd.args.clone())],
+            "compact" => vec![AssistantEffect::CompactConversation],
+            "export" => vec![AssistantEffect::ExportConversation],
             "model" if cmd.args.is_empty() => vec![AssistantEffect::ShowModelSetting],
             "model" => {
                 let tier = match cmd.args.as_str() {
@@ -488,9 +529,15 @@ impl AssistantModel {
             "effort" if cmd.args.is_empty() => vec![AssistantEffect::ShowEffort],
             "effort" => match cmd.args.as_str() {
                 "auto" => vec![AssistantEffect::SetSessionEffort(None)],
-                "low" => vec![AssistantEffect::SetSessionEffort(Some(ReasoningEffort::Low))],
-                "medium" => vec![AssistantEffect::SetSessionEffort(Some(ReasoningEffort::Medium))],
-                "high" => vec![AssistantEffect::SetSessionEffort(Some(ReasoningEffort::High))],
+                "low" => vec![AssistantEffect::SetSessionEffort(Some(
+                    ReasoningEffort::Low,
+                ))],
+                "medium" => vec![AssistantEffect::SetSessionEffort(Some(
+                    ReasoningEffort::Medium,
+                ))],
+                "high" => vec![AssistantEffect::SetSessionEffort(Some(
+                    ReasoningEffort::High,
+                ))],
                 _ => {
                     self.turns.push(Turn::now(
                         TurnRole::Error,
@@ -1175,5 +1222,45 @@ mod tests {
         )
         .unwrap();
         assert_eq!(legacy.status, None);
+    }
+
+    #[test]
+    fn conversation_commands_emit_store_backed_effects() {
+        let mut model = AssistantModel::fresh();
+        assert_eq!(
+            submitted(&mut model, "/resume"),
+            vec![AssistantEffect::ListConversations]
+        );
+        assert_eq!(
+            submitted(&mut model, "/resume 2"),
+            vec![AssistantEffect::ResumeConversation("2".to_string())]
+        );
+        assert_eq!(
+            submitted(&mut model, "/history"),
+            vec![AssistantEffect::ShowHistory]
+        );
+        assert_eq!(
+            submitted(&mut model, "/rewind turn:2"),
+            vec![AssistantEffect::RewindConversation("turn:2".to_string())]
+        );
+        assert_eq!(
+            submitted(&mut model, "/compact"),
+            vec![AssistantEffect::CompactConversation]
+        );
+        assert_eq!(
+            submitted(&mut model, "/export"),
+            vec![AssistantEffect::ExportConversation]
+        );
+    }
+
+    #[test]
+    fn rewind_requires_an_explicit_selector() {
+        let mut model = AssistantModel::fresh();
+        let effects = submitted(&mut model, "/rewind");
+        assert!(matches!(
+            effects.as_slice(),
+            [AssistantEffect::SessionWrite { .. }]
+        ));
+        assert!(model.turns.last().unwrap().text.contains("Usage: /rewind"));
     }
 }

--- a/src/assistant/store.rs
+++ b/src/assistant/store.rs
@@ -13,6 +13,7 @@
 //! finish out of submission order (a reply commits at its anchor while
 //! slash-view rows append), so disk order mirrors memory order by rewrite.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use super::model::Turn;
@@ -30,6 +31,46 @@ struct StateToml {
     active_agent_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     effort_override: Option<ReasoningEffort>,
+    #[serde(default)]
+    turn_in_flight: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConversationSummary {
+    pub id: String,
+    pub title: String,
+    pub turn_count: usize,
+    pub active: bool,
+    updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CheckpointMetadata {
+    pub id: String,
+    pub label: String,
+    pub created_at: String,
+    pub turn_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct CompactionMetadata {
+    pub checkpoint_id: String,
+    pub created_at: String,
+    pub compacted_turns: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ConversationHistory {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub updated_at: String,
+    #[serde(default)]
+    pub checkpoints: Vec<CheckpointMetadata>,
+    #[serde(default)]
+    pub compactions: Vec<CompactionMetadata>,
+    #[serde(default)]
+    pub interruptions: Vec<String>,
 }
 
 /// Handle to the on-disk Assistant store for one workspace.
@@ -55,6 +96,43 @@ impl AssistantStore {
         self.dir.join("conversations").join(format!("{id}.jsonl"))
     }
 
+    fn history_path(&self, id: &str) -> PathBuf {
+        self.dir.join("history").join(format!("{id}.json"))
+    }
+
+    fn checkpoint_path(&self, conversation_id: &str, checkpoint_id: &str) -> PathBuf {
+        self.dir
+            .join("checkpoints")
+            .join(conversation_id)
+            .join(format!("{checkpoint_id}.jsonl"))
+    }
+
+    fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
+        let parent = path
+            .parent()
+            .ok_or_else(|| format!("write {}: missing parent", path.display()))?;
+        std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+        let temp = parent.join(format!(
+            ".{}.tmp-{}",
+            path.file_name().unwrap_or_default().to_string_lossy(),
+            uuid::Uuid::new_v4()
+        ));
+        let result = (|| {
+            let mut file = std::fs::File::create(&temp)
+                .map_err(|e| format!("create {}: {e}", temp.display()))?;
+            file.write_all(bytes)
+                .map_err(|e| format!("write {}: {e}", temp.display()))?;
+            file.sync_all()
+                .map_err(|e| format!("sync {}: {e}", temp.display()))?;
+            std::fs::rename(&temp, path)
+                .map_err(|e| format!("rename {} to {}: {e}", temp.display(), path.display()))
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(&temp);
+        }
+        result
+    }
+
     /// Parse the current `state.toml`, if present and valid.
     fn read_state(&self) -> Option<StateToml> {
         let raw = std::fs::read_to_string(self.state_path()).ok()?;
@@ -71,11 +149,8 @@ impl AssistantStore {
     }
 
     fn write_state(&self, state: &StateToml) -> Result<(), String> {
-        std::fs::create_dir_all(&self.dir)
-            .map_err(|e| format!("create {}: {e}", self.dir.display()))?;
         let raw = toml::to_string(state).map_err(|e| format!("serialize state.toml: {e}"))?;
-        std::fs::write(self.state_path(), raw)
-            .map_err(|e| format!("write {}: {e}", self.state_path().display()))
+        Self::atomic_write(&self.state_path(), raw.as_bytes())
     }
 
     /// The persisted active conversation id, if any.
@@ -97,7 +172,11 @@ impl AssistantStore {
         state.session_name = session_name.map(str::to_string);
         state.active_agent_id = Some(active_agent_id.to_string());
         state.effort_override = effort_override;
-        self.write_state(&state)
+        self.write_state(&state)?;
+        let mut history = self.load_history(id)?;
+        history.name = session_name.map(str::to_string);
+        history.updated_at = crate::host::event_log::now_timestamp();
+        self.write_history(id, &history)
     }
 
     /// The persisted session name for the active conversation, if any.
@@ -127,16 +206,34 @@ impl AssistantStore {
         self.write_state(&state)
     }
 
+    pub fn set_turn_in_flight(&self, in_flight: bool) -> Result<(), String> {
+        let mut state = self.read_state().unwrap_or_default();
+        state.turn_in_flight = in_flight;
+        self.write_state(&state)
+    }
+
+    /// Clear a persisted in-flight marker and record that restart interrupted it.
+    pub fn recover_interrupted_turn(&self, conversation_id: &str) -> Result<bool, String> {
+        let mut state = self.read_state().unwrap_or_default();
+        if !state.turn_in_flight || state.active_conversation != conversation_id {
+            return Ok(false);
+        }
+        let mut history = self.load_history(conversation_id)?;
+        history
+            .interruptions
+            .push(crate::host::event_log::now_timestamp());
+        self.write_history(conversation_id, &history)?;
+        state.turn_in_flight = false;
+        self.write_state(&state)?;
+        Ok(true)
+    }
+
     /// Write the full conversation transcript, replacing the file. A turn
     /// finishing mid-conversation inserts at its anchor rather than at the
     /// end, so disk order can only be kept equal to memory order by
     /// rewriting — append-only would freeze the order of the racing rows.
     pub fn write_turns(&self, id: &str, turns: &[Turn]) -> Result<(), String> {
         let path = self.conversation_path(id);
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("create {}: {e}", parent.display()))?;
-        }
         let mut raw = String::new();
         for turn in turns {
             let line =
@@ -144,7 +241,7 @@ impl AssistantStore {
             raw.push_str(&line);
             raw.push('\n');
         }
-        std::fs::write(&path, raw).map_err(|e| format!("write {}: {e}", path.display()))
+        Self::atomic_write(&path, raw.as_bytes())
     }
 
     /// Load every turn of a conversation. Missing file = empty conversation.
@@ -175,6 +272,163 @@ impl AssistantStore {
             }
         }
         turns
+    }
+
+    pub fn list_conversations(&self) -> Result<Vec<ConversationSummary>, String> {
+        let active = self.active_conversation();
+        let dir = self.dir.join("conversations");
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(format!("list {}: {e}", dir.display())),
+        };
+        let mut items = Vec::new();
+        for entry in entries {
+            let entry = entry.map_err(|e| format!("list {}: {e}", dir.display()))?;
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let Some(id) = path.file_stem().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            let turns = self.load_turns(id);
+            let title = turns
+                .iter()
+                .find(|turn| matches!(turn.role, super::model::TurnRole::User))
+                .map(|turn| turn.text.chars().take(60).collect())
+                .unwrap_or_else(|| "Untitled conversation".to_string());
+            let history = self.load_history(id)?;
+            items.push(ConversationSummary {
+                id: id.to_string(),
+                title: history.name.unwrap_or(title),
+                turn_count: turns.len(),
+                active: active.as_deref() == Some(id),
+                updated_at: history.updated_at,
+            });
+        }
+        items.sort_by(|a, b| {
+            b.updated_at
+                .cmp(&a.updated_at)
+                .then_with(|| b.id.cmp(&a.id))
+        });
+        Ok(items)
+    }
+
+    pub fn load_history(&self, id: &str) -> Result<ConversationHistory, String> {
+        let path = self.history_path(id);
+        match std::fs::read_to_string(&path) {
+            Ok(raw) => match serde_json::from_str(&raw) {
+                Ok(history) => Ok(history),
+                Err(e) => {
+                    log::error!(
+                        "assistant store: invalid {}: {e}; using empty history metadata",
+                        path.display()
+                    );
+                    Ok(ConversationHistory::default())
+                }
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                Ok(ConversationHistory::default())
+            }
+            Err(e) => Err(format!("read {}: {e}", path.display())),
+        }
+    }
+
+    fn write_history(&self, id: &str, history: &ConversationHistory) -> Result<(), String> {
+        let raw = serde_json::to_vec_pretty(history)
+            .map_err(|e| format!("serialize history for {id}: {e}"))?;
+        Self::atomic_write(&self.history_path(id), &raw)
+    }
+
+    pub fn write_checkpoint(
+        &self,
+        conversation_id: &str,
+        label: &str,
+        turns: &[Turn],
+    ) -> Result<CheckpointMetadata, String> {
+        let id = format!("checkpoint-{}", uuid::Uuid::new_v4());
+        let mut raw = String::new();
+        for turn in turns {
+            raw.push_str(
+                &serde_json::to_string(turn)
+                    .map_err(|e| format!("serialize checkpoint {id}: {e}"))?,
+            );
+            raw.push('\n');
+        }
+        Self::atomic_write(&self.checkpoint_path(conversation_id, &id), raw.as_bytes())?;
+        let metadata = CheckpointMetadata {
+            id,
+            label: label.to_string(),
+            created_at: crate::host::event_log::now_timestamp(),
+            turn_count: turns.len(),
+        };
+        let mut history = self.load_history(conversation_id)?;
+        history.checkpoints.push(metadata.clone());
+        self.write_history(conversation_id, &history)?;
+        Ok(metadata)
+    }
+
+    pub fn load_checkpoint(
+        &self,
+        conversation_id: &str,
+        checkpoint_id: &str,
+    ) -> Result<Vec<Turn>, String> {
+        let history = self.load_history(conversation_id)?;
+        let checkpoint_id = history
+            .checkpoints
+            .iter()
+            .find(|checkpoint| checkpoint.id == checkpoint_id)
+            .map(|checkpoint| checkpoint.id.as_str())
+            .ok_or_else(|| format!("unknown checkpoint `{checkpoint_id}`"))?;
+        let path = self.checkpoint_path(conversation_id, checkpoint_id);
+        let raw =
+            std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        raw.lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| {
+                serde_json::from_str(line).map_err(|e| format!("parse {}: {e}", path.display()))
+            })
+            .collect()
+    }
+
+    pub fn record_compaction(
+        &self,
+        conversation_id: &str,
+        checkpoint_id: &str,
+        compacted_turns: usize,
+    ) -> Result<(), String> {
+        let mut history = self.load_history(conversation_id)?;
+        history.compactions.push(CompactionMetadata {
+            checkpoint_id: checkpoint_id.to_string(),
+            created_at: crate::host::event_log::now_timestamp(),
+            compacted_turns,
+        });
+        self.write_history(conversation_id, &history)
+    }
+
+    pub fn export_conversation(
+        &self,
+        id: &str,
+        turns: &[Turn],
+        audit: &str,
+    ) -> Result<PathBuf, String> {
+        let path = self.dir.join("exports").join(format!("{id}.md"));
+        let mut raw = format!("# Assistant conversation {id}\n\n");
+        for turn in turns {
+            raw.push_str(&format!(
+                "## {:?}, {}\n\n{}\n\n",
+                turn.role, turn.created_at, turn.text
+            ));
+            if let Some(thoughts) = &turn.thoughts {
+                raw.push_str(&format!("### Reasoning\n\n{thoughts}\n\n"));
+            }
+        }
+        raw.push_str("# Tool and permission audit\n\n```jsonl\n");
+        raw.push_str(audit);
+        raw.push_str("\n```\n");
+        Self::atomic_write(&path, raw.as_bytes())?;
+        Ok(path)
     }
 }
 
@@ -289,5 +543,64 @@ mod tests {
         let turns = store.load_turns(id);
         assert_eq!(turns.len(), 2, "corrupt line skipped, valid lines kept");
         assert_eq!(turns[1].text, "after");
+    }
+
+    #[test]
+    fn lists_multiple_conversations_with_active_marker() {
+        let ws = tempfile::tempdir().unwrap();
+        let store = AssistantStore::new(ws.path());
+        store
+            .write_turns("older", &[Turn::now(TurnRole::User, "first topic")])
+            .unwrap();
+        store
+            .write_turns("newer", &[Turn::now(TurnRole::User, "second topic")])
+            .unwrap();
+        store
+            .set_active_conversation("newer", Some("Notes"), "default", None)
+            .unwrap();
+
+        let conversations = store.list_conversations().unwrap();
+        assert_eq!(conversations.len(), 2);
+        assert!(conversations
+            .iter()
+            .any(|item| item.id == "newer" && item.active));
+        assert!(conversations
+            .iter()
+            .any(|item| item.id == "older" && !item.active));
+    }
+
+    #[test]
+    fn checkpoint_preserves_raw_turns_and_history_metadata() {
+        let ws = tempfile::tempdir().unwrap();
+        let store = AssistantStore::new(ws.path());
+        let turns = vec![
+            Turn::now(TurnRole::User, "one"),
+            Turn::now(TurnRole::Assistant, "two"),
+        ];
+        let checkpoint = store
+            .write_checkpoint("conv", "rewind-safety", &turns)
+            .unwrap();
+        assert_eq!(
+            store.load_checkpoint("conv", &checkpoint.id).unwrap(),
+            turns
+        );
+        let history = store.load_history("conv").unwrap();
+        assert_eq!(history.checkpoints.len(), 1);
+        assert_eq!(history.checkpoints[0].turn_count, 2);
+    }
+
+    #[test]
+    fn export_contains_transcript_and_audit_material() {
+        let ws = tempfile::tempdir().unwrap();
+        let store = AssistantStore::new(ws.path());
+        let turns = vec![Turn::now(TurnRole::User, "hello")];
+        let path = store
+            .export_conversation("conv", &turns, "{\"kind\":\"tool_call\"}\n")
+            .unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("# Assistant conversation conv"));
+        assert!(raw.contains("hello"));
+        assert!(raw.contains("tool_call"));
+        assert!(path.starts_with(ws.path().join(crate::config::workspace_channel_dir())));
     }
 }


### PR DESCRIPTION
Stint task 0228

No linked GitHub issue.

## Summary

- Persists channel-aware conversation metadata and interrupted-turn state with atomic transcript writes.
- Adds `/resume`, `/history`, `/rewind`, `/compact`, and `/export` to the Assistant pane.
- Preserves immutable safety checkpoints for rewind and raw pre-compaction history while bounding active context.
- Exports the transcript with the channel audit log and avoids logging command arguments.

## Test evidence

- Focused Assistant suite: 111 passed, 0 failed.
- Full Rust suite: 1,605 passed, 2 pre-existing send-to-pane failures, 1 ignored.
- cargo build: passed.
- Codex review: initial lossy compaction finding corrected; bounded summary now preserves head/tail intent and exact raw checkpoints.