### PR TITLE
feat: expose Python SDK connector tools

### DIFF
--- a/sdk/python/AUTHORING.md
+++ b/sdk/python/AUTHORING.md
@@ -95,6 +95,46 @@ use it only when a key must survive an app restart. There are no `LogInfo` /
 `LogWarn` / `LogError` effects — logging goes through the `log` module (below).
 Network fetches use `HttpFetch`, not `HttpRequest`.
 
+## App Tools
+
+Apps can expose tools to the Assistant with `ExposeTools`. Declare the full
+set in `init()`. When the Assistant calls one, `update()` receives a
+`ToolCall`; return one `ToolResult` with the matching `call_id`.
+
+```python
+import json
+
+from plexi_sdk.effects import AiTool, ExposeTools, ToolResult
+from plexi_sdk.events import ToolCall
+
+
+def init(size, args):
+    return [ExposeTools([
+        AiTool(
+            name="csv.describe_table",
+            description="Describe the current table.",
+            input_schema={"type": "object", "properties": {}},
+            read_only=True,
+        ),
+    ])]
+
+
+def update(event):
+    if isinstance(event, ToolCall) and event.name == "csv.describe_table":
+        return [ToolResult(event.call_id, output_json=json.dumps({"rows": 42}))]
+    return []
+```
+
+`input_schema` is a JSON Schema object. `ToolCall.input_json` is the JSON
+string supplied by the Assistant. Return `output_json` for success or `error`
+for failure, never both. A declaration replaces the pane's previous tool set,
+so send every current tool when it changes.
+
+Set `read_only=True` only for tools that never mutate app or workspace state.
+The Assistant runs read-only tools without a write-grant prompt, while still
+recording every call. Mutating tools prompt for an allow-once or persisted
+narrow grant before they run.
+
 ## UI Components
 
 Import from `plexi_sdk.ui`. Read `sdk.md` (UI Components section) for the full

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -3,6 +3,10 @@
 Apps expose module-level ``init(size, args)``, ``update(event)``, and ``view()``
 functions. The V3AppRuntime drives the event loop: host sends JSON events on
 stdin, app responds with effects and component trees on stdout.
