### PR TITLE
testing: complete shared host e2e loop

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -28,7 +28,13 @@ Before a test can be called flaky:
 
 ```bash
 git diff --name-only origin/alpha...HEAD
+git diff --name-only HEAD
+git ls-files --others --exclude-standard
 ```
+
+The first command classifies committed branch changes; the latter two include
+the current pre-push worktree. Do not classify from `origin/alpha...HEAD` alone
+when implementation is still uncommitted.
 
 | Touched | Layer | Evidence required |
 |---|---|---|
@@ -49,6 +55,10 @@ cargo test --bin plexi
 ```
 
 Record pass/fail counts and the module filters used. New `AppRequest`/`HostEffect` handlers must have a `HostHarness` test (`src/testing/mod.rs`) — written first, per repo discipline.
+Use `-- --exact` only with the fully-qualified test name; a basename plus
+`--exact` can succeed after running zero tests. The full bin suite must be green
+in the current attempt; do not substitute an earlier run without recording when
+and against which diff it ran.
 
 ## Step 3 — UI & App Evidence: Scenes and AppHarness
 
@@ -68,16 +78,17 @@ For a new or changed overlay/widget/pane type: **add a committed scene file** un
 size = [1280.0, 800.0]
 
 [[steps]]
-open_app = "apps/dev/balls"          # real Python process; args = [...] surface as ctx.args
+open = { kind = "process", path = "apps/dev/balls", as = "balls" }
 [[steps]]
-wait_app_frame = { timeout_s = 15.0 }
+wait_app_frame = { target = "balls", timeout_s = 15.0 }
 [[steps]]
-assert = { pane_count = 1, lifecycle = "running", tree_contains = "balls" }
+assert = { target = "balls", pane_count = 1, lifecycle = "running", tree_contains = "balls" }
 [[steps]]
 shot = "balls.png"
 ```
 
-For scene DSL reference (verbs, assertions, SceneReport format), see `docs/TESTING.md`.
+For the canonical scene DSL reference, coverage map, assertions, and SceneReport
+format, see `src/testing/TESTING.md`.
 
 ### Python PGAP apps — AppHarness PNG renders
 
@@ -121,6 +132,9 @@ Append to the Ship Log entry for this attempt (issue body), or the PR descriptio
 Conclusion rules:
 - `install skippable — full coverage`: every touched layer has green tests AND any visual change has an inspected screenshot.
 - `binary install required`: PTY/terminal interaction, keyboard-capture flows, anything `#[ignore = "requires-pty"]`, or behavior only observable in the installed bundle (menus, dock, file associations).
+- A `LiveBackend` change always requires `just scene-live` against the installed
+  PR channel. Headless parity proves schema semantics, not CLI execution or
+  eventual polling against a real host.
 
 ## Guards
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Every new feature must be instrumented. No new capability, command, or user-visi
 
 ## Testing
 
-**Full reference: [`src/testing/TESTING.md`](src/testing/TESTING.md).** Observable state → TOML scene. Return value or invariant → Rust `#[test]`. `cargo test --bin plexi` must be green before any push.
+**Mandatory self-validation contract: [`src/testing/TESTING.md`](src/testing/TESTING.md).** Every coding agent follows it before push. Observable state → TOML scene. Return value or invariant → Rust `#[test]`. `cargo test --bin plexi` must be green before any push.
 
 **`just pr-install <N>` must run from the relevant feature worktree.** The recipe runs pre-install tests against the current working tree before building. Running it from alpha/root validates and installs the wrong tree.
 

