### PR TITLE
feat(wasm): async staging-ring readback for GPU surface composition

### DIFF
--- a/src/host/wasm_app.rs
+++ b/src/host/wasm_app.rs
@@ -714,14 +714,36 @@ impl WasmApp {
             .map(|g| g.alloc_surface(width, height))
     }
 
-    /// Read a surface texture back to an RGBA image for compositing into egui
-    /// (the live leg) or pixel assertions (the gate leg).
+    /// Read a surface texture back to an RGBA image for pixel assertions.
+    /// Test-only: live composition never blocks the UI thread on a synchronous
+    /// readback — see `request_surface_readback`/`take_surface_readback`.
+    #[cfg(test)]
     pub fn read_surface(&self, handle: u64) -> Option<image::RgbaImage> {
         self.store
             .data()
             .gpu
             .as_ref()
             .and_then(|g| g.read_texture(handle).ok())
+    }
+
+    /// Start a nonblocking copy of a surface for the dedicated-device fallback.
+    /// Live panes on the host render device use `surface_srgb_view` instead.
+    pub fn request_surface_readback(&mut self, handle: u64) -> Result<(), String> {
+        self.store
+            .data_mut()
+            .gpu
+            .as_mut()
+            .ok_or_else(|| "gpu capability not granted".to_string())?
+            .request_surface_readback(handle)
+    }
+
+    /// Take the newest completed dedicated-device surface readback.
+    pub fn take_surface_readback(&mut self) -> Option<Result<image::RgbaImage, String>> {
+        self.store
+            .data_mut()
+            .gpu
+            .as_mut()
+            .and_then(|g| g.take_surface_readback())
     }
     /// sRGB view of the surface texture for zero-copy egui compositing.
     pub fn surface_srgb_view(&self, handle: u64) -> Option<wgpu::TextureView> {

--- a/src/host/wasm_gpu.rs
+++ b/src/host/wasm_gpu.rs
@@ -22,6 +22,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::OnceLock;
+#[cfg(test)]
 use std::time::Instant;
 
 use crate::host::wasm_app::bindings::plexi::platform::gpu as wit;

--- a/src/host/wasm_gpu.rs
+++ b/src/host/wasm_gpu.rs
@@ -20,6 +20,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::OnceLock;
 use std::time::Instant;
 
@@ -55,6 +56,173 @@ struct GpuPipeline {
     compute: Option<wgpu::ComputePipeline>,
 }
 
+/// Number of GPU copies that may be in flight for a non-shared surface.
+/// Three buffers let the renderer display the newest completed frame while the
+/// GPU is writing the next two; it never needs to wait for the current frame.
+const SURFACE_READBACK_RING: usize = 3;
+
+struct AsyncReadbackSlot {
+    buffer: wgpu::Buffer,
+    busy: bool,
+}
+
+struct AsyncReadbackComplete {
+    slot: usize,
+    image: Result<image::RgbaImage, String>,
+}
+
+/// Nonblocking surface readback for the rare non-shared-device path.
+///
+/// `map_async` is issued from the UI thread, but the blocking `Maintain::Wait`
+/// poll and row packing run on a worker. The UI only drains completed images;
+/// if every staging buffer is busy it keeps displaying the most recent frame.
+struct AsyncSurfaceReadbackRing {
+    slots: Vec<AsyncReadbackSlot>,
+    width: u32,
+    height: u32,
+    padded_bytes_per_row: u32,
+    next_slot: usize,
+    completed_tx: Sender<AsyncReadbackComplete>,
+    completed_rx: Receiver<AsyncReadbackComplete>,
+}
+
+impl AsyncSurfaceReadbackRing {
+    fn new() -> Self {
+        let (completed_tx, completed_rx) = mpsc::channel();
+        Self {
+            slots: Vec::new(),
+            width: 0,
+            height: 0,
+            padded_bytes_per_row: 0,
+            next_slot: 0,
+            completed_tx,
+            completed_rx,
+        }
+    }
+
+    fn ensure_size(&mut self, device: &wgpu::Device, width: u32, height: u32) -> bool {
+        if self.width == width && self.height == height && !self.slots.is_empty() {
+            return true;
+        }
+        if self.slots.iter().any(|slot| slot.busy) {
+            // Preserve in-flight buffers until their workers finish. A resize
+            // gets picked up on the next frame instead of blocking the UI.
+            return false;
+        }
+        let padded_bytes_per_row = width.saturating_mul(4).div_ceil(256) * 256;
+        let size = padded_bytes_per_row as u64 * height as u64;
+        self.slots = (0..SURFACE_READBACK_RING)
+            .map(|_index| AsyncReadbackSlot {
+                buffer: device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("plexi-surface-readback-ring"),
+                    size,
+                    usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                }),
+                busy: false,
+            })
+            .collect();
+        self.width = width;
+        self.height = height;
+        self.padded_bytes_per_row = padded_bytes_per_row;
+        self.next_slot = 0;
+        log::info!(
+            "wasm gpu: allocated async readback ring buffers={} size={}x{} padded_row={}",
+            SURFACE_READBACK_RING,
+            width,
+            height,
+            padded_bytes_per_row,
+        );
+        true
+    }
+
+    fn submit(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texture: &wgpu::Texture,
+        width: u32,
+        height: u32,
+    ) {
+        if !self.ensure_size(device, width, height) {
+            return;
+        }
+        let Some(slot_index) = (0..self.slots.len())
+            .map(|offset| (self.next_slot + offset) % self.slots.len())
+            .find(|&index| !self.slots[index].busy)
+        else {
+            return;
+        };
+        self.next_slot = (slot_index + 1) % self.slots.len();
+        let slot = &mut self.slots[slot_index];
+        slot.busy = true;
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("plexi-async-surface-readback"),
+        });
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &slot.buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(self.padded_bytes_per_row),
+                    rows_per_image: Some(height),
+                },
+            },
+            wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(Some(encoder.finish()));
+
+        let (mapped_tx, mapped_rx) = mpsc::channel();
+        slot.buffer.slice(..).map_async(wgpu::MapMode::Read, move |result| {
+            let _ = mapped_tx.send(result.map_err(|err| err.to_string()));
+        });
+        let worker_device = device.clone();
+        let worker_buffer = slot.buffer.clone();
+        let completed_tx = self.completed_tx.clone();
+        let padded_bytes_per_row = self.padded_bytes_per_row;
+        std::thread::spawn(move || {
+            worker_device.poll(wgpu::Maintain::Wait);
+            let image = match mapped_rx.recv() {
+                Ok(Ok(())) => {
+                    let mapped = worker_buffer.slice(..).get_mapped_range();
+                    let packed = pack_rgba_rows(&mapped, width, height, padded_bytes_per_row);
+                    drop(mapped);
+                    worker_buffer.unmap();
+                    packed
+                }
+                Ok(Err(err)) => Err(format!("async surface map failed: {err}")),
+                Err(err) => Err(format!("async surface map callback closed: {err}")),
+            };
+            let _ = completed_tx.send(AsyncReadbackComplete {
+                slot: slot_index,
+                image,
+            });
+        });
+    }
+
+    fn take_latest(&mut self) -> Option<Result<image::RgbaImage, String>> {
+        let mut latest = None;
+        while let Ok(completed) = self.completed_rx.try_recv() {
+            if let Some(slot) = self.slots.get_mut(completed.slot) {
+                slot.busy = false;
+            }
+            latest = Some(completed.image);
+        }
+        latest
+    }
+}
+
 /// Owns a wgpu device and the opaque-handle registries the `gpu` import refers
 /// to. One per app with the gpu capability granted; lives inside `HostCtx`.
 pub struct GpuDevice {
@@ -70,6 +238,9 @@ pub struct GpuDevice {
     /// this at zero; only the capture path (`read_texture`) increments it. The
     /// perf gate reads this per-device count so it is isolated from other tests.
     readbacks: AtomicU64,
+    /// Dedicated-device surface presentation uses this bounded asynchronous ring
+    /// instead of synchronously polling the GPU on the UI thread.
+    async_surface_readbacks: AsyncSurfaceReadbackRing,
 }
 
 impl GpuDevice {
@@ -115,6 +286,7 @@ impl GpuDevice {
             pipelines: HashMap::new(),
             bind_groups: HashMap::new(),
             readbacks: AtomicU64::new(0),
+            async_surface_readbacks: AsyncSurfaceReadbackRing::new(),
         }
     }
 
@@ -167,7 +339,10 @@ impl GpuDevice {
     }
 
     /// Read a texture (typically a surface) back to a tightly-packed RGBA8
-    /// image for compositing or pixel assertions. Errors for non-RGBA8 formats.
+    /// image for pixel assertions. Test-only: live composition uses the
+    /// zero-copy shared-device path or the async readback ring, never this
+    /// synchronous UI-thread-blocking call.
+    #[cfg(test)]
     pub fn read_texture(&self, handle: u64) -> Result<image::RgbaImage, String> {
         self.readbacks.fetch_add(1, Ordering::Relaxed);
         let tex = self.textures.get(&handle).ok_or("unknown texture handle")?;
@@ -259,6 +434,27 @@ impl GpuDevice {
             format: Some(wgpu::TextureFormat::Rgba8UnormSrgb),
             ..Default::default()
         }))
