### PR TITLE
feat: assistant terminal run and compact feedback

### DIFF
--- a/src/app/assistant_host_tools.rs
+++ b/src/app/assistant_host_tools.rs
@@ -1,5 +1,6 @@
 //! Native execution seam for Assistant-owned host tools.
 
+use crate::app::permissions::Capability;
 use crate::plexi_ai::tool_dispatch::ToolCallResult;
 
 use super::PlexiApp;
@@ -138,14 +139,147 @@ impl PlexiApp {
                     Vec::new(),
                     cwd,
                 ) {
-                    Ok(pane_id) => succeeded(
-                        serde_json::json!({"ok": true, "pane_id": pane_id, "type": "terminal"}),
-                    ),
+                    Ok(pane_id) => {
+                        if let Err(error) =
+                            self.assistant_bind_terminal(origin_pane_id, origin_context_id, pane_id)
+                        {
+                            return failed(format!("open_terminal_failed: {error}"));
+                        }
+                        succeeded(
+                            serde_json::json!({"ok": true, "pane_id": pane_id, "type": "terminal"}),
+                        )
+                    }
                     Err(error) => failed(format!("open_terminal_failed: {error}")),
+                }
+            }
+            "host.terminals.run" => {
+                let Some(terminal_pane_id) = parsed
+                    .get("terminal_pane_id")
+                    .and_then(serde_json::Value::as_u64)
+                else {
+                    return failed("invalid_input: terminal_pane_id is required".to_string());
+                };
+                let Some(command) = parsed.get("command").and_then(serde_json::Value::as_str)
+                else {
+                    return failed("invalid_input: command is required".to_string());
+                };
+                if command.trim().is_empty() {
+                    return failed("invalid_input: command must be non-empty".to_string());
+                }
+                if parsed.get("echo").and_then(serde_json::Value::as_bool) != Some(true) {
+                    return failed(
+                        "invalid_input: echo must be true so the human-observed terminal receives Enter"
+                            .to_string(),
+                    );
+                }
+                match self.assistant_run_terminal(
+                    origin_pane_id,
+                    origin_context_id,
+                    terminal_pane_id,
+                    command,
+                ) {
+                    Ok(()) => succeeded(serde_json::json!({
+                        "ok": true,
+                        "terminal_pane_id": terminal_pane_id,
+                        "echo": true,
+                    })),
+                    Err(error) => failed(format!("run_terminal_failed: {error}")),
                 }
             }
             _ => failed(format!("host_tool_unknown: {name}")),
         }
