### PR TITLE
refactor(host): dedup FocusLayer sync helpers, add PlexiInput hotkey/overlay router (stint 0240)

### DIFF
--- a/.agents/skills/babysitter/SKILL.md
+++ b/.agents/skills/babysitter/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: babysitter
+description: "Land a queue of stint tasks as fast as possible by orchestrating Codex instances in Plexi panes. You give a ready Codex pane id + a list of stints; this loop batches them into as few PRs as possible, drives a WORKER Codex pane to implement each batch, spawns a separate TESTER Codex pane to validate the PR against the real install build, routes bugs between them until it passes, merges, then recycles panes for the next batch. You are the router, never the coder. Checks in every 15 min, manages Codex's 5-hour usage window. Triggered by /babysitter, \"babysit codex\", \"queue these stints in the other pane\"."
+source: local
+date_added: "2026-07-11"
+---
+
+# Babysitter — Orchestrate Worker + Tester Codex Panes Through a Stint Queue
+
+You are a **router and coordinator, not a coder.** You never touch code, git, or the repo yourself. You drive Codex instances running in Plexi panes and pass messages between them. Two roles exist per batch:
+
+- **Worker** — a Codex pane that implements the batch and opens the PR.
+- **Tester** — a *separate, fresh* Codex pane that installs the PR build, drives the app to verify it, and reports bugs back to you.
+
+You are the wire between them: Worker → PR → Tester → (bugs) → you → Worker → (fix) → you → Tester → … → pass → merge → recycle.
+
+## Invocation
+
+```
+/babysitter <PANE_ID> <STINT_ID> [<STINT_ID> ...]
+```
+
+- `<PANE_ID>` — a pane running a **ready** Codex chat (user hands this to you, already at an idle prompt). This is your first Worker.
+- `<STINT_ID...>` — stints to land, in order.
+
+First action: confirm the worker pane is real and idle, and label it.
+```
+plexi pane capture <PANE_ID> --from-cursor 0
+plexi pane name <PANE_ID> "worker-1"
+```
+If it isn't a live Codex prompt, stop and tell the user. Never assume — capture first.
+
+## Verified command cheatsheet
+
+Exact forms confirmed against the Codex TUI. Use them; don't invent variants.
+
+| Need | Command |
+|---|---|
+| **Is Codex busy or idle?** (source of truth) | `plexi pane list` → find pane → `agent.state` (`working`/`idle`) |
+| Pipeline slots (pr#, phase, status, error) | read files under the pane's `slots.*` paths from `pane list` |
+| **Read the last N lines (default read)** | `plexi pane capture <id> --lines 20` |
+| Read full pane buffer (verdict parsing only) | `plexi pane capture <id> --from-cursor 0` |
+| Read only *new* output (delta) | `plexi pane capture <id> --from-cursor <CURSOR>` |
+| Pane UI state as JSON | `plexi pane state <id>` |
+| Type a prompt (Codex TUI) | `plexi pane send <id> "<text>"` |
+| **Submit** the prompt | `plexi pane key <id> enter` |
+| Interrupt Codex | `plexi pane key <id> ctrl+c` |
+| Open a new terminal pane | `plexi pane new -n "<label>"` |
+| Launch Codex in a shell pane | `plexi pane command <id> "co" --enter` |
+| Rename / label a pane | `plexi pane name <id> "<label>"` |
+| List panes (alive? find by name) | `plexi pane list` |
+| Close a pane | `plexi pane close <id>` |
+
+`co` is the alias for `codex -s danger-full-access`. **Label every pane** (`worker-N`, `tester-N`) so you can find them in `plexi pane list` by name instead of tracking bare ids.
+
+### Capture forms — `--lines 20` is the default; full-buffer reads are the exception
+
+Since stint 0383 (PR #2390), `capture --lines N` returns the last N real content lines on full-screen TUIs. Cost order, cheapest first:
+
+- `plexi pane capture <id> --lines 20` → bounded tail. **Default for every status check** — it answers "what is Codex's last message" in ~20 lines.
+- `plexi pane capture <id> --from-cursor <CURSOR>` → delta since a known cursor.
+- `plexi pane capture <id> --from-cursor 0` → full buffer. Only when parsing a long verdict/report whose start you'd otherwise miss — and delegate that read to a sub-agent.
+
+Known pre-existing bug (stint 0385): `--from-cursor <N>` deltas can return empty on a live pane. If a delta comes back empty, fall back to `--lines`, not to a full-buffer dump.
+
+Append `2>&1 | grep -v "sudo:"` to plexi commands run from your own Bash — the background-updater bug (#2339) spews `sudo:` noise on stderr that otherwise dominates every output.
+
+The **source of truth for whether Codex is busy is `plexi pane list` → the pane's `agent.state`** (`working` = mid-task, `idle` = at prompt / done). Machine-readable progress lives in the pane's **slot files** (`slots.pr`, `slots.pipeline_phase`, `slots.status`, `slots.last_error`, `slots.issue`) — read those files, not scrollback. Use capture for human-readable context, but gate decisions on `agent.state`, never on capture.
+
+### ANTI-THRASH — never re-fire a command to "confirm" it landed
+
+The failure mode this skill exists to prevent: send a key → capture comes back empty → assume it didn't land → re-send → loop forever. **Banned.**
+
+- Send a prompt/keystroke **once**. To verify it registered, poll `plexi pane list` `agent.state` flipping `idle → working` (or a slot file changing) — **never** by re-sending.
+- If a capture is empty or a cursor is unchanged, that tells you nothing. Do **not** act on it and do **not** repeat the command. Fall back to `pane list` / slot files.
+- If you catch yourself about to run the exact same command a **second** time in a row, STOP. Something is wrong with your read path, not the pane. Re-orient via `pane list`.
+- `sudo: a terminal is required to read the password` lines are the background-updater bug (#2339). They are **noise**, not a command failure — the `plexi` command itself still returned `exit 0`. Never retry because of them.
+
+### CRITICAL gotcha — send does not submit
+
+`plexi pane send`'s `\n` does **not** reliably auto-submit inside the Codex TUI. Standing two-step, used dozens of times:
+
+```
+plexi pane send <id> "<prompt text>"
+sleep 1
+plexi pane key <id> enter
+sleep 3
+plexi pane capture <id> --from-cursor 0   # confirm it took; re-send enter ONCE if not
+```
+
+(This is for the Codex *TUI*. To launch `co` at the *shell* level in a fresh pane, `plexi pane command <id> "co" --enter` is fine.)
+
+## Batch into as few PRs as possible (hard rule)
+
+Before feeding anything, group the queue. **Fewer PRs is always better.** Small or related stints ship together in **one** PR — never one-PR-per-stint when they can combine. Parallelize implementation where stints don't share files, but collapse the result into the smallest number of PRs that makes sense. A **batch** is the unit of work below, not a single stint. Group by shared subsystem/files, small size, logical cohesion. When in doubt, combine.
+
+## Spawning a Codex pane
+
+```
+plexi pane new -n "worker-<N>"          # or tester-<N>
+# grab the new pane id from the command output (fall back to `plexi pane list`)
+plexi pane command <newid> "co" --enter
+sleep 4
+plexi pane capture <newid> --from-cursor 0   # confirm Codex booted to its prompt
+```
+
+## The loop
+
+For each **batch**, in order:
+
+1. **Worker: implement + open PR.** Send the worker Codex a directive:
+   > "Land stints `<ID>[, <ID>...]` **together in a single PR**. Run `stint show <ID>` for each, then claim them, implement in one worktree branched from alpha, and open ONE PR to alpha covering all of them per the repo AGENTS.md ship pipeline. Do NOT merge — a separate tester will validate first. **Before pushing, run the full CI-equivalent local gate, not just `cargo test --bin plexi`**: `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py`, and every `just gen-*-docs` / `just check-*-docs` generator touched by the diff (SDK, capability, config, authoring, CLI docs) — regenerate and commit any that are stale. `cargo test --bin plexi` passing is not sufficient evidence the PR is green; confirm with `gh pr checks <PR#>` after push and fix any red check before reporting done. **HARD GATE: paste the final green summary line of every suite you ran (`just test`, sdk pytest, mypy) in your reply — an unverified push gets bounced back without a tester round.** **Never end your turn while a build or test is still running — wait on it in the foreground and report its result.** Reply with the PR number when it's open and checks are green."
+
+   These two brief clauses exist because they were the top two token sinks in practice: workers pushing red (each unverified push burns a full tester round — install + validation) and workers yielding their turn mid-compile (each yield burns a nudge round-trip). State them up front in every worker brief, including fix-round briefs.
+
+   **Verify, don't trust the worker's self-report.** After the worker replies with a PR number, you run `gh pr checks <PR#>` yourself before spawning the tester. If anything is red, send it straight back to the worker as a bug (same routing as a tester-found bug) — do not spawn the tester against a build with known-red CI.
+
+   Send → `key enter` **once**. Confirm it registered by polling `plexi pane list` until the pane's `agent.state` reads `working` — not by re-sending, not by capture.
+
+2. **Check in every 15 min — cheaply.** `ScheduleWakeup` `delaySeconds: 900`. On each wake, the default check is **two direct commands, no sub-agent**:
+
+   ```
+   plexi pane list 2>&1 | grep -v "sudo:"           # agent.state: working or idle
+   plexi pane capture <id> --lines 20 2>&1 | grep -v "sudo:"   # Codex's last message
+   ```
+
+   `working` → reschedule, done. `idle` → the 20-line tail almost always contains the verdict/reply/blocker; act on it directly. This replaced ~40k-token sub-agent reads with ~1k-token direct reads in practice.
+
+   **Escalate to a sub-agent only when the tail is not enough** — a long tester report whose numbered bug list scrolled past 20 lines, or evidence that must be quoted verbatim from deep in the buffer. Sub-agent brief (pass the pane id):
+   > "Inspect Plexi pane `<id>` for status only — do not touch it. Run `plexi pane list` for its `agent.state`, then `plexi pane capture <id> --from-cursor 0` and read the END of the buffer. Report ≤8 lines: (a) task/PR + phase, (b) working / idle / blocked / usage-limited, (c) verdict or bug list verbatim if present, (d) any question verbatim. Never re-send a command to force output. Ignore 'sudo:' noise lines."
+
+   Act: progressing → reschedule 15 min. Idle-at-prompt / question / blocked → answer or nudge (send + enter). Errored / looping → `ctrl+c`, re-orient. Detect "done" by an explicit signal (PR number, "merged"), never by silence. **A worker idle with unfinished work gets nudged immediately, not next cycle.**
+
+   **Waiting on a merge or any single external state change:** don't poll with wakeups or sub-agents — arm one background watch and act when it fires:
+   ```
+   Bash (run_in_background): until [ "$(gh pr view <PR#> --json state --jq .state)" != "OPEN" ]; do sleep 15; done; gh pr view <PR#> --json state,mergedAt
+   ```
+
+3. **Spawn the Tester (fresh Codex pane) once the PR is open.** New pane, `co`, labeled `tester-<N>`. First gate on the diff: **if the PR is docs/scripts/manifests-only with no runtime behavior change, the tester does a diff review + `just test` and skips the 5-minute install** — say so in the brief and let the tester judge from `gh pr diff <PR#> --name-only`. Otherwise brief it:
+   > "Validate PR #`<PR#>` for Plexi. Install it with `just pr-install <PR#>` (from that PR's worktree), then **actually drive the installed `plexi-pr-<PR#>` build** — open the app, use the specific feature these stints added, and confirm end-to-end that it really works (not just that it compiles). Where the PR adds an assertion/validation/guard, prove it is **falsifiable**: deliberately violate it locally, watch it fail with a clear message, revert. Use the host's own primitives to observe it, never macOS `screencapture`/screen-recording (see below). Do NOT re-run test suites (`cargo test`, `just test`, pytest) — CI already proved them green; your job is exclusively behavior the suites can't see. Report a clear PASS, or a numbered list of concrete bugs/repro steps. Do not touch the code."
+
+   **Never let the tester reach for macOS `screencapture`, screen recording, or any OS permission prompt to observe the host.** Plexi ships its own capture primitives that need zero OS permission — use them instead:
+   - `plexi-pr-<N> pane state <id>` — normalized semantic tree (assert on `semantic.nodes`, not pixels).
+   - `plexi-pr-<N> pane capture <id>` — terminal/output content.
+   - `~/.plexi-pr-<N>/plexi.log` — every frame already logs `paint_fps`/`guest_fps`/`avg_host_ms`; this is FPS ground truth, not a screenshot.
+   - For an actual headless screenshot (human-review only): `just scene-live <scene.toml> pr-<N>` — its `shot` step captures the whole host framebuffer via `drive-host` capture, no OS permission needed.
+   - Full loop reference: `.agents/skills/drive-host/SKILL.md`.
+   If a tester pane starts calling `screencapture` or a permission dialog shows up in its transcript, that's a sign it's improvising instead of following this brief — correct it immediately with the primitives above.
+
+4. **Route the verdict.** Check the tester the same 15-min way (direct `--lines 20` read; sub-agent only for a long report).
+   - **Bugs found** → relay them verbatim to the **worker** pane, with the same hard-gate + no-yield clauses as the initial brief:
+     > "Tester found these on PR #`<PR#>`: <bug list>. Root-cause and fix on the same branch/PR — first determine whether each bug is caused by your change or pre-existing on alpha (prove pre-existing with a baseline repro before claiming it). Verify the fix yourself the same way the tester found it, paste green suite summary lines, push, reply with the commit."
+     If the worker proves a bug pre-existing on alpha with baseline evidence, drop it from this PR's gate and have the worker file a follow-up stint for it — never scope-creep the PR.
+     When the worker reports fixed, bounce back to the **tester** with a **targeted re-check, not a full re-run**:
+     > "New commits pushed to PR #`<PR#>` (<what changed>). Re-install and re-validate ONLY the changed path thoroughly, plus a one-item smoke of the previously-passed area. Everything else already passed at <prior commit> — do not repeat it. PASS or bugs?"
+     Loop worker ↔ tester until the tester returns a clean PASS. You are the only channel between them.
+   - **PASS** → proceed to merge.
+
+5. **Merge (only after tester PASS).** You confirm the state yourself, then have the worker squash-merge to alpha (it owns git):
+   ```
+   gh pr view <PR#> --json state,mergedAt
+   ```
+   Instruct the worker to squash-merge to alpha, then re-verify `state == MERGED` and `stint show <ID>` reflects done. **Then have the worker clean up its own worktree** — a bare `gh pr merge --squash` leaves the feature worktree behind (they piled up ~20 deep before this rule). Have it run `just merge-cleanup <PR#> <BRANCH>` (channel-clean + `wtp remove` + remote-branch delete), or at minimum `wtp remove <BRANCH>`, so the merged worktree is gone before the batch boundary. Squash-merge does not update `git branch --merged`, so never rely on that to find stale worktrees later — remove at merge time, here, while you still know the PR/branch.
+
+6. **Recycle panes for the next batch.** Default: `/compact` both panes in place at the batch boundary (send `/compact`, `key enter`, wait for `agent.state` idle) — this keeps the pane's environment while resetting context rot, and proved cheaper than close+respawn across many batches. Close and respawn fresh only when a pane has misbehaved (looping, degraded quality) or hit its usage wall:
+   ```
+   plexi pane close <worker-id> && plexi pane new -n "worker-<N+1>" ...
+   ```
+   Compact at clean boundaries only — batch merged, or pane about to take an unrelated task. Never mid-fix.
+
+## Usage-window management (Codex's 5-hour limit)
+
+When a pane prints `■ You've hit your usage limit. ... try again at 8:39 PM.`, parse the reset time and branch:
+
+- **Reset < 1 hour away** → wait. `ScheduleWakeup` for just past the reset, then resume that pane's task (send `enter` or re-send the prompt) and capture to confirm it picked back up.
+- **Reset ≥ 1 hour away** (window burned, too long to idle) → switch usage buckets instead of waiting; we have resets to spend. **In that pane:**
+  ```
+  plexi pane send <id> "/usage"
+  sleep 1
+  plexi pane key <id> enter
+  sleep 2
+  plexi pane capture <id> --from-cursor 0      # read the menu
+  ```
+  Drive the menu with `plexi pane key <id> <up|down|enter>` to re-enable / select the next allotment (options are TUI-version-dependent — read them each time). Capture after every keypress. Then resume the in-flight task.
+
+Applies to whichever pane hit the wall — worker or tester.
+
+## Stop conditions
+
+- Queue empty → report a summary (each batch → stints → PR# → merged) and stop scheduling wakeups.
+- A batch hard-fails repeatedly (worker can't clear the tester's bugs after a couple of full worker↔tester rounds) → stop, leave it, surface to the user with the last tester report. Don't thrash.
+- User says stop / takes over.
+
+## Status reports
+
+When the user asks for a report, status, or "is the loop running", the deliverable is a written summary, not tool output — they can see your tool calls; don't make them parse JSON. Answer in prose, lead with the current state: what's merged (PR# → stints), what's in flight (batch, PR, which pane is doing what, how long), any incidents, and what remains in the queue. Keep it under ~8 lines.
+
+## Rules
+
+- You never write code, run git, or merge yourself. You spawn, label, route messages, and observe. All work is the Codex panes'.
+- **Two panes per batch**: worker implements, a *separate fresh* tester validates. The tester must drive the real `plexi-pr-<N>` install build and use the feature — no pass on a compile alone.
+- **Fewest PRs possible** — batch small/related stints into one PR.
+- **No merge without a tester PASS.** Bugs route worker ↔ tester through you until clean.
+- **Protect your context.** Never dump full pane captures into your own window — delegate reading to a sub-agent that returns a minified report, and use `--from-cursor` for deltas. You hold summaries, not scrollback.
+- **Label every pane** and recycle (close both, spawn fresh worker) between batches.
+- Verify state with `gh`/`stint`, not any pane's self-report.
+- Keep the 15-min cadence via `ScheduleWakeup`; nudge rather than wait passively.

--- a/.agents/skills/whats-next/WHATS_NEXT.md
+++ b/.agents/skills/whats-next/WHATS_NEXT.md
@@ -6,17 +6,17 @@
 
 ---
 
-## Current State (2026-07-11, Assistant feature chain + full scene loop landed)
+## Current State (2026-07-11, dogfooding audit lands 15 assistant/UX tasks)
 
-`alpha` is at `ae73660e`: the Assistant feature chain through conversation history, skills, and native host tools (`0225`, `0226`, `0228`, `0229`) is landed. The shared headless/live testing stack and its full-host coverage audit (`0362`, `0363`, `0364`, `0361`) are also landed. Details live in `docs/DEVLOG.md`.
+`alpha` is at `56b994dc`: workspace saves are atomic (`0367`), CLI commands route by binary channel (`0365`), and the Assistant E2E harness with local/cheap-model verification (`0359`) is landed. Details in `docs/DEVLOG.md`.
 
-**Free v1 finish line is now effectively complete.** The last tracked P1 gap (`0349`) is merged. Remaining gap: production hosted-registry install smoke after deploying alpha — not yet a stint task.
+**Free v1 finish line: one verification pass remains.** `0358` (P1, small) — production hosted-registry install smoke from a clean machine after deploying alpha. It is the only tracked Epoch 1 gap.
 
-**Critical constraint — the Polar AUP wall.** Polar is a merchant of record for **first-party** digital products only; its AUP **bars the marketplace model** (third-party sellers collecting with payouts owed back). Epoch 3 is split: Plexi can sell **its own** apps + the AI Pro subscription on Polar now (`0355`, done); paying outside publishers their 85% needs a different rail (Stripe Connect / etc.) and is deferred to `0352`.
+**Dogfooding verdict (three live sessions, 2026-07-11):** the assistant-as-operator story has a load-bearing hole — the host's v3.7 tool protocol (`ExposeTools`/`AiTool`, landed in `0227`) was never wrapped in the Python SDK, so **zero apps can expose connector tools** (`0369`, P1). The assistant also cannot type into a terminal it opens (`0376`, P1), has no internet fetch (`0381`), can't target an existing pane (`0374`), and has no answer for "do you take MCP connectors?" (`0382`, scope task). Permission modal and assistant-UX papercuts round out the batch (`0372`/`0373`/`0375`/`0377`/`0378`/`0379`/`0380`).
 
-**First-party sales are code-complete, dark behind `SALES_ENABLED`.** `0356` (new, P1) is the single ops runbook to go live: production Polar org, product creation (`ensure-ai-pro` + `set-app`), private Railway artifact bucket, webhook registration, confirm legal live, flip the switch, real smoke purchase+refund. Pure provisioning, no code.
+**Commercial launch deferred post-v2 (decision 2026-07-11):** Ian is the sole publisher for now and no sales ship at launch. `0344`/`0352`/`0353`/`0356` moved to backlog, tagged `post-v2`. No code stubs needed — sales are already dark behind `SALES_ENABLED=false` and the publish/package seams (`publisher` field, `PublishClient`) are landed. Polar AUP constraint unchanged: first-party MoR only; third-party payouts need `0352`'s rail decision when the marketplace opens.
 
-Other open PRs affecting priority reading:
+Open PRs affecting priority reading:
 
 - `#2353` open: toolbar button focus-steal fix (external branch).
 - `#2323` draft: WASM SDK v3 platform POCs (`0285`/`0287` lane).
@@ -25,7 +25,7 @@ Other open PRs affecting priority reading:
 - `#2282` open: collapsible subcontexts (`0241`), failed build check.
 - `#1604` open: Windows port (external branch).
 
-Not real yet: first-party sales live (needs `0356` provisioning), production hosted-registry install smoke after alpha deploy, managed `ai.query` backend (`0323`), and the third-party publisher economy (`0344`/`0352`/`0353`).
+Not real yet: first-party sales live (`0356`), production registry install smoke (`0358`), app connector tools reachable from any app (`0369`), managed `ai.query` backend (`0323`), third-party publisher economy (`0344`/`0352`/`0353`).
 
 ---
 
@@ -33,40 +33,46 @@ Not real yet: first-party sales live (needs `0356` provisioning), production hos
 
 Every epoch feeds the next; the whole line points at `NORTH_STAR.md` ("the last app you'll ever need" — a portable, ownable computing environment where the marketplace is how it gets apps and makes money). Tasks are indented under the outcome they serve; nested tasks are blocked by their parent.
 
-### Epoch 1 — Land v1 (now) — effectively done
+### Epoch 1 — Land v1 (now) — one verification pass from done
 
 A stranger installs, an agent builds an app first try, a free reviewed app installs from the hosted registry.
 
-- First-user surface is landed (onboarding, website, registry go-live, palette scroll, app-builder DX, exemplar apps, SDK coverage, hosted Core catalog, native pane-key driving, agent pip color, explorer native media viewers `0349`). Detail in `docs/DEVLOG.md`.
-- **Missing tracked gap:** production hosted-registry smoke after deploy from alpha. Create a stint if it can't fold into release verification.
+- First-user surface is landed; detail in `docs/DEVLOG.md`.
+- `0358` production hosted-registry install smoke after alpha deploy — the last tracked gap, and the release gate.
 
 ### Epoch 2 — Intelligence (NORTH_STAR Phase 3; runs parallel to Epoch 3)
 
 The host Assistant becomes the workspace operator: typed host tools behind the permission broker, named agent personas, skills, app connectors.
 
-- Agent registry, model routing, settings scopes, conversation history, skills, and native host tools are landed (`0225`, `0226`, `0228`, `0229`).
-- `0359` adds deterministic Assistant orchestration traces and verifies the shipped loop against local and cheap cloud models.
+- Registry/routing/settings/history/skills/host-tools/E2E-harness are landed (`0225`–`0229`, `0359`).
+- **The connector-tool chain — the epoch's current spine:**
+  - `0369` Python SDK wrapper for `ExposeTools`/`AiTool`/`ToolResult` — unblocks every app exposing tools
+    - `0370` calculator exposes its operations as tools (first real connector)
+    - `0371` connector-tools POC app under `apps/dev/`
+  - `0382` scope: MCP servers as assistant tool sources (design decision, likely rides the `0369` connector path)
+- **Assistant operator gaps (each independently shippable):**
+  - `0376` terminal send-input tool (wraps existing `RunInLinkedTerminal`) — makes "run a command" real
+  - `0381` internet fetch tool (wraps existing `HttpRequest`/`net.http`)
+  - `0374` pane-targeting for `host.apps.open`/`host.panes.open`
+  - `0380` slash-command output visible to the assistant
+- **Assistant/permission UX (trust surface for everything above):**
+  - `0377` permission modal keyboard nav; `0378` modal responsive sizing
+  - `0373` interactive permissions manager (replaces `/revoke <target_id>`)
+  - `0372` `/model` interactive picker; `0375` `/compact` progress/success feedback
 
 ### Testing foundation: shared headless/live vocabulary
 
 Agents can drive and verify the host through one scene language. Generic verbs and symbolic handles, normalized Process/native/WASM semantics, the installed-host backend, and the full-host coverage audit are landed (`0362`, `0363`, `0364`, `0361`).
 
-### Epoch 3 — Commercial launch (Track B)
+### Epoch 3 — Commercial launch (Track B) — deferred post-v2 (decision 2026-07-11)
 
-The registry brokers money; never a dependency for running installed apps. Spec: `docs/marketplace-monetization.md` (`0315`, done). **Constraint (2026-07-10): Polar's AUP bars the third-party-marketplace model; Polar is first-party MoR only.** The path splits:
+The registry brokers money; never a dependency for running installed apps. Spec: `docs/marketplace-monetization.md` (`0315`, done). **Constraint (2026-07-10): Polar's AUP bars the third-party-marketplace model; Polar is first-party MoR only.**
 
-**Buy-side foundation — landed (0339/0347/0325 merged this session).**
+**Decision (2026-07-11): Ian is the only publisher for now; no sales at launch.** The whole money surface is deferred post-v2 — no code stubs required: first-party sales are already code-complete behind `SALES_ENABLED=false` (`website/src/server/env.ts`), the package envelope already carries `publisher`, and `PublishClient`/`Submission` (`src/app/marketplace.rs`) already serve the first-party publish path. The door is open; nothing in the free path references the deferred work.
 
-**First-party monetization — landed (`0355`, #2374 merged).** Polar product seam under Plexi's org + AI Pro wiring + operator CLI; `#2370`'s fixtures replaced with real sandbox-recorded order/subscription shapes (never-mock gap closed). **Remaining to go live:** `0356` (new, P1) — provision Polar org/product-ids/webhook-secret + private Railway bucket, confirm legal live, then flip `SALES_ENABLED` (ops, not a code task).
-  - `0322` host account-gated paid downloads — unblocks once `0339` lands
-    - `0341` marketplace app + paywall handoff
-  - `0354` verify AI Pro subscription gates on *active status*, not row presence
-  - `0323` Plexi-managed `ai.query` backend (recurring-revenue surface)
-
-**Third-party publisher economy (deferred until opening the marketplace to outside publishers):**
-- `0352` publisher payout rail (Stripe-Connect-vs-etc **decision**) + onboarding + tax — the gate for everything below
-  - `0344` publisher submission pipeline + review queue; its third-party Polar product creation is blocked on `0352`
-  - `0353` refund/chargeback clawback from publisher balance
+- Buy-side foundation + first-party monetization code: landed (`0339`/`0347`/`0325`/`0355`).
+- Backlogged post-v2: `0356` (sales go-live ops), `0352` (payout-rail decision) → `0344` (third-party submission pipeline), `0353` (clawback).
+- Still active (door-keeping code + recurring-revenue groundwork): `0322` paid-download host gating → `0341` marketplace app + paywall; `0354` subscription active-status gating; `0323` managed `ai.query` backend.
 
 ### Epoch 4 — The Platform (WASM, mobile, hosted)
 
@@ -91,11 +97,14 @@ Maintenance (input debt, hygiene, polish) deliberately does not appear here — 
 ## Priority Stack (flat view)
 
 P0: none.
-P1: `0356` (ops: go-live provisioning), `0241` (open PR needs fixing), `0285` (draft PR), `0322` (paid-download host gating), `0344`, `0341`*.
-P2 and below: `0354` (subscription active-gating), `0352`, `0353`, `0323`, `0317`, `0295`, `0297`, `0360` (P3, deactivate noise), `0357` (P3, sudo noise), plus the backlog in `stint list`.
+P1: `0358` (release gate: production install smoke), `0369` (SDK connector-tool wrapper — Epoch 2 chain head), `0376` (assistant terminal input), `0285` (draft PR), `0341`*, `0286`* (deep-blocked: `0344` now backlog), `0287`*.
+P2: `0322`, `0354`, `0323`, `0317`, `0295`, `0297`, `0374`, `0375`, `0377`, `0381`, `0368`, `0370`*, plus backlog.
+P3 and below: `0371`*, `0372`, `0373`, `0378`, `0379`, `0380`, `0382`, `0310`, `0318`, `0357`, `0360`, `0366`, post-v2 money cluster (`0344`, `0352`, `0353`, `0356`), plus backlog in `stint list`.
 (* = blocked; see the Arc for what unblocks them.)
 
-**Next recommended task:** `0356`, the production provisioning runbook that takes first-party sales live.
+**v1 release gate (decision 2026-07-11):** `0369` → `0376` → `0377` → `0358`. The first three close the assistant's broken-promise gaps (advertised capabilities that don't work: connector tools unreachable, no terminal input, mouse-only permission modal); `0358` runs last so the install smoke validates the build containing them. Everything else in the `0368`–`0382` dogfooding batch is post-v1 polish.
+
+**Next recommended task:** `0369` — SDK connector-tool wrapper, head of the release-gate chain.
 
 ---
 
@@ -110,6 +119,7 @@ P2 and below: `0354` (subscription active-gating), `0352`, `0353`, `0323`, `0317
 | `docs/marketplace-monetization.md` | Monetization + anti-fork model; the payout-rail decision (`0352`) records here |
 | `docs/package-envelope.md` | App/agent/skill package envelope spec (`0325`) |
 | `docs/workspace-env-secrets.md` | Shared resolver contract for secrets |
+| `docs/assistant-host-app.md` | Assistant spec: connectors, permissions, slash commands |
 | `docs/wasm-runtime.md` | WASM runtime spec |
 | `sdk/python/SDK_V3.md` | SDK v3 API reference |
 | `src/testing/TESTING.md` | Test infra reference |
@@ -119,5 +129,3 @@ P2 and below: `0354` (subscription active-gating), `0352`, `0353`, `0323`, `0317
 ## How To Update This File
 
 Run `/whats-next` at the start of any session -- it re-runs `stint list` + open-PR check and rewrites the Arc + Priority Stack. `/merge-pr` runs the same routine after every merge. Landed-work history goes to `docs/DEVLOG.md` (append a dated entry), never accumulates here. Sprints are retired: do not create sprint files or `sprint:` fields; new work slots into the Arc under the outcome it serves, with `blocked_by` wiring. Always update stint tasks first when new work is discovered.
-</content>
-</invoke>

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -24,3 +24,4 @@ A PRM is the destination spec for a feature. It describes what to build and why.
 | `wasm-runtime-impl-plan.md` | WASM runtime build sequence (G1-G7, G11-G13) | see file |
 | `workspace-env-secrets.md` | Workspace env secret injection | 0237 |
 | `package-envelope.md` | One package format for apps, agents, and skills | 0325 |
+| `scene-v2-e2e.md` | Scene v2 eventual assertions, geometry invariants, and failure artifacts | 0384 |

--- a/docs/DEVLOG.md
+++ b/docs/DEVLOG.md
@@ -6,6 +6,10 @@ or `/merge-pr` trims the orientation file; do not rewrite old entries.
 
 ---
 
+## 2026-07-11 — Durability + channel-routing fixes; assistant dogfooding audit
+
+`0367` made workspace saves atomic and durable (#2384); `0365` routed CLI commands by binary channel (#2385). Same evening, three live dogfooding sessions against the alpha assistant produced a 15-task audit batch (`0368`–`0382`): the headline finding is that the host-side v3.7 tool protocol (`ExposeTools`/`AiTool`, stint 0227) was never wrapped in the Python SDK, so zero apps can expose connector tools; the assistant also lacks terminal-input, internet, and pane-targeting tools, and the permission modal lacks keyboard support. Full detail on each task.
+
 ## 2026-07-11: Assistant E2E and affordable-model verification
 
 `0359` added a deterministic, non-egui Assistant harness around the real `AssistantApp` effect path and gated tool dispatcher. Tests script model/tool outcomes and capture typed events for agent and model selection, skills offered and activated, calls and JSON arguments, permission decisions, tool results, native host effects, results observed by the model, and final outcomes. Assertions reject missing, repeated, reordered, unexpected, or wrong-argument calls. Connector result injection fails before dispatch because connector success requires a registered app; HostHarness owns that integration layer.

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -54,18 +54,64 @@ impl FocusSegmentReason {
     }
 }
 
+/// Identity for a single owner on `PlexiApp.focus_stack` (stint 0240).
+///
+/// This is intentionally a thin trait over the `FocusLayer` enum rather than
+/// `Box<dyn FocusOwner>` trait objects. A genuine per-owner trait-object
+/// design (each overlay holding its own state behind `handle_input`/`render`
+/// methods) would require extracting every overlay's fields out of `PlexiApp`
+/// (e.g. `rename_buffer`, `text_overlay`, `pending_notifications`,
+/// `pending_event_consents`, `pending_raw_wasm_launches` — 15 pieces of
+/// ambient state, several shared across overlays) into independent structs.
+/// That is a much larger, higher-risk redesign than this stint's scope, and
+/// the existing `focus_stack.last()` match arms in `src/app/mod.rs` already
+/// give every overlay a single, uniform push/pop/dispatch contract. The enum
+/// stack is kept as the dispatch key; `FocusOwner` exists so overlay identity
+/// has one shared, named contract instead of being implicit in match arms.
+pub(crate) trait FocusOwner {
+    /// Stable name for logging and test assertions.
+    fn name(&self) -> &'static str;
+}
+
+impl FocusOwner for FocusLayer {
+    fn name(&self) -> &'static str {
+        match self {
+            Self::NotificationModal => "NotificationModal",
+            Self::ConfirmClose => "ConfirmClose",
+            Self::CommandPalette => "CommandPalette",
+            Self::RenamePane => "RenamePane",
+            Self::ContextRename => "ContextRename",
+            Self::ContextDescription => "ContextDescription",
+            Self::QuickNote => "QuickNote",
+            Self::CliSetupPrompt => "CliSetupPrompt",
+            Self::TextInput => "TextInput",
+            Self::ContextCloseConfirm => "ContextCloseConfirm",
+            Self::CapabilityModal => "CapabilityModal",
+            Self::EventConsent => "EventConsent",
+            Self::RawWasmReview => "RawWasmReview",
+            Self::NotesPicker => "NotesPicker",
+            Self::NotesTriage => "NotesTriage",
+        }
+    }
+}
+
 /// Which layer currently owns keyboard input.
 ///
-/// The top of `PlexiApp.focus_stack` is the active layer. When a non-`Pane`
-/// layer is on top, keyboard `Event::Key` and `Event::Text` events are drained
-/// from `ctx.input` each frame *after* the owning overlay has rendered, so
-/// panes and other passive readers see an empty event buffer. Global
-/// keybinds (Cmd+Q, Cmd+W, Cmd+Shift+A) are handled in `keys::poll_actions`
-/// which runs before the drain and is always live.
+/// The top of `PlexiApp.focus_stack` is the active [`FocusOwner`]. When a
+/// non-`Pane` layer is on top, `input_captured_by_overlay()` is `true` for the
+/// rest of the frame: `dispatch_app_key_events` does not run, and the owning
+/// layer's `*_handle_key` method (called before its `draw_*` render call —
+/// see `update()`) gets first access to the frame's keyboard input. Global
+/// keybinds (Cmd+Q, Cmd+W, Cmd+Shift+A) are handled in `keys::poll_actions`,
+/// which always runs regardless of what owns the stack (see
+/// `src/app/input_router.rs`).
 ///
-/// New overlays should push their layer on open and pop on close to inherit
-/// input capture. All keyboard-owning overlays live here: notification modal,
-/// confirm-close, command palette, run palette, and rename-pane.
+/// Every layer is pushed/popped through the single `reconcile_focus_layer` /
+/// `reconcile_promoted_focus_layer` helpers below — one uniform pattern for
+/// every overlay, whether its visibility is a plain boolean (`ConfirmClose`,
+/// `CommandPalette`, ...) or a re-promotable queue-backed layer that must
+/// jump back to the top even if buried (`CapabilityModal`, `EventConsent`,
+/// `RawWasmReview`).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum FocusLayer {
     NotificationModal,
@@ -341,6 +387,42 @@ impl PlexiApp {
         FocusLogOutcome::Heartbeat
     }
 
+    /// Returns `(app_active, keyboard_capture_active)` for the pane focused in
+    /// the active window. `app_active` is true whenever the focused pane is
+    /// running an app surface at all; `keyboard_capture_active` mirrors that
+    /// pane's own declared `App::keyboard_capture()` (e.g. file-browser
+    /// rename/quick-look mode, a CLI-backed app's Form view) — an advisory
+    /// policy flag `keys::poll_actions` reads to suppress global shortcuts
+    /// while the app owns text input. This is intentionally separate from
+    /// `focus_stack`/`FocusLayer`: overlay layers are exclusive (they block
+    /// `dispatch_app_key_events` entirely), while app-declared capture must
+    /// NOT block the app from still receiving its own keys — folding the two
+    /// into one stack would make an app go deaf on the frame it starts
+    /// capturing. Deduplicates what was previously an inline block
+    /// re-computed at the `poll_actions` call site.
+    pub(crate) fn focused_app_capture_state(&self) -> (bool, bool) {
+        let context = &self.windows[self.active_window];
+        let focused_pane = context.focused_pane.and_then(|tile_id| {
+            if let Some(egui_tiles::Tile::Pane(pane_id)) = context.tree.tiles.get(tile_id) {
+                context.panes.get(pane_id)
+            } else {
+                None
+            }
+        });
+        let active = focused_pane
+            .map(|pane| pane.as_app().is_some())
+            .unwrap_or(false);
+        let capture = if active {
+            focused_pane
+                .and_then(|p| p.as_app())
+                .map(|a| a.runtime.keyboard_capture())
+                .unwrap_or(false)
+        } else {
+            false
+        };
+        (active, capture)
+    }
+
     /// Returns `true` when the current top focus layer is a non-critical modal
     /// that QuickNote (Cmd+0) is allowed to dismiss and replace.
     ///
@@ -418,6 +500,39 @@ impl PlexiApp {
     pub(crate) fn pop_focus_layer(&mut self, layer: &FocusLayer) {
         if self.focus_stack.last() == Some(layer) {
             self.focus_stack.pop();
+        }
+    }
+
+    /// Shared reconciliation for a plain boolean-backed focus layer: push it
+    /// when `should_own` becomes true and it isn't already in the stack, pop
+    /// it (via `retain`, so a stale entry buried under something else is still
+    /// removed) when `should_own` goes false. Every non-promoting `sync_*`
+    /// function is a one-line call to this — see `FocusLayer` doc comment for
+    /// why this replaces 11 near-identical bodies instead of dyn dispatch.
+    fn reconcile_focus_layer(&mut self, layer: FocusLayer, should_own: bool) {
+        let has_layer = self.focus_stack.contains(&layer);
+        if should_own && !has_layer {
+            self.push_focus_layer(layer);
+        } else if !should_own && has_layer {
+            log::info!("focus: {} layer removed by sync (retain)", layer.name());
+            self.focus_stack.retain(|l| *l != layer);
+        }
+    }
+
+    /// Shared reconciliation for a "promoted" focus layer: a queue-backed
+    /// overlay (capability prompts, event consents, raw-wasm review) that
+    /// must jump back to the top of the stack even if another layer pushed on
+    /// top of it while it was buried, not just toggle membership.
+    fn reconcile_promoted_focus_layer(&mut self, layer: FocusLayer, should_own: bool) {
+        let has_layer = self.focus_stack.contains(&layer);
+        let is_top = self.focus_stack.last() == Some(&layer);
+        if should_own && !is_top {
+            self.focus_stack.retain(|l| *l != layer);
+            log::info!("focus: {} promoted to top", layer.name());
+            self.push_focus_layer(layer);
+        } else if !should_own && has_layer {
+            log::info!("focus: {} layer released", layer.name());
+            self.focus_stack.retain(|l| *l != layer);
         }
     }
 
@@ -875,26 +990,14 @@ impl PlexiApp {
     /// toggled from multiple paths, and the focus stack must follow it
     /// deterministically each frame.
     pub(crate) fn sync_confirm_close_focus(&mut self) {
-        let should_own = self.pending_close;
-        let has_layer = self.focus_stack.contains(&FocusLayer::ConfirmClose);
-        if should_own && !has_layer {
-            self.push_focus_layer(FocusLayer::ConfirmClose);
-        } else if !should_own && has_layer {
-            log::info!("focus: ConfirmClose layer removed by sync (retain)");
-            self.focus_stack.retain(|l| *l != FocusLayer::ConfirmClose);
-        }
+        self.reconcile_focus_layer(FocusLayer::ConfirmClose, self.pending_close);
     }
 
     pub(crate) fn sync_context_close_focus(&mut self) {
-        let should_own = self.pending_context_close.is_some();
-        let has_layer = self.focus_stack.contains(&FocusLayer::ContextCloseConfirm);
-        if should_own && !has_layer {
-            self.push_focus_layer(FocusLayer::ContextCloseConfirm);
-        } else if !should_own && has_layer {
-            log::info!("focus: ContextCloseConfirm layer removed by sync (retain)");
-            self.focus_stack
-                .retain(|l| *l != FocusLayer::ContextCloseConfirm);
-        }
+        self.reconcile_focus_layer(
+            FocusLayer::ContextCloseConfirm,
+            self.pending_context_close.is_some(),
+        );
     }
 
     /// Returns the `context_id` of the child context if the focused pane is a Portal tile.
@@ -967,44 +1070,20 @@ impl PlexiApp {
     }
 
     pub(crate) fn sync_notification_modal_focus(&mut self) {
-        let should_own = self.show_notification_modal;
-        let has_layer = self.focus_stack.contains(&FocusLayer::NotificationModal);
-        if should_own && !has_layer {
-            self.push_focus_layer(FocusLayer::NotificationModal);
-        } else if !should_own && has_layer {
-            log::info!("focus: NotificationModal layer removed by sync (retain)");
-            self.focus_stack
-                .retain(|l| *l != FocusLayer::NotificationModal);
-        }
+        self.reconcile_focus_layer(FocusLayer::NotificationModal, self.show_notification_modal);
     }
 
     pub(crate) fn sync_cli_setup_prompt_focus(&mut self) {
-        let should_own = self.show_cli_setup_prompt;
-        let has_layer = self.focus_stack.contains(&FocusLayer::CliSetupPrompt);
-        if should_own && !has_layer {
-            log::info!("cli_setup: focus captured by CliSetupPrompt layer");
-            self.push_focus_layer(FocusLayer::CliSetupPrompt);
-        } else if !should_own && has_layer {
-            log::info!("cli_setup: CliSetupPrompt focus layer released");
-            // Use retain rather than pop_focus_layer so stale entries are removed
-            // even if another layer was pushed on top (e.g. via rapid state change).
-            self.focus_stack
-                .retain(|l| *l != FocusLayer::CliSetupPrompt);
-        }
+        self.reconcile_focus_layer(FocusLayer::CliSetupPrompt, self.show_cli_setup_prompt);
     }
 
     /// Reconcile the command-palette focus layer with `show_command_palette`.
     /// Same pattern as the notification modal: boolean visibility flag is the
     /// source of truth, focus stack follows it deterministically each frame.
     pub(crate) fn sync_command_palette_focus(&mut self) {
-        let should_own = self.show_command_palette;
-        let has_layer = self.focus_stack.contains(&FocusLayer::CommandPalette);
-        if should_own && !has_layer {
-            self.push_focus_layer(FocusLayer::CommandPalette);
-        } else if !should_own && has_layer {
-            log::info!("focus: CommandPalette layer removed by sync (retain)");
-            self.focus_stack
-                .retain(|l| *l != FocusLayer::CommandPalette);
+        let was_owned = self.focus_stack.contains(&FocusLayer::CommandPalette);
+        self.reconcile_focus_layer(FocusLayer::CommandPalette, self.show_command_palette);
+        if was_owned && !self.show_command_palette {
             // Explicitly surrender egui focus from palette_search so AccessKit
             // doesn't hold a stale focused node ID after the widget is gone.
             self.ctx.memory_mut(|m| {
@@ -1069,14 +1148,7 @@ impl PlexiApp {
 
     /// Reconcile the rename-pane focus layer with `renaming_pane`.
     pub(crate) fn sync_rename_pane_focus(&mut self) {
-        let should_own = self.renaming_pane.is_some();
-        let has_layer = self.focus_stack.contains(&FocusLayer::RenamePane);
-        if should_own && !has_layer {
-            self.push_focus_layer(FocusLayer::RenamePane);
-        } else if !should_own && has_layer {
-            log::info!("focus: RenamePane layer removed by sync (retain)");
-            self.focus_stack.retain(|l| *l != FocusLayer::RenamePane);
-        }
+        self.reconcile_focus_layer(FocusLayer::RenamePane, self.renaming_pane.is_some());
     }
 
     /// Reconcile the context-rename focus layer. Active when `renaming_window`
@@ -1084,25 +1156,12 @@ impl PlexiApp {
     /// never renders, so we promote the rename to a modal overlay instead.
     pub(crate) fn sync_context_rename_focus(&mut self) {
         let should_own = self.renaming_window.is_some() && !self.sidebar_visible;
-        let has_layer = self.focus_stack.contains(&FocusLayer::ContextRename);
-        if should_own && !has_layer {
-            self.push_focus_layer(FocusLayer::ContextRename);
-        } else if !should_own && has_layer {
-            log::info!("focus: ContextRename layer removed by sync (retain)");
-            self.focus_stack.retain(|l| *l != FocusLayer::ContextRename);
-        }
+        self.reconcile_focus_layer(FocusLayer::ContextRename, should_own);
     }
 
     /// Reconcile the text-input overlay focus layer with `text_overlay`.
     pub(crate) fn sync_text_input_focus(&mut self) {
-        let should_own = self.text_overlay.is_some();
-        let has_layer = self.focus_stack.contains(&FocusLayer::TextInput);
-        if should_own && !has_layer {
-            self.push_focus_layer(FocusLayer::TextInput);
-        } else if !should_own && has_layer {
-            log::info!("focus: TextInput layer removed by sync (retain)");
-            self.focus_stack.retain(|l| *l != FocusLayer::TextInput);
-        }
+        self.reconcile_focus_layer(FocusLayer::TextInput, self.text_overlay.is_some());
     }
 
     /// Push/pop `FocusLayer::CapabilityModal` based on whether the focused app
@@ -1111,19 +1170,7 @@ impl PlexiApp {
     /// lag.
     pub(crate) fn sync_capability_modal_focus(&mut self) {
         let should_own = self.focused_pane_has_pending_prompts();
-        let has_layer = self.focus_stack.contains(&FocusLayer::CapabilityModal);
-        let is_top = matches!(self.focus_stack.last(), Some(FocusLayer::CapabilityModal));
-        if should_own && !is_top {
-            // Push to top (re-promoting from buried position if already in stack).
-            self.focus_stack
-                .retain(|l| *l != FocusLayer::CapabilityModal);
-            log::info!("capability_modal: focus captured — pending prompts on focused pane");
-            self.push_focus_layer(FocusLayer::CapabilityModal);
-        } else if !should_own && has_layer {
-            log::info!("capability_modal: focus released — prompt queue drained");
-            self.focus_stack
-                .retain(|l| *l != FocusLayer::CapabilityModal);
-        }
+        self.reconcile_promoted_focus_layer(FocusLayer::CapabilityModal, should_own);
     }
 
     /// Promote/release the host event-consent modal layer to mirror
@@ -1131,30 +1178,12 @@ impl PlexiApp {
     /// keyboard so Enter/Esc resolve it instead of leaking to the focused pane.
     pub(crate) fn sync_event_consent_focus(&mut self) {
         let should_own = !self.pending_event_consents.is_empty();
-        let has_layer = self.focus_stack.contains(&FocusLayer::EventConsent);
-        let is_top = matches!(self.focus_stack.last(), Some(FocusLayer::EventConsent));
-        if should_own && !is_top {
-            self.focus_stack.retain(|l| *l != FocusLayer::EventConsent);
-            log::info!("event_consent: focus captured — subscribe consent awaiting decision");
-            self.push_focus_layer(FocusLayer::EventConsent);
-        } else if !should_own && has_layer {
-            log::info!("event_consent: focus released — consent queue drained");
-            self.focus_stack.retain(|l| *l != FocusLayer::EventConsent);
-        }
+        self.reconcile_promoted_focus_layer(FocusLayer::EventConsent, should_own);
     }
 
     pub(crate) fn sync_raw_wasm_review_focus(&mut self) {
         let should_own = !self.pending_raw_wasm_launches.is_empty();
-        let has_layer = self.focus_stack.contains(&FocusLayer::RawWasmReview);
-        let is_top = matches!(self.focus_stack.last(), Some(FocusLayer::RawWasmReview));
-        if should_own && !is_top {
-            self.focus_stack.retain(|l| *l != FocusLayer::RawWasmReview);
-            log::info!("raw_wasm_review: focus captured - launch review awaiting decision");
-            self.push_focus_layer(FocusLayer::RawWasmReview);
-        } else if !should_own && has_layer {
-            log::info!("raw_wasm_review: focus released - review queue drained");
-            self.focus_stack.retain(|l| *l != FocusLayer::RawWasmReview);
-        }
+        self.reconcile_promoted_focus_layer(FocusLayer::RawWasmReview, should_own);
     }
 
     /// Returns true when the focused app pane has at least one pending prompt.

--- a/src/app/input_router.rs
+++ b/src/app/input_router.rs
@@ -1,0 +1,185 @@
+//! `PlexiInput`: frame-scoped ownership-transfer router for keyboard/text input.
+//!
+//! Historically every consumer (overlays, app panes, `keys::poll_actions`, the
+//! vendored terminal widget) independently peeked or mutated the single shared
+//! `ctx.input()` queue. Ownership was enforced retroactively — whichever
+//! consumer's render call happened to run first got the event, and a stray
+//! reorder could silently change behavior (see the paste-leak class of bug,
+//! #1236). `PlexiInput` makes ownership explicit instead: at the start of each
+//! frame every input-*intent* event (physical keys, typed text, paste) is
+//! removed from `ctx` into an owned buffer. That buffer is handed, in order,
+//! to `keys::poll_actions` (the global hotkey allowlist — always runs first,
+//! see module doc on why) and then to the top [`crate::app::FocusLayer`] on
+//! `PlexiApp.focus_stack`, each consuming only what it claims. Whatever
+//! neither claims is handed back to `ctx` so the render pass (focused
+//! `TextEdit` widgets, app pane `handle_key`, the terminal widget) still sees
+//! it — this refactor is scoped to the overlay/global-hotkey ownership path;
+//! it does not (yet) migrate app-pane or terminal PTY input to full
+//! ownership-transfer (see `stint 0240` design-decision notes).
+//!
+//! Mouse events, scroll, hover, and paint requests are untouched: this router
+//! is keyboard/text-input scoped only.
+
+/// Returns true for events this router takes ownership of: physical keys,
+/// typed text, and paste. IME composition events
+/// (`Event::Ime`) are deliberately excluded — composition must reach the
+/// focused egui widget directly during the render pass for correct pre-edit
+/// rendering, so carving them out here (rather than letting them fall through
+/// a catch-all) avoids a silent foot-gun.
+fn is_input_intent(event: &egui::Event) -> bool {
+    matches!(
+        event,
+        egui::Event::Key { .. } | egui::Event::Text(_) | egui::Event::Paste(_)
+    )
+}
+
+/// Owned, frame-scoped buffer of input-intent events removed from `ctx`.
+pub(crate) struct PlexiInput {
+    events: Vec<egui::Event>,
+    modifiers: egui::Modifiers,
+}
+
+impl PlexiInput {
+    /// Remove all input-intent events from `ctx`'s raw event queue into an
+    /// owned buffer, leaving IME and non-keyboard events (paint, motion,
+    /// scroll, hover) untouched for egui's normal hit-testing/paint path.
+    pub(crate) fn take_from(ctx: &egui::Context) -> Self {
+        let (events, modifiers) = ctx.input_mut(|i| {
+            let mut taken = Vec::new();
+            i.events.retain(|e| {
+                if is_input_intent(e) {
+                    taken.push(e.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+            (taken, i.modifiers)
+        });
+        Self { events, modifiers }
+    }
+
+    pub(crate) fn modifiers(&self) -> egui::Modifiers {
+        self.modifiers
+    }
+
+    /// True when the buffer holds no more input-intent events (everything was
+    /// claimed by a consumer this frame, or none arrived).
+    pub(crate) fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Consume the first matching key-press event, removing it from the
+    /// buffer. Mirrors `egui::InputState::consume_key`, but operates on this
+    /// frame's owned buffer instead of the shared `ctx` queue, so a claim here
+    /// is final — no other consumer this frame (or the render pass that
+    /// follows, once events are given back) can see it again.
+    pub(crate) fn consume_key(&mut self, modifiers: egui::Modifiers, key: egui::Key) -> bool {
+        if let Some(pos) = self.events.iter().position(|e| {
+            matches!(
+                e,
+                egui::Event::Key { key: k, pressed: true, modifiers: m, .. }
+                    if *k == key && m.matches_logically(modifiers)
+            )
+        }) {
+            self.events.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Consume a key press only if it isn't a synthetic OS auto-repeat.
+    /// Mirrors `keys::consume_key_no_repeat`'s intent for callers holding a
+    /// `PlexiInput` instead of a raw `InputState`.
+    pub(crate) fn consume_key_no_repeat(&mut self, modifiers: egui::Modifiers, key: egui::Key) -> bool {
+        if let Some(pos) = self.events.iter().position(|e| {
+            matches!(
+                e,
+                egui::Event::Key { key: k, pressed: true, repeat: false, modifiers: m, .. }
+                    if *k == key && m.matches_logically(modifiers)
+            )
+        }) {
+            self.events.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Return every event still owned by this buffer to `ctx` so consumers
+    /// later in the frame (a focused `TextEdit`, `dispatch_app_key_events`,
+    /// the terminal widget's own read of `ctx.input()`) see whatever this
+    /// frame's router-level consumers didn't claim. No-op if the buffer is
+    /// already empty.
+    pub(crate) fn give_back(self, ctx: &egui::Context) {
+        if self.is_empty() {
+            return;
+        }
+        ctx.input_mut(|i| {
+            let mut merged = self.events;
+            merged.append(&mut i.events);
+            i.events = merged;
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key_event(key: egui::Key, modifiers: egui::Modifiers) -> egui::Event {
+        egui::Event::Key {
+            key,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers,
+        }
+    }
+
+    #[test]
+    fn take_from_removes_key_events_but_leaves_pointer_events() {
+        let ctx = egui::Context::default();
+        let mut raw = egui::RawInput::default();
+        raw.events.push(key_event(egui::Key::A, egui::Modifiers::COMMAND));
+        raw.events.push(egui::Event::PointerMoved(egui::pos2(1.0, 1.0)));
+        let _ = ctx.run(raw, |ctx| {
+            let input = PlexiInput::take_from(ctx);
+            assert_eq!(input.events.len(), 1);
+            // Pointer event stays behind in ctx.
+            ctx.input(|i| {
+                assert_eq!(i.events.len(), 1);
+                assert!(matches!(i.events[0], egui::Event::PointerMoved(_)));
+            });
+        });
+    }
+
+    #[test]
+    fn consume_key_claims_exactly_one_matching_event() {
+        let ctx = egui::Context::default();
+        let mut raw = egui::RawInput::default();
+        raw.events.push(key_event(egui::Key::A, egui::Modifiers::COMMAND));
+        let _ = ctx.run(raw, |ctx| {
+            let mut input = PlexiInput::take_from(ctx);
+            assert!(input.consume_key(egui::Modifiers::COMMAND, egui::Key::A));
+            assert!(!input.consume_key(egui::Modifiers::COMMAND, egui::Key::A));
+            assert!(input.is_empty());
+        });
+    }
+
+    #[test]
+    fn give_back_restores_unclaimed_events_to_ctx() {
+        let ctx = egui::Context::default();
+        let mut raw = egui::RawInput::default();
+        raw.events.push(key_event(egui::Key::B, egui::Modifiers::NONE));
+        let _ = ctx.run(raw, |ctx| {
+            let input = PlexiInput::take_from(ctx);
+            input.give_back(ctx);
+            ctx.input(|i| {
+                assert_eq!(i.events.len(), 1);
+                assert!(matches!(i.events[0], egui::Event::Key { key: egui::Key::B, .. }));
+            });
+        });
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11,6 +11,7 @@ pub mod host_mcp;
 pub mod host_version;
 pub mod http;
 pub mod image_viewer_app;
+pub(crate) mod input_router;
 pub(crate) mod launch_spec;
 mod lifecycle;
 pub mod marketplace;
@@ -2375,6 +2376,11 @@ impl eframe::App for PlexiApp {
         // even when an overlay holds focus (see early-return guard in `keys::poll_actions`).
         let mut early_modal_cmds: Vec<crate::app::app_trait::AppCommand> = Vec::new();
         let overlay_key_disposition = if self.input_captured_by_overlay() {
+            // Ownership-transfer (stint 0240): take this frame's input-intent
+            // events out of `ctx` once, hand them to the top `FocusLayer`
+            // below, then give back whatever it didn't claim before rendering
+            // — see `src/app/input_router.rs`.
+            let mut router_input = crate::app::input_router::PlexiInput::take_from(ctx);
             // Step 0: QuickNote preemption (#1626).
             // Cmd+0 is a high-priority action that must fire even when a non-critical
             // modal is open. Consume the key here — before the overlay draw phase can
@@ -2382,44 +2388,67 @@ impl eframe::App for PlexiApp {
             // modal and open QuickNote. Critical modals (ConfirmClose, CapabilityModal,
             // ContextCloseConfirm) are not preemptable and fall through to handle_key.
             let qn_binding = self.key_bindings.open_quick_note;
-            let qn_pressed = ctx.input_mut(|i| i.consume_key(qn_binding.0, qn_binding.1));
+            let qn_pressed = router_input.consume_key(qn_binding.0, qn_binding.1);
             if qn_pressed && self.is_quick_note_preemptable() {
                 self.dismiss_preemptable_modal();
                 self.open_quick_note_modal();
                 self.sync_notification_modal_focus();
                 self.sync_command_palette_focus();
                 log::info!("quick_note: opened by preempting non-critical modal");
+                router_input.give_back(ctx);
                 crate::app::app_trait::KeyDisposition::Consumed
             } else {
-                // Step 1: run the overlay's handle_key (consumes its owned key events).
+                // Step 1: run the overlay's handle_key (consumes its owned key events
+                // from this frame's ownership-transfer buffer, before any render).
                 let disposition = match self.focus_stack.last() {
-                    Some(FocusLayer::NotificationModal) => self.notification_modal_handle_key(ctx),
-                    Some(FocusLayer::ConfirmClose) => self.confirm_close_handle_key(ctx),
-                    Some(FocusLayer::CommandPalette) => self.command_palette_handle_key(ctx),
-                    Some(FocusLayer::RenamePane) => self.rename_pane_handle_key(ctx),
-                    Some(FocusLayer::ContextRename) => self.context_rename_handle_key(ctx),
+                    Some(FocusLayer::NotificationModal) => {
+                        self.notification_modal_handle_key(&mut router_input)
+                    }
+                    Some(FocusLayer::ConfirmClose) => {
+                        self.confirm_close_handle_key(&mut router_input)
+                    }
+                    Some(FocusLayer::CommandPalette) => {
+                        self.command_palette_handle_key(&mut router_input)
+                    }
+                    Some(FocusLayer::RenamePane) => self.rename_pane_handle_key(&mut router_input),
+                    Some(FocusLayer::ContextRename) => {
+                        self.context_rename_handle_key(&mut router_input)
+                    }
                     Some(FocusLayer::ContextDescription) => {
-                        self.context_description_handle_key(ctx)
+                        self.context_description_handle_key(&mut router_input)
                     }
-                    Some(FocusLayer::QuickNote) => self.quick_note_handle_key(ctx),
-                    Some(FocusLayer::CliSetupPrompt) => self.cli_setup_prompt_handle_key(ctx),
-                    Some(FocusLayer::TextInput) => self.text_input_handle_key(ctx),
+                    Some(FocusLayer::QuickNote) => self.quick_note_handle_key(&mut router_input),
+                    Some(FocusLayer::CliSetupPrompt) => {
+                        self.cli_setup_prompt_handle_key(&mut router_input)
+                    }
+                    Some(FocusLayer::TextInput) => self.text_input_handle_key(&mut router_input),
                     Some(FocusLayer::ContextCloseConfirm) => {
-                        self.context_close_confirm_handle_key(ctx)
+                        self.context_close_confirm_handle_key(&mut router_input)
                     }
-                    Some(FocusLayer::CapabilityModal) => self.capability_modal_handle_key(ctx),
-                    Some(FocusLayer::EventConsent) => self.event_consent_handle_key(ctx),
-                    Some(FocusLayer::RawWasmReview) => self.raw_wasm_review_handle_key(ctx),
+                    Some(FocusLayer::CapabilityModal) => {
+                        self.capability_modal_handle_key(&mut router_input)
+                    }
+                    Some(FocusLayer::EventConsent) => {
+                        self.event_consent_handle_key(&mut router_input)
+                    }
+                    Some(FocusLayer::RawWasmReview) => {
+                        self.raw_wasm_review_handle_key(&mut router_input)
+                    }
                     Some(FocusLayer::NotesPicker) => {
-                        self.notes_picker_handle_key(ctx);
+                        self.notes_picker_handle_key(&mut router_input);
                         crate::app::app_trait::KeyDisposition::Passthrough
                     }
                     Some(FocusLayer::NotesTriage) => {
-                        self.notes_triage_handle_key(ctx);
+                        self.notes_triage_handle_key(ctx, &mut router_input);
                         crate::app::app_trait::KeyDisposition::Passthrough
                     }
                     None => crate::app::app_trait::KeyDisposition::Passthrough,
                 };
+                // Give back whatever this overlay didn't claim so the render
+                // pass below (a focused `TextEdit`'s own Text/Key consumption)
+                // still sees it — this refactor transfers ownership for the
+                // *first* consumer each frame, not for the whole frame.
+                router_input.give_back(ctx);
                 // Step 2: render the overlay (visual only — key reads already done above).
                 match self.focus_stack.last().cloned() {
                     Some(FocusLayer::NotificationModal) => {
@@ -3772,41 +3801,33 @@ impl eframe::App for PlexiApp {
 
         // Determine if the focused pane has an active app surface, and whether
         // that app has declared keyboard_capture mode.
-        let (app_active, keyboard_capture_active) = {
-            let context = &self.windows[self.active_window];
-            let focused_pane = context.focused_pane.and_then(|tile_id| {
-                if let Some(egui_tiles::Tile::Pane(pane_id)) = context.tree.tiles.get(tile_id) {
-                    context.panes.get(pane_id)
-                } else {
-                    None
-                }
-            });
-            let active = focused_pane
-                .map(|pane| pane.as_app().is_some())
-                .unwrap_or(false);
-            let capture = if active {
-                focused_pane
-                    .and_then(|p| p.as_app())
-                    .map(|a| a.runtime.keyboard_capture())
-                    .unwrap_or(false)
-            } else {
-                false
-            };
-            (active, capture)
-        };
+        let (app_active, keyboard_capture_active) = self.focused_app_capture_state();
 
         // Handle keyboard shortcuts. Global shortcuts (Cmd+Q, Cmd+W, Cmd+P) always
         // fire; all other shortcuts are suppressed when an overlay holds focus via
         // the early-return guard in `keys::poll_actions`.
+        //
+        // `poll_actions` is the outer, always-first consumer of the frame's
+        // `PlexiInput` ownership-transfer buffer (stint 0240) — it claims
+        // global-hotkey events out of the router before giving back whatever
+        // it didn't claim. The call site (and its position in the frame) is
+        // otherwise unchanged from the previous `ctx.input_mut` closure: the
+        // router replaces *how* events are read, not the pipeline's ordering,
+        // since re-sequencing overlay/app/terminal dispatch around the router
+        // needs interactive verification beyond this refactor's scope (see
+        // `src/app/input_router.rs`).
         let modal_open = self.input_captured_by_overlay();
-        for action in keys::poll_actions(
-            ctx,
+        let mut router_input = crate::app::input_router::PlexiInput::take_from(ctx);
+        let poll_actions_result = keys::poll_actions(
+            &mut router_input,
             &self.binding_table,
             app_active,
             keyboard_capture_active,
             modal_open,
             self.show_shortcuts,
-        ) {
+        );
+        router_input.give_back(ctx);
+        for action in poll_actions_result {
             match action {
                 Action::SplitHorizontal => {
                     self.windows[self.active_window].clear_zoom();

--- a/src/host/keys.rs
+++ b/src/host/keys.rs
@@ -616,41 +616,6 @@ fn modifier_count(m: &egui::Modifiers) -> u32 {
     m.command as u32 + m.shift as u32 + m.ctrl as u32 + m.alt as u32
 }
 
-/// Consume the first matching key event that is NOT a key-repeat.
-/// Returns `true` if one was found and consumed.
-fn consume_key_no_repeat(
-    input: &mut egui::InputState,
-    modifiers: egui::Modifiers,
-    key: egui::Key,
-) -> bool {
-    let mut found = false;
-    input.events.retain(|event| {
-        if found {
-            return true;
-        }
-        if let egui::Event::Key {
-            key: ev_key,
-            pressed: true,
-            repeat: false,
-            modifiers: ev_mod,
-            ..
-        } = event
-        {
-            if *ev_key == key
-                && (!modifiers.command || ev_mod.command)
-                && (!modifiers.shift || ev_mod.shift)
-                && (!modifiers.ctrl || ev_mod.ctrl)
-                && (!modifiers.alt || ev_mod.alt)
-            {
-                found = true;
-                return false; // consume by dropping
-            }
-        }
-        true
-    });
-    found
-}
-
 // egui::Modifiers::COMMAND sets mac_cmd=false, but macOS runtime input always
 // sets mac_cmd=true when Cmd is held. Raw == comparison fails on macOS.
 // Compare only the four logical fields to avoid this platform mismatch.
@@ -1166,8 +1131,15 @@ pub fn build_binding_table(b: &KeyBindings) -> Vec<BindingEntry> {
 ///   Each overlay's `*_handle_key` method owns its own key contract and runs before this function.
 /// `shortcuts_overlay_open` — the shortcuts overlay is open; suppresses CloseApp (Escape)
 ///   so the overlay can own Escape for dismissal.
+///
+/// `input` is a [`crate::app::input_router::PlexiInput`] buffer already taken
+/// out of `ctx` for this frame (stint 0240's ownership-transfer router).
+/// `poll_actions` is the outer, always-first consumer — the global hotkey
+/// allowlist runs before any [`crate::app::FocusLayer`] on the focus stack
+/// sees an event, so a global shortcut can never be shadowed by overlay/app
+/// render order.
 pub fn poll_actions(
-    ctx: &egui::Context,
+    input: &mut crate::app::input_router::PlexiInput,
     table: &[BindingEntry],
     app_active: bool,
     keyboard_capture_active: bool,
@@ -1176,63 +1148,61 @@ pub fn poll_actions(
 ) -> Vec<Action> {
     let mut actions = Vec::new();
 
-    ctx.input_mut(|input| {
-        for entry in table {
-            match entry.context {
-                BindingContext::Global => {
-                    // Always checked — no suppression.
-                }
-                BindingContext::Normal => {
-                    if keyboard_capture_active || overlay_open {
-                        continue;
-                    }
-                }
-                BindingContext::AppActive => {
-                    if !app_active || keyboard_capture_active || overlay_open {
-                        continue;
-                    }
-                    // Escape is suppressed when the shortcuts overlay is open so the overlay
-                    // can own it for dismissal.
-                    if matches!(entry.action, Action::CloseApp) && shortcuts_overlay_open {
-                        continue;
-                    }
+    for entry in table {
+        match entry.context {
+            BindingContext::Global => {
+                // Always checked — no suppression.
+            }
+            BindingContext::Normal => {
+                if keyboard_capture_active || overlay_open {
+                    continue;
                 }
             }
-
-            if entry.exact && !modifiers_match_exact(&input.modifiers, &entry.modifiers) {
-                continue;
-            }
-
-            let triggered = if entry.no_repeat {
-                consume_key_no_repeat(input, entry.modifiers, entry.key)
-            } else {
-                input.consume_key(entry.modifiers, entry.key)
-            };
-            if triggered {
-                actions.push(entry.action.clone());
-            }
-        }
-
-        // Switch context (Cmd+1 through Cmd+9) — hardcoded loop; not individual table entries.
-        if !(keyboard_capture_active || overlay_open) {
-            let num_keys = [
-                egui::Key::Num1,
-                egui::Key::Num2,
-                egui::Key::Num3,
-                egui::Key::Num4,
-                egui::Key::Num5,
-                egui::Key::Num6,
-                egui::Key::Num7,
-                egui::Key::Num8,
-                egui::Key::Num9,
-            ];
-            for (i, key) in num_keys.into_iter().enumerate() {
-                if input.consume_key(egui::Modifiers::COMMAND, key) {
-                    actions.push(Action::SwitchContext(i));
+            BindingContext::AppActive => {
+                if !app_active || keyboard_capture_active || overlay_open {
+                    continue;
+                }
+                // Escape is suppressed when the shortcuts overlay is open so the overlay
+                // can own it for dismissal.
+                if matches!(entry.action, Action::CloseApp) && shortcuts_overlay_open {
+                    continue;
                 }
             }
         }
-    });
+
+        if entry.exact && !modifiers_match_exact(&input.modifiers(), &entry.modifiers) {
+            continue;
+        }
+
+        let triggered = if entry.no_repeat {
+            input.consume_key_no_repeat(entry.modifiers, entry.key)
+        } else {
+            input.consume_key(entry.modifiers, entry.key)
+        };
+        if triggered {
+            actions.push(entry.action.clone());
+        }
+    }
+
+    // Switch context (Cmd+1 through Cmd+9) — hardcoded loop; not individual table entries.
+    if !(keyboard_capture_active || overlay_open) {
+        let num_keys = [
+            egui::Key::Num1,
+            egui::Key::Num2,
+            egui::Key::Num3,
+            egui::Key::Num4,
+            egui::Key::Num5,
+            egui::Key::Num6,
+            egui::Key::Num7,
+            egui::Key::Num8,
+            egui::Key::Num9,
+        ];
+        for (i, key) in num_keys.into_iter().enumerate() {
+            if input.consume_key(egui::Modifiers::COMMAND, key) {
+                actions.push(Action::SwitchContext(i));
+            }
+        }
+    }
 
     actions
 }
@@ -1255,8 +1225,9 @@ mod tests {
         });
         let mut actions = Vec::new();
         let _ = ctx.run(raw, |ctx| {
+            let mut input = crate::app::input_router::PlexiInput::take_from(ctx);
             actions = poll_actions(
-                ctx, &table, /* app_active */ true, /* keyboard_capture */ false,
+                &mut input, &table, /* app_active */ true, /* keyboard_capture */ false,
                 /* overlay_open */ false, /* shortcuts_overlay_open */ false,
             );
         });

--- a/src/overlays/confirmations.rs
+++ b/src/overlays/confirmations.rs
@@ -226,21 +226,21 @@ impl PlexiApp {
 
     pub(crate) fn confirm_close_handle_key(
         &mut self,
-        _ctx: &egui::Context,
+        _input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         crate::app::app_trait::KeyDisposition::Consumed
     }
 
     pub(crate) fn context_close_confirm_handle_key(
         &mut self,
-        _ctx: &egui::Context,
+        _input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         crate::app::app_trait::KeyDisposition::Consumed
     }
 
     pub(crate) fn capability_modal_handle_key(
         &mut self,
-        _ctx: &egui::Context,
+        _input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         crate::app::app_trait::KeyDisposition::Consumed
     }
@@ -325,7 +325,7 @@ impl PlexiApp {
 
     pub(crate) fn event_consent_handle_key(
         &mut self,
-        _ctx: &egui::Context,
+        _input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         crate::app::app_trait::KeyDisposition::Consumed
     }
@@ -428,7 +428,7 @@ impl PlexiApp {
 
     pub(crate) fn raw_wasm_review_handle_key(
         &mut self,
-        _ctx: &egui::Context,
+        _input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         crate::app::app_trait::KeyDisposition::Consumed
     }

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -775,35 +775,35 @@ impl PlexiApp {
 
     pub(crate) fn rename_pane_handle_key(
         &mut self,
-        _ctx: &egui::Context,
+        _input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         crate::app::app_trait::KeyDisposition::Consumed
     }
 
     pub(crate) fn context_rename_handle_key(
         &mut self,
-        _ctx: &egui::Context,
+        _input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         crate::app::app_trait::KeyDisposition::Consumed
     }
 
     pub(crate) fn context_description_handle_key(
         &mut self,
-        _ctx: &egui::Context,
+        _input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         crate::app::app_trait::KeyDisposition::Consumed
     }
 
     pub(crate) fn text_input_handle_key(
         &mut self,
-        _ctx: &egui::Context,
+        _input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         crate::app::app_trait::KeyDisposition::Consumed
     }
 
     pub(crate) fn command_palette_handle_key(
         &mut self,
-        _ctx: &egui::Context,
+        _input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         crate::app::app_trait::KeyDisposition::Consumed
     }

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -118,7 +118,7 @@ impl PlexiApp {
         }
     }
 
-    pub(crate) fn notes_picker_handle_key(&mut self, ctx: &egui::Context) {
+    pub(crate) fn notes_picker_handle_key(&mut self, input: &mut crate::app::input_router::PlexiInput) {
         let visible = self.notes_picker_filtered().len();
 
         #[derive(Clone, Copy)]
@@ -131,27 +131,25 @@ impl PlexiApp {
             OpenNew,
         }
 
-        let action = ctx.input_mut(|i| {
-            if i.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
-                Some(PickerKey::Escape)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::Enter) {
-                Some(PickerKey::Enter)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
-                || i.consume_key(egui::Modifiers::COMMAND, egui::Key::J)
-            {
-                Some(PickerKey::Down)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
-                || i.consume_key(egui::Modifiers::COMMAND, egui::Key::K)
-            {
-                Some(PickerKey::Up)
-            } else if i.consume_key(egui::Modifiers::COMMAND, egui::Key::S) {
-                Some(PickerKey::OpenNew)
-            } else if i.consume_key(egui::Modifiers::COMMAND, egui::Key::Backspace) {
-                Some(PickerKey::Delete)
-            } else {
-                None
-            }
-        });
+        let action = if input.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
+            Some(PickerKey::Escape)
+        } else if input.consume_key(egui::Modifiers::NONE, egui::Key::Enter) {
+            Some(PickerKey::Enter)
+        } else if input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown)
+            || input.consume_key(egui::Modifiers::COMMAND, egui::Key::J)
+        {
+            Some(PickerKey::Down)
+        } else if input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp)
+            || input.consume_key(egui::Modifiers::COMMAND, egui::Key::K)
+        {
+            Some(PickerKey::Up)
+        } else if input.consume_key(egui::Modifiers::COMMAND, egui::Key::S) {
+            Some(PickerKey::OpenNew)
+        } else if input.consume_key(egui::Modifiers::COMMAND, egui::Key::Backspace) {
+            Some(PickerKey::Delete)
+        } else {
+            None
+        };
         match action {
             Some(PickerKey::Escape) => {
                 if self.notes_picker_query.is_empty() {

--- a/src/overlays/notes_triage.rs
+++ b/src/overlays/notes_triage.rs
@@ -32,7 +32,11 @@ impl PlexiApp {
 
     /// Handle keyboard input for the triage overlay. Must surrender egui focus
     /// so the TextEdit in the modal does not reclaim it.
-    pub(crate) fn notes_triage_handle_key(&mut self, ctx: &egui::Context) {
+    pub(crate) fn notes_triage_handle_key(
+        &mut self,
+        ctx: &egui::Context,
+        input: &mut crate::app::input_router::PlexiInput,
+    ) {
         ctx.memory_mut(|m| {
             if let Some(id) = m.focused() {
                 m.surrender_focus(id);
@@ -55,46 +59,42 @@ impl PlexiApp {
             Action(u8),
         }
 
-        let action = ctx.input_mut(|i| {
-            if i.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
-                Some(TriageKey::Close)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::S) {
-                Some(TriageKey::Keep)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::D)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::X)
-            {
-                Some(TriageKey::Trash)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::H)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowLeft)
-            {
-                Some(TriageKey::Prev)
-            } else if i.consume_key(egui::Modifiers::NONE, egui::Key::L)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::N)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
-                || i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowRight)
-            {
-                Some(TriageKey::Next)
-            } else {
-                // Check digit keys 1–9 for actions.
-                let digits = [
-                    (egui::Key::Num1, 1u8),
-                    (egui::Key::Num2, 2),
-                    (egui::Key::Num3, 3),
-                    (egui::Key::Num4, 4),
-                    (egui::Key::Num5, 5),
-                    (egui::Key::Num6, 6),
-                    (egui::Key::Num7, 7),
-                    (egui::Key::Num8, 8),
-                    (egui::Key::Num9, 9),
-                ];
-                for (key, digit) in digits {
-                    if i.consume_key(egui::Modifiers::NONE, key) {
-                        return Some(TriageKey::Action(digit));
-                    }
-                }
-                None
-            }
-        });
+        let action = if input.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
+            Some(TriageKey::Close)
+        } else if input.consume_key(egui::Modifiers::NONE, egui::Key::S) {
+            Some(TriageKey::Keep)
+        } else if input.consume_key(egui::Modifiers::NONE, egui::Key::D)
+            || input.consume_key(egui::Modifiers::NONE, egui::Key::X)
+        {
+            Some(TriageKey::Trash)
+        } else if input.consume_key(egui::Modifiers::NONE, egui::Key::H)
+            || input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowLeft)
+        {
+            Some(TriageKey::Prev)
+        } else if input.consume_key(egui::Modifiers::NONE, egui::Key::L)
+            || input.consume_key(egui::Modifiers::NONE, egui::Key::N)
+            || input.consume_key(egui::Modifiers::NONE, egui::Key::Enter)
+            || input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowRight)
+        {
+            Some(TriageKey::Next)
+        } else {
+            // Check digit keys 1–9 for actions.
+            let digits = [
+                (egui::Key::Num1, 1u8),
+                (egui::Key::Num2, 2),
+                (egui::Key::Num3, 3),
+                (egui::Key::Num4, 4),
+                (egui::Key::Num5, 5),
+                (egui::Key::Num6, 6),
+                (egui::Key::Num7, 7),
+                (egui::Key::Num8, 8),
+                (egui::Key::Num9, 9),
+            ];
+            digits
+                .into_iter()
+                .find(|(key, _)| input.consume_key(egui::Modifiers::NONE, *key))
+                .map(|(_, digit)| TriageKey::Action(digit))
+        };
 
         match action {
             Some(TriageKey::Close) => {

--- a/src/overlays/notification_modal.rs
+++ b/src/overlays/notification_modal.rs
@@ -758,7 +758,7 @@ impl PlexiApp {
 
     pub(crate) fn notification_modal_handle_key(
         &mut self,
-        ctx: &egui::Context,
+        input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         use crate::app_protocol::NotifyKind;
         let shortcuts_blocked = self
@@ -772,14 +772,13 @@ impl PlexiApp {
             .map(|n| matches!(n.kind, NotifyKind::Input))
             .unwrap_or(true);
 
-        let (h_pressed, l_pressed) = ctx.input_mut(|i| {
-            if shortcuts_blocked || !i.modifiers.is_none() {
-                return (false, false);
-            }
-            let h = i.consume_key(egui::Modifiers::NONE, egui::Key::H);
-            let l = i.consume_key(egui::Modifiers::NONE, egui::Key::L);
+        let (h_pressed, l_pressed) = if shortcuts_blocked || !input.modifiers().is_none() {
+            (false, false)
+        } else {
+            let h = input.consume_key(egui::Modifiers::NONE, egui::Key::H);
+            let l = input.consume_key(egui::Modifiers::NONE, egui::Key::L);
             (h, l)
-        });
+        };
 
         if h_pressed {
             log::info!("notification cycle: prev (H)");

--- a/src/overlays/quick_note.rs
+++ b/src/overlays/quick_note.rs
@@ -132,13 +132,11 @@ impl PlexiApp {
 
     pub(crate) fn quick_note_handle_key(
         &mut self,
-        ctx: &egui::Context,
+        input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         // Consume Cmd+0 so poll_actions doesn't fire OpenQuickNote while the modal
         // is already open — that would reset mid-session note state.
-        ctx.input_mut(|i| {
-            i.consume_key(egui::Modifiers::COMMAND, egui::Key::Num0);
-        });
+        input.consume_key(egui::Modifiers::COMMAND, egui::Key::Num0);
         crate::app::app_trait::KeyDisposition::Consumed
     }
 }

--- a/src/overlays/setup.rs
+++ b/src/overlays/setup.rs
@@ -362,7 +362,7 @@ impl PlexiApp {
 impl PlexiApp {
     pub(crate) fn cli_setup_prompt_handle_key(
         &mut self,
-        _ctx: &egui::Context,
+        _input: &mut crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         crate::app::app_trait::KeyDisposition::Consumed
     }

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -775,7 +775,8 @@ fn notification_modal_handle_key_returns_consumed() {
     let mut h = HostHarness::new();
     h.app.push_focus_layer(FocusLayer::NotificationModal);
     let ctx = h.app.ctx.clone();
-    let disposition = h.app.notification_modal_handle_key(&ctx);
+    let mut input = crate::app::input_router::PlexiInput::take_from(&ctx);
+    let disposition = h.app.notification_modal_handle_key(&mut input);
     assert_eq!(
         disposition,
         KeyDisposition::Consumed,


### PR DESCRIPTION
Stint task: 0240. No linked GitHub issue.

Former GH issues #1238 and #1239 covered this scope originally. Both were closed; their bodies were used as the spec reference for this work. This PR is tracked purely via the operating graph going forward.

## Summary

- Deduped all 15 `sync_*_focus` bodies (src/app/focus.rs) into two shared helpers (`reconcile_focus_layer`, `reconcile_promoted_focus_layer`) — `grep -rn focus_stack src/` now shows one uniform push/pop/retain pattern.
- Added `PlexiInput` (src/app/input_router.rs): a frame-scoped router that takes ownership of Key/Text/Paste events out of `ctx` at frame start and dispatches them to `keys::poll_actions` (global hotkeys) then the active `FocusLayer`, before any render pass runs. IME events explicitly excluded (must reach the focused widget directly for composition).
- Migrated all 15 overlay `*_handle_key` methods to take `&mut PlexiInput` instead of reading `ctx.input()` directly.

## Scope note — this is a partial slice

This does not complete the full plan described in the original closed-issue bodies (former #1238/#1239):
- `FocusLayer` enum was not deleted — kept as an enum, just deduped. Deleting it requires extracting ~15 pieces of ambient `PlexiApp` state into independent `FocusOwner`-implementing structs; judged too large/risky for this pass.
- Terminal panes and app-pane `dispatch_app_key_events` were not migrated onto the router — the vendored `egui_term` widget still reads `ctx.input()` directly. That migration needs interactive drive-host verification of real terminal typing that this pass could not safely perform headless.
- The terminal Cmd+A bug (the router's original motivating case) is not fixed — root cause lives in the unmigrated terminal path.

Follow-up task 0387 covers the remaining FocusLayer deletion + terminal-pane router migration + Cmd+A fix, blocked on this PR merging. Task 0258 (Cmd+A select-all) is re-pointed to block on 0387 instead of 0240.

## Test evidence

- `cargo test --bin plexi`: 1479 passed, 0 failed, 2 ignored.
- Codex automated review could not run this pass (CLI version rejects the `--base`/`--uncommitted` + custom prompt combination used by the skill; also hit account usage limit). No automated review pass — flagging for manual review attention.
- Conclusion: binary install required for full confidence — this touches global hotkey dispatch and every overlay's key handling. `cargo test` covers headless HostHarness scenarios but not real keyboard-event timing; install via `just pr-install <PR>` and exercise overlays (command palette, notifications, quick note, rename, notes picker/triage) plus global hotkeys before merge.
