### PR TITLE
fix: route CLI commands by binary channel (stint 0365)

### DIFF
--- a/.agents/skills/drive-host/SKILL.md
+++ b/.agents/skills/drive-host/SKILL.md
@@ -26,7 +26,7 @@ When a committed TOML scene already describes the flow, prefer `just scene-live 
 
 ## The loop
 
-All four steps run against one channel. For a PR build the channel is `pr-<N>` and the binary is `plexi-pr-<N>`; substitute your channel throughout. `host start/stop/status` resolve the socket from the channel's own config dir (`~/.plexi-<channel>/notify.sock`), so they ignore any inherited `PLEXI_SOCKET` — the drive commands in step 2 do not, which is the whole reason for the env discipline below.
+All four steps run against one channel. For a PR build the channel is `pr-<N>` and the binary is `plexi-pr-<N>`; substitute your channel throughout. Current channel-suffixed binaries resolve commands from their own config dir (`~/.plexi-<channel>/notify.sock`). Keep the explicit socket and channel environment below so the loop also works with older installed binaries.
 
 ### 1. Boot
 
@@ -59,7 +59,7 @@ plexi-pr-<N> pane new "npm run dev" -n dev
 
 Every drive command needs the env discipline below. Always target panes by the id from `pane list` — never rely on "current pane" defaults, which read stale `PLEXI_*` vars from the pane you launched this skill in.
 
-**Env discipline (the trap).** `pane list/send/state/capture/key/new` resolve their target from `PLEXI_SOCKET`, not from the channel. Inside another Plexi pane that variable points at *your* host, not the PR host, and `PLEXI_PANE_ID` / `PLEXI_CONTEXT_ID` / `PLEXI_CONTEXT_ROOT` are likewise stale. Point every drive command at the PR host's own socket and strip the inherited pane/context identity:
+**Env discipline.** Current channel-suffixed binaries reject a socket inherited from another channel. Keep pointing every drive command at the PR host's socket for compatibility with older binaries, and strip inherited pane/context identity because those values still describe the launching pane:
 
 ```bash
 env -u PLEXI_PANE_ID -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_ROOT -u PLEXI_RUNNING \

--- a/.agents/skills/validate-pr/SKILL.md
+++ b/.agents/skills/validate-pr/SKILL.md
@@ -305,7 +305,8 @@ plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} pane name "#<n> · needs-you"
 pipeline_slots_set validate "$ISSUE_NUMBER" "$PR_NUMBER" needs-you "Review the [TESTING] block, then reply pass/fail/modify." ""
 # Route reply to PM pane if PM dispatched this skill, otherwise this pane
 REPLY_PANE="${PM_PANE_ID:-$PLEXI_PANE_ID}"
-plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} notify --no-wait \
+PLEXI_SOCKET="$PLEXI_SOCKET" PLEXI_CHANNEL="$PLEXI_CHANNEL" \
+  plexi${PLEXI_CHANNEL:+-$PLEXI_CHANNEL} notify --no-wait \
   --title "PR #<n> quality checks done (attempt $((ATTEMPT_COUNT+1))/3)" \
   --body "<title>. Review the [TESTING] block, then reply pass/fail/modify." \
   --choice "talk:Talk to Claude:pane_focus:$REPLY_PANE"

--- a/src/cli/AGENTS.md
+++ b/src/cli/AGENTS.md
@@ -13,7 +13,7 @@ Every CLI command and feature must work identically on alpha, beta, main, and PR
 
 **Path rules:** Never hardcode a profile directory path — always use `config_dir()`. Never hardcode `.plexi/` as a workspace dir — always use `workspace_channel_dir()` or `workspace_config_path()`.
 