+    }
+
+    /// Bind the Assistant's existing pane to the terminal it just opened.
+    /// `RunInLinkedTerminal` is intentionally link-scoped: the Assistant is a
+    /// built-in app with `terminal.bindings`, while ordinary apps still need
+    /// their manifest capability and their own linked terminal.
+    fn assistant_bind_terminal(
+        &mut self,
+        origin_pane_id: u64,
+        origin_context_id: u64,
+        terminal_pane_id: u64,
+    ) -> Result<(), String> {
+        let window = self
+            .windows
+            .iter_mut()
+            .find(|window| window.context_id == origin_context_id)
+            .ok_or_else(|| format!("origin context {origin_context_id} closed"))?;
+        if !window.panes.contains_key(&terminal_pane_id) {
+            return Err(format!("terminal pane {terminal_pane_id} was not created"));
+        }
+        let Some(app) = window
+            .panes
+            .get_mut(&origin_pane_id)
+            .and_then(crate::host::pane::Pane::as_app_mut)
+        else {
+            return Err(format!("origin pane {origin_pane_id} is not an app pane"));
+        };
+        if !app.permissions.is_builtin
+            && !app
+                .permissions
+                .capabilities
+                .contains(&Capability::TerminalBindings)
+        {
+            return Err("origin app lacks terminal.bindings capability".to_string());
+        }
+        app.linked_pane_id = Some(terminal_pane_id);
+        Ok(())
+    }
+
+    fn assistant_run_terminal(
+        &mut self,
+        origin_pane_id: u64,
+        origin_context_id: u64,
+        terminal_pane_id: u64,
+        command: &str,
+    ) -> Result<(), String> {
+        let active_context = self.windows[self.active_window].context_id;
+        if active_context != origin_context_id {
+            return Err(format!(
+                "terminal context {origin_context_id} is not active (active context {active_context})"
+            ));
+        }
+        let window = self
+            .windows
+            .iter()
+            .find(|window| window.context_id == origin_context_id)
+            .ok_or_else(|| format!("origin context {origin_context_id} closed"))?;
+        let Some(app) = window
+            .panes
+            .get(&origin_pane_id)
+            .and_then(crate::host::pane::Pane::as_app)
+        else {
+            return Err(format!("origin pane {origin_pane_id} is not an app pane"));
+        };
+        if !app.permissions.is_builtin
+            && !app
+                .permissions
+                .capabilities
+                .contains(&Capability::TerminalBindings)
+        {
+            return Err("origin app lacks terminal.bindings capability".to_string());
+        }
+        if app.linked_pane_id != Some(terminal_pane_id) {
+            return Err(format!(
+                "terminal pane {terminal_pane_id} is not the Assistant's linked terminal"
+            ));
+        }
+        if !window.panes.contains_key(&terminal_pane_id) {
+            return Err(format!("terminal pane {terminal_pane_id} not found"));
+        }
+        log::info!(
+            "assistant_host_tool: terminal.bindings inject origin={origin_pane_id} terminal={terminal_pane_id} command={command:?} echo=true"
+        );
+        // Reuse the production DrawCommand execution path; its link check is
+        // the terminal.bindings capability boundary for app-originated input.
+        self.dispatch_run_in_linked_terminal(
+            origin_pane_id,
+            terminal_pane_id,
+            command.to_string(),
+            true,
+        );
+        Ok(())
     }
 
     fn assistant_spawn_pane(
@@ -385,5 +519,44 @@ mod tests {
         );
         assert!(terminal.error.is_none(), "{:?}", terminal.error);
         assert!(harness.pane_count() > after_app);
+        let terminal_id = serde_json::from_str::<serde_json::Value>(
+            terminal.output_json.as_deref().expect("terminal output"),
+        )
+        .unwrap()["pane_id"]
+            .as_u64()
+            .expect("terminal pane id");
+
+        let ran = harness.app.handle_assistant_host_tool(
+            "host.terminals.run",
+            &serde_json::json!({
+                "terminal_pane_id": terminal_id,
+                "command": "echo assistant-terminal-tool",
+                "echo": true,
+            })
+            .to_string(),
+            origin,
+            context,
+        );
+        assert!(ran.error.is_none(), "{:?}", ran.error);
+
+        let hidden_echo = harness.app.handle_assistant_host_tool(
+            "host.terminals.run",
+            &serde_json::json!({
+                "terminal_pane_id": terminal_id,
+                "command": "echo must-be-observed",
+                "echo": false,
+            })
+            .to_string(),
+            origin,
+            context,
+        );
+        assert!(
+            hidden_echo
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("echo must be true")),
+            "{:?}",
+            hidden_echo.error
+        );
     }
 }

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -2201,6 +2201,17 @@ impl AssistantApp {
         self.execute_effects(effects);
     }
 