--- a/src/app/tests/navigation_tests.rs
+++ b/src/app/tests/navigation_tests.rs
@@ -129,9 +129,9 @@ fn pane_navigate_cross_window_syncs_router() {
 /// returned "not found" when `active_window == 0`.
 ///
 /// Strategy: insert an App pane into a second window, keep `active_window = 0`,
-/// inject `SendToPane` targeting that pane. The response must contain
-/// "not a terminal pane" (pane was found across windows but is an App pane),
-/// NOT "not found" (which would indicate the pre-fix single-window search).
+/// inject `SendToPane` targeting that pane. App panes accept text through the
+/// production egui input path, so success plus cross-window focus proves the
+/// lookup reached the target instead of returning "not found".
 #[test]
 fn send_to_pane_searches_all_windows() {
     let mut h = HostHarness::new();
@@ -194,14 +194,16 @@ fn send_to_pane_searches_all_windows() {
 
     let response = std::fs::read_to_string(&resp_file)
         .expect("response file must be written by SendToPane handler");
-    // Pre-fix: response contains "not found" (pane not visible from active window).
-    // Post-fix: pane IS found across windows but is an App pane → "is not a terminal pane".
-    // The distinct error messages let us confirm the cross-window search reached the pane.
-    assert!(
-        response.contains("is not a terminal pane"),
-        "expected cross-window lookup to find the pane (error contains 'is not a terminal pane'), \
-         got: {response}. If 'not found', the single-window regression is back."
-    );
+    assert_eq!(response, r#"{"ok":true}"#);
+    assert_eq!(h.app.active_window, 1, "target window must become active");
+    let focused_pane = h.app.windows[1]
+        .focused_pane
+        .and_then(|tile_id| h.app.windows[1].tree.tiles.get(tile_id))
+        .and_then(|tile| match tile {
+            egui_tiles::Tile::Pane(pane_id) => Some(*pane_id),
+            _ => None,
+        });
+    assert_eq!(focused_pane, Some(cross_window_pane_id));
     let _ = std::fs::remove_file(&resp_file);
 }
 

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -154,6 +154,10 @@ pub enum Step {
     Text { text: TextSpec },
     /// Press a key combo against a pane handle or the whole host.
     Key { key: KeySpec },
+    /// Focus an opened pane through the production pane-navigation path.
+    Focus { focus: String },
+    /// Close an opened pane through the production pane-close path.
+    Close { close: String },
     /// Toggle the host sidebar.
     Sidebar { sidebar: bool },
     /// Switch to the context at this router index.
@@ -261,6 +265,10 @@ pub struct AssertSpec {
     /// Portal panes across all windows.
     pub portal_count: Option<usize>,
     pub sidebar: Option<bool>,
+    /// Whether the target pane currently exists.
+    pub exists: Option<bool>,
+    /// Whether the target pane is the active focused pane.
+    pub focused: Option<bool>,
     /// Lifecycle of the target app pane, lowercase (e.g. "running").
     pub lifecycle: Option<String>,
     /// Substring match against the target app's serialized L1 tree.
@@ -925,6 +933,51 @@ impl LiveBackend {
                     value: key.value.clone(),
                 }))
             }
+            Step::Focus { focus } => {
+                let pane_id = self.handles.resolve(focus)?;
+                self.command(&["pane".into(), "focus".into(), pane_id.to_string()], true)?;
+                poll_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
+                    self.json(&["pane", "list"]).ok().and_then(|value| {
+                        value.as_array()?.iter().find_map(|pane| {
+                            (pane.get("id").and_then(serde_json::Value::as_u64) == Some(pane_id)
+                                && pane.get("focused").and_then(serde_json::Value::as_bool)
+                                    == Some(true))
+                            .then_some(())
+                        })
+                    })
+                })?;
+                log::info!(
+                    "scene_live: step=focus channel={} handle={} pane_id={pane_id}",
+                    self.channel,
+                    focus
+                );
+                Ok(Some(StepDetail::Message {
+                    message: format!("focused {focus} (pane {pane_id})"),
+                }))
+            }
+            Step::Close { close } => {
+                let pane_id = self.handles.resolve(close)?;
+                self.command(&["pane".into(), "close".into(), pane_id.to_string()], true)?;
+                poll_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
+                    self.json(&["pane", "list"]).ok().and_then(|value| {
+                        value
+                            .as_array()?
+                            .iter()
+                            .all(|pane| {
+                                pane.get("id").and_then(serde_json::Value::as_u64) != Some(pane_id)
+                            })
+                            .then_some(())
+                    })
+                })?;
+                log::info!(
+                    "scene_live: step=close channel={} handle={} pane_id={pane_id}",
+                    self.channel,
+                    close
+                );
+                Ok(Some(StepDetail::Message {
+                    message: format!("closed {close} (pane {pane_id})"),
+                }))
+            }
             Step::WaitAppFrame { wait_app_frame } => {
                 let pane_id = self.handles.resolve(&wait_app_frame.target)?;
                 let _ =
@@ -1136,7 +1189,54 @@ impl LiveBackend {
                 host.context_count
             ));
         }