-**Socket rule:** Honor `PLEXI_SOCKET` when set; fall back to channel-specific mechanisms only when it is not. New host commands must follow the socket-first pattern in `open_cli()`.
+**Socket rule:** A channel-suffixed binary always sends commands to its own profile's `notify.sock`, even when it inherits a different `PLEXI_SOCKET`. The bare `plexi` binary honors `PLEXI_SOCKET`. Route new command dispatch through `resolve_command_socket()`.
 
 **Completion testing on PR builds:** `just pr-install` skips completion install. To test, manually run `plexi-pr-<N> completions zsh > <path>` and restore after.
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -28,6 +28,10 @@ pub struct Cli {
     #[arg(long, global = true, hide = true)]
     pub profile: Option<String>,
 
+    /// Override the host command socket path.
+    #[arg(long, global = true, value_hint = ValueHint::FilePath)]
+    pub socket: Option<std::path::PathBuf>,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 
@@ -1489,6 +1493,23 @@ mod tests {
         normalize_config_scope_aliases, AppCmd, Cli, Commands, ConfigCmd, ConfigScope, SecretCmd,
     };
     use clap::Parser;
+
+    #[test]
+    fn global_socket_override_parses_after_subcommand() {
+        let cli = Cli::try_parse_from([
+            "plexi",
+            "pane",
+            "list",
+            "--socket",
+            "/tmp/explicit.sock",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            cli.socket,
+            Some(std::path::PathBuf::from("/tmp/explicit.sock"))
+        );
+    }
 
     #[test]
     fn secret_list_accepts_global_flag() {

--- a/src/cli/events.rs
+++ b/src/cli/events.rs
@@ -22,9 +22,9 @@ use std::os::unix::net::UnixStream;
 /// behaviour of `send_to_socket`, but returns the live stream so the caller can
 /// stream NDJSON responses back.
 fn connect_socket() -> Result<UnixStream, i32> {
-    let socket_path = match std::env::var("PLEXI_SOCKET") {
-        Ok(v) => v,
-        Err(_) => {
+    let socket_path = match super::resolve_command_socket() {
+        Some(path) => path,
+        None => {
             eprintln!("error: PLEXI_SOCKET is not set — run this inside a Plexi terminal pane");
             return Err(1);
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -248,10 +248,208 @@ pub(super) fn print_tip(msg: &str) {
     }
 }
 
+#[cfg(test)]
+mod socket_resolution_tests {
+    use super::{command_socket_available_from, resolve_command_socket_from};
+    use std::ffi::OsStr;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn pr_binary_uses_own_channel_socket_when_ambient_socket_mismatches() {
+        let actual = resolve_command_socket_from(
+            None,
+            Some("pr-2384"),
+            Some(OsStr::new("/tmp/alpha.sock")),
+            Path::new("/Users/test"),
+        );
+
+        assert_eq!(
+            actual,
+            Some(PathBuf::from(
+                "/Users/test/.plexi-pr-2384/notify.sock"
+            ))
+        );
+    }
+
+    #[test]
+    fn alpha_binary_uses_own_channel_socket_when_ambient_socket_mismatches() {
+        let actual = resolve_command_socket_from(
+            None,
+            Some("alpha"),
+            Some(OsStr::new("/tmp/beta.sock")),
+            Path::new("/Users/test"),
+        );
+
+        assert_eq!(
+            actual,
+            Some(PathBuf::from("/Users/test/.plexi-alpha/notify.sock"))
+        );
+    }
+
+    #[test]
+    fn beta_binary_uses_own_channel_socket_when_ambient_socket_mismatches() {
+        let actual = resolve_command_socket_from(
+            None,
+            Some("beta"),
+            Some(OsStr::new("/tmp/alpha.sock")),
+            Path::new("/Users/test"),
+        );
+
+        assert_eq!(
+            actual,
+            Some(PathBuf::from("/Users/test/.plexi-beta/notify.sock"))
+        );
+    }
+
+    #[test]
+    fn bare_binary_preserves_ambient_socket() {
+        let actual = resolve_command_socket_from(
+            None,
+            None,
+            Some(OsStr::new("/tmp/ambient.sock")),
+            Path::new("/Users/test"),
+        );
+
+        assert_eq!(actual, Some(PathBuf::from("/tmp/ambient.sock")));
+    }
+
+    #[test]
+    fn suffixed_binary_accepts_matching_channel_socket() {
+        let actual = resolve_command_socket_from(
+            None,
+            Some("alpha"),
+            Some(OsStr::new("/Users/test/.plexi-alpha/notify.sock")),
+            Path::new("/Users/test"),
+        );
+
+        assert_eq!(
+            actual,
+            Some(PathBuf::from("/Users/test/.plexi-alpha/notify.sock"))
+        );
+    }
+
+    #[test]
+    fn explicit_socket_override_wins_for_suffixed_binary() {
+        let actual = resolve_command_socket_from(
+            Some(Path::new("/tmp/explicit.sock")),
+            Some("pr-2384"),
+            Some(OsStr::new("/tmp/ambient.sock")),
+            Path::new("/Users/test"),
+        );
+
+        assert_eq!(actual, Some(PathBuf::from("/tmp/explicit.sock")));
+    }
+
+    #[test]
+    fn explicit_socket_override_enables_direct_dispatch_without_ambient_socket() {
+        assert!(command_socket_available_from(true, false));
+    }
+
+    #[test]
+    fn binary_suffix_alone_does_not_enable_direct_dispatch() {
+        let resolved = resolve_command_socket_from(
+            None,
+            Some("alpha"),
+            None,
+            Path::new("/Users/test"),
+        );
+
+        assert_eq!(
+            (resolved, command_socket_available_from(false, false)),
+            (
+                Some(PathBuf::from("/Users/test/.plexi-alpha/notify.sock")),
+                false,
+            )
+        );
+    }
+}
+
+fn resolve_command_socket_from(
+    explicit_socket: Option<&std::path::Path>,
+    binary_channel: Option<&str>,
+    ambient_socket: Option<&std::ffi::OsStr>,
+    home_dir: &std::path::Path,
+) -> Option<std::path::PathBuf> {
+    if let Some(socket) = explicit_socket {
+        return Some(socket.to_path_buf());
+    }
+    if let Some(channel) = binary_channel {
+        return Some(
+            home_dir
+                .join(format!(".plexi-{channel}"))
+                .join("notify.sock"),
+        );
+    }
+    ambient_socket.map(std::path::PathBuf::from)
+}
+
+static COMMAND_SOCKET_OVERRIDE: std::sync::OnceLock<std::path::PathBuf> =
+    std::sync::OnceLock::new();
+
+pub fn set_command_socket_override(path: std::path::PathBuf) {
+    if COMMAND_SOCKET_OVERRIDE.set(path.clone()).is_err() {
+        log::warn!("cli: command socket override was already set; keeping the first path");
+    } else {
+        log::info!("cli: set explicit command socket override path={path:?}");
+    }
+}
+
+fn command_socket_available_from(explicit_override: bool, ambient_socket: bool) -> bool {
+    explicit_override || ambient_socket
+}
+
+pub(super) fn command_socket_available() -> bool {
+    command_socket_available_from(
+        COMMAND_SOCKET_OVERRIDE.get().is_some(),
+        std::env::var_os("PLEXI_SOCKET").is_some(),
+    )
+}
+
+fn command_binary_channel() -> Option<String> {
+    let channel = crate::config::build_channel();
+    #[cfg(test)]
+    {
+        let is_cargo_test_artifact = std::env::current_exe()
+            .ok()
+            .and_then(|path| path.parent().map(|parent| parent.ends_with("deps")))
+            .unwrap_or(false);
+        if is_cargo_test_artifact {
+            return None;
+        }
+    }
+    channel
+}
+
+pub(super) fn resolve_command_socket() -> Option<std::path::PathBuf> {
+    let channel = command_binary_channel();
+    let ambient = std::env::var_os("PLEXI_SOCKET");
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let explicit = COMMAND_SOCKET_OVERRIDE.get();
+    let socket = resolve_command_socket_from(
+        explicit.map(std::path::PathBuf::as_path),
+        channel.as_deref(),
+        ambient.as_deref(),
+        &home,
+    );
+    if let Some(path) = socket.as_ref() {
+        let source = if explicit.is_some() {
+            "--socket"
+        } else if channel.is_some() {
+            "binary-channel"
+        } else {
+            "PLEXI_SOCKET"
+        };
+        log::info!(
+            "cli: resolved command socket source={source} binary_channel={channel:?} path={path:?}"
+        );
+    }
+    socket
+}
+
 pub(super) fn send_to_socket(payload: serde_json::Value) -> i32 {
-    let socket_path = match std::env::var("PLEXI_SOCKET") {
-        Ok(v) => v,
-        Err(_) => {
+    let socket_path = match resolve_command_socket() {
+        Some(path) => path,
+        None => {
             eprintln!("error: PLEXI_SOCKET is not set — run this inside a Plexi terminal pane");
             return 1;
         }

--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -158,7 +158,7 @@ pub fn notes_open_cli() -> i32 {
         return 1;
     }
 
-    if std::env::var("PLEXI_SOCKET").is_err() {
+    if !super::command_socket_available() {
         eprintln!("hint: run inside a Plexi pane for interactive note picking");
         eprintln!("notes directory: {notes_dir_str}");
         return 0;

--- a/src/cli/notify.rs
+++ b/src/cli/notify.rs
@@ -7,9 +7,9 @@ pub fn notify_cli(
     timeout_secs: u64,
     scope: Option<crate::app_protocol::NotifyScope>,
 ) -> i32 {
-    let socket_path = match std::env::var("PLEXI_SOCKET") {
-        Ok(v) => v,
-        Err(_) => {
+    let socket_path = match super::resolve_command_socket() {
+        Some(path) => path,
+        None => {
             eprintln!("error: PLEXI_SOCKET is not set — run this inside a Plexi terminal pane");
             return 1;
         }

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -86,7 +86,7 @@ pub fn pane_new_cli(
     let from_pane_id = from_pane_id.or_else(|| std::env::var("PLEXI_PANE_ID").ok()?.parse().ok());
 
     // Socket path — inside a Plexi pane
-    if std::env::var("PLEXI_SOCKET").is_ok() {
+    if super::command_socket_available() {
         let id = uuid::Uuid::new_v4();
         let response_file = crate::config::config_dir()
             .join(format!("spawn-pane-response-{id}.json"))
@@ -543,7 +543,7 @@ fn open_app_by_path(
         }
     };
 
-    if std::env::var("PLEXI_SOCKET").is_ok() {
+    if super::command_socket_available() {
         let id = uuid::Uuid::new_v4();
         let response_file = crate::config::config_dir()
             .join(format!("spawn-pane-response-{id}.json"))

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -433,9 +433,9 @@ pub fn pane_self_cli() -> i32 {
 /// Merges in client-side fields (socket, channel) and pretty-prints the result
 /// as JSON. Returns 0 on success, 1 on error.
 pub fn pane_info_cli(previous: Option<u64>) -> i32 {
-    let socket_path = match std::env::var("PLEXI_SOCKET") {
-        Ok(v) => v,
-        Err(_) => {
+    let socket_path = match super::resolve_command_socket() {
+        Some(path) => path,
+        None => {
             eprintln!("error: PLEXI_SOCKET is not set — run this inside a Plexi terminal pane");
             return 1;
         }
@@ -503,7 +503,9 @@ pub fn pane_info_cli(previous: Option<u64>) -> i32 {
                             return 1;
                         }
                         let mut obj = v;
-                        obj["socket"] = serde_json::Value::String(socket_path);
+                        obj["socket"] = serde_json::Value::String(
+                            socket_path.to_string_lossy().into_owned(),
+                        );
                         let channel =
                             crate::config::build_channel().unwrap_or_else(|| "main".to_string());
                         obj["channel"] = serde_json::Value::String(channel);
@@ -912,7 +914,7 @@ pub(super) fn open_github_ephemeral(
         "open_github_ephemeral: launching from {abs_path} workspace_root={workspace_root:?}"
     );
 
-    if std::env::var("PLEXI_SOCKET").is_ok() {
+    if super::command_socket_available() {
         let id = uuid::Uuid::new_v4();
         let response_file = crate::config::config_dir()
             .join(format!("spawn-pane-response-{id}.json"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,9 @@ fn main() -> eframe::Result {
 
     match Cli::try_parse_from(&args) {
         Ok(cli) => {
+            if let Some(socket) = cli.socket {
+                cli::set_command_socket_override(socket);
+            }
             if let Some(cmd) = cli.command {
                 match cmd {
                     Commands::Run {


### PR DESCRIPTION
Stint: 0365 (no linked GitHub issue)

## Summary

- route channel-suffixed CLI binaries to their own profile socket instead of a mismatched ambient `PLEXI_SOCKET`
- add an explicit global `--socket <path>` override with precedence over binary-channel routing
- centralize socket resolution across pane, notify, event, app, context, notes, and direct-dispatch availability paths
- retain explicit validation env guidance for compatibility with older installed binaries

## Test evidence

- `cargo test --bin plexi socket_resolution_tests`: 8 passed, 0 failed
- CLI global socket parse regression: passed
- `cargo test --bin plexi`: 1637 passed, 0 failed, 1 ignored
- `cargo build`: passed
- PR install: passed 59 SDK tests, cold recompiled `plexi`, installed `/usr/local/bin/plexi-pr-2385`
- Codex validation review: clean after fixing explicit `--socket` direct-dispatch availability
- Conclusion: binary install required — validate real channel-suffixed executable routing against isolated host sockets