+
+Python apps are native processes, not sandboxed. Treat third-party Python apps
+like other reviewed native code; capabilities gate Plexi host APIs but do not
+restrict ambient process access.
 """
 
 __version__ = "3.0.0"

--- a/sdk/python/plexi_sdk/_v3_runtime.py
+++ b/sdk/python/plexi_sdk/_v3_runtime.py
@@ -121,6 +121,13 @@ class V3AppRuntime:
             self._handle_text_submitted(ev)
         elif t == "http_response":
             self._handle_http_response(ev)
+        elif t == "tool_call":
+            self._dispatch(events.ToolCall(
+                call_id=ev.get("call_id", ""),
+                name=ev.get("name", ""),
+                input_json=ev.get("input_json", ""),
+                caller_id=ev.get("caller_id", ""),
+            ))
         elif t == "file_read_result":
             content = ev.get("content")
             self._dispatch(events.FileReadResult(
@@ -389,6 +396,27 @@ class V3AppRuntime:
                 })
             elif isinstance(effect, effects.CloseSelf):
                 _emit({"type": "close_self"})
+            elif isinstance(effect, effects.ExposeTools):
+                _emit({
+                    "type": "expose_tools",
+                    "tools": [
+                        {
+                            "name": tool.name,
+                            "description": tool.description,
+                            "input_schema": tool.input_schema,
+                            "timeout_ms": tool.timeout_ms,
+                            "read_only": tool.read_only,
+                        }
+                        for tool in effect.tools
+                    ],
+                })
+            elif isinstance(effect, effects.ToolResult):
+                payload = {"type": "tool_result", "call_id": effect.call_id}
+                if effect.output_json is not None:
+                    payload["output_json"] = effect.output_json
+                if effect.error is not None:
+                    payload["error"] = effect.error
+                _emit(payload)
         if state_changed:
             self._set_state(in_view=False)
 

--- a/sdk/python/plexi_sdk/effects.py
+++ b/sdk/python/plexi_sdk/effects.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Any, Optional
 
 
 @dataclass
@@ -51,6 +51,27 @@ class AiQuery:
     model_tier: str
     system: str
     messages: list
+
+
+@dataclass
+class AiTool:
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    timeout_ms: Optional[int] = None
+    read_only: bool = False
+
+
+@dataclass
+class ExposeTools:
+    tools: list[AiTool]
+
+
+@dataclass
+class ToolResult:
+    call_id: str
+    output_json: Optional[str] = None
+    error: Optional[str] = None
 
 
 @dataclass

--- a/sdk/python/plexi_sdk/events.py
+++ b/sdk/python/plexi_sdk/events.py
@@ -132,6 +132,14 @@ class AiResponse:
 
 
 @dataclass
+class ToolCall:
+    call_id: str
+    name: str
+    input_json: str
+    caller_id: str
+
+
+@dataclass
 class DeclareEventStreamsResult:
     streams: Optional[list]
     error: Optional[str]

--- a/sdk/python/plexi_sdk/templates/test_app_init.py
+++ b/sdk/python/plexi_sdk/templates/test_app_init.py
@@ -13,7 +13,12 @@ import pytest
 
 from plexi_sdk.testing import AppHarness
 
-APP = Path(__file__).resolve().parent.parent / "main.py"
+APP_DIR = Path(__file__).resolve().parent.parent
+APP = APP_DIR / "main.py"
+if not APP.exists():
+    # This template is collected as part of the SDK suite before `app init`
+    # copies it into a generated app. Exercise the template app in place.
+    APP = Path(__file__).resolve().parent / "app_init.py"
 
 
 @pytest.mark.parametrize("size", [(300, 200), (800, 600)])

--- a/sdk/python/tests/test_v3_adapter.py
+++ b/sdk/python/tests/test_v3_adapter.py
@@ -13,13 +13,14 @@ from plexi_sdk import _v3_state
 from plexi_sdk import state
 from plexi_sdk._adapter import _decode_event, _encode_effect, _encode_uitree
 from plexi_sdk._adapter import call_lifecycle, load_app
-from plexi_sdk.effects import HttpFetch, SetState, SetTitle
+from plexi_sdk.effects import AiTool, ExposeTools, HttpFetch, SetState, SetTitle, ToolResult
 from plexi_sdk.events import (
     HttpResponse,
     KeyEvent,
     PipeMessage,
     PipePayload,
     SystemStatsResult,
+    ToolCall,
 )
 from plexi_sdk.ui import (
     Button,
@@ -46,6 +47,50 @@ def test_effects_encode_http_fetch_bytes_as_json_list() -> None:
         "headers": {},
         "body": [111, 107],
     }
+
+
+def test_tool_effects_encode_rust_wire_shape() -> None:
+    tool = AiTool(
+        name="csv.describe_table",
+        description="Describe the current table.",
+        input_schema={"type": "object", "properties": {}},
+        timeout_ms=1_500,
+        read_only=True,
+    )
+
+    assert _encode_effect(ExposeTools([tool])) == {
+        "type": "ExposeTools",
+        "tools": [{
+            "name": "csv.describe_table",
+            "description": "Describe the current table.",
+            "input_schema": {"type": "object", "properties": {}},
+            "timeout_ms": 1_500,
+            "read_only": True,
+        }],
+    }
+    assert _encode_effect(ToolResult("call-7", output_json='{"rows":3}')) == {
+        "type": "ToolResult",
+        "call_id": "call-7",
+        "output_json": '{"rows":3}',
+        "error": None,
+    }
+
+
+def test_events_decode_tool_call_rust_wire_shape() -> None:
+    event = _decode_event({
+        "type": "ToolCall",
+        "call_id": "call-7",
+        "name": "csv.describe_table",
+        "input_json": "{}",
+        "caller_id": "assistant",
+    })
+
+    assert event == ToolCall(
+        call_id="call-7",
+        name="csv.describe_table",
+        input_json="{}",
+        caller_id="assistant",
+    )
 
 
 def test_events_decode_key_event_with_modifiers() -> None:

--- a/sdk/python/tests/test_v3_runtime_regression.py
+++ b/sdk/python/tests/test_v3_runtime_regression.py
@@ -254,6 +254,57 @@ class TestEffects:
         finally:
             proc.kill()
 
+    def test_expose_tools_uses_v37_wire_shape(self, tmp_path):
+        app = self._app_with_init_effects(
+            tmp_path,
+            "ExposeTools([AiTool('csv.describe_table', 'Describe the table', {'type': 'object'}, timeout_ms=1500, read_only=True)])",
+        )
+        proc = _spawn_v3_app(app)
+        try:
+            events = _init_and_render(proc)
+            exposed = _find_events(events, "expose_tools")
+            assert exposed == [{
+                "type": "expose_tools",
+                "tools": [{
+                    "name": "csv.describe_table",
+                    "description": "Describe the table",
+                    "input_schema": {"type": "object"},
+                    "timeout_ms": 1500,
+                    "read_only": True,
+                }],
+            }]
+        finally:
+            proc.kill()
+
+    def test_tool_call_dispatches_and_emits_matching_result(self, tmp_path):
+        app = tmp_path / "tool_app.py"
+        app.write_text(textwrap.dedent("""
+            from plexi_sdk.effects import ToolResult
+            from plexi_sdk.events import ToolCall
+            from plexi_sdk.ui import Text
+
+            def init(size, args): return []
+            def update(event):
+                if isinstance(event, ToolCall):
+                    return [ToolResult(event.call_id, output_json=event.input_json)]
+                return []
+            def view(): return Text("tools")
+        """).lstrip())
+        proc = _spawn_v3_app(app)
+        try:
+            _init_app(proc)
+            _send_event(proc, {
+                "type": "tool_call",
+                "call_id": "call-7",
+                "name": "csv.describe_table",
+                "input_json": '{"rows":3}',
+                "caller_id": "assistant",
+            })
+            events = _collect_until(proc, "schedule_render")
+            assert {"type": "tool_result", "call_id": "call-7", "output_json": '{"rows":3}'} in events
+        finally:
+            proc.kill()
+
 
 # =============================================================================
 # Event dispatch tests: verify each event type reaches update() correctly

--- a/src/app/app_trait.rs
+++ b/src/app/app_trait.rs
@@ -18,6 +18,17 @@ pub struct AppRenderContext<'a> {
 
 /// Commands an app can issue back to the system.
 pub enum AppCommand {
+    /// Register the app's v3.7 connector tools with the host broker.
+    ExposeTools {
+        tools: Vec<crate::app_protocol::AiTool>,
+        pane_id: Option<u64>,
+    },
+    /// Resolve a pending v3.7 connector tool call.
+    ToolResult {
+        call_id: String,
+        output_json: Option<String>,
+        error: Option<String>,
+    },
     /// Execute an Assistant host tool against live host state without shelling
     /// out to the CLI. The host replies directly to the blocked model worker.
     AssistantHostTool {

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -196,6 +196,13 @@ impl PlexiApp {
             let resolved_scope = self.registry.default_notification_scope_for(&type_id);
             for cmd in cmds {
                 match cmd {
+                    AppCommand::ExposeTools { tools, .. } => {
+                        deferred.push(AppCommand::ExposeTools {
+                            tools,
+                            pane_id: Some(pane_id),
+                        });
+                    }
+                    AppCommand::ToolResult { .. } => deferred.push(cmd),
                     AppCommand::AssistantHostTool {
                         name,
                         input_json,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2343,6 +2343,44 @@ impl eframe::App for PlexiApp {
                 continue;
             }
             match cmd {
+                AppCommand::ExposeTools {
+                    tools,
+                    pane_id: Some(pane_id),
+                } => {
+                    let provider = self.windows.iter().find_map(|window| {
+                        window.panes.get(&pane_id).and_then(|pane| {
+                            pane.as_app().and_then(|app| {
+                                app.runtime.python_tool_event_sender().map(|stdin| {
+                                    (app.manifest_id.clone(), app.workspace_root.clone(), stdin)
+                                })
+                            })
+                        })
+                    });
+                    if let Some((app_id, workspace_root, stdin)) = provider {
+                        crate::plexi_ai::tool_dispatch::register(
+                            pane_id,
+                            app_id,
+                            tools,
+                            crate::plexi_ai::tool_dispatch::AppEventSender::Python(stdin),
+                            workspace_root,
+                        );
+                    } else {
+                        log::warn!(
+                            "tool_dispatch: ignore ExposeTools from non-Python pane {pane_id}"
+                        );
+                    }
+                }
+                AppCommand::ExposeTools { pane_id: None, .. } => {
+                    log::warn!("tool_dispatch: ExposeTools missing source pane")
+                }
+                AppCommand::ToolResult {
+                    call_id,
+                    output_json,
+                    error,
+                } => crate::plexi_ai::tool_dispatch::resolve_pending(
+                    &call_id,
+                    crate::plexi_ai::tool_dispatch::ToolCallResult { output_json, error },
+                ),
                 AppCommand::AssistantHostTool {
                     name,
                     input_json,

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -3040,7 +3040,7 @@ enabled = ["allowed.tool"]
             9200,
             "csv".to_string(),
             vec![ro_tool, rw_tool],
-            AppEventSender { tx },
+            AppEventSender::Channel(tx),
             ws.path().to_path_buf(),
         );
         // No grants seeded — read-only tool must be auto-allowed; mutating
@@ -3074,7 +3074,7 @@ enabled = ["allowed.tool"]
                 timeout_ms: None,
                 read_only: true,
             }],
-            AppEventSender { tx },
+            AppEventSender::Channel(tx),
             ws.path().to_path_buf(),
         );
         // Explicit deny must still win even though the tool is read-only.
@@ -3111,7 +3111,7 @@ enabled = ["allowed.tool"]
                 timeout_ms: None,
                 read_only: true,
             }],
-            AppEventSender { tx },
+            AppEventSender::Channel(tx),
             ws.path().to_path_buf(),
         );
 
@@ -3153,7 +3153,7 @@ enabled = ["allowed.tool"]
                     read_only: false,
                 },
             ],
-            AppEventSender { tx },
+            AppEventSender::Channel(tx),
             ws.path().to_path_buf(),
         );
         seed_grant(&mut app, "app.csv.write_cell", Decision::Allow);
@@ -3217,7 +3217,7 @@ enabled = ["allowed.tool"]
                     read_only: false,
                 },
             ],
-            AppEventSender { tx },
+            AppEventSender::Channel(tx),
             ws.path().to_path_buf(),
         );
         app.model.composer = "/apps".to_string();
@@ -3422,7 +3422,7 @@ enabled = ["allowed.tool"]
             pane_id,
             "test-app".to_string(),
             tools,
-            AppEventSender { tx },
+            AppEventSender::Channel(tx),
             ws,
         );
         std::thread::spawn(move || {

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -194,10 +194,7 @@ impl SemanticPaneState {
         }
     }
 
-    pub(crate) fn expose_canvas_commands(
-        &mut self,
-        tree: &crate::host::wasm_app::UiTree,
-    ) {
+    pub(crate) fn expose_canvas_commands(&mut self, tree: &crate::host::wasm_app::UiTree) {
         use crate::host::wasm_app::UiNodeData;
 
         for (state_node, tree_node) in self.nodes.iter_mut().zip(&tree.nodes) {
@@ -655,8 +652,17 @@ impl AppRuntime {
     pub fn queue_outbound_event(&mut self, event: crate::app_protocol::PlexiEvent) {
         match self {
             AppRuntime::Builtin(app) => app.queue_outbound_event(event),
-            AppRuntime::Python(_) => {}
+            AppRuntime::Python(app) => app.queue_outbound_event(event),
             AppRuntime::Wasm(_) => {}
+        }
+    }
+
+    pub(crate) fn python_tool_event_sender(
+        &self,
+    ) -> Option<crate::host::wasm_python::AppendableStdin> {
+        match self {
+            AppRuntime::Python(app) => Some(app.tool_event_sender()),
+            AppRuntime::Builtin(_) | AppRuntime::Wasm(_) => None,
         }
     }
 

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -1312,6 +1312,35 @@ impl LivePythonPane {
     pub fn wants_close(&self) -> bool {
         self.wants_close
     }
+
+    pub fn queue_outbound_event(&mut self, event: crate::app_protocol::PlexiEvent) {
+        let crate::app_protocol::PlexiEvent::ToolCall {
+            call_id,
+            name,
+            input_json,
+            caller_id,
+        } = event
+        else {
+            return;
+        };
+        if let Err(error) = self.runtime.send(&json!({
+            "type": "tool_call",
+            "call_id": call_id,
+            "name": name,
+            "input_json": input_json,
+            "caller_id": caller_id,
+        })) {
+            log::error!(
+                "app::{}: queue ToolCall to Python runtime: {error}",
+                self.app_id
+            );
+            self.error = Some(error.to_string());
+        }
+    }
+
+    pub(crate) fn tool_event_sender(&self) -> crate::host::wasm_python::AppendableStdin {
+        self.runtime.stdin.clone()
+    }
     pub fn take_pending_commands(&mut self) -> Vec<crate::app::app_trait::AppCommand> {
         std::mem::take(&mut self.pending_commands)
     }
@@ -1364,7 +1393,10 @@ fn python_semantic_state(tree: Option<&PythonUiTree>) -> crate::host::pane::Sema
                 super::wasm_render::CanvasFit::Fill => "fill",
                 super::wasm_render::CanvasFit::Contain => "contain",
             };
-            node.value = Some(format!("{} fit={fit}", node.value.as_deref().unwrap_or("canvas")));
+            node.value = Some(format!(
+                "{} fit={fit}",
+                node.value.as_deref().unwrap_or("canvas")
+            ));
         }
     }
     state
@@ -1502,6 +1534,23 @@ fn app_command_from_python_message(message: &Value) -> Option<crate::app::app_tr
             .to_string()
     };
     match message.get("type").and_then(Value::as_str)? {
+        "expose_tools" => serde_json::from_value(message.get("tools")?.clone())
+            .ok()
+            .map(|tools| AppCommand::ExposeTools {
+                tools,
+                pane_id: None,
+            }),
+        "tool_result" => Some(AppCommand::ToolResult {
+            call_id: text("call_id"),
+            output_json: message
+                .get("output_json")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            error: message
+                .get("error")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        }),
         "notify" => Some(AppCommand::Notify(text("message"))),
         "spawn_app" => Some(AppCommand::SpawnApp {
             type_id: text("app_id"),
@@ -2014,7 +2063,10 @@ fn decode_python_ui_tree_value(value: &Value) -> Result<PythonUiTree, WasmPython
         let Some(data) = node.get("data") else {
             continue;
         };
-        if !matches!(data.get("type").and_then(Value::as_str), Some("Canvas" | "canvas")) {
+        if !matches!(
+            data.get("type").and_then(Value::as_str),
+            Some("Canvas" | "canvas")
+        ) {
             continue;
         }
         let id = required_u32(node, "id")?;
@@ -2681,10 +2733,12 @@ mod tests {
         let now = std::time::Instant::now();
         let mut scheduler = PythonFrameScheduler::new(now);
         let frame_id = scheduler.poll_render(now).expect("first frame");
-        let pending_tree = decode_python_ui_tree_value(&serde_json::from_str(
-            r#"{"root":0,"nodes":[{"id":0,"key":"0","data":{"type":"Text","text":"new"}}]}"#,
+        let pending_tree = decode_python_ui_tree_value(
+            &serde_json::from_str(
+                r#"{"root":0,"nodes":[{"id":0,"key":"0","data":{"type":"Text","text":"new"}}]}"#,
+            )
+            .expect("valid JSON"),
         )
-        .expect("valid JSON"))
         .expect("pending tree");
         let mut pending = HashMap::from([(frame_id, pending_tree)]);
         let mut visible = None;

--- a/src/plexi_ai/tool_dispatch.rs
+++ b/src/plexi_ai/tool_dispatch.rs
@@ -37,15 +37,41 @@ use crate::app_protocol::{AiTool, PlexiEvent};
 
 /// Thin wrapper that lets external code send `PlexiEvent`s into a pane's
 /// stdin channel without exposing the `StdinItem` enum publicly.
-pub(crate) struct AppEventSender {
-    pub(crate) tx: std::sync::mpsc::Sender<String>,
+pub(crate) enum AppEventSender {
+    #[cfg(test)]
+    Channel(std::sync::mpsc::Sender<String>),
+    Python(crate::host::wasm_python::AppendableStdin),
 }
 
 impl AppEventSender {
     pub(crate) fn send_event(&self, event: &PlexiEvent) {
-        if let Ok(mut json) = serde_json::to_string(event) {
-            json.push('\n');
-            let _ = self.tx.send(json);
+        match self {
+            #[cfg(test)]
+            Self::Channel(tx) => {
+                if let Ok(mut json) = serde_json::to_string(event) {
+                    json.push('\n');
+                    let _ = tx.send(json);
+                }
+            }
+            Self::Python(stdin) => {
+                if let PlexiEvent::ToolCall {
+                    call_id,
+                    name,
+                    input_json,
+                    caller_id,
+                } = event
+                {
+                    if let Err(error) = stdin.push_json_line(&serde_json::json!({
+                        "type": "tool_call",
+                        "call_id": call_id,
+                        "name": name,
+                        "input_json": input_json,
+                        "caller_id": caller_id,
+                    })) {
+                        log::error!("tool_dispatch: send ToolCall to Python app: {error}");
+                    }
+                }
+            }
         }
     }
 }
@@ -76,7 +102,6 @@ impl ToolRegistry {
         }
     }
 
-    #[cfg(test)]
     fn register(
         &mut self,
         pane_id: u64,
@@ -188,7 +213,6 @@ fn global_registry() -> &'static Arc<Mutex<ToolRegistry>> {
 
 /// Register (or replace) the tools for `pane_id`. Called by routing when
 /// `DrawCommand::ExposeTools` arrives.
-#[cfg(test)]
 pub(crate) fn register(
     pane_id: u64,
     app_id: String,
@@ -232,7 +256,6 @@ fn pending_calls(
 
 /// Called by `routing.rs` when `DrawCommand::ToolResult` arrives for a pane.
 /// Resolves the pending `call_id` so the blocking broker thread can continue.
-#[cfg(test)]
 pub(crate) fn resolve_pending(call_id: &str, result: ToolCallResult) {
     let tx = pending_calls().lock().unwrap().remove(call_id);
     match tx {
@@ -569,7 +592,7 @@ mod tests {
             1,
             "search-app".to_string(),
             vec![make_tool("search")],
-            AppEventSender { tx },
+            AppEventSender::Channel(tx),
             ws.clone(),
         );
 
@@ -589,14 +612,14 @@ mod tests {
             10,
             "attacker-app".to_string(),
             vec![make_tool("dangerous_tool")],
-            AppEventSender { tx: tx.clone() },
+            AppEventSender::Channel(tx.clone()),
             PathBuf::from("/workspace/attacker"),
         );
         reg.register(
             20,
             "victim-app".to_string(),
             vec![make_tool("safe_tool")],
-            AppEventSender { tx },
+            AppEventSender::Channel(tx),
             PathBuf::from("/workspace/victim"),
         );
 
@@ -626,7 +649,7 @@ mod tests {
             5,
             "app-x".to_string(),
             vec![make_tool("tool_a")],
-            AppEventSender { tx },
+            AppEventSender::Channel(tx),
             ws.clone(),
         );
 
@@ -659,7 +682,7 @@ mod tests {
             999,
             "app-b".to_string(),
             vec![make_tool("secret_tool")],
-            AppEventSender { tx: tx_b },
+            AppEventSender::Channel(tx_b),
             PathBuf::from("/workspace/b"),
         );
 
@@ -704,14 +727,14 @@ mod tests {
             10,
             "app-conflict-1".to_string(),
             vec![make_tool("shared_tool"), make_tool("unique_a")],
-            AppEventSender { tx: tx1 },
+            AppEventSender::Channel(tx1),
             ws.clone(),
         );
         reg.register(
             20,
             "app-conflict-2".to_string(),
             vec![make_tool("shared_tool"), make_tool("unique_b")],
-            AppEventSender { tx: tx2 },
+            AppEventSender::Channel(tx2),
             ws.clone(),
         );
 
@@ -749,7 +772,7 @@ mod tests {
             998,
             "hooks-app".to_string(),
             vec![make_tool("gated_tool")],
-            AppEventSender { tx },
+            AppEventSender::Channel(tx),
             PathBuf::from("/workspace/hooks-test"),
         );
         let mut dispatcher = ToolDispatcher::from_registry(

--- a/website/src/content/docs/sdk.md
+++ b/website/src/content/docs/sdk.md
@@ -14,6 +14,10 @@ Apps expose module-level ``init(size, args)``, ``update(event)``, and ``view()``
 functions. The V3AppRuntime drives the event loop: host sends JSON events on
 stdin, app responds with effects and component trees on stdout.
 
+Python apps are native processes, not sandboxed. Treat third-party Python apps
+like other reviewed native code; capabilities gate Plexi host APIs but do not
+restrict ambient process access.
+
 ## Effects
 
 ### `SetState`

--- a/website/src/content/docs/sdk.md
+++ b/website/src/content/docs/sdk.md
@@ -8,287 +8,121 @@ order: 6
 
 ## Overview
 
-Plexi Python SDK v3 for native ProcessApp apps.
+Plexi Python SDK.
 
-App modules expose exactly three lifecycle functions:
-
-``init(size, args) -> list``
-    Called once at launch. Return startup effects such as ``SetTitle`` or
-    ``SetState``.
-
-``update(event) -> list``
-    Called for keyboard, mouse, timer, render, and host-result events. Return
-    effects; do not mutate Plexi state directly.
-
-``view() -> Component``
-    Called after state changes to produce the current component tree. Keep it
-    pure: read ``state`` here, but return state-changing effects from
-    ``update``.
-
-Useful entry points:
-``plexi_sdk.effects`` for effect dataclasses,
-``plexi_sdk.events`` for event dataclasses, and
-``plexi_sdk.ui`` for declarative components.
-
-SDK v3 Python apps run as reviewed native processes through ``ProcessApp``.
-Capabilities gate host APIs; they are not a process sandbox. CPython-in-WASM is
-deferred and is not this runtime.
+Apps expose module-level ``init(size, args)``, ``update(event)``, and ``view()``
+functions. The V3AppRuntime drives the event loop: host sends JSON events on
+stdin, app responds with effects and component trees on stdout.
 
 ## Effects
 
-Effect dataclasses returned from a Plexi app's ``init()`` or ``update()``.
-
-Effects describe work for the host to perform after the lifecycle function
-returns. They are data objects, not imperative calls: return
-``[SetTitle("Demo"), SetState({"count": 1})]`` instead of mutating host state
-directly. The adapter matches each class name to the PGAP host effect with the
-same meaning.
-
 ### `SetState`
-
-Update process-local runtime state before the next ``view()`` call.
-
-``data`` should be a JSON-shaped dict. Values are merged into the runtime
-snapshot and are not written to durable app storage.
 
 ### `PersistState`
 
-Update runtime state and request a durable app-state save.
-
 ### `SetSchedulerMode`
-
-Control host-paced render scheduling.
-
-``mode`` is ``"idle"``, ``"scheduled"``, or ``"continuous"``. Continuous
-mode sends ``RenderFrame`` events at ``fps`` for games and animations.
-
-### `SetMouseTracking`
-
-Enable or disable mouse-motion events for the pane.
 
 ### `FileRead`
 
-Read a workspace-scoped file and receive a ``FileReadResult`` event.
-
-### `FileList`
-
-List a workspace-scoped directory and receive a ``FileListResult`` event.
-
 ### `FileWrite`
-
-Write bytes to a workspace-scoped file through the host.
 
 ### `HttpFetch`
 
-Request an HTTP(S) fetch through the host capability gate.
-
-### `OpenUrl`
-
-Ask the host to open an HTTP(S) URL in the default browser.
-
 ### `AiMessage`
-
-One chat message in an ``AiQuery`` request.
 
 ### `AiQuery`
 
-Send a managed AI request and receive chunks/results by ``request_id``.
+### `AiTool`
+
+### `ExposeTools`
+
+### `ToolResult`
 
 ### `SetTimer`
 
-Schedule a timer; the host replies with ``TimerFired(id)``.
-
 ### `CancelTimer`
-
-Cancel a timer previously scheduled with ``SetTimer``.
 
 ### `GetSystemStats`
 
-Request host system metrics and receive ``SystemStatsResult``.
-
 ### `SetTitle`
-
-Set the pane title shown by Plexi chrome.
 
 ### `SetStatus`
 
-Set the pane status text shown by Plexi chrome.
-
-### `SetPipStatus`
-
-Report this app's own pip status — a red/yellow/green activity dot.
-
-Takes priority over the host's derived activity until the app reports a
-new status. The host stamps the pane id, so an app can only ever set its
-own pip. ``status`` must be ``"green"``, ``"yellow"``, or ``"red"``.
-
 ### `CloseSelf`
-
-Ask the host to close this app pane.
 
 ### `RequestCapability`
 
-Prompt for a named capability grant at runtime.
-
 ### `EventStreamDecl`
-
-Declare one structured event stream emitted by the app.
 
 ### `DeclareEventStreams`
 
-Register app event streams before emitting events into them.
-
 ### `EmitEvent`
-
-Emit one structured app event for host/audit consumers.
 
 ## Events
 
-Input and host-result events delivered to an app's ``update(event)``.
-
-The ProcessApp adapter converts PGAP input into these dataclasses before it
-calls ``update``. Apps usually branch with ``isinstance(event, KeyEvent)`` or
-``isinstance(event, UiAction)`` and return a list of effects in response.
-
 ### `Modifiers`
-
-Keyboard modifier state attached to ``KeyEvent``.
 
 ### `KeyEvent`
 
-Keyboard input. ``key`` uses Plexi's normalized lowercase key names.
-
 ### `MouseEvent`
-
-Pointer input in pane coordinates, including buttons, scroll, and region.
 
 ### `UiAction`
 
-Click/activation event from a component or host action.
-
 ### `UiValueChange`
-
-Value-change event from an editable component with matching ``handler_id``.
-
-### `ListSelect`
-
-Selection changed in a host-rendered list component.
-
-### `ListActivate`
-
-Item activated in a host-rendered list component.
 
 ### `Resize`
 
-Pane size changed. Dimensions are logical pixels.
-
 ### `FocusGained`
-
-This pane received focus.
 
 ### `FocusLost`
 
-This pane lost focus.
-
 ### `FocusChanged`
-
-Workspace focus telemetry delivered to apps that consume it.
 
 ### `TimerFired`
 
-A ``SetTimer`` timer fired; ``id`` echoes the scheduled timer id.
-
 ### `RenderFrame`
-
-Host-paced render tick for continuous or scheduled apps.
 
 ### `SystemStats`
 
-Snapshot of host system metrics returned by ``GetSystemStats``.
-
 ### `SystemStatsResult`
-
-Result event for ``GetSystemStats``.
 
 ### `FileReadResult`
 
-Result event for ``FileRead``. ``error`` is ``None`` on success.
-
-### `FileListEntry`
-
-One directory entry returned by ``FileListResult``.
-
-### `FileListResult`
-
-Result event for ``FileList``. ``entries`` is ``None`` on error.
-
 ### `FileWriteResult`
-
-Result event for ``FileWrite``. ``error`` is ``None`` on success.
 
 ### `HttpResponse`
 
-Result event for ``HttpFetch``.
-
 ### `AiStreamChunk`
-
-Streaming partial response for an ``AiQuery`` request.
 
 ### `AiResponse`
 
-Final response for an ``AiQuery`` request.
+### `ToolCall`
 
 ### `DeclareEventStreamsResult`
 
-Result event for ``DeclareEventStreams``.
-
 ### `EmitEventResult`
-
-Result event for ``EmitEvent``.
 
 ### `SurfaceReady`
 
-GPU surface became available for advanced surface apps.
-
 ### `SurfaceResized`
-
-GPU surface size changed for advanced surface apps.
 
 ### `PipePayload`
 
-Payload carried by a typed pipe message.
-
 ### `PipeMessage`
-
-Typed pipe message delivered from another pane/app.
 
 ### `PipePeerConnected`
 
-A peer connected to an opened typed pipe.
-
 ### `PipeClosed`
-
-A typed pipe closed.
 
 ### `PipeError`
 
-A typed pipe operation failed.
-
 ### `CapabilityGranted`
-
-A requested capability was granted.
 
 ### `CapabilityDenied`
 
-A requested capability was denied.
-
 ### `PaymentComplete`
 
-Payment flow completed for the app.
-
 ### `PaymentFailed`
-
-Payment flow failed with a human-readable reason.
 
 ## State and Logging
 
@@ -318,17 +152,10 @@ Payment flow failed with a human-readable reason.
 
 ## UI Components
 
-Declarative UI primitives returned from an app's ``view()``.
+Declarative UI primitives.
 
-Build a tree of ``Component`` objects such as ``Column([AppBar(...), Text(...)])``
-and return it from ``view()``. Components describe what to render; effects from
-``init()`` and ``update(event)`` describe what the host should do. Keep those
-two concepts separate: ``view()`` should read state and return components, not
-change state or request host work.
-
-Normal apps should use these host-rendered components. Games, simulations, and
-custom visualizations can return ``Canvas([...])`` and update state from
-``RenderFrame`` events.
+Apps return a component tree from ``view()``. The host owns layout,
+theme, input, and rendering.
 
 ### `HasToNode`
 
@@ -355,22 +182,15 @@ the first line's top at the component's `y`.
 
 ### `Text`
 
-Host-rendered text node for labels, counters, and short body copy.
-
-``size`` overrides the default body size. ``bold`` and ``color`` are
-inherited from ``Label``. Use ``Label`` when you want tone-based body,
-caption, or hint text; use ``Text`` when matching the SDK v3 wire node.
+SDK v3 inline text node.
 
 ### `Button`
 
-Clickable host-rendered button.
+### `HStack`
 
-``on_click`` is the handler id delivered back as a ``UiAction`` event.
-Return state/effect changes from ``update(event)`` when that event arrives.
+### `Sized`
 
 ### `ActionBar`
-
-Horizontal row of contextual action buttons.
 
 ### `Spacer`
 
@@ -378,7 +198,49 @@ Fixed or flex gap. `grow=True` expands to consume remaining space.
 
 ### `Badge`
 
-Small host-rendered pill label for status, shortcuts, and metadata.
+### `Tooltip`
+
+### `Avatar`
+
+### `Icon`
+
+### `CodeBlock`
+
+### `Table`
+
+### `KeyValue`
+
+### `Breadcrumb`
+
+### `Pagination`
+
+### `Accordion`
+
+### `Checkbox`
+
+### `Radio`
+
+### `Switch`
+
+### `Slider`
+
+### `Select`
+
+### `DateTimePicker`
+
+### `Progress`
+
+### `Spinner`
+
+### `Banner`
+
+### `TabBar`
+
+### `EmptyState`
+
+### `Skeleton`
+
+### `Modal`
 
 ### `Divider`
 
@@ -386,29 +248,11 @@ A horizontal 1px rule.
 
 ### `CanvasRect`
 
-Rectangle drawing command for ``Canvas``.
-
 ### `CanvasCircle`
-
-Circle drawing command for ``Canvas``.
 
 ### `CanvasLine`
 
-Line drawing command for ``Canvas``.
-
 ### `CanvasText`
-
-Text drawing command for ``Canvas``.
-
-Coordinates are in the canvas coordinate space. Use component ``Text`` for
-normal app UI; use ``CanvasText`` only inside a ``Canvas`` command list.
-
-### `CanvasButton`
-
-Convenience primitive: a clickable button on a Canvas.
-
-Decomposes into a CanvasRect + CanvasText with a shared hit_region.
-Use ``to_commands()`` (plural) to get the list of underlying primitives.
 
 ### `Canvas`
 
@@ -597,6 +441,19 @@ vertically with a configurable gap. A 1px border in `theme.highlight` separates
 it from the pane background — essential when surface and bg are close
 in brightness.
 
+### `TextInput`
+
+Layout-aware text input. Place inside a Column like any other child.
+
+Return it from ``view()`` inside a component tree. After the render pass,
+read ``.submitted`` to get the text the user submitted (pressed Enter), or
+``None`` if nothing was submitted this frame.
+
+Create once (in ``on_init``) and update ``placeholder`` as needed — the
+instance is stable across renders so the host can track focus state.
+
+When ``multiline=True``, Shift+Enter inserts a newline and Enter submits.
+
 ### `TextEdit`
 
 Host-rendered text editor. Use inside ``view()`` like any other component.
@@ -625,7 +482,7 @@ assistant messages (surface bg). Error messages use ``role="error"``.
 
 ### `Markdown`
 
-Host-rendered markdown block for rich read-only text in component trees.
+Host-rendered markdown block for SDK v3 component trees.
 
 ### `SelectList`
 
@@ -639,7 +496,7 @@ Call handle_key(key) from on_key. Call hit_index(click_y) from on_click.
 
 ### `FormField`
 
-Label + TextEdit row. Create in on_init (stable across renders).
+Label + TextInput row. Create in on_init (stable across renders).
 
 Read .submitted after the render pass; it contains the text entered by the
 user when they pressed Enter, or None if no submission this frame.
@@ -654,21 +511,6 @@ Padding defaults to `SPACE_XL` (24px) on the sides and bottom, and
 `SPACE_SM` (8px) on the top. Pass `padding=0` for full-width content
 (e.g. apps whose children manage their own horizontal margins).
 Override top-only with `padding_top=`.
-
-### `HStack`
-
-Horizontal flex container. Lays children left-to-right, partitioning
-remaining width to any grow children (``Canvas(grow=True)``, ``Spacer(grow=True)``)
-after fixed-width siblings (e.g. a ``Sized`` sidebar) are subtracted.
-
-Emits a horizontal ``Stack`` node so the host width-partitions exactly like
-a vertical Column height-partitions.
-
-### `Sized`
-
-Explicit-size wrapper. Constrains ``child`` to an exact ``width`` and/or
-``height``. ``None`` on an axis means "inherit available". Primary use: a
-fixed-width sidebar beside a growing ``Canvas`` inside an ``HStack``.
 
 ### `render_tree(ctx, root, fill=None)`
 
@@ -808,99 +650,6 @@ Example::
 
     bar = ProgressBar(0.75, color="accent")
     ctx.render_tree(bar.to_node())
-
-### `Checkbox`
-
-Boolean checkbox. Fires a ``change`` event with the toggled ``checked``.
-
-### `Radio`
-
-Single-select radio group. Fires ``change`` with the picked index in ``value``.
-
-### `Switch`
-
-On/off switch. Fires ``change`` with the toggled ``on`` value.
-
-### `Slider`
-
-Horizontal value slider. Clicking the track fires ``change`` with ``value``.
-
-### `Select`
-
-Dropdown/combobox trigger. Clicking fires ``click``; the app owns the popover.
-
-### `DateTimePicker`
-
-Date/time picker trigger. Clicking fires ``click``; the app owns the popover.
-
-``mode`` is ``"date"``, ``"time"``, or ``"datetime"``.
-
-### `Progress`
-
-Progress bar. ``value`` is 0.0–1.0; set ``indeterminate`` for unknown work.
-
-### `Spinner`
-
-Loading spinner with an optional caption.
-
-### `Tooltip`
-
-Hover tooltip wrapping a single child component.
-
-### `Avatar`
-
-Circular avatar rendering the initials of ``label``.
-
-### `Icon`
-
-Named glyph icon. ``name`` is a semantic key resolved by the host.
-
-### `CodeBlock`
-
-Monospace code block with an optional ``language`` label.
-
-### `Table`
-
-Static data table with column headers and string cells.
-
-### `Banner`
-
-Inline banner/callout. ``tone`` is info/success/warning/danger.
-
-### `KeyValue`
-
-Key/value description list. ``rows`` is a list of ``(key, value)`` pairs.
-
-### `Breadcrumb`
-
-Breadcrumb trail; the last item is the current location.
-
-### `Pagination`
-
-Pagination control. Prev/next fire ``change`` with the new zero-based page in ``value``.
-
-### `Accordion`
-
-Disclosure/accordion. The header fires ``click``; ``child`` shows when ``open``.
-
-### `TabBar`
-
-Native tab strip (headers only). Selecting a tab fires ``change`` with the index in ``value``.
-
-The app renders the active tab's body itself. Distinct from :class:`Tabs`,
-which decomposes to L0 nodes; ``TabBar`` maps to the native ``tabs`` node.
-
-### `EmptyState`
-
-Empty-state placeholder with a title, optional description and icon token.
-
-### `Skeleton`
-
-Skeleton loading placeholder — ``rows`` shimmer bars of the given ``height``.
-
-### `Modal`
-
-Modal dialog wrapping a child body. The close affordance fires ``click``.
 
 ## Testing
 


### PR DESCRIPTION
Stint 0369. Adds Python AiTool, ExposeTools, ToolCall, and ToolResult wrappers, documents the declare receive respond loop, and wires the CPython-WASM runtime into the v3.7 tool dispatcher. Validation: just test; Python SDK tests.