-        if let Some(target) = spec.target.as_deref() {
+        if let Some(expected) = spec.focused {
+            let target = spec.target.as_deref().ok_or_else(|| {
+                SceneError::new(
+                    "missing_assert_target",
+                    "assert focused requires target = '<handle>'",
+                )
+            })?;
+            let pane_id = self.handles.resolve(target)?;
+            let panes = self.json(&["pane", "list"])?;
+            let actual = panes.as_array().and_then(|entries| {
+                entries.iter().find_map(|pane| {
+                    (pane.get("id").and_then(serde_json::Value::as_u64) == Some(pane_id))
+                        .then(|| pane.get("focused").and_then(serde_json::Value::as_bool))
+                        .flatten()
+                })
+            });
+            if actual != Some(expected) {
+                failures.push(format!(
+                    "focused: expected {expected}, got {}",
+                    actual.map_or_else(|| "unavailable".to_string(), |value| value.to_string())
+                ));
+            }
+        }
+        if let Some(expected) = spec.exists {
+            let target = spec.target.as_deref().ok_or_else(|| {
+                SceneError::new(
+                    "missing_assert_target",
+                    "assert exists requires target = '<handle>'",
+                )
+            })?;
+            let pane_id = self.handles.resolve(target)?;
+            let panes = self.json(&["pane", "list"])?;
+            let actual = panes.as_array().is_some_and(|entries| {
+                entries
+                    .iter()
+                    .any(|pane| pane.get("id").and_then(serde_json::Value::as_u64) == Some(pane_id))
+            });
+            if actual != expected {
+                failures.push(format!("exists: expected {expected}, got {actual}"));
+            }
+        }
+        if spec.lifecycle.is_some() || spec.tree_contains.is_some() {
+            let target = spec.target.as_deref().ok_or_else(|| {
+                SceneError::new(
+                    "missing_assert_target",
+                    "assert lifecycle/tree_contains requires target = '<handle>'",
+                )
+            })?;
             let pane_id = self.handles.resolve(target)?;
             let state = self.pane_state(pane_id)?;
             if let Some(expected) = &spec.lifecycle {
@@ -1304,6 +1404,8 @@ fn step_label(step: &Step) -> String {
             text.value.chars().count()
         ),
         Step::Key { key } => format!("key {} {}", key.target, key.value),
+        Step::Focus { focus } => format!("focus {focus}"),
+        Step::Close { close } => format!("close {close}"),
         Step::Sidebar { sidebar } => format!("sidebar {sidebar}"),
         Step::SwitchContext { switch_context } => format!("switch_context {switch_context}"),
         Step::PushToSubcontext { push_to_subcontext } => {
@@ -1486,6 +1588,34 @@ impl HeadlessBackend {
                     value: key.value.clone(),
                 }))
             }
+            Step::Focus { focus } => {
+                let pane_id = self.handles.resolve(focus)?;
+                self.h
+                    .focus_pane(pane_id)
+                    .map_err(|message| SceneError::new("focus_failed", message))?;
+                // Focus changes can invalidate pane rectangles for the current
+                // frame; settle one render and one post-layout frame before a
+                // following assertion or screenshot observes the host.
+                self.h.run_steps(2);
+                log::info!("scene: focus handle={focus} pane_id={pane_id}");
+                Ok(Some(StepDetail::Message {
+                    message: format!("focused {focus} (pane {pane_id})"),
+                }))
+            }
+            Step::Close { close } => {
+                let pane_id = self.handles.resolve(close)?;
+                self.h
+                    .close_pane(pane_id)
+                    .map_err(|message| SceneError::new("close_failed", message))?;
+                // Closing rewrites the tile tree before egui recomputes the
+                // surviving pane rect. Settle both phases so an immediately
+                // following shot cannot capture the transient old clip rect.
+                self.h.run_steps(2);
+                log::info!("scene: close handle={close} pane_id={pane_id}");
+                Ok(Some(StepDetail::Message {
+                    message: format!("closed {close} (pane {pane_id})"),
+                }))
+            }
             Step::Sidebar { sidebar } => {
                 let v = *sidebar;
                 self.h.with_app_mut(|app| app.sidebar_visible = v);
@@ -1604,6 +1734,45 @@ impl HeadlessBackend {
         }
         if let Some(v) = spec.sidebar {
             expect("sidebar", v.to_string(), host.sidebar.to_string());
+        }
+        if let Some(expected) = spec.exists {
+            let target = spec.target.as_deref().ok_or_else(|| {
+                SceneError::new(
+                    "missing_assert_target",
+                    "assert exists requires target = '<handle>'",
+                )
+            })?;
+            let pane_id = self.handles.resolve(target)?;
+            let actual = self.h.with_app(|app| {
+                app.windows
+                    .iter()
+                    .any(|window| window.panes.contains_key(&pane_id))
+            });
+            expect("exists", expected.to_string(), actual.to_string());
+        }
+        if let Some(expected) = spec.focused {
+            let target = spec.target.as_deref().ok_or_else(|| {
+                SceneError::new(
+                    "missing_assert_target",
+                    "assert focused requires target = '<handle>'",
+                )
+            })?;
+            let pane_id = self.handles.resolve(target)?;
+            let actual = self.h.with_app(|app| {
+                app.windows
+                    .iter()
+                    .enumerate()
+                    .any(|(window_index, window)| {
+                        window_index == app.active_window
+                            && window.focused_pane.is_some_and(|tile_id| {
+                                matches!(
+                                    window.tree.tiles.get(tile_id),
+                                    Some(egui_tiles::Tile::Pane(id)) if *id == pane_id
+                                )
+                            })
+                    })
+            });
+            expect("focused", expected.to_string(), actual.to_string());
         }
         if spec.lifecycle.is_some() || spec.tree_contains.is_some() {
             let target = spec.target.as_deref().ok_or_else(|| {
@@ -1824,6 +1993,12 @@ mod tests {
             key = { target = "assistant", value = "enter" }
 
             [[steps]]
+            focus = "assistant"
+
+            [[steps]]
+            close = "assistant"
+
+            [[steps]]
             assert_label = { target = "assistant", label = "Assistant settings" }
         "#;
 
@@ -1837,12 +2012,16 @@ mod tests {
                 },
                 Step::Text { text: TextSpec { target: text_target, .. } },
                 Step::Key { key: KeySpec { target: key_target, .. } },
+                Step::Focus { focus },
+                Step::Close { close },
                 Step::AssertLabel {
                     assert_label: AssertLabelSpec { target: label_target, .. }
                 }
             ] if handle == "assistant"
                 && text_target == "assistant"
                 && key_target == "assistant"
+                && focus == "assistant"
+                && close == "assistant"
                 && label_target == "assistant"
         ));
     }

--- a/src/testing/AGENTS.md
+++ b/src/testing/AGENTS.md
@@ -8,7 +8,7 @@ Test infrastructure for the Plexi host. `HostHarness` (headless egui test harnes
 
 ## Reference
 
-- [TESTING.md](TESTING.md) — full testing guide: layers, scene format, conventions, profile isolation.
+- [TESTING.md](TESTING.md) — mandatory self-validation contract for every coding agent: layers, scene format, coverage map, evidence workflow, and profile isolation.
 
 ## Rules
 

--- a/src/testing/TESTING.md
+++ b/src/testing/TESTING.md
@@ -46,6 +46,8 @@ shot = "balls.png"                          # optional; written to the out dir
 | `open = { kind = "builtin", id = "<id>", as = "<handle>", cwd = "<dir>" }` | Open a compiled-in host app by id. `cwd` is optional and defaults to a fresh harness-owned directory. |
 | `text = { target = "<handle>", value = "hello" }` | Focus a pane and insert text through egui's normal text-input path. The report records the character count, not the text. |
 | `key = { target = "<handle>", value = "enter" }` | Focus a pane and press a key combo (`cmd`/`ctrl`/`alt`/`shift` plus a key name). Use `target = "host"` for a whole-host shortcut. |
+| `focus = "<handle>"` | Focus an opened pane through the production pane-navigation path (`plexi pane focus` live). |
+| `close = "<handle>"` | Close an opened pane through the production pane lifecycle path (`plexi pane close` live). |
 | `sidebar = true` | Show/hide the host sidebar. |
 | `switch_context = 0` | Switch to the context at this router index. |
 | `push_to_subcontext = "Name"` | Push the focused pane into a new subcontext (creates a portal). |
@@ -59,7 +61,7 @@ Every `open` step binds one unique symbolic handle. Later pane steps reject miss
 
 ### Assertions
 
-`pane_count`, `window_count`, `context_count`, `portal_count` (across all windows), and `sidebar` assert host state. `lifecycle` and `tree_contains` require `target = "<handle>"`; they inspect that process or WASM app's serialized L1 state. Native builtins use `assert_label`. Every present key must match.
+`pane_count`, `window_count`, `context_count`, `portal_count` (across all windows), and `sidebar` assert host state. `exists`, `focused`, `lifecycle`, and `tree_contains` require `target = "<handle>"`; `exists` and `focused` check pane lifecycle/focus while the latter two inspect a process or WASM app's serialized L1 state. Native builtins use `assert_label`. Every present key must match. Prefer handle-scoped assertions in scenes meant for both backends: an installed profile may restore unrelated panes, so absolute global counts are intentionally profile-dependent.
 
 ### Running
 
@@ -78,7 +80,34 @@ Every run writes `<out>/<scene>.json` (`schema_version: 3`). It includes the sel
 
 `just scene-live` requires an explicit installed channel, boots that channel's host, drives generic app open/text/key/context switch/context push operations through the public CLI/IPC surface, observes `pane state` and context metadata, and always tears down a runner-owned host. Set `PLEXI_SCENE_ATTACH=1` only to attach deliberately; attached hosts are never stopped by the runner. The outer script writes a runner-only ownership marker, so SIGINT/SIGTERM/HUP cleanup can stop an owned host without touching an attached one. Unsupported live verbs fail with `unsupported_live_verb` rather than silently diverging from headless semantics. Live assertions use bounded eventual polling with a small poll interval and a stable-state barrier, never fixed workflow sleeps.
 
+Changes to `LiveBackend` require a `just scene-live` run against the installed PR
+channel. A passing headless scene does not exercise CLI command construction,
+host startup/ownership, or eventual polling.
+
 Whole-host `text`, `key`, and `assert_label` targets are headless-only because the installed host exposes no sanctioned generic host-input or host-semantic CLI/IPC seam. The live backend returns `unsupported_live_target` for `target = "host"`; pane targets retain the shared semantics.
+
+## Host Surface Coverage
+
+Use this map before extending the DSL. “Scene” means observable coverage through
+the shared TOML schema; “logic” names the lower layer for invariants that are not
+pixels. A blank scene cell is a deliberate gap, not permission to add an ad hoc
+driver.
+
+| Host surface | Scene coverage | Logic coverage | Live CLI surface |
+|---|---|---|---|
+| Open process, builtin, and WASM panes | `open`, app-specific scenes | launch and lifecycle tests | `plexi app open` |
+| Pane focus, close, text, and native/process/WASM keys | `focus`, `close`, `text`, `key`; `pane-lifecycle.toml`, `assistant-settings.toml`, `wasm-sysmon.toml` | `HostHarness` IPC and native key tests | `plexi pane focus/close/send/key` |
+| Split directions, tabs, overlays, and multi-window placement | host shortcuts can be driven with whole-host `key`; placement state is covered in focused Rust tests | pane layout, window cleanup, and spawn tests | `plexi pane new` / `plexi app open` placement flags |
+| Context switch, subcontext push, and portals | `switch_context`, `push_to_subcontext`; `subcontext-portal.toml` | context and portal lifecycle tests | `plexi context zoom/push/list` |
+| Sidebar and context drag/drop | `sidebar`; file-browser sidebar scene. Pointer drag remains a direct `PlexiUiHarness` edge-case test. | sidebar reorder/drop resolver tests | no generic pointer-injection command; context mutations use `plexi context` |
+| Command palette and host overlays | whole-host `key` plus semantic/pixel assertions; direct harness tests cover draw-pass focus edge cases | palette, notification, quick-note, and focus-stack tests | no generic whole-host key command; invoke the underlying pane/context/app CLI command |
+| Agent panes and terminal PTY behavior | host state and pane chrome can be captured; PTY behavior is not simulated | agent-state and `#[ignore = "requires-pty"]` tests | `plexi pane new`, `plexi agent report`, `plexi pane capture` |
+| Native, process, WASM, portal, sidebar, and overlay screenshots | `shot` captures the entire headless host framebuffer, so pane type does not require a separate capture path | renderer and semantic-state tests | live scenes intentionally skip `shot`; installed validation uses `drive-host` capture |
+
+Do not require scene and CLI syntax to be identical. They must converge on the
+same production host operation. Pointer-only UI affordances and whole-host
+overlays have no sanctioned live input seam; test their observable UI headlessly
+and test the underlying mutation through its public CLI command.
 
 ## Real App Processes in Tests
 
@@ -86,7 +115,11 @@ Whole-host `text`, `key`, and `assert_label` targets are headless-only because t
 
 ## Pre-Push Evidence
 
-The `/testing` skill (`.agents/skills/testing/SKILL.md`) is the agent workflow: classify the diff, run the matching layer's tests/scenes, inspect screenshots, write the `**Test evidence:**` block into the issue Ship Log. validate-pr reads that block; `install skippable — full coverage` means diff-review-only validation.
+This file is the self-validation contract for every coding agent. The `/testing`
+skill (`.agents/skills/testing/SKILL.md`) is its executable workflow: classify the
+diff, run every touched layer, inspect every generated screenshot, and write the
+`**Test evidence:**` block into the issue Ship Log or PR body. validate-pr reads
+that block; `install skippable — full coverage` means diff-review-only validation.
 
 ## Conventions
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -1799,9 +1799,8 @@ fn pgap_send_to_pane_denied_without_panes_control() {
 }
 
 /// App WITH `panes.control` sends SendToPane via PGAP: the request reaches the
-/// host pane-IPC handler. The target is the app's own (non-terminal) pane, so
-/// the handler — not the capability gate — answers with its pane-type error,
-/// proving the forward happened.
+/// host pane-IPC handler. App panes accept text through the production egui
+/// input path, so an `ok` response proves the capability gate forwarded it.
 #[test]
 fn pgap_send_to_pane_forwarded_with_panes_control() {
     let mut h = HostHarness::new();
@@ -1828,11 +1827,9 @@ fn pgap_send_to_pane_forwarded_with_panes_control() {
         v.get("capability").is_none(),
         "granted request must not produce a capability denial: {content}"
     );
-    assert!(
-        v["error"]
-            .as_str()
-            .is_some_and(|e| e.contains("not a terminal pane")),
-        "host handler must answer with its own pane-type error: {content}"
+    assert_eq!(
+        v["ok"], true,
+        "host handler must accept app text: {content}"
     );
 }
 

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -273,6 +273,20 @@ impl PlexiUiHarness {
         }
     }
 
+    /// Close a pane through the same lifecycle path used by `plexi pane close`.
+    pub fn close_pane(&mut self, pane_id: PaneId) -> Result<(), String> {
+        let exists = self.with_app(|app| {
+            app.windows
+                .iter()
+                .any(|window| window.panes.contains_key(&pane_id))
+        });
+        if !exists {
+            return Err(format!("pane {pane_id} no longer exists"));
+        }
+        self.with_app_mut(|app| app.close_pane_by_id(pane_id));
+        Ok(())
+    }
+
     /// Exact semantic-label lookup scoped to one rendered pane rectangle.
     pub fn pane_has_label(&mut self, pane_id: PaneId, label: &str) -> bool {
         use egui_kittest::kittest::Queryable;

--- a/tests/scenes/pane-lifecycle.toml
+++ b/tests/scenes/pane-lifecycle.toml
@@ -1,0 +1,32 @@
+# Pane focus and close use the same host lifecycle paths as the public CLI.
+size = [1280.0, 800.0]
+
+[[steps]]
+open = { kind = "builtin", id = "file_browser", cwd = ".", as = "files" }
+
+[[steps]]
+open = { kind = "builtin", id = "file_browser", cwd = "tests", as = "second" }
+
+[[steps]]
+assert = { target = "second", exists = true }
+
+[[steps]]
+focus = "second"
+
+[[steps]]
+assert = { target = "second", focused = true }
+
+[[steps]]
+focus = "files"
+
+[[steps]]
+assert = { target = "files", focused = true }
+
+[[steps]]
+close = "second"
+
+[[steps]]
+assert = { target = "second", exists = false }
+
+[[steps]]
+shot = "pane-lifecycle.png"


### PR DESCRIPTION
Stint task 0361

No linked GitHub issue.

## Summary

- Adds shared `focus` and `close` scene verbs plus handle-scoped `exists` and `focused` assertions across headless and live backends.
- Uses production pane navigation/close paths, bounded live polling, and a two-frame headless layout settle so immediate screenshots are complete.
- Adds a pane lifecycle scene and updates stale SendToPane assertions for native app text injection.
- Documents the host-surface coverage map and hardens the mandatory agent testing workflow from a fresh-agent dry run.

## Test evidence

- Full Rust suite: 1,617 passed, 0 failed, 1 ignored.
- Scene suite: passed.
- Process Balls scene: passed.
- Headless pane lifecycle: 10/10 steps passed; screenshot inspected and complete.
- Installed alpha live pane lifecycle: 10/10 steps passed; runner-owned host stopped cleanly.
- cargo build: passed.
- Fresh-agent testing dry run: completed; all reported friction incorporated.
- Codex review: round 1 clean; round 2 unavailable due usage limit, no unresolved finding.