+    /// Complete a queued `/compact` after the visible status frame. Active
+    /// panes call this from [`App::ui`]; inactive panes use `background_tick`.
+    fn run_pending_compaction(&mut self) -> bool {
+        if !self.compact_pending {
+            return false;
+        }
+        self.compact_pending = false;
+        self.cmd_compact_conversation();
+        true
+    }
+
     fn cmd_export_conversation(&mut self) {
         let audit_path = self.profile_dir.join("audit.jsonl");
         let audit = match std::fs::read_to_string(&audit_path) {
@@ -2701,10 +2712,7 @@ impl App for AssistantApp {
 
     fn background_tick(&mut self) {
         self.pump_turn_io();
-        if self.compact_pending {
-            self.compact_pending = false;
-            self.cmd_compact_conversation();
-        }
+        self.run_pending_compaction();
     }
 
     fn needs_background_tick(&self) -> bool {
@@ -2740,11 +2748,9 @@ impl App for AssistantApp {
 
     fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
         self.pump_turn_io();
-        if self.model.streaming.in_flight || self.compact_pending {
-            // Keep frames coming while a worker thread streams a turn.
-            ui.ctx()
-                .request_repaint_after(std::time::Duration::from_millis(50));
-        }
+        // Active panes do not receive `background_tick`; defer until after
+        // this frame draws the status row, then compact before the next frame.
+        let compact_visible_this_frame = self.compact_pending;
         let event = AssistantRenderer::draw(
             ui,
             &mut self.model,
@@ -2760,6 +2766,13 @@ impl App for AssistantApp {
             }
             Some(ComposerEvent::Permission(choice)) => self.resolve_permission(choice),
             None => {}
+        }
+        if compact_visible_this_frame && self.run_pending_compaction() {
+            ui.ctx().request_repaint();
+        }
+        if self.model.streaming.in_flight || self.compact_pending {
+            ui.ctx()
+                .request_repaint_after(std::time::Duration::from_millis(50));
         }
     }
 }
@@ -4626,7 +4639,7 @@ enabled = ["allowed.tool"]
     }
 
     #[test]
-    fn compact_posts_completion_and_preserves_observable_checkpoint_state() {
+    fn active_ui_frame_drains_compaction_and_preserves_observable_checkpoint_state() {
         let ws = tempfile::tempdir().unwrap();
         let mut app = test_app(ws.path());
         for index in 0..7 {
@@ -4635,8 +4648,19 @@ enabled = ["allowed.tool"]
                 .push(model::Turn::now(TurnRole::User, format!("turn {index}")));
         }
         app.model.begin_compaction();
+        app.compact_pending = true;
 
-        app.cmd_compact_conversation();
+        let egui_ctx = egui::Context::default();
+        let colors = crate::ui::theme::colors_from_config(&crate::config::PlexiConfig::default());
+        let _ = egui_ctx.run(egui::RawInput::default(), |ctx| {
+            egui::CentralPanel::default().show(ctx, |ui| {
+                let render_ctx = AppRenderContext {
+                    colors: &colors,
+                    is_focused: true,
+                };
+                App::ui(&mut app, ui, &render_ctx);
+            });
+        });
 
         let model::CompactionState::Completed {
             compacted_turns,

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -70,8 +70,10 @@ When a delivered event hands you the turn, ACT: if the situation calls for a \
 tool call, make it immediately rather than only describing what you would do. \
 Do not narrate intentions you can carry out — take the action, then report the \
 result. \
-Use the host.panes.*, host.apps.open, and host.terminals.open tools for native \
-pane, app, and terminal operations; never shell out to the plexi CLI.";
+Use the host.panes.*, host.apps.open, host.terminals.open, and host.terminals.run \
+tools for native pane, app, and terminal operations; never shell out to the plexi \
+CLI. When a terminal pane has already been opened or focused, reuse its pane id \
+with host.terminals.run; do not open a redundant terminal. ";
 
 /// Host tool names the Assistant injects into its dispatcher snapshot.
 const HOST_TOOL_SUBSCRIBE: &str = "host.events.subscribe";
@@ -83,6 +85,7 @@ const HOST_TOOL_PANES_FOCUS: &str = "host.panes.focus";
 const HOST_TOOL_PANES_CLOSE: &str = "host.panes.close";
 const HOST_TOOL_APPS_OPEN: &str = "host.apps.open";
 const HOST_TOOL_TERMINALS_OPEN: &str = "host.terminals.open";
+const HOST_TOOL_TERMINALS_RUN: &str = "host.terminals.run";
 
 /// Broker identity for the Assistant: actor id at the permission tiers,
 /// `agent:assistant` as the `ToolDispatcher` caller id (Phase C convention).
@@ -312,6 +315,9 @@ pub struct AssistantApp {
     commonmark_cache: egui_commonmark::CommonMarkCache,
     /// Cached soft-break conversion for committed markdown turns.
     markdown_text_cache: MarkdownTextCache,
+    /// `/compact` yields once so the renderer can show its progress row before
+    /// the existing synchronous storage operation starts.
+    compact_pending: bool,
 }
 
 /// An ask-gated subscribe waiting on the permission sheet.
@@ -432,6 +438,7 @@ impl AssistantApp {
             turn_cancel: CancelToken::new(),
             commonmark_cache: egui_commonmark::CommonMarkCache::default(),
             markdown_text_cache: MarkdownTextCache::default(),
+            compact_pending: false,
         };
         // Persist the active id immediately so close-then-reopen resumes
         // this conversation even before the first turn.
@@ -570,7 +577,13 @@ impl AssistantApp {
                 AssistantEffect::RewindConversation(selector) => {
                     self.cmd_rewind_conversation(&selector)
                 }
-                AssistantEffect::CompactConversation => self.cmd_compact_conversation(),
+                AssistantEffect::CompactConversation => {
+                    self.compact_pending = true;
+                    log::info!(
+                        "assistant[{}]: compaction queued; showing progress indicator",
+                        self.model.conversation_id
+                    );
+                }
                 AssistantEffect::ExportConversation => self.cmd_export_conversation(),
                 AssistantEffect::PersistShowThoughts(show) => {
                     if let Err(e) = self.store.set_show_thoughts(show) {
@@ -762,7 +775,10 @@ impl AssistantApp {
             if (!declared_tools.is_empty() && !declared_tools.contains(&tool.name))
                 || (!settings_tools.is_empty() && !settings_tools.contains(&tool.name))
             {
-                log::info!("assistant: host tool '{}' withheld by enabled-tool filter", tool.name);
+                log::info!(
+                    "assistant: host tool '{}' withheld by enabled-tool filter",
+                    tool.name
+                );
                 continue;
             }
             match self.host_tool_decision(&tool) {
@@ -897,6 +913,13 @@ impl AssistantApp {
                 timeout_ms: Some(30_000),
                 read_only: false,
             },
+            AiTool {
+                name: HOST_TOOL_TERMINALS_RUN.into(),
+                description: "Run a command in a terminal pane already opened or focused by the Assistant. The terminal remains human-observed; echo=true submits the command with Enter.".into(),
+                input_schema: serde_json::json!({"type":"object","properties":{"terminal_pane_id":{"type":"integer"},"command":{"type":"string"},"echo":{"type":"boolean","description":"Must be true; the command is visibly submitted to the terminal."}},"required":["terminal_pane_id","command","echo"]}),
+                timeout_ms: Some(30_000),
+                read_only: false,
+            },
         ]
     }
 
@@ -965,6 +988,14 @@ impl AssistantApp {
     ) {
         if !matches!(tool, HOST_TOOL_SUBSCRIBE | HOST_TOOL_UNSUBSCRIBE) {
             log::info!("assistant: queueing native host tool '{tool}'");
+            if tool == HOST_TOOL_TERMINALS_RUN {
+                self.audit.append(&AuditEvent::now(
+                    "terminal_command",
+                    HOST_TOOL_TERMINALS_RUN,
+                    "requested",
+                    &summarize_input(input_json),
+                ));
+            }
             self.pending_commands.push(AppCommand::AssistantHostTool {
                 name: tool.to_string(),
                 input_json: input_json.to_string(),
@@ -1087,15 +1118,14 @@ impl AssistantApp {
         });
         let concrete_model = agent.model_routes.for_tier(tier).cloned();
         let effort = self.model.effort_override.or(agent.effort);
-        let selected_skill = self
-            .pending_skill
-            .take()
-            .or_else(|| {
-                self.skill_registry
-                    .matching_enabled(&prompt, &agent.skills)
-                    .cloned()
-            });
+        let selected_skill = self.pending_skill.take().or_else(|| {
+            self.skill_registry
+                .matching_enabled(&prompt, &agent.skills)
+                .cloned()
+        });
         let mut system = agent.prompt;
+        system.push_str("\n\nCompaction status: ");
+        system.push_str(&self.model.compaction_status());
         if let Some(skill) = selected_skill {
             log::info!(
                 "assistant[{conversation_id}]: loading {} skill '{}' from {}",
@@ -2109,6 +2139,7 @@ impl AssistantApp {
         const RETAIN_RECENT: usize = 6;
         const SUMMARY_BUDGET_CHARS: usize = 4_096;
         if self.model.turns.len() <= RETAIN_RECENT {
+            self.model.clear_compaction();
             let effects = self
                 .model
                 .push_info("Nothing to compact yet; fewer than seven turns are active.");
@@ -2124,6 +2155,7 @@ impl AssistantApp {
             {
                 Ok(checkpoint) => checkpoint,
                 Err(e) => {
+                    self.model.clear_compaction();
                     log::error!("assistant[{id}]: /compact checkpoint failed: {e}");
                     let effects = self.model.push_error(format!(
                         "Compaction stopped: could not preserve raw history: {e}"
@@ -2145,6 +2177,7 @@ impl AssistantApp {
         )];
         compacted_turns.extend(recent);
         if let Err(e) = self.store.record_compaction(&id, &checkpoint.id, compacted) {
+            self.model.clear_compaction();
             log::error!("assistant[{id}]: failed to record compaction boundary: {e}");
             let effects = self.model.push_error(format!(
                 "Raw checkpoint written, but compaction stopped because boundary metadata failed: {e}"
@@ -2153,13 +2186,19 @@ impl AssistantApp {
             return;
         }
         self.pending_skill = None;
+        self.model
+            .complete_compaction(compacted, checkpoint.id.clone());
         let cancel = self.model.switch_conversation(id.clone(), compacted_turns);
         self.execute_effects(cancel);
         log::info!(
             "assistant[{id}]: compacted {compacted} turn(s) checkpoint={}",
             checkpoint.id
         );
-        self.session_write();
+        let effects = self.model.push_info(format!(
+            "Compacted {compacted} turns into checkpoint `{}`.",
+            checkpoint.id
+        ));
+        self.execute_effects(effects);
     }
 
     fn cmd_export_conversation(&mut self) {
@@ -2352,17 +2391,17 @@ impl AssistantApp {
     }
 
     fn cmd_list_skills(&mut self) {
-        let enabled = self.active_agent().map(|agent| agent.skills.as_slice()).unwrap_or(&[]);
+        let enabled = self
+            .active_agent()
+            .map(|agent| agent.skills.as_slice())
+            .unwrap_or(&[]);
         let visible = self
             .skill_registry
             .all()
             .iter()
             .filter(|skill| enabled.is_empty() || enabled.contains(&skill.name))
             .collect::<Vec<_>>();
-        log::info!(
-            "assistant: /skills — {} installed skill(s)",
-            visible.len()
-        );
+        log::info!("assistant: /skills — {} installed skill(s)", visible.len());
         let text = if visible.is_empty() {
             "No skills are installed for this channel or workspace.".to_string()
         } else {
@@ -2383,7 +2422,10 @@ impl AssistantApp {
     }
 
     fn cmd_invoke_skill(&mut self, name: &str, args: &str) {
-        let enabled = self.active_agent().map(|agent| agent.skills.as_slice()).unwrap_or(&[]);
+        let enabled = self
+            .active_agent()
+            .map(|agent| agent.skills.as_slice())
+            .unwrap_or(&[]);
         if !enabled.is_empty() && !enabled.iter().any(|skill| skill == name) {
             let effects = self.model.push_error(format!(
                 "Skill `/{name}` is not enabled for agent `{}`.",
@@ -2659,10 +2701,14 @@ impl App for AssistantApp {
 
     fn background_tick(&mut self) {
         self.pump_turn_io();
+        if self.compact_pending {
+            self.compact_pending = false;
+            self.cmd_compact_conversation();
+        }
     }
 
     fn needs_background_tick(&self) -> bool {
-        self.model.streaming.in_flight || !self.pending_commands.is_empty()
+        self.model.streaming.in_flight || self.compact_pending || !self.pending_commands.is_empty()
     }
 
     fn handle_key(&mut self, input: &egui::InputState) -> KeyDisposition {
@@ -2694,7 +2740,7 @@ impl App for AssistantApp {
 
     fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
         self.pump_turn_io();
-        if self.model.streaming.in_flight {
+        if self.model.streaming.in_flight || self.compact_pending {
             // Keep frames coming while a worker thread streams a turn.
             ui.ctx()
                 .request_repaint_after(std::time::Duration::from_millis(50));
@@ -2886,7 +2932,10 @@ enabled = ["allowed.tool"]
 
         let seen = broker.seen.lock().unwrap();
         assert_eq!(seen.len(), 2);
-        assert_eq!(seen[0].system, "Writer system prompt");
+        assert_eq!(
+            seen[0].system,
+            "Writer system prompt\n\nCompaction status: No compaction is running."
+        );
         assert_eq!(seen[0].model_tier, ModelTier::Medium);
         assert_eq!(
             seen[0].concrete_model.as_ref().unwrap().model,
@@ -3316,6 +3365,7 @@ enabled = ["allowed.tool"]
         app.model.composer = "/compact".to_string();
         let effects = app.model.submit();
         app.execute_effects(effects);
+        App::background_tick(&mut app);
         assert!(app.model.turns[0].text.contains("Compacted context"));
         assert!(app.model.turns[0].text.contains("beginning-intent"));
         assert!(app.model.turns[0].text.contains("ending-intent"));
@@ -4573,6 +4623,34 @@ enabled = ["allowed.tool"]
             commands.as_slice(),
             [AppCommand::AssistantHostTool { name, .. }] if name == HOST_TOOL_PANES_LIST
         ));
+    }
+
+    #[test]
+    fn compact_posts_completion_and_preserves_observable_checkpoint_state() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = test_app(ws.path());
+        for index in 0..7 {
+            app.model
+                .turns
+                .push(model::Turn::now(TurnRole::User, format!("turn {index}")));
+        }
+        app.model.begin_compaction();
+
+        app.cmd_compact_conversation();
+
+        let model::CompactionState::Completed {
+            compacted_turns,
+            checkpoint_id,
+        } = &app.model.compaction
+        else {
+            panic!("compaction state must remain observable after completion");
+        };
+        assert_eq!(*compacted_turns, 1);
+        assert!(checkpoint_id.starts_with("checkpoint-"));
+        assert_eq!(
+            app.model.turns.last().unwrap().text,
+            format!("Compacted 1 turns into checkpoint `{checkpoint_id}`.")
+        );
     }
 
     #[test]

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -99,6 +99,25 @@ pub struct StreamingState {
     pub partial_reasoning: String,
 }
 
+/// Observable lifecycle for `/compact`. This deliberately records feedback,
+/// not compaction mechanics: raw history and checkpoint format remain owned
+/// by the store layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompactionState {
+    Idle,
+    Compacting,
+    Completed {
+        compacted_turns: usize,
+        checkpoint_id: String,
+    },
+}
+
+impl Default for CompactionState {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
 /// Side effects the model requests from the pane shell.
 #[derive(Debug, Clone, PartialEq)]
 pub enum AssistantEffect {
@@ -192,6 +211,9 @@ pub struct AssistantModel {
     pub show_thoughts: bool,
     pub active_agent_id: String,
     pub effort_override: Option<ReasoningEffort>,
+    /// `/compact` lifecycle exposed to the renderer and injected into the
+    /// next model turn so the Assistant can answer status questions.
+    pub compaction: CompactionState,
     /// Shell-style composer history cursor over prior user turns. `None`
     /// means normal editing; `Some(0)` is the newest user message.
     history_cursor: Option<usize>,
@@ -214,6 +236,7 @@ impl AssistantModel {
             show_thoughts: false,
             active_agent_id: "default".to_string(),
             effort_override: None,
+            compaction: CompactionState::Idle,
             history_cursor: None,
         }
     }
@@ -230,6 +253,34 @@ impl AssistantModel {
     /// Start a brand-new conversation.
     pub fn fresh() -> Self {
         Self::resume(new_conversation_id(), Vec::new())
+    }
+
+    pub fn begin_compaction(&mut self) {
+        self.compaction = CompactionState::Compacting;
+    }
+
+    pub fn complete_compaction(&mut self, compacted_turns: usize, checkpoint_id: String) {
+        self.compaction = CompactionState::Completed {
+            compacted_turns,
+            checkpoint_id,
+        };
+    }
+
+    pub fn clear_compaction(&mut self) {
+        self.compaction = CompactionState::Idle;
+    }
+
+    pub fn compaction_status(&self) -> String {
+        match &self.compaction {
+            CompactionState::Idle => "No compaction is running.".to_string(),
+            CompactionState::Compacting => "Compaction is in progress.".to_string(),
+            CompactionState::Completed {
+                compacted_turns,
+                checkpoint_id,
+            } => format!(
+                "Compaction completed: {compacted_turns} turns into checkpoint {checkpoint_id}."
+            ),
+        }
     }
 
     /// True while the slash-command picker should be visible.
@@ -491,7 +542,10 @@ impl AssistantModel {
                 }]
             }
             "rewind" => vec![AssistantEffect::RewindConversation(cmd.args.clone())],
-            "compact" => vec![AssistantEffect::CompactConversation],
+            "compact" => {
+                self.begin_compaction();
+                vec![AssistantEffect::CompactConversation]
+            }
             "export" => vec![AssistantEffect::ExportConversation],
             "model" if cmd.args.is_empty() => vec![AssistantEffect::ShowModelSetting],
             "model" => {
@@ -1271,6 +1325,7 @@ mod tests {
             submitted(&mut model, "/compact"),
             vec![AssistantEffect::CompactConversation]
         );
+        assert_eq!(model.compaction, CompactionState::Compacting);
         assert_eq!(
             submitted(&mut model, "/export"),
             vec![AssistantEffect::ExportConversation]

--- a/src/assistant/render.rs
+++ b/src/assistant/render.rs
@@ -22,7 +22,7 @@ use crate::ui::style;
 use crate::ui::theme::Colors;
 
 use super::commands;
-use super::model::{AssistantModel, PermissionChoice, ToolStatus, TurnRole};
+use super::model::{AssistantModel, CompactionState, PermissionChoice, ToolStatus, TurnRole};
 
 /// What the composer asked the pane shell to do this frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -288,6 +288,15 @@ impl AssistantRenderer {
                 }
                 for active in &model.active_tools {
                     Self::draw_active_tool_row(ui, colors, &active.tool);
+                }
+                if matches!(model.compaction, CompactionState::Compacting) {
+                    ui.label(
+                        RichText::new("⟳ compacting…")
+                            .size(style::TEXT_CAPTION)
+                            .monospace()
+                            .color(colors.accent),
+                    );
+                    ui.add_space(style::SPACE_SM);
                 }
                 if model.streaming.in_flight {
                     ui.push_id("streaming", |ui| {


### PR DESCRIPTION
## Summary

- Adds `host.terminals.run`, permission-gated through the Assistant broker and restricted to echoed commands in the Assistant-linked terminal.
- Records an audit entry and info trace for each requested terminal command.
- Shows `compacting…`, posts the checkpoint completion row, and supplies compaction state to the Assistant model context.

## Test evidence

- `cargo test --bin plexi assistant_host_tools`: 2 passed.
- `cargo test --bin plexi scoped_and_session_model_tiers_route_active_agent_concretely`: passed.
- `cargo test --bin plexi resume_history_rewind_compact_and_export_are_observable`: passed.
- `just test`: 1456 passed, 0 failed, 2 ignored.
- Binary install required before validation because terminal PTY injection is observable only in the installed host.