### PR TITLE
assistant: add skills and native host tools

### DIFF
--- a/src/app/app_trait.rs
+++ b/src/app/app_trait.rs
@@ -18,6 +18,15 @@ pub struct AppRenderContext<'a> {
 
 /// Commands an app can issue back to the system.
 pub enum AppCommand {
+    /// Execute an Assistant host tool against live host state without shelling
+    /// out to the CLI. The host replies directly to the blocked model worker.
+    AssistantHostTool {
+        name: String,
+        input_json: String,
+        origin_pane_id: u64,
+        origin_context_id: u64,
+        reply: std::sync::mpsc::SyncSender<crate::plexi_ai::tool_dispatch::ToolCallResult>,
+    },
     /// Post an ephemeral notification.
     Notify(String),
     /// Request the host to spawn a new app pane.
@@ -212,6 +221,14 @@ pub trait App: Send {
     /// so the host can act on them each frame without changing the trait signature.
     fn take_pending_commands(&mut self) -> Vec<AppCommand> {
         vec![]
+    }
+
+    /// Pump asynchronous work while the app's context is off-screen.
+    fn background_tick(&mut self) {}
+
+    /// Whether `background_tick` can currently make progress.
+    fn needs_background_tick(&self) -> bool {
+        false
     }
 
     /// Returns true if this app wants to capture all keyboard input, preventing

--- a/src/app/assistant_host_tools.rs
+++ b/src/app/assistant_host_tools.rs
@@ -1,0 +1,389 @@
+//! Native execution seam for Assistant-owned host tools.
+
+use crate::plexi_ai::tool_dispatch::ToolCallResult;
+
+use super::PlexiApp;
+
+impl PlexiApp {
+    pub(super) fn handle_assistant_host_tool(
+        &mut self,
+        name: &str,
+        input_json: &str,
+        origin_pane_id: u64,
+        origin_context_id: u64,
+    ) -> ToolCallResult {
+        let parsed: serde_json::Value = match serde_json::from_str(input_json) {
+            Ok(value) => value,
+            Err(error) => return failed(format!("invalid_input: {error}")),
+        };
+        log::info!("assistant_host_tool: executing '{name}' in process");
+        match name {
+            "host.panes.list" => succeeded(self.assistant_pane_list()),
+            "host.panes.state" => {
+                let Some(id) = parsed.get("pane_id").and_then(serde_json::Value::as_u64) else {
+                    return failed("invalid_input: pane_id is required".to_string());
+                };
+                match self.assistant_pane_state(id) {
+                    Some(value) => succeeded(value),
+                    None => failed(format!("pane_not_found: {id}")),
+                }
+            }
+            "host.panes.open" => {
+                let Some(type_id) = parsed.get("type_id").and_then(serde_json::Value::as_str)
+                else {
+                    return failed("invalid_input: type_id is required".to_string());
+                };
+                let layout = parsed
+                    .get("layout")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+                let cwd = parsed
+                    .get("cwd")
+                    .and_then(serde_json::Value::as_str)
+                    .map(std::path::PathBuf::from);
+                let args = parsed
+                    .get("args")
+                    .and_then(serde_json::Value::as_array)
+                    .map(|args| {
+                        args.iter()
+                            .filter_map(serde_json::Value::as_str)
+                            .map(str::to_string)
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                match self.assistant_spawn_pane(
+                    origin_pane_id,
+                    origin_context_id,
+                    type_id,
+                    layout,
+                    args,
+                    cwd,
+                ) {
+                    Ok(pane_id) => succeeded(
+                        serde_json::json!({"ok": true, "pane_id": pane_id, "type_id": type_id}),
+                    ),
+                    Err(error) => failed(format!("open_pane_failed: {error}")),
+                }
+            }
+            "host.panes.focus" => {
+                let Some(id) = parsed.get("pane_id").and_then(serde_json::Value::as_u64) else {
+                    return failed("invalid_input: pane_id is required".to_string());
+                };
+                if self.pane_navigate(id) {
+                    succeeded(serde_json::json!({"ok": true, "pane_id": id}))
+                } else {
+                    failed(format!("pane_not_found: {id}"))
+                }
+            }
+            "host.panes.close" => {
+                let Some(id) = parsed.get("pane_id").and_then(serde_json::Value::as_u64) else {
+                    return failed("invalid_input: pane_id is required".to_string());
+                };
+                let existed = self
+                    .windows
+                    .iter()
+                    .any(|window| window.panes.contains_key(&id));
+                if !existed {
+                    return failed(format!("pane_not_found: {id}"));
+                }
+                self.close_pane_by_id(id);
+                succeeded(serde_json::json!({"ok": true, "pane_id": id}))
+            }
+            "host.apps.open" => {
+                let Some(app) = parsed.get("app").and_then(serde_json::Value::as_str) else {
+                    return failed("invalid_input: app is required".to_string());
+                };
+                let layout = parsed
+                    .get("layout")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+                let args = parsed
+                    .get("args")
+                    .and_then(serde_json::Value::as_array)
+                    .map(|args| {
+                        args.iter()
+                            .filter_map(serde_json::Value::as_str)
+                            .map(str::to_string)
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+                match self.assistant_spawn_pane(
+                    origin_pane_id,
+                    origin_context_id,
+                    app,
+                    layout,
+                    args,
+                    None,
+                ) {
+                    Ok(pane_id) => {
+                        succeeded(serde_json::json!({"ok": true, "pane_id": pane_id, "app": app}))
+                    }
+                    Err(error) => failed(format!("open_app_failed: {error}")),
+                }
+            }
+            "host.terminals.open" => {
+                let layout = parsed
+                    .get("layout")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_string);
+                let cwd = parsed
+                    .get("cwd")
+                    .and_then(serde_json::Value::as_str)
+                    .map(std::path::PathBuf::from);
+                match self.assistant_spawn_pane(
+                    origin_pane_id,
+                    origin_context_id,
+                    "terminal",
+                    layout,
+                    Vec::new(),
+                    cwd,
+                ) {
+                    Ok(pane_id) => succeeded(
+                        serde_json::json!({"ok": true, "pane_id": pane_id, "type": "terminal"}),
+                    ),
+                    Err(error) => failed(format!("open_terminal_failed: {error}")),
+                }
+            }
+            _ => failed(format!("host_tool_unknown: {name}")),
+        }
+    }
+
+    fn assistant_spawn_pane(
+        &mut self,
+        origin_pane_id: u64,
+        origin_context_id: u64,
+        type_id: &str,
+        layout: Option<String>,
+        args: Vec<String>,
+        cwd: Option<std::path::PathBuf>,
+    ) -> Result<u64, String> {
+        if !self.windows.iter().any(|window| {
+            window.context_id == origin_context_id && window.panes.contains_key(&origin_pane_id)
+        }) {
+            return Err(format!(
+                "origin pane {origin_pane_id} is no longer in context {origin_context_id}"
+            ));
+        }
+        let before = self
+            .windows
+            .iter()
+            .flat_map(|window| window.panes.keys().copied())
+            .collect::<std::collections::HashSet<_>>();
+        let focused_before = self
+            .windows
+            .iter()
+            .find(|window| window.context_id == origin_context_id)
+            .and_then(|window| {
+                window
+                    .focused_pane
+                    .and_then(|tile| window.tree.tiles.get(tile))
+            })
+            .and_then(|tile| match tile {
+                egui_tiles::Tile::Pane(id) => Some(*id),
+                _ => None,
+            });
+        self.handle_pane_ipc_request(crate::app_protocol::AppRequest::SpawnPane {
+            type_id: type_id.to_string(),
+            layout,
+            args,
+            from_pane_id: Some(origin_pane_id),
+            request_id: None,
+            response_file: None,
+            ephemeral: false,
+            cwd: cwd.map(|path| path.to_string_lossy().into_owned()),
+            no_focus: false,
+            path: None,
+            workspace_root: None,
+            target_context: None,
+            name: None,
+        });
+        if let Some(created) = self
+            .windows
+            .iter()
+            .flat_map(|window| window.panes.keys().copied())
+            .find(|pane_id| !before.contains(pane_id))
+        {
+            return Ok(created);
+        }
+        let window = self
+            .windows
+            .iter()
+            .find(|window| window.context_id == origin_context_id)
+            .ok_or_else(|| format!("origin context {origin_context_id} closed"))?;
+        let focused = window
+            .focused_pane
+            .and_then(|tile| window.tree.tiles.get(tile))
+            .and_then(|tile| match tile {
+                egui_tiles::Tile::Pane(id) => Some(*id),
+                _ => None,
+            });
+        focused
+            .filter(|pane_id| Some(*pane_id) != focused_before)
+            .ok_or_else(|| format!("open request for '{type_id}' did not create or focus a pane"))
+    }
+
+    fn assistant_pane_list(&self) -> serde_json::Value {
+        let active = self.active_window;
+        let entries = self
+            .windows
+            .iter()
+            .enumerate()
+            .flat_map(|(window_index, window)| {
+                let focused = window
+                    .focused_pane
+                    .and_then(|tile| window.tree.tiles.get(tile))
+                    .and_then(|tile| match tile {
+                        egui_tiles::Tile::Pane(id) => Some(*id),
+                        _ => None,
+                    });
+                window
+                    .panes
+                    .iter()
+                    .filter(move |(id, _)| window.tree.tiles.find_pane(id).is_some())
+                    .map(move |(id, pane)| {
+                        let (kind, title) = match pane {
+                            crate::host::pane::Pane::Terminal(term) => (
+                                "terminal",
+                                term.name.clone().unwrap_or_else(|| "terminal".to_string()),
+                            ),
+                            crate::host::pane::Pane::App(app) => ("app", app.name.clone()),
+                            crate::host::pane::Pane::Portal(portal) => {
+                                ("portal", format!("portal:{}", portal.target_context_id))
+                            }
+                        };
+                        serde_json::json!({
+                            "id": id, "type": kind, "title": title,
+                            "focused": window_index == active && focused == Some(*id),
+                            "context_id": window.context_id, "window_id": window.window_id,
+                        })
+                    })
+            })
+            .collect::<Vec<_>>();
+        serde_json::Value::Array(entries)
+    }
+
+    fn assistant_pane_state(&self, pane_id: u64) -> Option<serde_json::Value> {
+        let pane = self
+            .windows
+            .iter()
+            .find_map(|window| window.panes.get(&pane_id))?;
+        Some(if let Some(app) = pane.as_app() {
+            serde_json::json!({
+                "pane_id": pane_id, "type": "app", "title": app.name,
+                "manifest_id": app.manifest_id, "runtime": app.runtime.runtime_kind(),
+                "semantic": app.semantic_state(),
+            })
+        } else if let Some(term) = pane.as_terminal() {
+            serde_json::json!({
+                "pane_id": pane_id, "type": "terminal",
+                "title": term.name.clone().unwrap_or_else(|| "terminal".to_string()),
+            })
+        } else {
+            serde_json::json!({"pane_id": pane_id, "type": "portal"})
+        })
+    }
+}
+
+fn succeeded(value: serde_json::Value) -> ToolCallResult {
+    ToolCallResult {
+        output_json: Some(value.to_string()),
+        error: None,
+    }
+}
+
+fn failed(error: String) -> ToolCallResult {
+    ToolCallResult {
+        output_json: None,
+        error: Some(error),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::testing::HostHarness;
+
+    #[test]
+    fn native_host_tools_list_read_focus_and_close_real_harness_panes() {
+        let mut harness = HostHarness::new();
+        let pane = harness.add_test_pane();
+        let context = harness.app.windows[0].context_id;
+
+        let listed = harness
+            .app
+            .handle_assistant_host_tool("host.panes.list", "{}", pane, context);
+        assert!(listed.error.is_none());
+        assert!(listed
+            .output_json
+            .unwrap()
+            .contains(&format!("\"id\":{pane}")));
+
+        let state = harness.app.handle_assistant_host_tool(
+            "host.panes.state",
+            &serde_json::json!({"pane_id": pane}).to_string(),
+            pane,
+            context,
+        );
+        assert!(state
+            .output_json
+            .unwrap()
+            .contains("\"runtime\":\"process\""));
+
+        let focused = harness.app.handle_assistant_host_tool(
+            "host.panes.focus",
+            &serde_json::json!({"pane_id": pane}).to_string(),
+            pane,
+            context,
+        );
+        assert!(focused.error.is_none());
+
+        let closed = harness.app.handle_assistant_host_tool(
+            "host.panes.close",
+            &serde_json::json!({"pane_id": pane}).to_string(),
+            pane,
+            context,
+        );
+        assert!(closed.error.is_none());
+        assert!(!harness
+            .app
+            .windows
+            .iter()
+            .any(|window| window.panes.contains_key(&pane)));
+    }
+
+    #[test]
+    fn native_open_tools_create_generic_app_and_terminal_panes() {
+        let mut harness = HostHarness::new();
+        let origin = harness.add_test_pane();
+        let context = harness.app.windows[0].context_id;
+        let initial = harness.pane_count();
+
+        let generic = harness.app.handle_assistant_host_tool(
+            "host.panes.open",
+            r#"{"type_id":"text-editor","layout":"split_h"}"#,
+            origin,
+            context,
+        );
+        assert!(generic.error.is_none(), "{:?}", generic.error);
+        assert!(harness.pane_count() > initial);
+        let after_generic = harness.pane_count();
+
+        let app = harness.app.handle_assistant_host_tool(
+            "host.apps.open",
+            r#"{"app":"text-editor","layout":"split_h","args":[]}"#,
+            origin,
+            context,
+        );
+        assert!(app.error.is_none(), "{:?}", app.error);
+        assert!(harness.pane_count() > after_generic);
+        let after_app = harness.pane_count();
+
+        let terminal = harness.app.handle_assistant_host_tool(
+            "host.terminals.open",
+            &serde_json::json!({"layout": "split_h", "cwd": std::env::temp_dir()}).to_string(),
+            origin,
+            context,
+        );
+        assert!(terminal.error.is_none(), "{:?}", terminal.error);
+        assert!(harness.pane_count() > after_app);
+    }
+}

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -503,6 +503,15 @@ impl PlexiApp {
             let resolved_scope = self.registry.default_notification_scope_for(&type_id);
             for cmd in cmds {
                 match cmd {
+                    AppCommand::AssistantHostTool { name, input_json, reply, .. } => {
+                        deferred.push(AppCommand::AssistantHostTool {
+                            name,
+                            input_json,
+                            origin_pane_id: pane_id,
+                            origin_context_id: context_id,
+                            reply,
+                        });
+                    }
                     AppCommand::SpawnApp { .. }
                     | AppCommand::SpawnPane { .. }
                     | AppCommand::ForwardPaneRequest { .. }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,5 +1,6 @@
 pub mod account;
 pub mod app_trait;
+mod assistant_host_tools;
 pub mod audio_player_app;
 mod canvas_bindings;
 mod dispatch;
@@ -2090,6 +2091,10 @@ fn is_overlay_unsafe_cmd(cmd: &crate::app::app_trait::AppCommand) -> bool {
         | AppCommand::RunInLinkedTerminal { .. }
         | AppCommand::InsertPathToken { .. }
         | AppCommand::OpenArtifact { .. } => true,
+        AppCommand::AssistantHostTool { name, .. } => !matches!(
+            name.as_str(),
+            "host.panes.list" | "host.panes.state"
+        ),
         AppCommand::DeliverNotifyAction { host_action, .. } => host_action
             .as_deref()
             .map(|a| a.starts_with("pane_focus:"))
@@ -2107,6 +2112,7 @@ fn overlay_unsafe_cmd_name(cmd: &crate::app::app_trait::AppCommand) -> &'static 
         AppCommand::RunInLinkedTerminal { .. } => "RunInLinkedTerminal",
         AppCommand::InsertPathToken { .. } => "InsertPathToken",
         AppCommand::OpenArtifact { .. } => "OpenArtifact",
+        AppCommand::AssistantHostTool { .. } => "AssistantHostTool",
         AppCommand::DeliverNotifyAction { .. } => "DeliverNotifyAction(pane_focus)",
         _ => "unknown",
     }
@@ -2346,6 +2352,23 @@ impl eframe::App for PlexiApp {
                 continue;
             }
             match cmd {
+                AppCommand::AssistantHostTool {
+                    name,
+                    input_json,
+                    origin_pane_id,
+                    origin_context_id,
+                    reply,
+                } => {
+                    let result = self.handle_assistant_host_tool(
+                        &name,
+                        &input_json,
+                        origin_pane_id,
+                        origin_context_id,
+                    );
+                    if reply.send(result).is_err() {
+                        log::warn!("assistant_host_tool: worker dropped reply for '{name}'");
+                    }
+                }
                 // Capability-gated pane read/control request from a PGAP app
                 // (stint 0013/0014). routing.rs already checked panes.read /
                 // panes.control; execute it through the same handler CLI

--- a/src/assistant/commands.rs
+++ b/src/assistant/commands.rs
@@ -28,6 +28,12 @@ pub const BUILT_IN_COMMANDS: &[(&str, &str)] = &[
         "Show app connector tools and event streams with their broker decisions.",
     ),
     ("apps", "Show app connectors available in the workspace."),
+    ("skills", "Show installed user and workspace skills."),
+    (
+        "context",
+        "Show token use, instructions, active context, and enabled tools.",
+    ),
+    ("hooks", "Show active lifecycle hooks and their source."),
     (
         "permissions",
         "Show persisted grants for the assistant actor.",

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -12,6 +12,7 @@ pub mod commands;
 pub mod model;
 pub mod render;
 pub mod settings;
+pub mod skills;
 pub mod store;
 
 use std::collections::HashSet;
@@ -20,6 +21,7 @@ use std::sync::mpsc::{Receiver, Sender, SyncSender};
 use std::sync::{Arc, Mutex};
 
 use crate::agent::{AgentDefinition, AgentRegistry, AgentSource};
+use crate::app::app_trait::AppCommand;
 use crate::app::app_trait::{App, AppRenderContext, KeyDisposition};
 use crate::app_protocol::{AiMessage, AiTool, ModelTier, PayloadMode, TriggerMode};
 use crate::broker::{
@@ -46,6 +48,7 @@ use audit::{AuditEvent, AuditLog};
 use model::{AssistantEffect, AssistantModel, PermissionChoice, TurnRole};
 use render::{AssistantRenderer, ComposerEvent, MarkdownTextCache};
 use settings::{AssistantSettings, SessionOverrides, SettingsLoadError, SettingsLoader};
+use skills::{SkillDefinition, SkillRegistry};
 use store::AssistantStore;
 
 pub(crate) const DEFAULT_AGENT_PROMPT: &str = "You are the Plexi Assistant, the workspace \
@@ -65,12 +68,19 @@ When a delivered event hands you the turn, ACT: if the situation calls for a \
 tool call, make it immediately rather than only describing what you would do. \
 Do not narrate intentions you can carry out — take the action, then report the \
 result. \
-Pane and terminal control arrives in a later phase — when \
-asked to act on panes, explain that those tools are not wired up yet.";
+Use the host.panes.*, host.apps.open, and host.terminals.open tools for native \
+pane, app, and terminal operations; never shell out to the plexi CLI.";
 
 /// Host tool names the Assistant injects into its dispatcher snapshot.
 const HOST_TOOL_SUBSCRIBE: &str = "host.events.subscribe";
 const HOST_TOOL_UNSUBSCRIBE: &str = "host.events.unsubscribe";
+const HOST_TOOL_PANES_LIST: &str = "host.panes.list";
+const HOST_TOOL_PANES_STATE: &str = "host.panes.state";
+const HOST_TOOL_PANES_OPEN: &str = "host.panes.open";
+const HOST_TOOL_PANES_FOCUS: &str = "host.panes.focus";
+const HOST_TOOL_PANES_CLOSE: &str = "host.panes.close";
+const HOST_TOOL_APPS_OPEN: &str = "host.apps.open";
+const HOST_TOOL_TERMINALS_OPEN: &str = "host.terminals.open";
 
 /// Broker identity for the Assistant: actor id at the permission tiers,
 /// `agent:assistant` as the `ToolDispatcher` caller id (Phase C convention).
@@ -260,6 +270,9 @@ pub struct AssistantApp {
     workspace_root: PathBuf,
     profile_dir: PathBuf,
     agent_registry: AgentRegistry,
+    skill_registry: SkillRegistry,
+    pending_skill: Option<SkillDefinition>,
+    pending_commands: Vec<AppCommand>,
     settings_loader: SettingsLoader,
     session_overrides: SessionOverrides,
     settings: AssistantSettings,
@@ -375,6 +388,7 @@ impl AssistantApp {
         }
         let settings_loader = SettingsLoader::new(profile_dir, &workspace_root);
         let agent_registry = AgentRegistry::load(profile_dir, &workspace_root);
+        let skill_registry = SkillRegistry::load(profile_dir, &workspace_root);
         if agent_registry.active(&model.active_agent_id).is_none() {
             log::warn!(
                 "assistant: persisted agent '{}' is unavailable; using default",
@@ -393,6 +407,9 @@ impl AssistantApp {
             workspace_root,
             profile_dir: profile_dir.to_path_buf(),
             agent_registry,
+            skill_registry,
+            pending_skill: None,
+            pending_commands: Vec::new(),
             settings_loader,
             session_overrides,
             settings: settings_report.settings,
@@ -526,6 +543,10 @@ impl AssistantApp {
                 AssistantEffect::SessionWrite { .. } => self.session_write(),
                 AssistantEffect::ListTools => self.cmd_list_tools(),
                 AssistantEffect::ListApps => self.cmd_list_apps(),
+                AssistantEffect::ListSkills => self.cmd_list_skills(),
+                AssistantEffect::ShowContext => self.cmd_show_context(),
+                AssistantEffect::ShowHooks => self.cmd_show_hooks(),
+                AssistantEffect::InvokeSkill { name, args } => self.cmd_invoke_skill(&name, &args),
                 AssistantEffect::ListPermissions => self.cmd_list_permissions(),
                 AssistantEffect::RevokeGrant { target_id } => self.cmd_revoke(&target_id),
                 AssistantEffect::ShowAudit => self.cmd_show_audit(),
@@ -558,6 +579,7 @@ impl AssistantApp {
                 // unblock worker threads parked on a permission reply so they
                 // can finish and have their stale outcome dropped.
                 AssistantEffect::CancelTurn => {
+                    self.pending_skill = None;
                     self.unblock_pending_workers(
                         "cancelled: the conversation was cleared mid-turn",
                     );
@@ -640,6 +662,24 @@ impl AssistantApp {
         self.grant_store.evaluate(&req, Some(&posture))
     }
 
+    fn host_tool_decision(&self, tool: &AiTool) -> Decision {
+        if self.settings.permissions.posture.value == settings::AssistantPermissionPosture::Plan
+            && !tool.read_only
+        {
+            return Decision::Deny;
+        }
+        let (actor_id, _) = self.connector_actor();
+        let req = PermissionRequest::new(
+            ActorType::Agent,
+            &actor_id,
+            TargetType::HostTool,
+            &tool.name,
+            Some(&self.workspace_root),
+        );
+        self.grant_store
+            .evaluate(&req, Some(&self.active_posture()))
+    }
+
     fn event_stream_decision(&self, app: &str, event: &str) -> Decision {
         let event_names = if event == "*" {
             Vec::new()
@@ -714,6 +754,26 @@ impl AssistantApp {
         );
         dispatcher.retain_allowed(&allowed);
         let (actor_id, actor_scope) = self.connector_actor();
+        let native_tools = Self::host_tools();
+        let mut visible_host_tools = Vec::new();
+        for tool in native_tools {
+            if (!declared_tools.is_empty() && !declared_tools.contains(&tool.name))
+                || (!settings_tools.is_empty() && !settings_tools.contains(&tool.name))
+            {
+                log::info!("assistant: host tool '{}' withheld by enabled-tool filter", tool.name);
+                continue;
+            }
+            match self.host_tool_decision(&tool) {
+                Decision::Deny => {
+                    log::info!("assistant: host tool '{}' withheld (deny)", tool.name)
+                }
+                Decision::Ask if !tool.read_only => {
+                    ask_tools.insert(tool.name.clone());
+                    visible_host_tools.push(tool);
+                }
+                Decision::Allow | Decision::Ask => visible_host_tools.push(tool),
+            }
+        }
         dispatcher.set_hooks(Arc::new(AssistantToolHooks {
             ask_tools,
             session_allowed: Mutex::new(HashSet::new()),
@@ -742,7 +802,8 @@ impl AssistantApp {
                 error: Some("host_tool_failed: assistant pane closed".to_string()),
             })
         });
-        dispatcher.add_host_tools(Self::host_event_tools(), handler);
+        visible_host_tools.extend(Self::host_event_tools());
+        dispatcher.add_host_tools(visible_host_tools, handler);
         dispatcher
     }
 
@@ -773,6 +834,64 @@ impl AssistantApp {
                 name: HOST_TOOL_UNSUBSCRIBE.to_string(),
                 description: "Stop receiving an app's event stream.".to_string(),
                 input_schema: schema,
+                timeout_ms: Some(30_000),
+                read_only: false,
+            },
+        ]
+    }
+
+    fn host_tools() -> Vec<AiTool> {
+        let pane_id = serde_json::json!({
+            "type": "object", "properties": {"pane_id": {"type": "integer"}},
+            "required": ["pane_id"]
+        });
+        vec![
+            AiTool {
+                name: HOST_TOOL_PANES_LIST.into(),
+                description: "List live Plexi panes and their context.".into(),
+                input_schema: serde_json::json!({"type":"object"}),
+                timeout_ms: Some(30_000),
+                read_only: true,
+            },
+            AiTool {
+                name: HOST_TOOL_PANES_STATE.into(),
+                description: "Read the semantic state of a live pane.".into(),
+                input_schema: pane_id.clone(),
+                timeout_ms: Some(30_000),
+                read_only: true,
+            },
+            AiTool {
+                name: HOST_TOOL_PANES_OPEN.into(),
+                description: "Open an app or terminal pane by native type id.".into(),
+                input_schema: serde_json::json!({"type":"object","properties":{"type_id":{"type":"string"},"layout":{"type":"string"},"cwd":{"type":"string"},"args":{"type":"array","items":{"type":"string"}}},"required":["type_id"]}),
+                timeout_ms: Some(30_000),
+                read_only: false,
+            },
+            AiTool {
+                name: HOST_TOOL_PANES_FOCUS.into(),
+                description: "Focus a live pane by id.".into(),
+                input_schema: pane_id.clone(),
+                timeout_ms: Some(30_000),
+                read_only: false,
+            },
+            AiTool {
+                name: HOST_TOOL_PANES_CLOSE.into(),
+                description: "Close a live pane by id.".into(),
+                input_schema: pane_id,
+                timeout_ms: Some(30_000),
+                read_only: false,
+            },
+            AiTool {
+                name: HOST_TOOL_APPS_OPEN.into(),
+                description: "Open an installed Plexi app in a pane.".into(),
+                input_schema: serde_json::json!({"type":"object","properties":{"app":{"type":"string"},"layout":{"type":"string"},"args":{"type":"array","items":{"type":"string"}}},"required":["app"]}),
+                timeout_ms: Some(30_000),
+                read_only: false,
+            },
+            AiTool {
+                name: HOST_TOOL_TERMINALS_OPEN.into(),
+                description: "Open a terminal pane, optionally at a cwd.".into(),
+                input_schema: serde_json::json!({"type":"object","properties":{"layout":{"type":"string"},"cwd":{"type":"string"}}}),
                 timeout_ms: Some(30_000),
                 read_only: false,
             },
@@ -842,6 +961,17 @@ impl AssistantApp {
         input_json: &str,
         reply: SyncSender<ToolCallResult>,
     ) {
+        if !matches!(tool, HOST_TOOL_SUBSCRIBE | HOST_TOOL_UNSUBSCRIBE) {
+            log::info!("assistant: queueing native host tool '{tool}'");
+            self.pending_commands.push(AppCommand::AssistantHostTool {
+                name: tool.to_string(),
+                input_json: input_json.to_string(),
+                origin_pane_id: 0,
+                origin_context_id: 0,
+                reply,
+            });
+            return;
+        }
         let err = |msg: String| ToolCallResult {
             output_json: None,
             error: Some(msg),
@@ -929,7 +1059,7 @@ impl AssistantApp {
     }
 
     /// Run one model turn on a worker thread (the broker blocks on network).
-    fn start_turn(&mut self, conversation_id: String, _prompt: String) {
+    fn start_turn(&mut self, conversation_id: String, prompt: String) {
         let (delta_tx, delta_rx) = std::sync::mpsc::channel();
         self.delta_rx = Some(delta_rx);
         // Fresh cancel token per turn — a clone goes to the worker/broker, the
@@ -955,12 +1085,31 @@ impl AssistantApp {
         });
         let concrete_model = agent.model_routes.for_tier(tier).cloned();
         let effort = self.model.effort_override.or(agent.effort);
+        let selected_skill = self
+            .pending_skill
+            .take()
+            .or_else(|| {
+                self.skill_registry
+                    .matching_enabled(&prompt, &agent.skills)
+                    .cloned()
+            });
+        let mut system = agent.prompt;
+        if let Some(skill) = selected_skill {
+            log::info!(
+                "assistant[{conversation_id}]: loading {} skill '{}' from {}",
+                skill.source.label(),
+                skill.name,
+                skill.path.display()
+            );
+            system.push_str("\n\nFollow this loaded skill for the current turn:\n");
+            system.push_str(&skill.instructions);
+        }
         let request = AiBrokerRequest {
             app_id: "assistant".to_string(),
             model_tier: tier,
             concrete_model,
             reasoning_effort: effort,
-            system: agent.prompt,
+            system,
             messages: self.history_messages(),
             tools: Vec::new(),
             workspace_root: Some(self.workspace_root.clone()),
@@ -1032,9 +1181,14 @@ impl AssistantApp {
                         "assistant: tool '{tool}' finished ({})",
                         if error.is_none() { "ok" } else { "error" }
                     );
+                    let audit_target = if tool.starts_with("host.") {
+                        tool.clone()
+                    } else {
+                        Self::connector_target(&tool)
+                    };
                     self.audit.append(&AuditEvent::now(
                         "tool_call",
-                        &Self::connector_target(&tool),
+                        &audit_target,
                         if error.is_none() { "ok" } else { "error" },
                         error.as_deref().unwrap_or(""),
                     ));
@@ -1249,7 +1403,17 @@ impl AssistantApp {
         let Some(pending) = self.model.pending_permission.clone() else {
             return;
         };
-        let target = Self::connector_target(&pending.tool);
+        let is_host_tool = pending.tool.starts_with("host.");
+        let target_type = if is_host_tool {
+            TargetType::HostTool
+        } else {
+            TargetType::AppConnector
+        };
+        let target = if is_host_tool {
+            pending.tool.clone()
+        } else {
+            Self::connector_target(&pending.tool)
+        };
         let (decision_str, reply) = match choice {
             PermissionChoice::Deny => ("deny", PermissionReply::Deny),
             PermissionChoice::AllowOnce => {
@@ -1257,7 +1421,7 @@ impl AssistantApp {
             }
             PermissionChoice::AllowSession => {
                 self.record_connector_grant(
-                    TargetType::AppConnector,
+                    target_type,
                     &target,
                     GrantDuration::Session,
                     GrantSource::Session,
@@ -1266,7 +1430,7 @@ impl AssistantApp {
             }
             PermissionChoice::AllowAlways => {
                 self.record_connector_grant(
-                    TargetType::AppConnector,
+                    target_type,
                     &target,
                     GrantDuration::Always,
                     GrantSource::User,
@@ -1808,6 +1972,7 @@ impl AssistantApp {
             }
         };
         let turn_count = turns.len();
+        self.pending_skill = None;
         let cancel = self.model.switch_conversation(id.clone(), turns);
         self.model.session_name = session_name;
         self.execute_effects(cancel);
@@ -1924,6 +2089,7 @@ impl AssistantApp {
                 return;
             }
         };
+        self.pending_skill = None;
         let cancel = self.model.switch_conversation(id.clone(), target);
         self.execute_effects(cancel);
         log::info!(
@@ -1984,6 +2150,7 @@ impl AssistantApp {
             self.execute_effects(effects);
             return;
         }
+        self.pending_skill = None;
         let cancel = self.model.switch_conversation(id.clone(), compacted_turns);
         self.execute_effects(cancel);
         log::info!(
@@ -2155,6 +2322,14 @@ impl AssistantApp {
             }
             out
         };
+        text.push_str("\nNative host tools:\n");
+        for tool in Self::host_tools() {
+            text.push_str(&format!(
+                "{} — {}\n",
+                tool.name,
+                self.host_tool_decision(&tool).as_str()
+            ));
+        }
         if streams.is_empty() {
             text.push_str("\nNo app event streams declared in this workspace.");
         } else {
@@ -2170,6 +2345,152 @@ impl AssistantApp {
                 ));
             }
         }
+        let effects = self.model.push_info(text);
+        self.execute_effects(effects);
+    }
+
+    fn cmd_list_skills(&mut self) {
+        let enabled = self.active_agent().map(|agent| agent.skills.as_slice()).unwrap_or(&[]);
+        let visible = self
+            .skill_registry
+            .all()
+            .iter()
+            .filter(|skill| enabled.is_empty() || enabled.contains(&skill.name))
+            .collect::<Vec<_>>();
+        log::info!(
+            "assistant: /skills — {} installed skill(s)",
+            visible.len()
+        );
+        let text = if visible.is_empty() {
+            "No skills are installed for this channel or workspace.".to_string()
+        } else {
+            let mut text = String::from("Installed skills:\n");
+            for skill in visible {
+                text.push_str(&format!(
+                    "- `/{}` — {} _({}: {})_\n",
+                    skill.name,
+                    skill.description,
+                    skill.source.label(),
+                    skill.path.display()
+                ));
+            }
+            text
+        };
+        let effects = self.model.push_info(text);
+        self.execute_effects(effects);
+    }
+
+    fn cmd_invoke_skill(&mut self, name: &str, args: &str) {
+        let enabled = self.active_agent().map(|agent| agent.skills.as_slice()).unwrap_or(&[]);
+        if !enabled.is_empty() && !enabled.iter().any(|skill| skill == name) {
+            let effects = self.model.push_error(format!(
+                "Skill `/{name}` is not enabled for agent `{}`.",
+                self.model.active_agent_id
+            ));
+            self.execute_effects(effects);
+            return;
+        }
+        let Some(skill) = self.skill_registry.get(name).cloned() else {
+            let effects = self.model.push_error(format!(
+                "Unknown command or installed skill `/{name}`. Type /help or /skills."
+            ));
+            self.execute_effects(effects);
+            return;
+        };
+        log::info!(
+            "assistant: manually invoking {} skill '{}'",
+            skill.source.label(),
+            name
+        );
+        self.pending_skill = Some(skill);
+        let prompt = if args.is_empty() {
+            format!("Run the /{name} skill.")
+        } else {
+            args.to_string()
+        };
+        let effects = self.model.submit_prompt(prompt);
+        self.execute_effects(effects);
+    }
+
+    fn cmd_show_context(&mut self) {
+        let chars: usize = self
+            .model
+            .turns
+            .iter()
+            .map(|turn| turn.text.chars().count())
+            .sum();
+        let tool_names = self
+            .gated_dispatcher()
+            .all_tools()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect::<Vec<_>>();
+        let agent = self.active_agent();
+        let enabled_skill_count = agent
+            .map(|agent| {
+                self.skill_registry
+                    .all()
+                    .iter()
+                    .filter(|skill| agent.skills.is_empty() || agent.skills.contains(&skill.name))
+                    .count()
+            })
+            .unwrap_or(0);
+        let panes = crate::plexi_ai::broker::get_pane_snapshot();
+        let pane_context = if panes.is_empty() {
+            "none reported yet".to_string()
+        } else {
+            panes
+                .iter()
+                .map(|pane| format!("{} (pane {})", pane.type_id, pane.pane_id))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let text = format!(
+            "Assistant context:\n- Estimated transcript tokens: ~{} ({} turns)\n- Loaded instructions: agent `{}` plus {} installed skill(s) available on demand\n- Active workspace context: `{}`\n- Open pane/app context: {}\n- Enabled tools: {}",
+            chars.div_ceil(4),
+            self.model.turns.len(),
+            agent.map(|agent| agent.id.as_str()).unwrap_or("default"),
+            enabled_skill_count,
+            self.workspace_root.display(),
+            pane_context,
+            if tool_names.is_empty() { "none".to_string() } else { tool_names.join(", ") },
+        );
+        log::info!(
+            "assistant: /context — turns={} estimated_tokens={}",
+            self.model.turns.len(),
+            chars.div_ceil(4)
+        );
+        let effects = self.model.push_info(text);
+        self.execute_effects(effects);
+    }
+
+    fn cmd_show_hooks(&mut self) {
+        let mut hooks = self.settings.hooks.enabled.value.clone();
+        if let Some(agent) = self.active_agent() {
+            hooks.extend(agent.hooks.iter().cloned());
+        }
+        hooks.sort();
+        hooks.dedup();
+        let source = &self.settings.hooks.enabled.source;
+        let text = if hooks.is_empty() {
+            "No Assistant lifecycle hooks are enabled.".to_string()
+        } else {
+            format!(
+                "Assistant lifecycle hooks (settings source: `{:?}` at `{}`):\n{}",
+                source.scope,
+                source
+                    .path
+                    .as_ref()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_else(|| "defaults".to_string()),
+                hooks
+                    .into_iter()
+                    .map(|hook| format!("- `{hook}`"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        };
+        log::info!("assistant: /hooks");
         let effects = self.model.push_info(text);
         self.execute_effects(effects);
     }
@@ -2223,6 +2544,8 @@ impl AssistantApp {
                 r.actor_type == ActorType::Agent
                     && ((r.target_type == TargetType::AppConnector
                         && r.actor_id == connector_actor_id)
+                        || (r.target_type == TargetType::HostTool
+                            && r.actor_id == connector_actor_id)
                         || (r.target_type == TargetType::AppEventStream
                             && r.actor_id == ASSISTANT_ACTOR_ID))
             })
@@ -2255,7 +2578,7 @@ impl AssistantApp {
     /// `/revoke <target_id>`: remove persisted grants for one target. Event
     /// stream targets also lose their live timeline subscription.
     fn cmd_revoke(&mut self, target_id: &str) {
-        let actor_id = if target_id.starts_with("app.") {
+        let actor_id = if target_id.starts_with("app.") || target_id.starts_with("host.") {
             self.connector_actor().0
         } else {
             ASSISTANT_ACTOR_ID.to_string()
@@ -2326,6 +2649,18 @@ impl App for AssistantApp {
 
     fn display_name(&self) -> String {
         "Assistant".to_string()
+    }
+
+    fn take_pending_commands(&mut self) -> Vec<AppCommand> {
+        std::mem::take(&mut self.pending_commands)
+    }
+
+    fn background_tick(&mut self) {
+        self.pump_turn_io();
+    }
+
+    fn needs_background_tick(&self) -> bool {
+        self.model.streaming.in_flight || !self.pending_commands.is_empty()
     }
 
     fn handle_key(&mut self, input: &egui::InputState) -> KeyDisposition {
@@ -2830,7 +3165,30 @@ enabled = ["allowed.tool"]
 
         assert!(visible.contains("csv.read_range"));
         assert!(!visible.contains("csv.write_cell"));
+        assert!(visible.contains(HOST_TOOL_PANES_LIST));
+        assert!(!visible.contains(HOST_TOOL_PANES_CLOSE));
+        assert!(!visible.contains(HOST_TOOL_APPS_OPEN));
         tool_dispatch::unregister(9207);
+    }
+
+    #[test]
+    fn enabled_tool_filter_applies_to_native_host_tools() {
+        let ws = tempfile::tempdir().unwrap();
+        let settings_path = ws.path().join("agents/settings.toml");
+        std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
+        std::fs::write(settings_path, "[tools]\nenabled = [\"host.panes.list\"]\n").unwrap();
+        let app = test_app(ws.path());
+
+        let visible = app
+            .gated_dispatcher()
+            .all_tools()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect::<HashSet<_>>();
+
+        assert!(visible.contains(HOST_TOOL_PANES_LIST));
+        assert!(!visible.contains(HOST_TOOL_PANES_CLOSE));
+        assert!(!visible.contains(HOST_TOOL_APPS_OPEN));
     }
 
     #[test]
@@ -3163,16 +3521,18 @@ enabled = ["allowed.tool"]
         let dispatcher = app.gated_dispatcher();
         let mut visible: Vec<String> = dispatcher.all_tools().into_iter().map(|t| t.name).collect();
         visible.sort();
+        let connectors = visible
+            .iter()
+            .filter(|name| name.starts_with("t_"))
+            .map(String::as_str)
+            .collect::<Vec<_>>();
         assert_eq!(
-            visible,
-            vec![
-                HOST_TOOL_SUBSCRIBE,
-                HOST_TOOL_UNSUBSCRIBE,
-                "t_allow",
-                "t_ask"
-            ],
-            "denied tool must be invisible; host tools always visible"
+            connectors,
+            vec!["t_allow", "t_ask"],
+            "denied connector must be invisible"
         );
+        assert!(visible.iter().any(|name| name == HOST_TOOL_PANES_LIST));
+        assert!(visible.iter().any(|name| name == HOST_TOOL_SUBSCRIBE));
 
         // Denied tool is also uninvocable.
         let result = dispatcher.dispatch_call("c-deny".to_string(), "t_deny", "{}".to_string());
@@ -4174,5 +4534,73 @@ enabled = ["allowed.tool"]
             .unwrap()
             .text
             .contains(settings_path.to_string_lossy().as_ref()));
+    }
+
+    #[test]
+    fn context_command_reports_open_pane_context() {
+        let ws = tempfile::tempdir().unwrap();
+        crate::plexi_ai::broker::update_pane_snapshot(vec![crate::plexi_ai::broker::PaneContext {
+            type_id: "text-editor".to_string(),
+            pane_id: 42,
+        }]);
+        let mut app = test_app(ws.path());
+        app.model.composer = "/context".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        let output = &app.model.turns.last().unwrap().text;
+        assert!(output.contains("Active workspace context"));
+        assert!(output.contains("text-editor (pane 42)"));
+    }
+
+    #[test]
+    fn background_tick_queues_native_host_calls_for_offscreen_assistant() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = test_app(ws.path());
+        let (reply, _reply_rx) = std::sync::mpsc::sync_channel(1);
+        app.model.streaming.in_flight = true;
+        app.flow_tx
+            .send(ToolFlowEvent::HostCall {
+                tool: HOST_TOOL_PANES_LIST.to_string(),
+                input_json: "{}".to_string(),
+                reply,
+            })
+            .unwrap();
+
+        assert!(App::needs_background_tick(&app));
+        App::background_tick(&mut app);
+        let commands = App::take_pending_commands(&mut app);
+        assert!(matches!(
+            commands.as_slice(),
+            [AppCommand::AssistantHostTool { name, .. }] if name == HOST_TOOL_PANES_LIST
+        ));
+    }
+
+    #[test]
+    fn unknown_slash_command_invokes_matching_installed_skill_with_args() {
+        let ws = tempfile::tempdir().unwrap();
+        let skill_path = ws.path().join(".plexi/skills/release/SKILL.md");
+        std::fs::create_dir_all(skill_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &skill_path,
+            "---\nname: release\ndescription: prepare a release\n---\nCHECK THE RELEASE CONTRACT",
+        )
+        .unwrap();
+        let broker = Arc::new(CapturingBroker::default());
+        let mut app = AssistantApp::new(ws.path().to_path_buf(), broker.clone(), ws.path());
+        app.model.composer = "/release /Users/ian/project".to_string();
+        let effects = app.model.submit();
+        assert!(matches!(
+            &effects[0],
+            AssistantEffect::InvokeSkill { name, args }
+                if name == "release" && args == "/Users/ian/project"
+        ));
+        app.execute_effects(effects);
+        wait_for_turn(&mut app);
+        let seen = broker.seen.lock().unwrap();
+        assert!(seen[0].system.contains("CHECK THE RELEASE CONTRACT"));
+        assert!(seen[0]
+            .messages
+            .iter()
+            .any(|message| message.content == "/Users/ian/project"));
     }
 }

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -115,6 +115,13 @@ pub enum AssistantEffect {
     ListTools,
     /// `/apps`: list running apps and their exposed connectors.
     ListApps,
+    ListSkills,
+    ShowContext,
+    ShowHooks,
+    InvokeSkill {
+        name: String,
+        args: String,
+    },
     /// `/permissions`: list persisted grants for the assistant actor.
     ListPermissions,
     /// `/revoke <target_id>`: remove persisted grants for one target.
@@ -256,6 +263,12 @@ impl AssistantModel {
         if let Some(cmd) = commands::parse_slash_command(&input) {
             return self.execute_command(&cmd);
         }
+        self.submit_prompt(input)
+    }
+
+    /// Submit text as a user prompt without slash-command reparsing. Used
+    /// after an installed skill command has already consumed its command name.
+    pub fn submit_prompt(&mut self, input: String) -> Vec<AssistantEffect> {
         if self.streaming.in_flight {
             log::info!(
                 "assistant[{}]: message queued — turn in flight ({} chars)",
@@ -459,6 +472,9 @@ impl AssistantModel {
             // and answers with an info row.
             "tools" => vec![AssistantEffect::ListTools],
             "apps" => vec![AssistantEffect::ListApps],
+            "skills" => vec![AssistantEffect::ListSkills],
+            "context" => vec![AssistantEffect::ShowContext],
+            "hooks" => vec![AssistantEffect::ShowHooks],
             "permissions" => vec![AssistantEffect::ListPermissions],
             "audit" => vec![AssistantEffect::ShowAudit],
             "settings" | "config" => vec![AssistantEffect::ShowSettings],
@@ -566,15 +582,10 @@ impl AssistantModel {
                     }]
                 }
             }
-            name => {
-                self.turns.push(Turn::now(
-                    TurnRole::Error,
-                    format!("Unknown command /{name}. Type /help for the list."),
-                ));
-                vec![AssistantEffect::SessionWrite {
-                    conversation_id: self.conversation_id.clone(),
-                }]
-            }
+            name => vec![AssistantEffect::InvokeSkill {
+                name: name.to_string(),
+                args: cmd.args.clone(),
+            }],
         }
     }
 
@@ -973,11 +984,20 @@ mod tests {
     }
 
     #[test]
-    fn removed_builtin_is_now_an_unknown_command() {
+    fn skills_context_and_hooks_route_to_real_effects() {
         let mut m = AssistantModel::fresh();
-        submitted(&mut m, "/skills");
-        assert_eq!(m.turns[0].role, TurnRole::Error);
-        assert!(m.turns[0].text.contains("Unknown command /skills"));
+        assert_eq!(
+            submitted(&mut m, "/skills"),
+            vec![AssistantEffect::ListSkills]
+        );
+        assert_eq!(
+            submitted(&mut m, "/context"),
+            vec![AssistantEffect::ShowContext]
+        );
+        assert_eq!(
+            submitted(&mut m, "/hooks"),
+            vec![AssistantEffect::ShowHooks]
+        );
     }
 
     #[test]
@@ -1101,11 +1121,15 @@ mod tests {
     }
 
     #[test]
-    fn unknown_command_answers_with_error_row() {
+    fn unknown_command_routes_to_skill_registry_fallback() {
         let mut m = AssistantModel::fresh();
-        submitted(&mut m, "/frobnicate");
-        assert_eq!(m.turns[0].role, TurnRole::Error);
-        assert!(m.turns[0].text.contains("/frobnicate"));
+        assert_eq!(
+            submitted(&mut m, "/frobnicate now"),
+            vec![AssistantEffect::InvokeSkill {
+                name: "frobnicate".to_string(),
+                args: "now".to_string(),
+            }]
+        );
     }
 
     #[test]

--- a/src/assistant/skills.rs
+++ b/src/assistant/skills.rs
@@ -1,0 +1,236 @@
+//! Channel-aware Assistant skill discovery.
+
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillSource {
+    User,
+    Workspace,
+}
+
+impl SkillSource {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Workspace => "workspace",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SkillDefinition {
+    pub name: String,
+    pub description: String,
+    pub instructions: String,
+    pub source: SkillSource,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Default)]
+pub struct SkillRegistry {
+    skills: Vec<SkillDefinition>,
+}
+
+impl SkillRegistry {
+    pub fn load(profile_dir: &Path, workspace_root: &Path) -> Self {
+        let mut skills = Vec::new();
+        load_root(profile_dir.join("skills"), SkillSource::User, &mut skills);
+        load_root(
+            workspace_root.join(".plexi/skills"),
+            SkillSource::Workspace,
+            &mut skills,
+        );
+        // Roots are loaded user first, workspace second, so map insertion gives
+        // workspace definitions deterministic precedence for duplicate names.
+        let mut by_name = std::collections::BTreeMap::new();
+        for skill in skills {
+            by_name.insert(skill.name.clone(), skill);
+        }
+        let skills = by_name.into_values().collect::<Vec<_>>();
+        log::info!("assistant: discovered {} skill(s)", skills.len());
+        Self { skills }
+    }
+
+    pub fn all(&self) -> &[SkillDefinition] {
+        &self.skills
+    }
+
+    pub fn get(&self, name: &str) -> Option<&SkillDefinition> {
+        self.skills.iter().find(|skill| skill.name == name)
+    }
+
+    /// Conservative prompt matching: only suggest when every meaningful word
+    /// in a skill's description occurs in the prompt. Explicit `/skill` use
+    /// remains the reliable invocation path.
+    pub fn matching_enabled(&self, prompt: &str, enabled: &[String]) -> Option<&SkillDefinition> {
+        let prompt_words = distinctive_words(prompt);
+        let mut matches = self
+            .skills
+            .iter()
+            .filter(|skill| enabled.is_empty() || enabled.contains(&skill.name))
+            .filter_map(|skill| {
+                let description_words = distinctive_words(&skill.description);
+                let overlap = prompt_words.intersection(&description_words).count();
+                let name_hit = prompt_words.contains(&skill.name.to_ascii_lowercase());
+                let prompt_coverage = overlap as f32 / prompt_words.len().max(1) as f32;
+                (name_hit || (overlap >= 2 && prompt_coverage >= 0.5))
+                    .then_some((skill, (name_hit as usize, overlap)))
+            })
+            .collect::<Vec<_>>();
+        matches.sort_by(|a, b| b.1.cmp(&a.1));
+        match matches.as_slice() {
+            [(skill, _), ..] if matches.get(1).is_none_or(|next| next.1 != matches[0].1) => {
+                Some(*skill)
+            }
+            _ => None,
+        }
+    }
+}
+
+fn distinctive_words(text: &str) -> std::collections::HashSet<String> {
+    const STOPWORDS: &[&str] = &[
+        "about", "after", "also", "and", "asks", "before", "from", "into", "that", "the", "their",
+        "this", "use", "user", "when", "with", "your",
+    ];
+    text.to_ascii_lowercase()
+        .split(|c: char| !c.is_alphanumeric() && c != '-')
+        .filter(|word| word.len() >= 4 && !STOPWORDS.contains(word))
+        .map(str::to_string)
+        .collect()
+}
+
+fn load_root(root: PathBuf, source: SkillSource, out: &mut Vec<SkillDefinition>) {
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let candidate = if path.is_dir() {
+            path.join("SKILL.md")
+        } else {
+            path
+        };
+        if candidate.extension().and_then(|ext| ext.to_str()) != Some("md") {
+            continue;
+        }
+        match parse_skill(&candidate, source) {
+            Ok(skill) => out.push(skill),
+            Err(error) => log::warn!("assistant: skipped skill {}: {error}", candidate.display()),
+        }
+    }
+}
+
+fn parse_skill(path: &Path, source: SkillSource) -> Result<SkillDefinition, String> {
+    let text = std::fs::read_to_string(path).map_err(|error| error.to_string())?;
+    let body = text
+        .strip_prefix("---\n")
+        .ok_or("missing YAML frontmatter")?;
+    let (frontmatter, instructions) = body
+        .split_once("\n---\n")
+        .ok_or("unterminated YAML frontmatter")?;
+    let value = |key: &str| {
+        frontmatter.lines().find_map(|line| {
+            let (found, value) = line.split_once(':')?;
+            (found.trim() == key).then(|| value.trim().trim_matches(['\"', '\'']).to_string())
+        })
+    };
+    let name = value("name").ok_or("frontmatter requires name")?;
+    let description = value("description").ok_or("frontmatter requires description")?;
+    if name.is_empty() || description.is_empty() || instructions.trim().is_empty() {
+        return Err("name, description, and instructions must be non-empty".to_string());
+    }
+    Ok(SkillDefinition {
+        name,
+        description,
+        instructions: instructions.trim().to_string(),
+        source,
+        path: path.to_path_buf(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovers_channel_and_workspace_skills_with_workspace_precedence() {
+        let root = tempfile::tempdir().unwrap();
+        let profile = root.path().join(".plexi-pr-1");
+        let workspace = root.path().join("workspace");
+        std::fs::create_dir_all(profile.join("skills/deploy")).unwrap();
+        std::fs::create_dir_all(workspace.join(".plexi/skills/deploy")).unwrap();
+        std::fs::write(
+            profile.join("skills/deploy/SKILL.md"),
+            "---\nname: deploy\ndescription: deploy a release\n---\nuser body",
+        )
+        .unwrap();
+        std::fs::write(
+            workspace.join(".plexi/skills/deploy/SKILL.md"),
+            "---\nname: deploy\ndescription: deploy workspace release\n---\nworkspace body",
+        )
+        .unwrap();
+
+        let registry = SkillRegistry::load(&profile, &workspace);
+        let skill = registry.get("deploy").unwrap();
+        assert_eq!(skill.source, SkillSource::Workspace);
+        assert_eq!(skill.instructions, "workspace body");
+    }
+
+    #[test]
+    fn malformed_skills_are_not_exposed() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(root.path().join("skills/bad")).unwrap();
+        std::fs::write(root.path().join("skills/bad/SKILL.md"), "# no frontmatter").unwrap();
+        assert!(SkillRegistry::load(root.path(), root.path())
+            .all()
+            .is_empty());
+    }
+
+    #[test]
+    fn auto_match_is_conservative() {
+        let release = SkillDefinition {
+            name: "release".into(),
+            description: "Prepare and deploy a production release by checking changelog, version, artifacts, and rollout health when the user asks to ship software.".into(),
+            instructions: "do it".into(),
+            source: SkillSource::User,
+            path: PathBuf::new(),
+        };
+        let docs = SkillDefinition {
+            name: "docs".into(), description: "Write and revise product documentation with clear examples and accurate command references.".into(),
+            instructions: "write".into(), source: SkillSource::User, path: PathBuf::new(),
+        };
+        let registry = SkillRegistry {
+            skills: vec![release, docs],
+        };
+        assert_eq!(
+            registry
+                .matching_enabled(
+                    "please check the changelog and deploy the production release",
+                    &[],
+                )
+                .unwrap()
+                .name,
+            "release"
+        );
+        assert!(registry
+            .matching_enabled("help me think about tomorrow", &[])
+            .is_none());
+    }
+
+    #[test]
+    fn auto_match_refuses_ambiguous_equal_scores() {
+        let make = |name: &str| SkillDefinition {
+            name: name.into(),
+            description: "audit production release artifacts".into(),
+            instructions: "do it".into(),
+            source: SkillSource::User,
+            path: PathBuf::new(),
+        };
+        let registry = SkillRegistry {
+            skills: vec![make("release-a"), make("release-b")],
+        };
+        assert!(registry
+            .matching_enabled("audit production artifacts", &[])
+            .is_none());
+    }
+}

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -625,11 +625,11 @@ impl AppRuntime {
         }
     }
 
-    /// Pump event I/O for a pane not in the active context. No-op for builtins.
+    /// Pump event I/O for a pane not in the active context.
     pub fn background_tick(&mut self) {
         match self {
             AppRuntime::Process(app) => app.background_tick(),
-            AppRuntime::Builtin(_) => {}
+            AppRuntime::Builtin(app) => app.background_tick(),
             // Timers advance only while the pane renders (visible). Background
             // ticking for off-screen WASM panes is deferred.
             AppRuntime::Wasm(_) => {}
@@ -637,12 +637,11 @@ impl AppRuntime {
     }
 
     /// Does this pane have pending background work that `background_tick`
-    /// would make progress on? Always false for builtins — they have no
-    /// subprocess, timers, or async workers (#2021).
+    /// would make progress on?
     pub fn needs_background_tick(&self) -> bool {
         match self {
             AppRuntime::Process(app) => app.needs_background_tick(),
-            AppRuntime::Builtin(_) => false,
+            AppRuntime::Builtin(app) => app.needs_background_tick(),
             AppRuntime::Wasm(_) => false,
         }
     }


### PR DESCRIPTION
Stint task 0229

No linked GitHub issue.

## Summary

- Discovers frontmatter-backed skills from the active channel and workspace, with workspace precedence, `/skills`, manual slash invocation, and conservative automatic matching.
- Adds `/context` and `/hooks` views for token estimates, loaded instructions, pane context, enabled tools, and lifecycle hook sources.
- Adds seven permission-gated in-process tools for pane, app, and terminal control without shelling out to the Plexi CLI.
- Preserves the originating pane/context, defers unsafe overlay mutations, audits tool decisions, and pumps off-screen Assistant work to completion.

## Test evidence

- Assistant suite: 119 passed, 0 failed.
- Native host-tool HostHarness suite: 2 passed, 0 failed.
- Full Rust suite: 1,612 passed, 2 pre-existing stale SendToPane expectation failures, 1 ignored.
- cargo build: passed.
- Codex review: two rounds; all findings resolved.