+    }
+
+    /// Queue a surface copy into the nonblocking staging ring. Completion is
+    /// obtained with [`Self::take_surface_readback`]; neither method waits for
+    /// GPU work on the caller thread.
+    pub fn request_surface_readback(&mut self, handle: u64) -> Result<(), String> {
+        let tex = self.textures.get(&handle).ok_or("unknown texture handle")?;
+        if !matches!(
+            tex.format,
+            wgpu::TextureFormat::Rgba8Unorm | wgpu::TextureFormat::Rgba8UnormSrgb
+        ) {
+            return Err("async readback only supports rgba8 surfaces".to_string());
+        }
+        self.async_surface_readbacks
+            .submit(&self.device, &self.queue, &tex.texture, tex.width, tex.height);
+        Ok(())
+    }
+
+    /// Return the newest completed asynchronous surface frame, if one is ready.
+    pub fn take_surface_readback(&mut self) -> Option<Result<image::RgbaImage, String>> {
+        self.async_surface_readbacks.take_latest()
     }
 
     // ── WIT-facing operations ────────────────────────────────────────────────

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -650,7 +650,9 @@ impl WasmPane {
     }
 
     /// Read the current surface texture back to an RGBA image, if a surface is
-    /// allocated. Used to composite into egui (live) and assert pixels (gates).
+    /// allocated. Test-only: pixel assertions in gate tests. Live composition
+    /// never blocks the UI thread on a synchronous readback.
+    #[cfg(test)]
     pub fn read_surface(&self) -> Option<image::RgbaImage> {
         let s = self.surface.as_ref()?;
         self.app.read_surface(s.handle)
@@ -670,6 +672,22 @@ impl WasmPane {
     /// Surface readbacks performed by this pane's device (capture path only).
     pub fn surface_readbacks(&self) -> u64 {
         self.app.surface_readbacks()
+    }
+
+    /// Queue a nonblocking copy of the live surface for the dedicated-device
+    /// fallback (no shared render state to composite into directly).
+    pub fn request_surface_readback(&mut self) -> Result<(), String> {
+        let handle = self
+            .surface
+            .as_ref()
+            .ok_or_else(|| "no surface allocated".to_string())?
+            .handle;
+        self.app.request_surface_readback(handle)
+    }
+
+    /// Drain the newest completed dedicated-device surface frame, if ready.
+    pub fn take_surface_readback(&mut self) -> Option<Result<image::RgbaImage, String>> {
+        self.app.take_surface_readback()
     }
 
     pub fn view(&mut self) -> wasmtime::Result<UiTree> {
@@ -1764,24 +1782,44 @@ impl LiveWasmPane {
                     }
                     self.surface_id
                 }
-                // Fallback: no shared device, so read the surface back and
-                // re-upload it as an egui texture (the slow legacy path).
+                // Fallback: no shared device. Keep an N-buffered async readback
+                // ring in flight so the UI thread never blocks on `poll(Wait)`:
+                // queue this frame's copy, then upload whichever previous copy
+                // has finished. The texture lags by at most a couple of frames
+                // instead of stalling until the current one completes.
                 None => {
-                    if let Some(img) = self.inner.read_surface() {
-                        let color = egui::ColorImage::from_rgba_unmultiplied(
-                            [w as usize, h as usize],
-                            img.as_raw(),
+                    if let Err(e) = self.inner.request_surface_readback() {
+                        log::warn!(
+                            "wasm present: async surface readback request failed for {}: {e}",
+                            self.spawn_name
                         );
-                        match &mut self.fallback_tex {
-                            Some(tex) => tex.set(color, egui::TextureOptions::LINEAR),
-                            none => {
-                                *none = Some(ui.ctx().load_texture(
-                                    format!("wasm-surface-{}", self.spawn_name),
-                                    color,
-                                    egui::TextureOptions::LINEAR,
-                                ));
+                    }
+                    match self.inner.take_surface_readback() {
+                        Some(Ok(img)) => {
+                            let color = egui::ColorImage::from_rgba_unmultiplied(
+                                [w as usize, h as usize],
+                                img.as_raw(),
+                            );
+                            match &mut self.fallback_tex {
+                                Some(tex) => tex.set(color, egui::TextureOptions::LINEAR),
+                                none => {
+                                    *none = Some(ui.ctx().load_texture(
+                                        format!("wasm-surface-{}", self.spawn_name),
+                                        color,
+                                        egui::TextureOptions::LINEAR,
+                                    ));
+                                }
                             }
                         }
+                        Some(Err(e)) => {
+                            log::warn!(
+                                "wasm present: async surface readback failed for {}: {e}",
+                                self.spawn_name
+                            );
+                        }
+                        // Nothing completed yet this frame; keep showing the
+                        // most recently uploaded texture rather than stalling.
+                        None => {}
                     }
                     self.fallback_tex.as_ref().map(|t| t.id())
                 }
@@ -3009,6 +3047,43 @@ mod tests {
             p.surface_readbacks() - before,
             1,
             "capture readback must be on-demand and isolated from the present path"
+        );
+        Ok(())
+    }
+
+    // ── Perf gate: dedicated-device fallback stays off the UI thread ─────────
+    //
+    // The async ring's whole purpose is to keep the non-shared-device fallback
+    // from blocking the UI thread on `poll(Wait)`. This locks a generous
+    // wall-clock ceiling on the request -> completion round trip at the pane's
+    // default 480x360 size so a regression back to synchronous readback gets
+    // caught before it lands.
+    #[test]
+    fn perf_gate_async_readback_within_budget() -> wasmtime::Result<()> {
+        let mut p = pong_pane();
+        p.init(&StateSnapshot { entries: vec![] }, (480.0, 360.0), 0, &[])?;
+        let (w, h) = p.surface_size().expect("surface allocated after init");
+
+        const THRESHOLD: std::time::Duration = std::time::Duration::from_millis(50);
+        let start = Instant::now();
+        p.request_surface_readback()
+            .expect("queue async surface readback");
+        let img = loop {
+            if let Some(result) = p.take_surface_readback() {
+                break result.expect("async surface readback succeeds");
+            }
+            assert!(
+                start.elapsed() < THRESHOLD,
+                "async surface readback exceeded {THRESHOLD:?} budget at {w}x{h}"
+            );
+            std::thread::yield_now();
+        };
+        assert_eq!(img.width(), w);
+        assert_eq!(img.height(), h);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < THRESHOLD,
+            "async surface readback took {elapsed:?}, budget {THRESHOLD:?} at {w}x{h}"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Implements stint 0234: async readback for the WASM GPU surface compositor's dedicated-device fallback path.
- Adds an N-buffered (3) async staging ring in `wasm_gpu.rs`: `map_async` is issued from the UI thread, but the blocking `poll(Maintain::Wait)` and row-packing run on a worker thread. The UI thread only drains the newest completed frame per pass — it never blocks on GPU completion.
- Wires the ring into `wasm_pane.rs`'s non-shared-device fallback branch, replacing the old per-frame synchronous `read_surface()` call.
- The shared-device zero-copy path (egui + WASM guest on the same wgpu device) already existed in alpha and is untouched — it stays the preferred path and this stint doesn't touch it.
- Adds `perf_gate_async_readback_within_budget`: a wall-clock assertion that the async request->completion round trip stays under a 50ms budget at 480x360, guarding against a regression back to synchronous readback.
- `read_texture`/`read_surface` (on `GpuDevice`/`WasmApp`/`WasmPane`) are now `#[cfg(test)]` since production composition no longer calls them directly — they remain the pixel-assertion path for gate tests (G7, capture-path isolation, etc.).

## Non-scope (per stint 0234)
- Multi-GPU / discrete GPU selection.
- Render-to-texture effect (apps issue GPU commands only).

## Test plan
- [x] `cargo test --bin plexi` — 1476 passed, 0 failed, 2 ignored
- [x] `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py` — no issues
- [x] `just check-docs` — CLI/config/SDK/capability/authoring docs all up to date, no regen needed