### PR TITLE
refactor(host): route terminal + app-pane input through PlexiInput, delete FocusLayer enum (stint 0387)

### DIFF
--- a/deps/egui_term/src/lib.rs
+++ b/deps/egui_term/src/lib.rs
@@ -22,4 +22,4 @@ pub use bindings::{Binding, BindingAction, InputKind, KeyboardBinding};
 pub use diag::set_repaint_diag_hook;
 pub use font::{FontSettings, TerminalFont};
 pub use theme::{ColorPalette, TerminalTheme};
-pub use view::TerminalView;
+pub use view::{terminal_widget_id, TerminalView};

--- a/deps/egui_term/src/view.rs
+++ b/deps/egui_term/src/view.rs
@@ -28,6 +28,20 @@ use alacritty_terminal::grid::Dimensions;
 
 const EGUI_TERM_WIDGET_ID_PREFIX: &str = "egui_term::instance::";
 
+/// Deterministic egui widget id for a terminal instance, keyed by the unique
+/// backend/pane id (`TerminalBackend::id`). Computed the same way on both sides:
+/// the terminal widget interacts under this id (see [`TerminalView::ui`]), and
+/// the Plexi host recomputes it to check whether the focused terminal actually
+/// owns egui keyboard focus before taking the frame's input for it (stint 0387
+/// regression fix). Because `backend_id` is globally unique and there is a
+/// single render site per terminal, a hierarchy-independent `Id::new` is
+/// collision-free and reconstructable outside the render tree — unlike
+/// `Ui::make_persistent_id`, which folds in the parent id and cannot be
+/// recomputed by the host.
+pub fn terminal_widget_id(backend_id: u64) -> Id {
+    Id::new(format!("{EGUI_TERM_WIDGET_ID_PREFIX}{backend_id}"))
+}
+
 #[derive(Debug, Clone)]
 enum InputAction {
     BackendCall(BackendCommand),
@@ -133,8 +147,15 @@ pub struct TerminalView<'a> {
 
 impl Widget for TerminalView<'_> {
     fn ui(self, ui: &mut egui::Ui) -> Response {
-        let (layout, painter) =
-            ui.allocate_painter(self.size, egui::Sense::click());
+        // Interact under the deterministic `widget_id` (not `allocate_painter`'s
+        // auto id) so egui keyboard focus is held under an id the host can
+        // recompute via `terminal_widget_id` (stint 0387). This mirrors
+        // `allocate_painter` (allocate space → interact → clip painter), only
+        // with our own id for the interaction.
+        let (_auto_id, rect) = ui.allocate_space(self.size);
+        let layout = ui.interact(rect, self.widget_id, egui::Sense::click());
+        let clip_rect = ui.clip_rect().intersect(rect);
+        let painter = ui.painter().with_clip_rect(clip_rect);
 
         let widget_id = self.widget_id;
         let mut state = ui.memory(|m| {
@@ -155,10 +176,7 @@ impl Widget for TerminalView<'_> {
 
 impl<'a> TerminalView<'a> {
     pub fn new(ui: &mut egui::Ui, backend: &'a mut TerminalBackend) -> Self {
-        let widget_id = ui.make_persistent_id(format!(
-            "{}{}",
-            EGUI_TERM_WIDGET_ID_PREFIX, backend.id
-        ));
+        let widget_id = terminal_widget_id(backend.id);
 
         Self {
             widget_id,

--- a/deps/egui_term/src/view.rs
+++ b/deps/egui_term/src/view.rs
@@ -102,6 +102,19 @@ impl Default for TerminalViewState {
     }
 }
 
+/// Host-supplied, frame-scoped keyboard input for a terminal (stint 0387).
+///
+/// The Plexi host takes these events out of egui's shared input queue *before*
+/// the render pass and hands them here via [`TerminalView::with_input`], so
+/// egui's own render-time widget machinery (e.g. `allocate_painter`'s built-in
+/// Cmd+A select-all) can no longer consume a key before the terminal processes
+/// it. Only keyboard-intent events belong here (`Key`/`Text`/`Copy`/`Cut`/
+/// `Paste`); pointer and wheel events stay on the normal egui/ctx path.
+pub struct SuppliedInput {
+    pub events: Vec<egui::Event>,
+    pub modifiers: egui::Modifiers,
+}
+
 pub struct TerminalView<'a> {
     widget_id: Id,
     has_focus: bool,
@@ -111,6 +124,11 @@ pub struct TerminalView<'a> {
     font: TerminalFont,
     theme: TerminalTheme,
     bindings_layout: BindingsLayout,
+    /// Keyboard input supplied by the host for this frame. `None` until the
+    /// host calls [`Self::with_input`]; when absent the terminal processes no
+    /// keyboard events (it never falls back to reading `ctx` for keys — that
+    /// silent fallback is exactly the Cmd+A-steal bug this design removes).
+    supplied_input: Option<SuppliedInput>,
 }
 
 impl Widget for TerminalView<'_> {
@@ -151,7 +169,22 @@ impl<'a> TerminalView<'a> {
             font: TerminalFont::default(),
             theme: TerminalTheme::default(),
             bindings_layout: BindingsLayout::new(),
+            supplied_input: None,
         }
+    }
+
+    /// Supply this frame's keyboard input from the host's ownership-transfer
+    /// buffer (stint 0387). Focused terminals receive the frame's taken events;
+    /// unfocused terminals receive an empty event list (they only need
+    /// pointer/wheel, which stays on the ctx path). See [`SuppliedInput`].
+    #[inline]
+    pub fn with_input(
+        mut self,
+        events: Vec<egui::Event>,
+        modifiers: egui::Modifiers,
+    ) -> Self {
+        self.supplied_input = Some(SuppliedInput { events, modifiers });
+        self
     }
 
     #[inline]
@@ -213,7 +246,7 @@ impl<'a> TerminalView<'a> {
     }
 
     fn process_input(
-        self,
+        mut self,
         layout: &Response,
         state: &mut TerminalViewState,
     ) -> Self {
@@ -226,20 +259,20 @@ impl<'a> TerminalView<'a> {
             return self;
         }
 
-        let modifiers = layout.ctx.input(|i| i.modifiers);
-        let events = layout.ctx.input(|i| i.events.clone());
-        // Temporary diagnostic
-        for event in &events {
-            if let egui::Event::Key {
-                key: egui::Key::A,
-                pressed: true,
-                modifiers: m,
-                ..
-            } = event
-            {
-                log::info!("[diag-term] Key::A in terminal events: cmd={} shift={} has_focus={}", m.command, m.shift, has_focus);
-            }
-        }
+        // Keyboard/text/copy/paste events come from the host-supplied
+        // ownership buffer (stint 0387), never from `ctx` — so egui's own
+        // render-time widget machinery can't swallow a key (e.g. Cmd+A) before
+        // the terminal sees it. Pointer + wheel events stay on the normal
+        // ctx path and are appended after the supplied keyboard events. When no
+        // input was supplied the terminal simply processes no keyboard this
+        // frame (no silent ctx fallback).
+        let supplied = self.supplied_input.take();
+        let modifiers = supplied
+            .as_ref()
+            .map(|s| s.modifiers)
+            .unwrap_or_else(|| layout.ctx.input(|i| i.modifiers));
+        let mut events = supplied.map(|s| s.events).unwrap_or_default();
+        events.extend(layout.ctx.input(|i| i.events.clone()));
         for event in events {
             let mut input_actions = vec![];
 

--- a/src/app/app_trait.rs
+++ b/src/app/app_trait.rs
@@ -232,9 +232,14 @@ pub trait App: Send {
     /// Render the app into the given Ui region.
     fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>);
 
-    /// Handle raw key input before it reaches the terminal.
+    /// Handle raw key input before the app's own render pass.
     /// Return `Consumed` to prevent downstream handlers from seeing the event.
-    fn handle_key(&mut self, _input: &egui::InputState) -> KeyDisposition {
+    ///
+    /// Reads from the frame's [`crate::app::input_router::PlexiInput`] ownership
+    /// buffer (via `input.key_pressed(..)` / `input.events()` /
+    /// `input.modifiers()`) rather than `ctx.input()`, so an app and the global
+    /// hotkey allowlist can never both claim the same key.
+    fn handle_key(&mut self, _input: &crate::app::input_router::PlexiInput) -> KeyDisposition {
         KeyDisposition::Passthrough
     }
 

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -68,6 +68,15 @@ impl PlexiApp {
     /// This is a read of focus state only; it never mutates `active_window` or
     /// `focused_pane` to steer the lookup (repo trap: don't switch global state
     /// to thread data through a function).
+    ///
+    /// Invariant (stint 0387 regression fix): the steal only fires when the
+    /// focused terminal actually owns egui keyboard focus. If any *other* egui
+    /// widget holds keyboard focus this frame — e.g. the inline sidebar
+    /// context-rename `TextEdit`, which is not a focus layer while the sidebar
+    /// is visible, or any future inline editor — this returns `None` so those
+    /// keystrokes stay in `ctx` for that widget. The terminal surrenders egui
+    /// focus in that situation via `render`'s `suppress_focus` path, so
+    /// `memory.focused()` names the other widget rather than the terminal.
     pub(super) fn take_focused_terminal_input(
         &mut self,
         ctx: &egui::Context,
@@ -92,6 +101,16 @@ impl PlexiApp {
         // "[process exited]" view auto-closes on the next keypress, which it now
         // reads from this buffer).
         self.windows[active].panes.get(&pane_id)?.as_terminal()?;
+
+        // Gate the steal on egui keyboard focus: if another widget owns focus
+        // (its id differs from this terminal's deterministic widget id), the
+        // frame's keyboard belongs to that widget — leave `ctx` untouched so it
+        // receives the keys. See the doc comment's invariant.
+        if let Some(focused_id) = ctx.memory(|m| m.focused()) {
+            if focused_id != egui_term::terminal_widget_id(pane_id) {
+                return None;
+            }
+        }
 
         let router = crate::app::input_router::PlexiInput::take_from(ctx);
         let (keyboard_events, modifiers) = router.into_events_and_modifiers();

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -10,10 +10,16 @@ impl PlexiApp {
     /// happens separately via [`drain_all_app_commands`] so background
     /// apps can surface notifications and other commands while the
     /// focused pane is something else (or while a modal holds focus).
-    pub(super) fn dispatch_app_key_events(&mut self, ctx: &egui::Context) {
+    pub(super) fn dispatch_app_key_events(
+        &mut self,
+        ctx: &egui::Context,
+        input: &mut crate::app::input_router::PlexiInput,
+    ) {
         // Block key delivery when the OS has focus elsewhere. `active_window` is not
         // cleared on blur, so without this guard keys route to the last-active pane
         // even while a different app (or Plexi window) owns the keyboard.
+        // `viewport().focused` is window-focus state, not an event, so it is
+        // untouched by the router's `take_from` — read it from `ctx` directly.
         if !ctx.input(|i| i.viewport().focused.unwrap_or(true)) {
             return;
         }
@@ -33,17 +39,83 @@ impl PlexiApp {
         let Some(app_pane) = pane.as_app_mut() else {
             return;
         };
-        // Capture whether the app consumed the key. If it did, also consume
-        // Escape from the InputState so poll_actions can't re-fire CloseApp
-        // for keys the app already handled (e.g. Escape exiting search mode
-        // in the file browser rather than closing the pane).
-        let disposition = ctx.input(|i| app_pane.runtime.handle_key(i));
+        // The app classifies keys from the frame's ownership-transfer buffer
+        // (stint 0387) rather than a second read of `ctx`. If it consumed the
+        // key, also claim Escape/ArrowUp out of the buffer so `poll_actions`
+        // (which takes the same buffer later this frame) can't re-fire CloseApp
+        // for keys the app already handled — e.g. Escape exiting search mode in
+        // the file browser rather than closing the pane, or ArrowUp recalling a
+        // prior message in the assistant.
+        let disposition = app_pane.runtime.handle_key(input);
         if disposition == crate::app::app_trait::KeyDisposition::Consumed {
-            ctx.input_mut(|i| {
-                i.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
-                i.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp);
-            });
+            input.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+            input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp);
         }
+    }
+
+    /// If the focused pane in the active window is a terminal and no overlay
+    /// owns keyboard input, take this frame's input-intent events out of `ctx`
+    /// and return them for the focused terminal (stint 0387). The caller threads
+    /// the result into `render_panels` → the tiling behavior → the focused
+    /// `TerminalView`, so the events reach the terminal without egui's
+    /// render-time widget machinery getting a chance to consume them first.
+    ///
+    /// Returns `None` (leaving `ctx` untouched) when an overlay owns input, when
+    /// the OS window is unfocused, or when the focused pane is not a terminal —
+    /// in those cases nothing takes ownership and the normal ctx/render path
+    /// handles keyboard.
+    ///
+    /// This is a read of focus state only; it never mutates `active_window` or
+    /// `focused_pane` to steer the lookup (repo trap: don't switch global state
+    /// to thread data through a function).
+    pub(super) fn take_focused_terminal_input(
+        &mut self,
+        ctx: &egui::Context,
+    ) -> Option<crate::render::terminal_pane::TerminalInput> {
+        if self.input_captured_by_overlay() {
+            return None;
+        }
+        // Same OS-focus guard as `dispatch_app_key_events`: don't route keys to
+        // the last-active pane while another window owns the keyboard.
+        if !ctx.input(|i| i.viewport().focused.unwrap_or(true)) {
+            return None;
+        }
+        let active = self.active_window;
+        let focused_tile = self.windows[active].focused_pane?;
+        let egui_tiles::Tile::Pane(pane_id) =
+            self.windows[active].tree.tiles.get(focused_tile)?
+        else {
+            return None;
+        };
+        let pane_id = *pane_id;
+        // Focused pane must be a terminal (including an exited one — its
+        // "[process exited]" view auto-closes on the next keypress, which it now
+        // reads from this buffer).
+        self.windows[active].panes.get(&pane_id)?.as_terminal()?;
+
+        let router = crate::app::input_router::PlexiInput::take_from(ctx);
+        let (keyboard_events, modifiers) = router.into_events_and_modifiers();
+
+        // Feature instrumentation (stint 0387): confirm the structural handoff
+        // delivered Cmd+A (egui's built-in select-all, the bug's signature) to
+        // the terminal rather than letting a widget swallow it. Targeted — only
+        // fires on the select-all chord, never per keystroke.
+        if keyboard_events.iter().any(|e| {
+            matches!(
+                e,
+                egui::Event::Key { key: egui::Key::A, pressed: true, modifiers: m, .. }
+                    if m.command
+            )
+        }) {
+            log::info!(
+                "terminal_input: routed Cmd+A (select-all) to focused terminal pane_id={pane_id} via ownership transfer"
+            );
+        }
+
+        Some(crate::render::terminal_pane::TerminalInput {
+            keyboard_events,
+            modifiers,
+        })
     }
 
     /// True when any non-active-context pane or parked background app has

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -54,66 +54,29 @@ impl FocusSegmentReason {
     }
 }
 
-/// Identity for a single owner on `PlexiApp.focus_stack` (stint 0240).
+/// Stable identity for a single overlay on `PlexiApp.focus_stack`.
 ///
-/// This is intentionally a thin trait over the `FocusLayer` enum rather than
-/// `Box<dyn FocusOwner>` trait objects. A genuine per-owner trait-object
-/// design (each overlay holding its own state behind `handle_input`/`render`
-/// methods) would require extracting every overlay's fields out of `PlexiApp`
-/// (e.g. `rename_buffer`, `text_overlay`, `pending_notifications`,
-/// `pending_event_consents`, `pending_raw_wasm_launches` — 15 pieces of
-/// ambient state, several shared across overlays) into independent structs.
-/// That is a much larger, higher-risk redesign than this stint's scope, and
-/// the existing `focus_stack.last()` match arms in `src/app/mod.rs` already
-/// give every overlay a single, uniform push/pop/dispatch contract. The enum
-/// stack is kept as the dispatch key; `FocusOwner` exists so overlay identity
-/// has one shared, named contract instead of being implicit in match arms.
-pub(crate) trait FocusOwner {
-    /// Stable name for logging and test assertions.
-    fn name(&self) -> &'static str;
-}
-
-impl FocusOwner for FocusLayer {
-    fn name(&self) -> &'static str {
-        match self {
-            Self::NotificationModal => "NotificationModal",
-            Self::ConfirmClose => "ConfirmClose",
-            Self::CommandPalette => "CommandPalette",
-            Self::RenamePane => "RenamePane",
-            Self::ContextRename => "ContextRename",
-            Self::ContextDescription => "ContextDescription",
-            Self::QuickNote => "QuickNote",
-            Self::CliSetupPrompt => "CliSetupPrompt",
-            Self::TextInput => "TextInput",
-            Self::ContextCloseConfirm => "ContextCloseConfirm",
-            Self::CapabilityModal => "CapabilityModal",
-            Self::EventConsent => "EventConsent",
-            Self::RawWasmReview => "RawWasmReview",
-            Self::NotesPicker => "NotesPicker",
-            Self::NotesTriage => "NotesTriage",
-        }
-    }
-}
-
-/// Which layer currently owns keyboard input.
+/// This is a **fieldless discriminant used purely for identity** — membership
+/// tests (`focus_stack` contains/last), promotion ordering, and log labels.
+/// It is NOT a state-bearing dispatch enum (the enum it replaced was matched
+/// on 15 arms to route keyboard + render): keyboard handling and rendering now
+/// dispatch through the [`FocusOwner`]
+/// trait. `FocusKind::owner()` maps a kind to its `&'static dyn FocusOwner`,
+/// and the two dispatch sites in `update()` call `handle_key`/`draw` on that
+/// token instead of matching 15 arms. Every overlay's working state stays on
+/// `PlexiApp`, where the per-frame reconcile-from-flags helpers
+/// (`reconcile_focus_layer` / `reconcile_promoted_focus_layer`) read the
+/// boolean/Option flag that decides ownership *before* the owner is pushed —
+/// so that state cannot move into the owner without duplicating it.
 ///
-/// The top of `PlexiApp.focus_stack` is the active [`FocusOwner`]. When a
-/// non-`Pane` layer is on top, `input_captured_by_overlay()` is `true` for the
-/// rest of the frame: `dispatch_app_key_events` does not run, and the owning
-/// layer's `*_handle_key` method (called before its `draw_*` render call —
-/// see `update()`) gets first access to the frame's keyboard input. Global
-/// keybinds (Cmd+Q, Cmd+W, Cmd+Shift+A) are handled in `keys::poll_actions`,
-/// which always runs regardless of what owns the stack (see
+/// When any kind is on top, `input_captured_by_overlay()` is `true` for the
+/// rest of the frame: `dispatch_app_key_events` does not run, and the top
+/// owner's `handle_key` (called before its `draw`) gets first access to the
+/// frame's keyboard input. Global keybinds (Cmd+Q, Cmd+W, Cmd+Shift+A) are
+/// handled in `keys::poll_actions`, which always runs (see
 /// `src/app/input_router.rs`).
-///
-/// Every layer is pushed/popped through the single `reconcile_focus_layer` /
-/// `reconcile_promoted_focus_layer` helpers below — one uniform pattern for
-/// every overlay, whether its visibility is a plain boolean (`ConfirmClose`,
-/// `CommandPalette`, ...) or a re-promotable queue-backed layer that must
-/// jump back to the top even if buried (`CapabilityModal`, `EventConsent`,
-/// `RawWasmReview`).
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum FocusLayer {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FocusKind {
     NotificationModal,
     ConfirmClose,
     CommandPalette,
@@ -150,6 +113,200 @@ pub(crate) enum FocusLayer {
     NotesPicker,
     /// Notes inbox triage overlay: shows inbox notes one at a time for keep/trash/action.
     NotesTriage,
+}
+
+impl FocusKind {
+    /// Stable name for logging and test assertions.
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Self::NotificationModal => "NotificationModal",
+            Self::ConfirmClose => "ConfirmClose",
+            Self::CommandPalette => "CommandPalette",
+            Self::RenamePane => "RenamePane",
+            Self::ContextRename => "ContextRename",
+            Self::ContextDescription => "ContextDescription",
+            Self::QuickNote => "QuickNote",
+            Self::CliSetupPrompt => "CliSetupPrompt",
+            Self::TextInput => "TextInput",
+            Self::ContextCloseConfirm => "ContextCloseConfirm",
+            Self::CapabilityModal => "CapabilityModal",
+            Self::EventConsent => "EventConsent",
+            Self::RawWasmReview => "RawWasmReview",
+            Self::NotesPicker => "NotesPicker",
+            Self::NotesTriage => "NotesTriage",
+        }
+    }
+
+    /// Map this identity to its stateless [`FocusOwner`] token. The token
+    /// carries no data — it only names which `PlexiApp` overlay methods this
+    /// frame's keyboard/render dispatch should call.
+    pub(crate) fn owner(self) -> &'static dyn FocusOwner {
+        match self {
+            Self::NotificationModal => &NotificationModalOwner,
+            Self::ConfirmClose => &ConfirmCloseOwner,
+            Self::CommandPalette => &CommandPaletteOwner,
+            Self::RenamePane => &RenamePaneOwner,
+            Self::ContextRename => &ContextRenameOwner,
+            Self::ContextDescription => &ContextDescriptionOwner,
+            Self::QuickNote => &QuickNoteOwner,
+            Self::CliSetupPrompt => &CliSetupPromptOwner,
+            Self::TextInput => &TextInputOwner,
+            Self::ContextCloseConfirm => &ContextCloseConfirmOwner,
+            Self::CapabilityModal => &CapabilityModalOwner,
+            Self::EventConsent => &EventConsentOwner,
+            Self::RawWasmReview => &RawWasmReviewOwner,
+            Self::NotesPicker => &NotesPickerOwner,
+            Self::NotesTriage => &NotesTriageOwner,
+        }
+    }
+}
+
+/// One overlay's keyboard + render contract. The top of `PlexiApp.focus_stack`
+/// names the active owner via its [`FocusKind`]; `FocusKind::owner()` maps it
+/// to the corresponding `&'static dyn FocusOwner`, and `update()` dispatches
+/// this frame's keyboard input and the overlay render through these methods
+/// instead of two 15-arm matches.
+///
+/// Owners are stateless unit structs: every overlay's working state (buffers,
+/// queues, `ContextCloseState`, ...) stays on `PlexiApp`, which the trait
+/// methods reach through the `&mut PlexiApp` parameter. This is a deliberate
+/// consequence of the reconcile-from-flags model — the flag that decides
+/// whether an overlay owns focus is read on `PlexiApp` every frame *before* the
+/// owner is pushed, so the state cannot live inside the owner without being
+/// duplicated. Extracting it would require inverting that model (owner owns the
+/// state, no per-frame reconcile), a larger redesign out of this stint's scope.
+pub(crate) trait FocusOwner {
+    /// Handle this frame's owned keyboard input, before any render pass. `ctx`
+    /// is only read by `NotesTriage` (to surrender egui widget focus before it
+    /// reads keys); the other owners ignore it.
+    fn handle_key(
+        &self,
+        app: &mut PlexiApp,
+        ctx: &egui::Context,
+        input: &mut crate::app::input_router::PlexiInput,
+    ) -> crate::app::app_trait::KeyDisposition;
+
+    /// Render the overlay (visual only — key reads already happened in
+    /// `handle_key`). Returns any commands the render produced; only the
+    /// notification modal emits any, the rest return an empty vec.
+    fn draw(
+        &self,
+        app: &mut PlexiApp,
+        ctx: &egui::Context,
+    ) -> Vec<crate::app::app_trait::AppCommand>;
+}
+
+/// Define the stateless owner tokens whose `handle_key` returns a
+/// `KeyDisposition` and whose `draw` produces no commands — the common shape
+/// for 12 of the 15 overlays. The three exceptions (notification modal's
+/// command-returning draw; NotesPicker / NotesTriage's forced `Passthrough`,
+/// and NotesTriage's extra `ctx`) are written out by hand below.
+macro_rules! focus_owner_tokens {
+    ($( $kind:ident => $token:ident { key: $key_fn:ident, draw: $draw_fn:ident } ),* $(,)?) => {
+        $(
+            pub(crate) struct $token;
+            impl FocusOwner for $token {
+                fn handle_key(
+                    &self,
+                    app: &mut PlexiApp,
+                    _ctx: &egui::Context,
+                    input: &mut crate::app::input_router::PlexiInput,
+                ) -> crate::app::app_trait::KeyDisposition {
+                    app.$key_fn(input)
+                }
+                fn draw(
+                    &self,
+                    app: &mut PlexiApp,
+                    ctx: &egui::Context,
+                ) -> Vec<crate::app::app_trait::AppCommand> {
+                    app.$draw_fn(ctx);
+                    Vec::new()
+                }
+            }
+        )*
+    };
+}
+
+focus_owner_tokens! {
+    ConfirmClose => ConfirmCloseOwner { key: confirm_close_handle_key, draw: draw_confirm_close },
+    CommandPalette => CommandPaletteOwner { key: command_palette_handle_key, draw: draw_command_palette },
+    RenamePane => RenamePaneOwner { key: rename_pane_handle_key, draw: draw_rename_pane_overlay },
+    ContextRename => ContextRenameOwner { key: context_rename_handle_key, draw: draw_rename_context_overlay },
+    ContextDescription => ContextDescriptionOwner { key: context_description_handle_key, draw: draw_edit_description_overlay },
+    QuickNote => QuickNoteOwner { key: quick_note_handle_key, draw: draw_quick_note_modal },
+    CliSetupPrompt => CliSetupPromptOwner { key: cli_setup_prompt_handle_key, draw: draw_cli_setup_modal },
+    TextInput => TextInputOwner { key: text_input_handle_key, draw: draw_text_input_overlay },
+    ContextCloseConfirm => ContextCloseConfirmOwner { key: context_close_confirm_handle_key, draw: draw_context_close_confirm },
+    CapabilityModal => CapabilityModalOwner { key: capability_modal_handle_key, draw: draw_capability_modal },
+    EventConsent => EventConsentOwner { key: event_consent_handle_key, draw: draw_event_consent_modal },
+    RawWasmReview => RawWasmReviewOwner { key: raw_wasm_review_handle_key, draw: draw_raw_wasm_review_modal },
+}
+
+/// Notification modal — the only overlay whose render produces commands
+/// (`DeliverNotifyAction`, routed back to the originating pane).
+pub(crate) struct NotificationModalOwner;
+impl FocusOwner for NotificationModalOwner {
+    fn handle_key(
+        &self,
+        app: &mut PlexiApp,
+        _ctx: &egui::Context,
+        input: &mut crate::app::input_router::PlexiInput,
+    ) -> crate::app::app_trait::KeyDisposition {
+        app.notification_modal_handle_key(input)
+    }
+    fn draw(
+        &self,
+        app: &mut PlexiApp,
+        ctx: &egui::Context,
+    ) -> Vec<crate::app::app_trait::AppCommand> {
+        app.draw_notification_modal(ctx)
+    }
+}
+
+/// Notes picker — its handler drives selection but never claims the key, so the
+/// key still reaches the focused text-editor pane (forced `Passthrough`).
+pub(crate) struct NotesPickerOwner;
+impl FocusOwner for NotesPickerOwner {
+    fn handle_key(
+        &self,
+        app: &mut PlexiApp,
+        _ctx: &egui::Context,
+        input: &mut crate::app::input_router::PlexiInput,
+    ) -> crate::app::app_trait::KeyDisposition {
+        app.notes_picker_handle_key(input);
+        crate::app::app_trait::KeyDisposition::Passthrough
+    }
+    fn draw(
+        &self,
+        app: &mut PlexiApp,
+        ctx: &egui::Context,
+    ) -> Vec<crate::app::app_trait::AppCommand> {
+        app.draw_notes_picker(ctx);
+        Vec::new()
+    }
+}
+
+/// Notes triage — like the picker, forces `Passthrough`, and its handler needs
+/// `ctx` to surrender egui widget focus before reading keys.
+pub(crate) struct NotesTriageOwner;
+impl FocusOwner for NotesTriageOwner {
+    fn handle_key(
+        &self,
+        app: &mut PlexiApp,
+        ctx: &egui::Context,
+        input: &mut crate::app::input_router::PlexiInput,
+    ) -> crate::app::app_trait::KeyDisposition {
+        app.notes_triage_handle_key(ctx, input);
+        crate::app::app_trait::KeyDisposition::Passthrough
+    }
+    fn draw(
+        &self,
+        app: &mut PlexiApp,
+        ctx: &egui::Context,
+    ) -> Vec<crate::app::app_trait::AppCommand> {
+        app.draw_notes_triage(ctx);
+        Vec::new()
+    }
 }
 
 /// A single pane entry shown in the context-close confirmation dialog.
@@ -394,7 +551,7 @@ impl PlexiApp {
     /// rename/quick-look mode, a CLI-backed app's Form view) — an advisory
     /// policy flag `keys::poll_actions` reads to suppress global shortcuts
     /// while the app owns text input. This is intentionally separate from
-    /// `focus_stack`/`FocusLayer`: overlay layers are exclusive (they block
+    /// `focus_stack`/`FocusKind`: overlay layers are exclusive (they block
     /// `dispatch_app_key_events` entirely), while app-declared capture must
     /// NOT block the app from still receiving its own keys — folding the two
     /// into one stack would make an app go deaf on the frame it starts
@@ -433,7 +590,7 @@ impl PlexiApp {
     pub(crate) fn is_quick_note_preemptable(&self) -> bool {
         matches!(
             self.focus_stack.last(),
-            Some(FocusLayer::NotificationModal) | Some(FocusLayer::CommandPalette)
+            Some(FocusKind::NotificationModal) | Some(FocusKind::CommandPalette)
         )
     }
 
@@ -441,17 +598,17 @@ impl PlexiApp {
     /// Only call after `is_quick_note_preemptable()` returns `true`.
     pub(crate) fn dismiss_preemptable_modal(&mut self) {
         match self.focus_stack.last().cloned() {
-            Some(FocusLayer::NotificationModal) => {
+            Some(FocusKind::NotificationModal) => {
                 log::info!("quick_note: dismissing NotificationModal to open QuickNote");
                 self.show_notification_modal = false;
                 self.focus_stack
-                    .retain(|l| *l != FocusLayer::NotificationModal);
+                    .retain(|l| *l != FocusKind::NotificationModal);
             }
-            Some(FocusLayer::CommandPalette) => {
+            Some(FocusKind::CommandPalette) => {
                 log::info!("quick_note: dismissing CommandPalette to open QuickNote");
                 self.show_command_palette = false;
                 self.focus_stack
-                    .retain(|l| *l != FocusLayer::CommandPalette);
+                    .retain(|l| *l != FocusKind::CommandPalette);
                 self.ctx.memory_mut(|m| {
                     let palette_id = egui::Id::new("palette_search");
                     if m.focused() == Some(palette_id) {
@@ -469,27 +626,27 @@ impl PlexiApp {
     pub(crate) fn input_captured_by_overlay(&self) -> bool {
         matches!(
             self.focus_stack.last(),
-            Some(FocusLayer::NotificationModal)
-                | Some(FocusLayer::ConfirmClose)
-                | Some(FocusLayer::CommandPalette)
-                | Some(FocusLayer::RenamePane)
-                | Some(FocusLayer::ContextRename)
-                | Some(FocusLayer::ContextDescription)
-                | Some(FocusLayer::QuickNote)
-                | Some(FocusLayer::CliSetupPrompt)
-                | Some(FocusLayer::TextInput)
-                | Some(FocusLayer::ContextCloseConfirm)
-                | Some(FocusLayer::CapabilityModal)
-                | Some(FocusLayer::EventConsent)
-                | Some(FocusLayer::RawWasmReview)
-                | Some(FocusLayer::NotesPicker)
-                | Some(FocusLayer::NotesTriage)
+            Some(FocusKind::NotificationModal)
+                | Some(FocusKind::ConfirmClose)
+                | Some(FocusKind::CommandPalette)
+                | Some(FocusKind::RenamePane)
+                | Some(FocusKind::ContextRename)
+                | Some(FocusKind::ContextDescription)
+                | Some(FocusKind::QuickNote)
+                | Some(FocusKind::CliSetupPrompt)
+                | Some(FocusKind::TextInput)
+                | Some(FocusKind::ContextCloseConfirm)
+                | Some(FocusKind::CapabilityModal)
+                | Some(FocusKind::EventConsent)
+                | Some(FocusKind::RawWasmReview)
+                | Some(FocusKind::NotesPicker)
+                | Some(FocusKind::NotesTriage)
         )
     }
 
     /// Push a focus layer. Idempotent — if the same layer is already on top,
     /// it's a no-op. Callers should pair with `pop_focus_layer`.
-    pub(crate) fn push_focus_layer(&mut self, layer: FocusLayer) {
+    pub(crate) fn push_focus_layer(&mut self, layer: FocusKind) {
         if self.focus_stack.last() != Some(&layer) {
             self.focus_stack.push(layer);
         }
@@ -497,7 +654,7 @@ impl PlexiApp {
 
     /// Pop the given layer if it's currently on top. No-op otherwise; this
     /// prevents out-of-order pops from corrupting the stack.
-    pub(crate) fn pop_focus_layer(&mut self, layer: &FocusLayer) {
+    pub(crate) fn pop_focus_layer(&mut self, layer: &FocusKind) {
         if self.focus_stack.last() == Some(layer) {
             self.focus_stack.pop();
         }
@@ -507,9 +664,9 @@ impl PlexiApp {
     /// when `should_own` becomes true and it isn't already in the stack, pop
     /// it (via `retain`, so a stale entry buried under something else is still
     /// removed) when `should_own` goes false. Every non-promoting `sync_*`
-    /// function is a one-line call to this — see `FocusLayer` doc comment for
+    /// function is a one-line call to this — see `FocusKind` doc comment for
     /// why this replaces 11 near-identical bodies instead of dyn dispatch.
-    fn reconcile_focus_layer(&mut self, layer: FocusLayer, should_own: bool) {
+    fn reconcile_focus_layer(&mut self, layer: FocusKind, should_own: bool) {
         let has_layer = self.focus_stack.contains(&layer);
         if should_own && !has_layer {
             self.push_focus_layer(layer);
@@ -523,7 +680,7 @@ impl PlexiApp {
     /// overlay (capability prompts, event consents, raw-wasm review) that
     /// must jump back to the top of the stack even if another layer pushed on
     /// top of it while it was buried, not just toggle membership.
-    fn reconcile_promoted_focus_layer(&mut self, layer: FocusLayer, should_own: bool) {
+    fn reconcile_promoted_focus_layer(&mut self, layer: FocusKind, should_own: bool) {
         let has_layer = self.focus_stack.contains(&layer);
         let is_top = self.focus_stack.last() == Some(&layer);
         if should_own && !is_top {
@@ -990,12 +1147,12 @@ impl PlexiApp {
     /// toggled from multiple paths, and the focus stack must follow it
     /// deterministically each frame.
     pub(crate) fn sync_confirm_close_focus(&mut self) {
-        self.reconcile_focus_layer(FocusLayer::ConfirmClose, self.pending_close);
+        self.reconcile_focus_layer(FocusKind::ConfirmClose, self.pending_close);
     }
 
     pub(crate) fn sync_context_close_focus(&mut self) {
         self.reconcile_focus_layer(
-            FocusLayer::ContextCloseConfirm,
+            FocusKind::ContextCloseConfirm,
             self.pending_context_close.is_some(),
         );
     }
@@ -1070,19 +1227,19 @@ impl PlexiApp {
     }
 
     pub(crate) fn sync_notification_modal_focus(&mut self) {
-        self.reconcile_focus_layer(FocusLayer::NotificationModal, self.show_notification_modal);
+        self.reconcile_focus_layer(FocusKind::NotificationModal, self.show_notification_modal);
     }
 
     pub(crate) fn sync_cli_setup_prompt_focus(&mut self) {
-        self.reconcile_focus_layer(FocusLayer::CliSetupPrompt, self.show_cli_setup_prompt);
+        self.reconcile_focus_layer(FocusKind::CliSetupPrompt, self.show_cli_setup_prompt);
     }
 
     /// Reconcile the command-palette focus layer with `show_command_palette`.
     /// Same pattern as the notification modal: boolean visibility flag is the
     /// source of truth, focus stack follows it deterministically each frame.
     pub(crate) fn sync_command_palette_focus(&mut self) {
-        let was_owned = self.focus_stack.contains(&FocusLayer::CommandPalette);
-        self.reconcile_focus_layer(FocusLayer::CommandPalette, self.show_command_palette);
+        let was_owned = self.focus_stack.contains(&FocusKind::CommandPalette);
+        self.reconcile_focus_layer(FocusKind::CommandPalette, self.show_command_palette);
         if was_owned && !self.show_command_palette {
             // Explicitly surrender egui focus from palette_search so AccessKit
             // doesn't hold a stale focused node ID after the widget is gone.
@@ -1148,7 +1305,7 @@ impl PlexiApp {
 
     /// Reconcile the rename-pane focus layer with `renaming_pane`.
     pub(crate) fn sync_rename_pane_focus(&mut self) {
-        self.reconcile_focus_layer(FocusLayer::RenamePane, self.renaming_pane.is_some());
+        self.reconcile_focus_layer(FocusKind::RenamePane, self.renaming_pane.is_some());
     }
 
     /// Reconcile the context-rename focus layer. Active when `renaming_window`
@@ -1156,21 +1313,21 @@ impl PlexiApp {
     /// never renders, so we promote the rename to a modal overlay instead.
     pub(crate) fn sync_context_rename_focus(&mut self) {
         let should_own = self.renaming_window.is_some() && !self.sidebar_visible;
-        self.reconcile_focus_layer(FocusLayer::ContextRename, should_own);
+        self.reconcile_focus_layer(FocusKind::ContextRename, should_own);
     }
 
     /// Reconcile the text-input overlay focus layer with `text_overlay`.
     pub(crate) fn sync_text_input_focus(&mut self) {
-        self.reconcile_focus_layer(FocusLayer::TextInput, self.text_overlay.is_some());
+        self.reconcile_focus_layer(FocusKind::TextInput, self.text_overlay.is_some());
     }
 
-    /// Push/pop `FocusLayer::CapabilityModal` based on whether the focused app
+    /// Push/pop `FocusKind::CapabilityModal` based on whether the focused app
     /// pane has pending prompts. Called every frame (both before and after the
     /// overlay render block) so the layer tracks prompt state without polling
     /// lag.
     pub(crate) fn sync_capability_modal_focus(&mut self) {
         let should_own = self.focused_pane_has_pending_prompts();
-        self.reconcile_promoted_focus_layer(FocusLayer::CapabilityModal, should_own);
+        self.reconcile_promoted_focus_layer(FocusKind::CapabilityModal, should_own);
     }
 
     /// Promote/release the host event-consent modal layer to mirror
@@ -1178,12 +1335,12 @@ impl PlexiApp {
     /// keyboard so Enter/Esc resolve it instead of leaking to the focused pane.
     pub(crate) fn sync_event_consent_focus(&mut self) {
         let should_own = !self.pending_event_consents.is_empty();
-        self.reconcile_promoted_focus_layer(FocusLayer::EventConsent, should_own);
+        self.reconcile_promoted_focus_layer(FocusKind::EventConsent, should_own);
     }
 
     pub(crate) fn sync_raw_wasm_review_focus(&mut self) {
         let should_own = !self.pending_raw_wasm_launches.is_empty();
-        self.reconcile_promoted_focus_layer(FocusLayer::RawWasmReview, should_own);
+        self.reconcile_promoted_focus_layer(FocusKind::RawWasmReview, should_own);
     }
 
     /// Returns true when the focused app pane has at least one pending prompt.

--- a/src/app/input_router.rs
+++ b/src/app/input_router.rs
@@ -6,30 +6,56 @@
 //! consumer's render call happened to run first got the event, and a stray
 //! reorder could silently change behavior (see the paste-leak class of bug,
 //! #1236). `PlexiInput` makes ownership explicit instead: at the start of each
-//! frame every input-*intent* event (physical keys, typed text, paste) is
-//! removed from `ctx` into an owned buffer. That buffer is handed, in order,
-//! to `keys::poll_actions` (the global hotkey allowlist — always runs first,
-//! see module doc on why) and then to the top [`crate::app::FocusLayer`] on
-//! `PlexiApp.focus_stack`, each consuming only what it claims. Whatever
-//! neither claims is handed back to `ctx` so the render pass (focused
-//! `TextEdit` widgets, app pane `handle_key`, the terminal widget) still sees
-//! it — this refactor is scoped to the overlay/global-hotkey ownership path;
-//! it does not (yet) migrate app-pane or terminal PTY input to full
-//! ownership-transfer (see `stint 0240` design-decision notes).
+//! frame every input-*intent* event (physical keys, typed text, paste, and the
+//! clipboard `Copy`/`Cut` shortcut events) is removed from `ctx` into an owned
+//! buffer, handed to consumers in a fixed order, each consuming only what it
+//! claims.
+//!
+//! Every keyboard consumer now routes through this buffer (stint 0387):
+//!   1. `keys::poll_actions` — the global hotkey allowlist. Always the outer,
+//!      first consumer of the frame; claims Cmd+Q/W/P etc.
+//!   2. The top [`crate::app::FocusLayer`] overlay's `*_handle_key`, when an
+//!      overlay owns input.
+//!   3. `dispatch_app_key_events` — the focused app pane's `App::handle_key`,
+//!      which reads this buffer directly (see [`PlexiInput::events`] /
+//!      [`PlexiInput::key_pressed`]) instead of `ctx.input()`.
+//!   4. The focused terminal widget. Because the host takes this buffer *before*
+//!      the render pass and hands the events straight to `egui_term` via
+//!      `TerminalView::with_input`, egui's own render-time widget machinery can
+//!      no longer swallow a key (e.g. Cmd+A select-all) before the terminal
+//!      sees it — the structural fix for the terminal Cmd+A bug.
+//!
+//! Overlay and app/global consumers `give_back` whatever they don't claim so
+//! the render pass (focused `TextEdit` widgets) still sees it. The focused
+//! terminal is the sole intended keyboard consumer for its frame, so its host
+//! handoff does *not* give events back: anything the terminal ignores is
+//! correctly dropped rather than leaking to an unfocused widget.
 //!
 //! Mouse events, scroll, hover, and paint requests are untouched: this router
-//! is keyboard/text-input scoped only.
+//! is keyboard/text-input scoped only. `Event::Ime` composition is also
+//! deliberately excluded — see [`is_input_intent`].
 
 /// Returns true for events this router takes ownership of: physical keys,
-/// typed text, and paste. IME composition events
-/// (`Event::Ime`) are deliberately excluded — composition must reach the
-/// focused egui widget directly during the render pass for correct pre-edit
-/// rendering, so carving them out here (rather than letting them fall through
-/// a catch-all) avoids a silent foot-gun.
+/// typed text, paste, and the clipboard `Copy`/`Cut` shortcut events (on macOS
+/// Cmd+C / Cmd+X arrive as `Event::Copy` / `Event::Cut`, and both the terminal
+/// widget and focused `TextEdit`s consume them). Widening the taken set is safe
+/// for the overlay/app/global consumers because they `give_back` everything
+/// unclaimed before their render pass, so a `TextEdit` still receives an
+/// unclaimed Copy/Cut.
+///
+/// IME composition events (`Event::Ime`) are deliberately excluded — pre-edit
+/// composition must reach the focused egui widget directly during the render
+/// pass for correct pre-edit rendering, and no router consumer processes
+/// composition. Carving it out here (rather than letting it fall through a
+/// catch-all) avoids a silent foot-gun.
 fn is_input_intent(event: &egui::Event) -> bool {
     matches!(
         event,
-        egui::Event::Key { .. } | egui::Event::Text(_) | egui::Event::Paste(_)
+        egui::Event::Key { .. }
+            | egui::Event::Text(_)
+            | egui::Event::Paste(_)
+            | egui::Event::Copy
+            | egui::Event::Cut
     )
 }
 
@@ -63,10 +89,40 @@ impl PlexiInput {
         self.modifiers
     }
 
+    /// The frame's owned input-intent events, in arrival order. Consumers that
+    /// need the raw event stream (e.g. `App::handle_key` for WASM/Python panes
+    /// that forward every key/text edge to their guest) read this instead of
+    /// `ctx.input(|i| &i.events)`.
+    pub(crate) fn events(&self) -> &[egui::Event] {
+        &self.events
+    }
+
+    /// Was `key` pressed this frame? Mirrors `egui::InputState::key_pressed`
+    /// exactly — any `Event::Key { pressed: true }` for this logical key,
+    /// modifiers ignored, key-repeat included — but over this frame's owned
+    /// buffer so `App::handle_key` classifies from the router rather than a
+    /// second read of the shared `ctx` queue.
+    pub(crate) fn key_pressed(&self, key: egui::Key) -> bool {
+        self.events.iter().any(|e| {
+            matches!(
+                e,
+                egui::Event::Key { key: k, pressed: true, .. } if *k == key
+            )
+        })
+    }
+
     /// True when the buffer holds no more input-intent events (everything was
     /// claimed by a consumer this frame, or none arrived).
     pub(crate) fn is_empty(&self) -> bool {
         self.events.is_empty()
+    }
+
+    /// Consume the whole buffer into its owned events + modifiers. Used by the
+    /// focused-terminal handoff, which hands every remaining event straight to
+    /// `egui_term` (the sole intended keyboard consumer for its frame) and
+    /// never gives events back to `ctx`.
+    pub(crate) fn into_events_and_modifiers(self) -> (Vec<egui::Event>, egui::Modifiers) {
+        (self.events, self.modifiers)
     }
 
     /// Consume the first matching key-press event, removing it from the
@@ -180,6 +236,52 @@ mod tests {
                 assert_eq!(i.events.len(), 1);
                 assert!(matches!(i.events[0], egui::Event::Key { key: egui::Key::B, .. }));
             });
+        });
+    }
+
+    #[test]
+    fn take_from_claims_copy_and_cut_but_leaves_ime() {
+        let ctx = egui::Context::default();
+        let mut raw = egui::RawInput::default();
+        raw.events.push(egui::Event::Copy);
+        raw.events.push(egui::Event::Cut);
+        raw.events
+            .push(egui::Event::Ime(egui::ImeEvent::Enabled));
+        let _ = ctx.run(raw, |ctx| {
+            let input = PlexiInput::take_from(ctx);
+            // Copy + Cut are input-intent and taken.
+            assert_eq!(input.events().len(), 2);
+            // IME composition is left behind for the render pass.
+            ctx.input(|i| {
+                assert_eq!(i.events.len(), 1);
+                assert!(matches!(i.events[0], egui::Event::Ime(_)));
+            });
+        });
+    }
+
+    #[test]
+    fn key_pressed_matches_buffer_ignoring_modifiers() {
+        let ctx = egui::Context::default();
+        let mut raw = egui::RawInput::default();
+        raw.events.push(key_event(egui::Key::A, egui::Modifiers::COMMAND));
+        let _ = ctx.run(raw, |ctx| {
+            let input = PlexiInput::take_from(ctx);
+            assert!(input.key_pressed(egui::Key::A));
+            assert!(!input.key_pressed(egui::Key::B));
+        });
+    }
+
+    #[test]
+    fn into_events_and_modifiers_yields_the_owned_buffer() {
+        let ctx = egui::Context::default();
+        let mut raw = egui::RawInput::default();
+        raw.modifiers = egui::Modifiers::COMMAND;
+        raw.events.push(key_event(egui::Key::A, egui::Modifiers::COMMAND));
+        let _ = ctx.run(raw, |ctx| {
+            let input = PlexiInput::take_from(ctx);
+            let (events, modifiers) = input.into_events_and_modifiers();
+            assert_eq!(events.len(), 1);
+            assert!(modifiers.command);
         });
     }
 }

--- a/src/app/input_router.rs
+++ b/src/app/input_router.rs
@@ -14,7 +14,7 @@
 //! Every keyboard consumer now routes through this buffer (stint 0387):
 //!   1. `keys::poll_actions` — the global hotkey allowlist. Always the outer,
 //!      first consumer of the frame; claims Cmd+Q/W/P etc.
-//!   2. The top [`crate::app::FocusLayer`] overlay's `*_handle_key`, when an
+//!   2. The top [`crate::app::FocusKind`] overlay's `*_handle_key`, when an
 //!      overlay owns input.
 //!   3. `dispatch_app_key_events` — the focused app pane's `App::handle_key`,
 //!      which reads this buffer directly (see [`PlexiInput::events`] /

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2527,7 +2527,14 @@ impl eframe::App for PlexiApp {
         if overlay_key_disposition == crate::app::app_trait::KeyDisposition::Passthrough
             && !self.input_captured_by_overlay()
         {
-            self.dispatch_app_key_events(ctx);
+            // Ownership-transfer (stint 0387): take this frame's input-intent
+            // events out of `ctx`, hand them to the focused app pane's
+            // `handle_key`, then give back whatever it didn't claim so the
+            // pane's own render pass (a focused `TextEdit`) still sees typed
+            // text. Mirrors the overlay and `poll_actions` router pairs.
+            let mut router_input = crate::app::input_router::PlexiInput::take_from(ctx);
+            self.dispatch_app_key_events(ctx, &mut router_input);
+            router_input.give_back(ctx);
         }
         // Drain every app pane's pending_commands every frame — including
         // while a modal holds focus. Background apps emitting notifications
@@ -4493,7 +4500,16 @@ impl eframe::App for PlexiApp {
             }
         }
 
-        self.render_panels(ctx);
+        // Ownership-transfer (stint 0387): if the focused pane is a terminal
+        // and no overlay owns input, take this frame's keyboard events out of
+        // `ctx` *before* the render pass and hand them to that terminal. Doing
+        // this before `render_panels` is what prevents egui's own render-time
+        // widget machinery (allocate_painter's built-in Cmd+A select-all) from
+        // swallowing a key before the terminal processes it. `poll_actions`
+        // above already claimed global hotkeys from the same buffer, so the
+        // terminal only ever sees what the global allowlist left behind.
+        let focused_terminal_input = self.take_focused_terminal_input(ctx);
+        self.render_panels(ctx, focused_terminal_input);
 
         // Detect genuine pane focus transitions, and periodically bank long
         // same-pane sessions so Stats has live data without keystroke tracking.
@@ -4788,13 +4804,15 @@ fn drive_native_pane_key(
 ) -> Result<app_trait::KeyDisposition, String> {
     let raw = key_str_to_egui_raw_input(key)
         .ok_or_else(|| format!("key {key:?} does not map to a native app key event"))?;
-    // Throwaway context: the cheapest way to build a well-formed InputState.
+    // Throwaway context: the cheapest way to build a well-formed input buffer.
     // handle_key only reads input — it never paints — so no fonts/render
-    // setup is needed.
+    // setup is needed. Route through the same `PlexiInput` ownership buffer the
+    // live frame uses so `pane key` exercises the production keyboard path.
     let ctx = egui::Context::default();
     let mut disposition = app_trait::KeyDisposition::Passthrough;
     let _ = ctx.run(raw, |ctx| {
-        ctx.input(|i| disposition = runtime.handle_key(i));
+        let input = crate::app::input_router::PlexiInput::take_from(ctx);
+        disposition = runtime.handle_key(&input);
     });
     Ok(disposition)
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -33,7 +33,7 @@ pub mod video_player_app;
 #[cfg(test)]
 pub(crate) use focus::FocusLogOutcome;
 pub(crate) use focus::{
-    ContextCloseState, FocusLayer, FocusSegmentReason, PendingRawWasmLaunch,
+    ContextCloseState, FocusKind, FocusSegmentReason, PendingRawWasmLaunch,
     FOCUS_HEARTBEAT_INTERVAL,
 };
 pub(crate) use notification_image::NotificationImageState;
@@ -285,8 +285,8 @@ pub struct PlexiApp {
     pub(crate) notifications_interrupt_threshold: u32,
     /// Input-focus stack. Top layer receives keyboard input; panes see an
     /// empty event buffer while a non-`Pane` layer is on top. See the
-    /// `FocusLayer` docs for the invariant.
-    pub(crate) focus_stack: Vec<FocusLayer>,
+    /// `FocusKind` docs for the invariant.
+    pub(crate) focus_stack: Vec<FocusKind>,
     /// Pane focus history for Cmd+[ time-travel. Each entry is (window_id, tile_id)
     /// captured just before a focus change. Capped at 100; oldest evicted from front.
     pub(crate) focus_history_depth: usize,
@@ -392,7 +392,7 @@ pub struct PlexiApp {
         std::sync::mpsc::Receiver<crate::host::event_subscriptions::HostPublishRequest>,
     /// Subscribe or publish requests the broker answered with `Ask`, parked for an explicit
     /// user decision. The front entry is surfaced as the host event-consent
-    /// modal; [`FocusLayer::EventConsent`] is promoted while this is non-empty.
+    /// modal; [`FocusKind::EventConsent`] is promoted while this is non-empty.
     pub(crate) pending_event_consents:
         std::collections::VecDeque<crate::host::event_subscriptions::PendingEventConsent>,
     /// App-runtime subscriptions waiting for the shared broker to answer.
@@ -2377,7 +2377,7 @@ impl eframe::App for PlexiApp {
         let mut early_modal_cmds: Vec<crate::app::app_trait::AppCommand> = Vec::new();
         let overlay_key_disposition = if self.input_captured_by_overlay() {
             // Ownership-transfer (stint 0240): take this frame's input-intent
-            // events out of `ctx` once, hand them to the top `FocusLayer`
+            // events out of `ctx` once, hand them to the top `FocusKind`
             // below, then give back whatever it didn't claim before rendering
             // — see `src/app/input_router.rs`.
             let mut router_input = crate::app::input_router::PlexiInput::take_from(ctx);
@@ -2398,50 +2398,11 @@ impl eframe::App for PlexiApp {
                 router_input.give_back(ctx);
                 crate::app::app_trait::KeyDisposition::Consumed
             } else {
-                // Step 1: run the overlay's handle_key (consumes its owned key events
-                // from this frame's ownership-transfer buffer, before any render).
-                let disposition = match self.focus_stack.last() {
-                    Some(FocusLayer::NotificationModal) => {
-                        self.notification_modal_handle_key(&mut router_input)
-                    }
-                    Some(FocusLayer::ConfirmClose) => {
-                        self.confirm_close_handle_key(&mut router_input)
-                    }
-                    Some(FocusLayer::CommandPalette) => {
-                        self.command_palette_handle_key(&mut router_input)
-                    }
-                    Some(FocusLayer::RenamePane) => self.rename_pane_handle_key(&mut router_input),
-                    Some(FocusLayer::ContextRename) => {
-                        self.context_rename_handle_key(&mut router_input)
-                    }
-                    Some(FocusLayer::ContextDescription) => {
-                        self.context_description_handle_key(&mut router_input)
-                    }
-                    Some(FocusLayer::QuickNote) => self.quick_note_handle_key(&mut router_input),
-                    Some(FocusLayer::CliSetupPrompt) => {
-                        self.cli_setup_prompt_handle_key(&mut router_input)
-                    }
-                    Some(FocusLayer::TextInput) => self.text_input_handle_key(&mut router_input),
-                    Some(FocusLayer::ContextCloseConfirm) => {
-                        self.context_close_confirm_handle_key(&mut router_input)
-                    }
-                    Some(FocusLayer::CapabilityModal) => {
-                        self.capability_modal_handle_key(&mut router_input)
-                    }
-                    Some(FocusLayer::EventConsent) => {
-                        self.event_consent_handle_key(&mut router_input)
-                    }
-                    Some(FocusLayer::RawWasmReview) => {
-                        self.raw_wasm_review_handle_key(&mut router_input)
-                    }
-                    Some(FocusLayer::NotesPicker) => {
-                        self.notes_picker_handle_key(&mut router_input);
-                        crate::app::app_trait::KeyDisposition::Passthrough
-                    }
-                    Some(FocusLayer::NotesTriage) => {
-                        self.notes_triage_handle_key(ctx, &mut router_input);
-                        crate::app::app_trait::KeyDisposition::Passthrough
-                    }
+                // Step 1: run the top overlay's handle_key through the
+                // `FocusOwner` trait (consumes its owned key events from this
+                // frame's ownership-transfer buffer, before any render).
+                let disposition = match self.focus_stack.last().copied() {
+                    Some(kind) => kind.owner().handle_key(self, ctx, &mut router_input),
                     None => crate::app::app_trait::KeyDisposition::Passthrough,
                 };
                 // Give back whatever this overlay didn't claim so the render
@@ -2449,54 +2410,15 @@ impl eframe::App for PlexiApp {
                 // still sees it — this refactor transfers ownership for the
                 // *first* consumer each frame, not for the whole frame.
                 router_input.give_back(ctx);
-                // Step 2: render the overlay (visual only — key reads already done above).
-                match self.focus_stack.last().cloned() {
-                    Some(FocusLayer::NotificationModal) => {
-                        early_modal_cmds = self.draw_notification_modal(ctx);
-                    }
-                    Some(FocusLayer::ConfirmClose) => {
-                        self.draw_confirm_close(ctx);
-                    }
-                    Some(FocusLayer::CommandPalette) => {
-                        self.draw_command_palette(ctx);
-                    }
-                    Some(FocusLayer::RenamePane) => {
-                        self.draw_rename_pane_overlay(ctx);
-                    }
-                    Some(FocusLayer::ContextRename) => {
-                        self.draw_rename_context_overlay(ctx);
-                    }
-                    Some(FocusLayer::ContextDescription) => {
-                        self.draw_edit_description_overlay(ctx);
-                    }
-                    Some(FocusLayer::QuickNote) => {
-                        self.draw_quick_note_modal(ctx);
-                    }
-                    Some(FocusLayer::CliSetupPrompt) => {
-                        self.draw_cli_setup_modal(ctx);
-                    }
-                    Some(FocusLayer::TextInput) => {
-                        self.draw_text_input_overlay(ctx);
-                    }
-                    Some(FocusLayer::ContextCloseConfirm) => {
-                        self.draw_context_close_confirm(ctx);
-                    }
-                    Some(FocusLayer::CapabilityModal) => {
-                        self.draw_capability_modal(ctx);
-                    }
-                    Some(FocusLayer::EventConsent) => {
-                        self.draw_event_consent_modal(ctx);
-                    }
-                    Some(FocusLayer::RawWasmReview) => {
-                        self.draw_raw_wasm_review_modal(ctx);
-                    }
-                    Some(FocusLayer::NotesPicker) => {
-                        self.draw_notes_picker(ctx);
-                    }
-                    Some(FocusLayer::NotesTriage) => {
-                        self.draw_notes_triage(ctx);
-                    }
-                    None => {}
+                // Step 2: render the top overlay (visual only — key reads
+                // already done above). `handle_key` may have popped or replaced
+                // the top layer (NotesPicker/QuickNote/ContextDescription
+                // self-close), so re-read the current top rather than reusing
+                // the kind dispatched above. Only the notification modal's
+                // `draw` returns commands; every other owner returns an empty
+                // vec, leaving `early_modal_cmds` empty as before.
+                if let Some(kind) = self.focus_stack.last().copied() {
+                    early_modal_cmds = kind.owner().draw(self, ctx);
                 }
                 // The overlay may have self-closed (notification queue drained,
                 // confirm-close confirmed/cancelled, palette picked an entry,
@@ -4601,7 +4523,7 @@ impl PlexiApp {
         self.notes_picker_entries = entries;
         self.notes_picker_selected = 0;
         self.notes_picker_query.clear();
-        self.push_focus_layer(FocusLayer::NotesPicker);
+        self.push_focus_layer(FocusKind::NotesPicker);
         // Surrender egui keyboard focus from the active TextEdit so the picker
         // receives j/k and other navigation keys immediately on the first frame.
         self.ctx.memory_mut(|m| {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -136,7 +136,14 @@ impl PlexiApp {
     /// Render the toolbar, toolbar separator, sidebar, central panel, quit overlay,
     /// feature effects, and focus re-request blocks. Called at the end of `update()`
     /// after all overlay dispatch and command draining.
-    pub(super) fn render_panels(&mut self, ctx: &egui::Context) {
+    pub(super) fn render_panels(
+        &mut self,
+        ctx: &egui::Context,
+        focused_terminal_input: Option<crate::render::terminal_pane::TerminalInput>,
+    ) {
+        // Taken by the CentralPanel's tiling behavior below; rebind as `mut`
+        // so it can be `.take()`n into the behavior for the focused terminal.
+        let mut focused_terminal_input = focused_terminal_input;
         // Toolbar
         egui::TopBottomPanel::top("toolbar")
             .exact_height(28.0)
@@ -188,19 +195,6 @@ impl PlexiApp {
                 .show(ctx, |ui| {
                     self.draw_sidebar(ui);
                 });
-            ctx.input(|i| {
-                for e in &i.events {
-                    if let egui::Event::Key {
-                        key: egui::Key::A,
-                        pressed: true,
-                        modifiers: m,
-                        ..
-                    } = e
-                    {
-                        log::info!("[diag-post-sidebar] Key::A alive: cmd={}", m.command);
-                    }
-                }
-            });
         }
 
         // Central panel — terminal tiles (or welcome screen when context is empty)
@@ -602,6 +596,8 @@ impl PlexiApp {
                     pane_gap: self.config.pane_gap.unwrap_or(4.0).clamp(0.0, 20.0),
                     pane_title_font_size: self.config.pane_title_font_size.unwrap_or(12.0).clamp(6.0, 32.0),
                     portal_zoom_request: None,
+                    focused_terminal_input: focused_terminal_input.take(),
+                    frame_modifiers: ui.input(|i| i.modifiers),
                 };
                 log::debug!("[DRAG] tiling: start (zoomed={}, hovered_files={hovered_files})", zoomed_pane.is_some());
                 ui.scope(|ui| {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -1,6 +1,6 @@
 //! Rendering helpers extracted from the main `eframe::App::update()` loop.
 
-use super::{ClickFlash, FocusLayer, PlexiApp};
+use super::{ClickFlash, FocusKind, PlexiApp};
 use crate::app_protocol::AgentState;
 use crate::spatial::tiling::{PaneId, PlexiBehavior};
 use egui::{Color32, CornerRadius, Stroke, StrokeKind, Vec2};
@@ -1039,7 +1039,7 @@ impl PlexiApp {
 
         // Command palette, run palette, rename-pane overlay, notification
         // modal, and confirm-close are all drawn by the early input-capture
-        // path at the top of `update()` — they own a `FocusLayer` and render
+        // path at the top of `update()` — they own a `FocusKind` and render
         // their own keystrokes before the drain. Drawing again here would
         // double-dispatch Enter/Escape after keys have been drained.
         // Quit confirmation overlay
@@ -1075,7 +1075,7 @@ impl PlexiApp {
 
         // Same pattern: QuickNote compose mode needs re-focus every frame so
         // pane TextInput widgets rendered in CentralPanel can't steal it.
-        if matches!(self.focus_stack.last(), Some(FocusLayer::QuickNote)) {
+        if matches!(self.focus_stack.last(), Some(FocusKind::QuickNote)) {
             ctx.memory_mut(|m| m.request_focus(egui::Id::new("quick_note_text")));
         }
 
@@ -1098,7 +1098,7 @@ impl PlexiApp {
         // Capability/secret modal: only re-request for Secret prompts — Capability prompts
         // have no text field, so requesting a non-existent ID would leave egui holding a
         // stale focus pointer that interferes with button interactions.
-        if matches!(self.focus_stack.last(), Some(FocusLayer::CapabilityModal)) {
+        if matches!(self.focus_stack.last(), Some(FocusKind::CapabilityModal)) {
             let has_secret_prompt = false;
             if has_secret_prompt {
                 log::debug!("capability_modal: re-requesting focus for capability_secret_input post-CentralPanel");

--- a/src/app/secrets_app.rs
+++ b/src/app/secrets_app.rs
@@ -301,7 +301,10 @@ impl App for SecretsApp {
         self.terminal_inject = terminal_inject;
     }
 
-    fn handle_key(&mut self, input: &egui::InputState) -> crate::app::app_trait::KeyDisposition {
+    fn handle_key(
+        &mut self,
+        input: &crate::app::input_router::PlexiInput,
+    ) -> crate::app::app_trait::KeyDisposition {
         use crate::app::app_trait::KeyDisposition;
         if self.mode == Mode::Adding {
             if input.key_pressed(egui::Key::Escape) {
@@ -317,7 +320,7 @@ impl App for SecretsApp {
             return KeyDisposition::Consumed;
         }
 
-        if input.modifiers.command || input.modifiers.alt {
+        if input.modifiers().command || input.modifiers().alt {
             return KeyDisposition::Passthrough;
         }
 

--- a/src/app/tests/focus_tests.rs
+++ b/src/app/tests/focus_tests.rs
@@ -296,7 +296,7 @@ fn split_with_new_pane_pushes_focus_history() {
 }
 
 /// Regression guard for #1110: setting renaming_pane + sync_rename_pane_focus()
-/// must push FocusLayer::RenamePane in the same call so input_captured_by_overlay()
+/// must push FocusKind::RenamePane in the same call so input_captured_by_overlay()
 /// is accurate immediately — not deferred to the next frame.
 #[test]
 fn rename_pane_focus_layer_syncs_immediately() {
@@ -313,8 +313,8 @@ fn rename_pane_focus_layer_syncs_immediately() {
 
     assert_eq!(
         h.app.focus_stack.last(),
-        Some(&FocusLayer::RenamePane),
-        "FocusLayer::RenamePane must be on the stack after sync"
+        Some(&FocusKind::RenamePane),
+        "FocusKind::RenamePane must be on the stack after sync"
     );
     assert!(
         h.app.input_captured_by_overlay(),

--- a/src/app/tests/notification_tests.rs
+++ b/src/app/tests/notification_tests.rs
@@ -458,17 +458,17 @@ fn auto_dismiss_does_not_touch_other_pane_notifications() {
 // ── QuickNote preemption tests (#1626) ────────────────────────────────────
 
 /// #1626: Cmd+0 with a NotificationModal on the focus stack must dismiss the
-/// modal and push FocusLayer::QuickNote to the top.
+/// modal and push FocusKind::QuickNote to the top.
 #[test]
 fn quicknote_preempts_notification_modal() {
     let mut h = HostHarness::new();
     h.add_test_pane();
 
     // Simulate a NotificationModal being open.
-    h.app.push_focus_layer(FocusLayer::NotificationModal);
+    h.app.push_focus_layer(FocusKind::NotificationModal);
     assert_eq!(
         h.app.focus_stack.last(),
-        Some(&FocusLayer::NotificationModal),
+        Some(&FocusKind::NotificationModal),
         "NotificationModal must be on top before preemption"
     );
     assert!(
@@ -481,19 +481,19 @@ fn quicknote_preempts_notification_modal() {
 
     assert_eq!(
         h.app.focus_stack.last(),
-        Some(&FocusLayer::QuickNote),
+        Some(&FocusKind::QuickNote),
         "QuickNote must be on top after preemption"
     );
 }
 
 /// #1626: Cmd+0 with CommandPalette on the focus stack must dismiss the
-/// palette and push FocusLayer::QuickNote to the top.
+/// palette and push FocusKind::QuickNote to the top.
 #[test]
 fn quicknote_preempts_command_palette() {
     let mut h = HostHarness::new();
     h.add_test_pane();
 
-    h.app.push_focus_layer(FocusLayer::CommandPalette);
+    h.app.push_focus_layer(FocusKind::CommandPalette);
     assert!(
         h.app.is_quick_note_preemptable(),
         "CommandPalette must be preemptable"
@@ -504,7 +504,7 @@ fn quicknote_preempts_command_palette() {
 
     assert_eq!(
         h.app.focus_stack.last(),
-        Some(&FocusLayer::QuickNote),
+        Some(&FocusKind::QuickNote),
         "QuickNote must be on top after preempting CommandPalette"
     );
 }
@@ -515,7 +515,7 @@ fn quicknote_does_not_preempt_confirm_close() {
     let mut h = HostHarness::new();
     h.add_test_pane();
 
-    h.app.push_focus_layer(FocusLayer::ConfirmClose);
+    h.app.push_focus_layer(FocusKind::ConfirmClose);
     assert!(
         !h.app.is_quick_note_preemptable(),
         "ConfirmClose must NOT be preemptable"
@@ -528,7 +528,7 @@ fn quicknote_does_not_preempt_capability_modal() {
     let mut h = HostHarness::new();
     h.add_test_pane();
 
-    h.app.push_focus_layer(FocusLayer::CapabilityModal);
+    h.app.push_focus_layer(FocusKind::CapabilityModal);
     assert!(
         !h.app.is_quick_note_preemptable(),
         "CapabilityModal must NOT be preemptable"
@@ -541,7 +541,7 @@ fn quicknote_does_not_preempt_context_close_confirm() {
     let mut h = HostHarness::new();
     h.add_test_pane();
 
-    h.app.push_focus_layer(FocusLayer::ContextCloseConfirm);
+    h.app.push_focus_layer(FocusKind::ContextCloseConfirm);
     assert!(
         !h.app.is_quick_note_preemptable(),
         "ContextCloseConfirm must NOT be preemptable"

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -703,10 +703,10 @@ impl App for TextEditorApp {
         false
     }
 
-    fn handle_key(&mut self, input: &egui::InputState) -> KeyDisposition {
+    fn handle_key(&mut self, input: &crate::app::input_router::PlexiInput) -> KeyDisposition {
         // Cmd+F: open find bar (or re-focus if already open).
         if input.key_pressed(egui::Key::F)
-            && input.modifiers.matches_logically(egui::Modifiers::COMMAND)
+            && input.modifiers().matches_logically(egui::Modifiers::COMMAND)
         {
             log::info!("TextEditorApp: Cmd+F — opening find bar");
             match &mut self.find_bar {
@@ -729,7 +729,7 @@ impl App for TextEditorApp {
             }
             // Enter: next match. Shift+Enter: previous match.
             if input.key_pressed(egui::Key::Enter) {
-                let forward = !input.modifiers.shift;
+                let forward = !input.modifiers().shift;
                 bar.advance(forward);
                 return KeyDisposition::Consumed;
             }

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -2729,12 +2729,12 @@ impl App for AssistantApp {
         self.model.streaming.in_flight || self.compact_pending || !self.pending_commands.is_empty()
     }
 
-    fn handle_key(&mut self, input: &egui::InputState) -> KeyDisposition {
+    fn handle_key(&mut self, input: &crate::app::input_router::PlexiInput) -> KeyDisposition {
         if input.key_pressed(egui::Key::Escape) && self.model.streaming.in_flight {
             self.interrupt_in_flight_turn();
             return KeyDisposition::Consumed;
         }
-        if !input.modifiers.any()
+        if !input.modifiers().any()
             && input.key_pressed(egui::Key::ArrowUp)
             && self.model.recall_previous_user_message()
         {

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -143,8 +143,8 @@ fn elide_path_leading(ui: &egui::Ui, path: &str, font_id: egui::FontId, max_widt
     ELLIPSIS.to_string()
 }
 
-fn key_pressed_no_repeat(input: &egui::InputState, key: egui::Key) -> bool {
-    input.events.iter().any(
+fn key_pressed_no_repeat(input: &crate::app::input_router::PlexiInput, key: egui::Key) -> bool {
+    input.events().iter().any(
         |e| matches!(e, egui::Event::Key { key: k, pressed: true, repeat: false, .. } if *k == key),
     )
 }
@@ -152,34 +152,34 @@ fn key_pressed_no_repeat(input: &egui::InputState, key: egui::Key) -> bool {
 // in_search gates all letter keys so that j/k/h/l/s/r/slash fall through
 // to AppendText instead of firing navigation/action commands while the user
 // is typing a query. Arrow keys, Enter, Escape, and Backspace always work.
-fn classify_key(input: &egui::InputState, in_search: bool) -> Option<FileBrowserAction> {
-    if !in_search && input.modifiers.command && key_pressed_no_repeat(input, egui::Key::A) {
+fn classify_key(input: &crate::app::input_router::PlexiInput, in_search: bool) -> Option<FileBrowserAction> {
+    if !in_search && input.modifiers().command && key_pressed_no_repeat(input, egui::Key::A) {
         return Some(FileBrowserAction::SelectAll);
     }
-    if !in_search && input.modifiers.command && key_pressed_no_repeat(input, egui::Key::N) {
+    if !in_search && input.modifiers().command && key_pressed_no_repeat(input, egui::Key::N) {
         return Some(FileBrowserAction::NewFolder);
     }
-    if !in_search && input.modifiers.command && key_pressed_no_repeat(input, egui::Key::R) {
+    if !in_search && input.modifiers().command && key_pressed_no_repeat(input, egui::Key::R) {
         return Some(FileBrowserAction::Rename);
     }
-    if !in_search && input.modifiers.command && key_pressed_no_repeat(input, egui::Key::C) {
+    if !in_search && input.modifiers().command && key_pressed_no_repeat(input, egui::Key::C) {
         return Some(FileBrowserAction::Copy);
     }
-    if !in_search && input.modifiers.command && key_pressed_no_repeat(input, egui::Key::X) {
+    if !in_search && input.modifiers().command && key_pressed_no_repeat(input, egui::Key::X) {
         return Some(FileBrowserAction::Cut);
     }
-    if !in_search && input.modifiers.command && key_pressed_no_repeat(input, egui::Key::V) {
+    if !in_search && input.modifiers().command && key_pressed_no_repeat(input, egui::Key::V) {
         return Some(FileBrowserAction::Paste);
     }
     // Cmd+D and Cmd+Shift+D are host split chords. Do not bind them inside
     // File Browser unless the full shortcut map is reviewed.
-    if !in_search && input.modifiers.command && key_pressed_no_repeat(input, egui::Key::Backspace) {
+    if !in_search && input.modifiers().command && key_pressed_no_repeat(input, egui::Key::Backspace) {
         return Some(FileBrowserAction::MoveToTrash);
     }
-    if !in_search && input.modifiers.command && key_pressed_no_repeat(input, egui::Key::O) {
+    if !in_search && input.modifiers().command && key_pressed_no_repeat(input, egui::Key::O) {
         return Some(FileBrowserAction::OpenWithDefault);
     }
-    if !in_search && input.modifiers.command && key_pressed_no_repeat(input, egui::Key::Enter) {
+    if !in_search && input.modifiers().command && key_pressed_no_repeat(input, egui::Key::Enter) {
         return Some(FileBrowserAction::Reveal);
     }
     if key_pressed_no_repeat(input, egui::Key::Escape) {
@@ -189,12 +189,12 @@ fn classify_key(input: &egui::InputState, in_search: bool) -> Option<FileBrowser
         return Some(FileBrowserAction::Backspace);
     }
     if input.key_pressed(egui::Key::ArrowDown)
-        || (!in_search && input.key_pressed(egui::Key::J) && !input.modifiers.any())
+        || (!in_search && input.key_pressed(egui::Key::J) && !input.modifiers().any())
     {
         return Some(FileBrowserAction::SelectNext);
     }
     if input.key_pressed(egui::Key::ArrowUp)
-        || (!in_search && input.key_pressed(egui::Key::K) && !input.modifiers.any())
+        || (!in_search && input.key_pressed(egui::Key::K) && !input.modifiers().any())
     {
         return Some(FileBrowserAction::SelectPrev);
     }
@@ -210,39 +210,39 @@ fn classify_key(input: &egui::InputState, in_search: bool) -> Option<FileBrowser
     if input.key_pressed(egui::Key::PageUp) {
         return Some(FileBrowserAction::PageUp);
     }
-    if !input.modifiers.command
+    if !input.modifiers().command
         && (key_pressed_no_repeat(input, egui::Key::Enter)
             || key_pressed_no_repeat(input, egui::Key::ArrowRight)
             || (!in_search && key_pressed_no_repeat(input, egui::Key::L)))
     {
         return Some(FileBrowserAction::Activate);
     }
-    if !input.modifiers.command
+    if !input.modifiers().command
         && (key_pressed_no_repeat(input, egui::Key::ArrowLeft)
             || (!in_search && key_pressed_no_repeat(input, egui::Key::H)))
     {
         return Some(FileBrowserAction::NavigateUp);
     }
-    if !in_search && key_pressed_no_repeat(input, egui::Key::Slash) && !input.modifiers.command {
+    if !in_search && key_pressed_no_repeat(input, egui::Key::Slash) && !input.modifiers().command {
         return Some(FileBrowserAction::EnterSearch);
     }
-    if !in_search && key_pressed_no_repeat(input, egui::Key::S) && !input.modifiers.any() {
+    if !in_search && key_pressed_no_repeat(input, egui::Key::S) && !input.modifiers().any() {
         return Some(FileBrowserAction::ToggleSort);
     }
-    if !in_search && key_pressed_no_repeat(input, egui::Key::I) && !input.modifiers.any() {
+    if !in_search && key_pressed_no_repeat(input, egui::Key::I) && !input.modifiers().any() {
         return Some(FileBrowserAction::ToggleInspector);
     }
-    if !in_search && key_pressed_no_repeat(input, egui::Key::Space) && !input.modifiers.any() {
+    if !in_search && key_pressed_no_repeat(input, egui::Key::Space) && !input.modifiers().any() {
         return Some(FileBrowserAction::ToggleQuickLook);
     }
-    if !in_search && key_pressed_no_repeat(input, egui::Key::R) && !input.modifiers.any() {
+    if !in_search && key_pressed_no_repeat(input, egui::Key::R) && !input.modifiers().any() {
         return Some(FileBrowserAction::Refresh);
     }
-    if !in_search && key_pressed_no_repeat(input, egui::Key::T) && !input.modifiers.any() {
+    if !in_search && key_pressed_no_repeat(input, egui::Key::T) && !input.modifiers().any() {
         return Some(FileBrowserAction::CdTerminalAndClose);
     }
     let mut text = String::new();
-    for event in &input.events {
+    for event in input.events() {
         if let egui::Event::Text(t) = event {
             text.push_str(t);
         }
@@ -2150,7 +2150,10 @@ impl App for FileBrowserApp {
         self.draw_rename_modal(ui.ctx(), colors);
     }
 
-    fn handle_key(&mut self, input: &egui::InputState) -> crate::app::app_trait::KeyDisposition {
+    fn handle_key(
+        &mut self,
+        input: &crate::app::input_router::PlexiInput,
+    ) -> crate::app::app_trait::KeyDisposition {
         use crate::app::app_trait::KeyDisposition;
         let mode = if self.in_search {
             Mode::Search
@@ -2290,7 +2293,7 @@ impl App for FileBrowserApp {
             (Mode::Normal, Some(FileBrowserAction::SelectNext)) => {
                 let last = self.entries.len().saturating_sub(1);
                 let next = (self.selected + 1).min(last);
-                if input.modifiers.shift {
+                if input.modifiers().shift {
                     self.extend_selection_to(next);
                 } else {
                     self.set_single_selection(next);
@@ -2300,7 +2303,7 @@ impl App for FileBrowserApp {
             }
             (Mode::Normal, Some(FileBrowserAction::SelectPrev)) => {
                 let prev = self.selected.saturating_sub(1);
-                if input.modifiers.shift {
+                if input.modifiers().shift {
                     self.extend_selection_to(prev);
                 } else {
                     self.set_single_selection(prev);
@@ -2480,9 +2483,8 @@ mod tests {
         };
         let mut consumed = false;
         let _ = ctx.run(raw, |ctx| {
-            ctx.input(|i| {
-                consumed = app.handle_key(i) == KeyDisposition::Consumed;
-            });
+            let input = crate::app::input_router::PlexiInput::take_from(ctx);
+            consumed = app.handle_key(&input) == KeyDisposition::Consumed;
         });
         consumed
     }
@@ -2785,9 +2787,8 @@ mod tests {
         // key_pressed_no_repeat returns false when no events are present.
         let ctx = egui::Context::default();
         let _ = ctx.run(RawInput::default(), |ctx| {
-            ctx.input(|i| {
-                assert!(!super::key_pressed_no_repeat(i, Key::ArrowRight));
-            });
+            let input = crate::app::input_router::PlexiInput::take_from(ctx);
+            assert!(!super::key_pressed_no_repeat(&input, Key::ArrowRight));
         });
     }
 
@@ -2801,9 +2802,8 @@ mod tests {
             ..Default::default()
         };
         let _ = ctx.run(raw, |ctx| {
-            ctx.input(|i| {
-                assert!(super::key_pressed_no_repeat(i, Key::ArrowRight));
-            });
+            let input = crate::app::input_router::PlexiInput::take_from(ctx);
+            assert!(super::key_pressed_no_repeat(&input, Key::ArrowRight));
         });
     }
 
@@ -2991,9 +2991,8 @@ mod tests {
         let ctx = egui::Context::default();
         let mut consumed = false;
         let _ = ctx.run(raw, |ctx| {
-            ctx.input(|i| {
-                consumed = app.handle_key(i) == crate::app::app_trait::KeyDisposition::Consumed;
-            });
+            let input = crate::app::input_router::PlexiInput::take_from(ctx);
+            consumed = app.handle_key(&input) == crate::app::app_trait::KeyDisposition::Consumed;
         });
 
         assert!(consumed, "injected Enter must be consumed by the app");

--- a/src/host/keys.rs
+++ b/src/host/keys.rs
@@ -1135,7 +1135,7 @@ pub fn build_binding_table(b: &KeyBindings) -> Vec<BindingEntry> {
 /// `input` is a [`crate::app::input_router::PlexiInput`] buffer already taken
 /// out of `ctx` for this frame (stint 0240's ownership-transfer router).
 /// `poll_actions` is the outer, always-first consumer — the global hotkey
-/// allowlist runs before any [`crate::app::FocusLayer`] on the focus stack
+/// allowlist runs before any [`crate::app::FocusKind`] on the focus stack
 /// sees an event, so a global shortcut can never be shadowed by overlay/app
 /// render order.
 pub fn poll_actions(

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -616,7 +616,7 @@ impl AppRuntime {
 
     pub fn handle_key(
         &mut self,
-        input: &egui::InputState,
+        input: &crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         match self {
             AppRuntime::Builtin(app) => app.handle_key(input),

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -1905,9 +1905,9 @@ impl LiveWasmPane {
     /// press and release edges are forwarded so apps can track held state (a game
     /// paddle, a key being held down); OS auto-repeat is collapsed and Cmd-chords
     /// are reserved for host shortcuts. See [`translate_key_event`].
-    pub fn handle_key(&mut self, input: &egui::InputState) -> KeyDisposition {
+    pub fn handle_key(&mut self, input: &crate::app::input_router::PlexiInput) -> KeyDisposition {
         let mut consumed = false;
-        for event in &input.events {
+        for event in input.events() {
             match event {
                 egui::Event::Key { .. } => {
                     if let Some(ke) = translate_key_event(event) {

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -1295,9 +1295,9 @@ impl LivePythonPane {
 
     pub fn handle_key(
         &mut self,
-        input: &egui::InputState,
+        input: &crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
-        let events = python_key_events(&input.events);
+        let events = python_key_events(input.events());
         if events.is_empty() {
             crate::app::app_trait::KeyDisposition::Passthrough
         } else {

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -543,7 +543,7 @@ impl PlexiApp {
         };
 
         // Consume Enter/Escape at the context level so they cannot bleed into
-        // the focused pane this frame. Pairs with `FocusLayer::RenamePane` —
+        // the focused pane this frame. Pairs with `FocusKind::RenamePane` —
         // the overlay owns its own commit/cancel keys.
         let (commit, cancel) = ctx.input_mut(|i| {
             let enter = i.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
@@ -700,7 +700,7 @@ impl PlexiApp {
             Some(idx) if idx < self.router.len() => idx,
             _ => {
                 self.editing_description = None;
-                self.pop_focus_layer(&crate::app::FocusLayer::ContextDescription);
+                self.pop_focus_layer(&crate::app::FocusKind::ContextDescription);
                 return;
             }
         };
@@ -757,7 +757,7 @@ impl PlexiApp {
             log::info!("context_description: edit cancelled ctx_idx={ctx_idx}");
             self.editing_description = None;
             self.description_focus_requested = false;
-            self.pop_focus_layer(&crate::app::FocusLayer::ContextDescription);
+            self.pop_focus_layer(&crate::app::FocusKind::ContextDescription);
         } else if commit {
             let new_desc = self.description_buffer.trim().to_string();
             self.router.get_mut(ctx_idx).description = if new_desc.is_empty() {
@@ -767,7 +767,7 @@ impl PlexiApp {
             };
             self.editing_description = None;
             self.description_focus_requested = false;
-            self.pop_focus_layer(&crate::app::FocusLayer::ContextDescription);
+            self.pop_focus_layer(&crate::app::FocusKind::ContextDescription);
             self.save_workspace();
             log::info!("context_description: updated ctx_idx={ctx_idx}");
         }

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -9,7 +9,7 @@
 //!   Esc — close (or exit search/rename mode first)
 
 use crate::app::text_editor_app::note_path_identity;
-use crate::app::{FocusLayer, PlexiApp};
+use crate::app::{FocusKind, PlexiApp};
 use crate::ui::style;
 use crate::ui::{
     hints::{HintBar, HintGroup},
@@ -102,7 +102,7 @@ impl PlexiApp {
                 "notes_picker: refusing to delete open note in pane {existing_pane_id} — close it first"
             );
             self.set_window_focused_pane(active, existing_tile_id);
-            self.pop_focus_layer(&FocusLayer::NotesPicker);
+            self.pop_focus_layer(&FocusKind::NotesPicker);
             return;
         }
 
@@ -153,7 +153,7 @@ impl PlexiApp {
         match action {
             Some(PickerKey::Escape) => {
                 if self.notes_picker_query.is_empty() {
-                    self.pop_focus_layer(&FocusLayer::NotesPicker);
+                    self.pop_focus_layer(&FocusKind::NotesPicker);
                 } else {
                     self.notes_picker_query.clear();
                     self.notes_picker_selected = 0;
@@ -191,7 +191,7 @@ impl PlexiApp {
             log::info!("notes_picker: already open in pane {existing_pane_id}, focusing");
             self.set_window_focused_pane(active, existing_tile_id);
             emit_note_opened(&path);
-            self.pop_focus_layer(&FocusLayer::NotesPicker);
+            self.pop_focus_layer(&FocusKind::NotesPicker);
             return;
         }
         // Reuse the focused pane only when it's already a text-editor;
@@ -216,7 +216,7 @@ impl PlexiApp {
                         emit_note_opened(&path);
                     }
                 }
-                self.pop_focus_layer(&FocusLayer::NotesPicker);
+                self.pop_focus_layer(&FocusKind::NotesPicker);
             }
             None => {
                 log::info!(
@@ -241,7 +241,7 @@ impl PlexiApp {
         {
             emit_note_opened(&path);
         }
-        self.pop_focus_layer(&FocusLayer::NotesPicker);
+        self.pop_focus_layer(&FocusKind::NotesPicker);
     }
 
     pub(crate) fn draw_notes_picker(&mut self, ctx: &egui::Context) {
@@ -370,7 +370,7 @@ impl PlexiApp {
         // Dismiss on click outside the modal (processed after picker Area so it
         // doesn't fire when clicking inside the modal itself).
         if modal_response.dismissed {
-            self.pop_focus_layer(&FocusLayer::NotesPicker);
+            self.pop_focus_layer(&FocusKind::NotesPicker);
         }
     }
 }
@@ -455,7 +455,7 @@ mod tests {
         app.windows[0].focused_pane = Some(focused_tile);
         app.notes_picker_entries = vec![picker_entry(note_path.clone(), "note")];
         app.notes_picker_selected = 0;
-        app.push_focus_layer(FocusLayer::NotesPicker);
+        app.push_focus_layer(FocusKind::NotesPicker);
 
         app.notes_picker_open_selected();
 
@@ -475,7 +475,7 @@ mod tests {
             state_path(&focused_state),
             other_path.to_string_lossy().to_string()
         );
-        assert!(!app.focus_stack.contains(&FocusLayer::NotesPicker));
+        assert!(!app.focus_stack.contains(&FocusKind::NotesPicker));
     }
 
     #[test]
@@ -497,7 +497,7 @@ mod tests {
         app.windows[0].focused_pane = Some(focused_tile);
         app.notes_picker_entries = vec![picker_entry(alias_path, "note")];
         app.notes_picker_selected = 0;
-        app.push_focus_layer(FocusLayer::NotesPicker);
+        app.push_focus_layer(FocusKind::NotesPicker);
 
         app.notes_picker_open_selected();
 
@@ -506,7 +506,7 @@ mod tests {
             app.find_open_text_editor_tile(0, &note_path),
             Some((existing_tile, existing_pane))
         );
-        assert!(!app.focus_stack.contains(&FocusLayer::NotesPicker));
+        assert!(!app.focus_stack.contains(&FocusKind::NotesPicker));
 
         let focused_state = app.windows[0]
             .panes
@@ -537,14 +537,14 @@ mod tests {
         app.windows[0].focused_pane = Some(focused_tile);
         app.notes_picker_entries = vec![picker_entry(note_path.clone(), "keep")];
         app.notes_picker_selected = 0;
-        app.push_focus_layer(FocusLayer::NotesPicker);
+        app.push_focus_layer(FocusKind::NotesPicker);
 
         app.notes_picker_delete_entry(0);
 
         assert_eq!(app.windows[0].focused_pane, Some(existing_tile));
         assert_eq!(app.notes_picker_entries.len(), 1);
         assert!(note_path.exists());
-        assert!(!app.focus_stack.contains(&FocusLayer::NotesPicker));
+        assert!(!app.focus_stack.contains(&FocusKind::NotesPicker));
 
         let _ = std::fs::remove_file(&note_path);
     }

--- a/src/overlays/notes_triage.rs
+++ b/src/overlays/notes_triage.rs
@@ -1,7 +1,7 @@
 //! Notes inbox triage overlay. Currently has no UI entry point — the `t`
 //! binding in the notes picker was removed pending a triage rework; the
 //! overlay is kept alive (and smoke-tested) by pushing
-//! `FocusLayer::NotesTriage` directly.
+//! `FocusKind::NotesTriage` directly.
 //!
 //! Shows inbox notes one at a time. Key bindings:
 //!   h / ←          — previous note
@@ -11,7 +11,7 @@
 //!   1–9            — run configured action, then trash and advance
 //!   Esc            — back to the notes picker
 
-use crate::app::{FocusLayer, PlexiApp};
+use crate::app::{FocusKind, PlexiApp};
 use crate::notes::{InboxNote, TriageAction};
 use crate::ui::style;
 use crate::ui::{
@@ -24,8 +24,8 @@ impl PlexiApp {
     /// advancing past the last note). The picker re-scans, so the inbox
     /// section reflects what triage just moved.
     fn notes_triage_back_to_picker(&mut self) {
-        self.pop_focus_layer(&FocusLayer::NotesTriage);
-        if !self.focus_stack.contains(&FocusLayer::NotesPicker) {
+        self.pop_focus_layer(&FocusKind::NotesTriage);
+        if !self.focus_stack.contains(&FocusKind::NotesPicker) {
             self.open_notes_picker();
         }
     }
@@ -453,13 +453,13 @@ mod tests {
         let mut app = test_app();
         app.notes_triage_notes = vec![inbox_note("only")];
         app.notes_triage_index = 0;
-        app.push_focus_layer(FocusLayer::NotesTriage);
+        app.push_focus_layer(FocusKind::NotesTriage);
 
         // Removing the last note must land back on the picker, not just close.
         app.notes_triage_advance();
 
-        assert!(!app.focus_stack.contains(&FocusLayer::NotesTriage));
-        assert!(app.focus_stack.contains(&FocusLayer::NotesPicker));
+        assert!(!app.focus_stack.contains(&FocusKind::NotesTriage));
+        assert!(app.focus_stack.contains(&FocusKind::NotesPicker));
     }
 
     #[test]
@@ -467,12 +467,12 @@ mod tests {
         let mut app = test_app();
         app.notes_triage_notes = vec![inbox_note("a"), inbox_note("b")];
         app.notes_triage_index = 0;
-        app.push_focus_layer(FocusLayer::NotesTriage);
+        app.push_focus_layer(FocusKind::NotesTriage);
 
         app.notes_triage_advance();
 
-        assert!(app.focus_stack.contains(&FocusLayer::NotesTriage));
-        assert!(!app.focus_stack.contains(&FocusLayer::NotesPicker));
+        assert!(app.focus_stack.contains(&FocusKind::NotesTriage));
+        assert!(!app.focus_stack.contains(&FocusKind::NotesPicker));
         assert_eq!(app.notes_triage_notes.len(), 1);
         assert_eq!(app.notes_triage_index, 0);
     }
@@ -480,16 +480,16 @@ mod tests {
     #[test]
     fn triage_back_to_picker_does_not_double_push_picker_layer() {
         let mut app = test_app();
-        app.push_focus_layer(FocusLayer::NotesPicker);
-        app.push_focus_layer(FocusLayer::NotesTriage);
+        app.push_focus_layer(FocusKind::NotesPicker);
+        app.push_focus_layer(FocusKind::NotesTriage);
 
         app.notes_triage_back_to_picker();
 
-        assert!(!app.focus_stack.contains(&FocusLayer::NotesTriage));
+        assert!(!app.focus_stack.contains(&FocusKind::NotesTriage));
         assert_eq!(
             app.focus_stack
                 .iter()
-                .filter(|l| **l == FocusLayer::NotesPicker)
+                .filter(|l| **l == FocusKind::NotesPicker)
                 .count(),
             1
         );

--- a/src/overlays/quick_note.rs
+++ b/src/overlays/quick_note.rs
@@ -9,7 +9,7 @@ impl PlexiApp {
         // Consume Esc to close.
         let esc = ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
         if esc {
-            self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
+            self.pop_focus_layer(&crate::app::FocusKind::QuickNote);
             self.quick_note_text.clear();
             log::info!("QuickNote: modal dismissed");
             return;
@@ -76,7 +76,7 @@ impl PlexiApp {
         if commit && !self.quick_note_text.trim().is_empty() {
             let text = self.quick_note_text.clone();
             if self.commit_quick_note_to_inbox(&text) {
-                self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
+                self.pop_focus_layer(&crate::app::FocusKind::QuickNote);
                 self.quick_note_text.clear();
                 log::info!("QuickNote: committed to inbox");
             }
@@ -124,7 +124,7 @@ impl PlexiApp {
                 }
             });
         if response.dismissed {
-            self.pop_focus_layer(&crate::app::FocusLayer::QuickNote);
+            self.pop_focus_layer(&crate::app::FocusKind::QuickNote);
             self.quick_note_text.clear();
             log::info!("QuickNote: modal dismissed via click-away");
         }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1578,7 +1578,7 @@ impl PlexiApp {
         }
     }
 
-    /// Open the quick note modal: capture context and push FocusLayer::QuickNote.
+    /// Open the quick note modal: capture context and push FocusKind::QuickNote.
     pub(crate) fn open_quick_note_modal(&mut self) {
         let active = self.active_window;
         let cwd = self.windows[active]
@@ -1593,7 +1593,7 @@ impl PlexiApp {
             workspace_root,
             context_root,
         };
-        self.push_focus_layer(crate::app::FocusLayer::QuickNote);
+        self.push_focus_layer(crate::app::FocusKind::QuickNote);
         log::info!(
             "QuickNote: modal opened — cwd={}, workspace={:?}",
             self.quick_note_ctx.cwd.display(),

--- a/src/render/cli_renderer_app.rs
+++ b/src/render/cli_renderer_app.rs
@@ -736,7 +736,7 @@ impl App for CliRendererApp {
         matches!(self.view, View::Form)
     }
 
-    fn handle_key(&mut self, input: &egui::InputState) -> KeyDisposition {
+    fn handle_key(&mut self, input: &crate::app::input_router::PlexiInput) -> KeyDisposition {
         match &self.view {
             View::List => {
                 let commands = self.commands_at_path();
@@ -755,7 +755,7 @@ impl App for CliRendererApp {
                 }
                 // Cmd+Enter is the host pane-zoom toggle (src/host/keys.rs) — let
                 // it pass through; plain Enter opens the selected command.
-                if input.key_pressed(egui::Key::Enter) && !input.modifiers.command {
+                if input.key_pressed(egui::Key::Enter) && !input.modifiers().command {
                     self.navigate_into(self.selected);
                     return KeyDisposition::Consumed;
                 }
@@ -774,7 +774,7 @@ impl App for CliRendererApp {
                 // Enter has no in-field meaning to compete with). Cmd+Enter is
                 // reserved for the host pane-zoom toggle (src/host/keys.rs), so
                 // let it pass through instead of running.
-                if input.key_pressed(egui::Key::Enter) && !input.modifiers.command {
+                if input.key_pressed(egui::Key::Enter) && !input.modifiers().command {
                     self.execute();
                     return KeyDisposition::Consumed;
                 }
@@ -1036,7 +1036,8 @@ mod tests {
                 ..Default::default()
             },
             |ctx| {
-                ctx.input(|i| disposition = app.handle_key(i));
+                let input = crate::app::input_router::PlexiInput::take_from(ctx);
+                disposition = app.handle_key(&input);
             },
         );
         disposition

--- a/src/render/terminal_pane.rs
+++ b/src/render/terminal_pane.rs
@@ -24,6 +24,19 @@ use std::time::{Duration, Instant};
 const TAB_PIP_RADIUS: f32 = 4.0;
 const TAB_PIP_MARGIN: f32 = 7.0;
 
+/// Host-supplied, frame-scoped keyboard input for one terminal pane
+/// (stint 0387). Built in `PlexiApp::update` by taking the frame's
+/// `PlexiInput` ownership buffer *before* the render pass and threaded down to
+/// the focused terminal so egui's render-time widget machinery can't swallow a
+/// key (e.g. Cmd+A) first. The focused pane receives the taken events;
+/// unfocused panes receive an empty `keyboard_events` list (they only need
+/// pointer/wheel, which stays on the ctx path).
+#[derive(Default)]
+pub struct TerminalInput {
+    pub keyboard_events: Vec<egui::Event>,
+    pub modifiers: egui::Modifiers,
+}
+
 const OUTSIDE_WORKSPACE_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 const TERMINAL_GLYPH_PADDING_X: f32 = 2.0;
 static LOG_TERMINAL_GLYPH_PADDING: Once = Once::new();
@@ -46,6 +59,7 @@ pub fn render(
     tab_activities: &HashMap<PaneId, AgentState>,
     workspace_root: Option<&Path>,
     pane_title_font_size: f32,
+    input: TerminalInput,
 ) -> (bool, Option<(TileId, TabBarAction)>) {
     if terminal.exited {
         let rect = ui.max_rect();
@@ -55,12 +69,14 @@ pub fn render(
                 ui.colored_label(colors.text_dim, "[process exited]");
             });
         });
+        // Auto-close on any keypress. Keyboard events were taken out of `ctx`
+        // before the render pass (stint 0387), so read them from the
+        // host-supplied buffer rather than `ui.input()`.
         let close = is_focused
-            && ui.input(|i| {
-                i.events
-                    .iter()
-                    .any(|e| matches!(e, egui::Event::Key { pressed: true, .. }))
-            });
+            && input
+                .keyboard_events
+                .iter()
+                .any(|e| matches!(e, egui::Event::Key { pressed: true, .. }));
         return (close, None);
     }
 
@@ -90,7 +106,8 @@ pub fn render(
         .set_theme(theme.clone())
         .set_font(theme::terminal_font(font_size))
         .set_padding(Vec2::new(TERMINAL_GLYPH_PADDING_X, 0.0))
-        .set_size(Vec2::new(ui.available_width(), ui.available_height()));
+        .set_size(Vec2::new(ui.available_width(), ui.available_height()))
+        .with_input(input.keyboard_events, input.modifiers);
     ui.add(view);
 
     (false, tab_action)

--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -393,6 +393,16 @@ pub struct PlexiBehavior<'a> {
     pub pane_gap: f32,
     /// Resolved pane title bar font size (from config, default 11.0).
     pub pane_title_font_size: f32,
+    /// Keyboard input the host took from `ctx` before the render pass, destined
+    /// for the focused terminal pane (stint 0387). Consumed (via `take`) by the
+    /// pane whose `is_focused` is true, so egui's render-time widget machinery
+    /// can't swallow a key (Cmd+A) first. `None` when the focused pane is not a
+    /// terminal (or an overlay owns input).
+    pub focused_terminal_input: Option<crate::render::terminal_pane::TerminalInput>,
+    /// This frame's modifier state, used to build the empty [`TerminalInput`]
+    /// for unfocused terminals (which still need current modifiers for pointer
+    /// link-hover and mouse reporting).
+    pub frame_modifiers: egui::Modifiers,
 }
 
 impl Behavior<PaneId> for PlexiBehavior<'_> {
@@ -498,6 +508,21 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             ui.painter()
                 .rect_filled(pane_rect, 0.0, self.colors.terminal_bg);
             let mut terminal_ui = ui.new_child(egui::UiBuilder::new().max_rect(pane_rect));
+            // The focused terminal consumes the host-supplied keyboard buffer;
+            // every other terminal gets an empty one (pointer/wheel only).
+            let terminal_input = if is_focused {
+                self.focused_terminal_input.take().unwrap_or_else(|| {
+                    render::terminal_pane::TerminalInput {
+                        keyboard_events: Vec::new(),
+                        modifiers: self.frame_modifiers,
+                    }
+                })
+            } else {
+                render::terminal_pane::TerminalInput {
+                    keyboard_events: Vec::new(),
+                    modifiers: self.frame_modifiers,
+                }
+            };
             let (close_exited, tab_action) = render::terminal_pane::render(
                 &mut terminal_ui,
                 terminal,
@@ -512,6 +537,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
                 &tab_activities,
                 self.workspace_root.as_deref(),
                 self.pane_title_font_size,
+                terminal_input,
             );
             if close_exited {
                 self.close_exited = Some(tile_id);

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -820,9 +820,9 @@ fn palette_close_surrenders_focus_before_pane_close() {
 #[test]
 fn notification_modal_handle_key_returns_consumed() {
     use crate::app::app_trait::KeyDisposition;
-    use crate::app::FocusLayer;
+    use crate::app::FocusKind;
     let mut h = HostHarness::new();
-    h.app.push_focus_layer(FocusLayer::NotificationModal);
+    h.app.push_focus_layer(FocusKind::NotificationModal);
     let ctx = h.app.ctx.clone();
     let mut input = crate::app::input_router::PlexiInput::take_from(&ctx);
     let disposition = h.app.notification_modal_handle_key(&mut input);
@@ -880,7 +880,7 @@ fn cwd_for_welcome_tab_falls_back_to_window_path_when_no_root() {
 
 #[test]
 fn buried_stale_focus_layer_is_removed_by_sync() {
-    use crate::app::FocusLayer;
+    use crate::app::FocusKind;
 
     let mut h = HostHarness::new();
 
@@ -888,7 +888,7 @@ fn buried_stale_focus_layer_is_removed_by_sync() {
     h.app.pending_close = true;
     h.app.sync_confirm_close_focus();
     assert!(
-        h.app.focus_stack.contains(&FocusLayer::ConfirmClose),
+        h.app.focus_stack.contains(&FocusKind::ConfirmClose),
         "ConfirmClose must be pushed when pending_close is true"
     );
 
@@ -897,11 +897,11 @@ fn buried_stale_focus_layer_is_removed_by_sync() {
     h.app.sync_command_palette_focus();
     assert_eq!(
         h.app.focus_stack.last(),
-        Some(&FocusLayer::CommandPalette),
+        Some(&FocusKind::CommandPalette),
         "CommandPalette must be at the top after its source state becomes true"
     );
     assert!(
-        h.app.focus_stack.contains(&FocusLayer::ConfirmClose),
+        h.app.focus_stack.contains(&FocusKind::ConfirmClose),
         "ConfirmClose must still be in the stack (buried beneath CommandPalette)"
     );
 
@@ -910,14 +910,14 @@ fn buried_stale_focus_layer_is_removed_by_sync() {
     h.app.sync_confirm_close_focus();
 
     assert!(
-        !h.app.focus_stack.contains(&FocusLayer::ConfirmClose),
+        !h.app.focus_stack.contains(&FocusKind::ConfirmClose),
         "ConfirmClose must be removed from the stack even though CommandPalette was on top. \
          If this fails, sync_confirm_close_focus used pop_focus_layer (top-only) instead of retain."
     );
 
     // The layer that was on top must still be present — we only removed ConfirmClose.
     assert!(
-        h.app.focus_stack.contains(&FocusLayer::CommandPalette),
+        h.app.focus_stack.contains(&FocusKind::CommandPalette),
         "CommandPalette must remain in the stack after removing the buried ConfirmClose layer"
     );
 }
@@ -937,7 +937,7 @@ fn quick_note_paste_inserts_into_note_text() {
     let mut h = HostHarness::new();
 
     // Open QuickNote.
-    h.app.push_focus_layer(crate::app::FocusLayer::QuickNote);
+    h.app.push_focus_layer(crate::app::FocusKind::QuickNote);
 
     // Run two idle frames so the overlay and focus fully settle.
     h.run_frames(2);
@@ -965,7 +965,7 @@ fn quick_note_paste_inserts_into_note_text() {
 fn quick_note_paste_consumed_from_queue() {
     let mut h = HostHarness::new();
 
-    h.app.push_focus_layer(crate::app::FocusLayer::QuickNote);
+    h.app.push_focus_layer(crate::app::FocusKind::QuickNote);
     h.run_frames(2);
 
     // Inject paste + a non-input event that must survive.
@@ -1032,12 +1032,12 @@ fn command_palette_text_field_registry_wins_after_central_panel_steal() {
 /// re-claim focus for `rename_pane_input` before the frame ends.
 #[test]
 fn rename_pane_overlay_focus_wins_after_central_panel_steal() {
-    use crate::app::FocusLayer;
+    use crate::app::FocusKind;
     let mut h = HostHarness::new();
     let pane = h.add_test_pane();
     h.app.renaming_pane = Some(pane);
     h.app.rename_buffer = "test name".to_string();
-    h.app.push_focus_layer(FocusLayer::RenamePane);
+    h.app.push_focus_layer(FocusKind::RenamePane);
     // Frame 1: one-shot fires, focus = rename_pane_input.
     h.run_frames(1);
     // Simulate CentralPanel pane widget stealing focus.
@@ -1055,12 +1055,12 @@ fn rename_pane_overlay_focus_wins_after_central_panel_steal() {
 /// must retain egui focus after CentralPanel renders.
 #[test]
 fn context_rename_overlay_focus_wins_after_central_panel_steal() {
-    use crate::app::FocusLayer;
+    use crate::app::FocusKind;
     let mut h = HostHarness::new();
     h.app.renaming_window = Some(0);
     h.app.rename_buffer = "new context".to_string();
     h.app.sidebar_visible = false;
-    h.app.push_focus_layer(FocusLayer::ContextRename);
+    h.app.push_focus_layer(FocusKind::ContextRename);
     h.run_frames(1);
     steal_focus(&h);
     h.run_frames(1);
@@ -1075,11 +1075,11 @@ fn context_rename_overlay_focus_wins_after_central_panel_steal() {
 /// after CentralPanel renders.
 #[test]
 fn edit_description_overlay_focus_wins_after_central_panel_steal() {
-    use crate::app::FocusLayer;
+    use crate::app::FocusKind;
     let mut h = HostHarness::new();
     h.app.editing_description = Some(0);
     h.app.description_buffer = "my description".to_string();
-    h.app.push_focus_layer(FocusLayer::ContextDescription);
+    h.app.push_focus_layer(FocusKind::ContextDescription);
     h.run_frames(1);
     steal_focus(&h);
     h.run_frames(1);
@@ -1094,7 +1094,7 @@ fn edit_description_overlay_focus_wins_after_central_panel_steal() {
 /// egui focus after CentralPanel renders.
 #[test]
 fn text_input_overlay_focus_wins_after_central_panel_steal() {
-    use crate::app::{FocusLayer, OverlayTarget, TextInputOverlay};
+    use crate::app::{FocusKind, OverlayTarget, TextInputOverlay};
     let mut h = HostHarness::new();
     h.app.text_overlay = Some((
         TextInputOverlay {
@@ -1105,7 +1105,7 @@ fn text_input_overlay_focus_wins_after_central_panel_steal() {
         },
         OverlayTarget::ContextRoot(0),
     ));
-    h.app.push_focus_layer(FocusLayer::TextInput);
+    h.app.push_focus_layer(FocusKind::TextInput);
     h.run_frames(1);
     steal_focus(&h);
     h.run_frames(1);

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -98,7 +98,7 @@ impl crate::app::app_trait::App for TextInputProbe {
 
     fn handle_key(
         &mut self,
-        input: &egui::InputState,
+        input: &crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         if input.key_pressed(egui::Key::Enter) {
             self.enter_handled = true;
@@ -209,6 +209,55 @@ fn consumed_native_key_is_not_replayed_into_render_input() {
     assert_eq!(state["enter_rendered"], false);
 }
 
+
+/// Stint 0387: a real keyboard event injected via `RawInput` must reach the
+/// focused app pane's `handle_key` through the migrated `PlexiInput`
+/// ownership-transfer router in `dispatch_app_key_events` — not just the
+/// synthesized `plexi pane key` IPC path. Proves the app-dispatch migration is
+/// wired into the live frame, reading the frame's owned buffer.
+#[test]
+fn raw_key_event_reaches_focused_app_via_router() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.open_builtin_app_pane(
+        Box::<TextInputProbe>::default(),
+        AppPermissions::builtin(),
+        tmp.path().to_path_buf(),
+        None,
+        Some("split_h"),
+        None,
+    );
+    let pane_id = h.state().open_panes[0];
+    h.focus_pane(pane_id);
+    h.run_frames(2);
+
+    // Drive a genuine Enter key event through a real frame's RawInput.
+    h.frame(egui::RawInput {
+        screen_rect: Some(egui::Rect::from_min_size(
+            egui::Pos2::ZERO,
+            egui::vec2(1280.0, 800.0),
+        )),
+        events: vec![egui::Event::Key {
+            key: egui::Key::Enter,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: egui::Modifiers::NONE,
+        }],
+        ..Default::default()
+    });
+
+    let state = h.app.windows[0]
+        .panes
+        .get(&pane_id)
+        .and_then(Pane::as_app)
+        .and_then(|pane| pane.runtime.serialize_state())
+        .expect("probe state after Enter");
+    assert_eq!(
+        state["enter_handled"], true,
+        "RawInput Enter must reach handle_key through the ownership router"
+    );
+}
 
 #[test]
 fn pane_slots_write_read_list_delete() {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -682,7 +682,7 @@ impl PlexiApp {
                     self.description_buffer =
                         self.router.get(i).description.clone().unwrap_or_default();
                     self.description_focus_requested = false;
-                    self.push_focus_layer(crate::app::FocusLayer::ContextDescription);
+                    self.push_focus_layer(crate::app::FocusKind::ContextDescription);
                 }
                 WindowMenuAction::MoveToTop => {
                     self.renaming_window = None;

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -492,7 +492,7 @@ impl PlexiUiHarness {
 mod tests {
     use super::*;
     use crate::app::permissions::AppPermissions;
-    use crate::app::FocusLayer;
+    use crate::app::FocusKind;
     use crate::host::context::Window;
     use crate::host::pane::{AppPane, AppRuntime, Pane, PortalPane};
     use egui_kittest::kittest::Queryable;
@@ -748,7 +748,7 @@ mod tests {
         let queued = h.with_app(|app| app.pending_raw_wasm_launches.len());
         assert_eq!(queued, 1, "raw .wasm path launch should queue one review");
         let has_review_focus =
-            h.with_app(|app| matches!(app.focus_stack.last(), Some(FocusLayer::RawWasmReview)));
+            h.with_app(|app| matches!(app.focus_stack.last(), Some(FocusKind::RawWasmReview)));
         assert!(has_review_focus, "raw WASM review should own focus");
         let has_wasm = h.with_app(|app| {
             app.windows[app.active_window]
@@ -1070,7 +1070,7 @@ mod tests {
         h.with_app(|app| {
             assert!(app
                 .focus_stack
-                .contains(&crate::app::FocusLayer::NotesPicker));
+                .contains(&crate::app::FocusKind::NotesPicker));
         });
         // ListRow titles are painted as galleys (not accessible labels);
         // assert on the section headers, which are real ui.label widgets.
@@ -1223,14 +1223,14 @@ mod tests {
             }];
             app.notes_triage_actions = Vec::new();
             app.notes_triage_index = 0;
-            app.push_focus_layer(crate::app::FocusLayer::NotesTriage);
+            app.push_focus_layer(crate::app::FocusKind::NotesTriage);
         });
         // Two steps for the egui Area sizing pass (see picker smoke test).
         h.run_steps(2);
         h.with_app(|app| {
             assert!(app
                 .focus_stack
-                .contains(&crate::app::FocusLayer::NotesTriage));
+                .contains(&crate::app::FocusKind::NotesTriage));
         });
         h.harness().get_by_label("Inbox Triage (1/1)");
         h.harness().get_by_label("triage me");
@@ -1242,10 +1242,10 @@ mod tests {
         h.with_app(|app| {
             assert!(!app
                 .focus_stack
-                .contains(&crate::app::FocusLayer::NotesTriage));
+                .contains(&crate::app::FocusKind::NotesTriage));
             assert!(app
                 .focus_stack
-                .contains(&crate::app::FocusLayer::NotesPicker));
+                .contains(&crate::app::FocusKind::NotesPicker));
         });
     }
 
@@ -1829,7 +1829,7 @@ mod tests {
             let ctx_idx = app.router.active_idx();
             app.rename_buffer = "My Project".to_string();
             app.renaming_window = Some(ctx_idx);
-            app.focus_stack.push(FocusLayer::ContextRename);
+            app.focus_stack.push(FocusKind::ContextRename);
         });
 
         // Queue Enter for the next frame — processed by draw_rename_context_overlay.
@@ -1857,7 +1857,7 @@ mod tests {
             let ctx_idx = app.router.active_idx();
             app.rename_buffer = "Discarded Name".to_string();
             app.renaming_window = Some(ctx_idx);
-            app.focus_stack.push(FocusLayer::ContextRename);
+            app.focus_stack.push(FocusKind::ContextRename);
         });
 
         h.harness().press_key(egui::Key::Escape);
@@ -1884,7 +1884,7 @@ mod tests {
             let ctx_idx = app.router.active_idx();
             app.rename_buffer = "   ".to_string(); // whitespace-only trims to empty
             app.renaming_window = Some(ctx_idx);
-            app.focus_stack.push(FocusLayer::ContextRename);
+            app.focus_stack.push(FocusKind::ContextRename);
         });
 
         h.harness().press_key(egui::Key::Enter);

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1897,6 +1897,74 @@ mod tests {
         );
     }
 
+    /// Regression (stint 0387 follow-up): the inline sidebar context-rename
+    /// TextEdit must receive typed characters even while a terminal pane is the
+    /// focused tile. The terminal-input ownership transfer
+    /// (`take_focused_terminal_input`) runs before the render pass and, before
+    /// the fix, stole every Key/Text event out of `ctx` whenever the focused
+    /// tile was a terminal — starving the sidebar rename box (which is not a
+    /// focus layer when the sidebar is visible). With the fix, the steal is
+    /// gated on egui keyboard focus, so the box (which holds egui focus) keeps
+    /// its keystrokes.
+    #[test]
+    fn sidebar_inline_rename_receives_text_with_focused_terminal() {
+        let mut h = PlexiUiHarness::new_sized(1000.0, 700.0);
+        h.step();
+
+        // Need a real focused terminal pane. Seed an app pane, then split — the
+        // split spawns a real TerminalPane and focuses it.
+        add_focused_pane(&mut h);
+        h.step();
+        h.with_app_mut(|app| app.split_focused(true, None, false, false, None));
+        h.run_steps(2);
+
+        let focused_is_terminal = h.with_app(|app| {
+            let win = &app.windows[app.active_window];
+            win.focused_pane
+                .and_then(|t| match win.tree.tiles.get(t) {
+                    Some(egui_tiles::Tile::Pane(pid)) => win.panes.get(pid),
+                    _ => None,
+                })
+                .map(|p| matches!(p, Pane::Terminal(_)))
+                .unwrap_or(false)
+        });
+        assert!(
+            focused_is_terminal,
+            "focused pane must be a real terminal for this regression to be meaningful"
+        );
+
+        // Enter inline sidebar rename: sidebar visible → sync_context_rename_focus
+        // leaves should_own=false, so NO ContextRename focus layer is pushed and
+        // the inline TextEdit (not an overlay) owns keyboard input.
+        h.with_app_mut(|app| {
+            app.sidebar_visible = true;
+            let ctx_idx = app.router.active_idx();
+            app.rename_buffer.clear();
+            app.renaming_window = Some(ctx_idx);
+        });
+        // Let the TextEdit mount and grab egui focus (terminal surrenders focus
+        // via suppress_focus while renaming_window is set).
+        h.run_steps(3);
+
+        // Type into the rename box.
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::Text("x".to_string()));
+        h.step();
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::Text("y".to_string()));
+        h.step();
+
+        let buffer = h.with_app(|app| app.rename_buffer.clone());
+        assert_eq!(
+            buffer, "xy",
+            "inline sidebar rename box must receive typed characters even while a terminal is the focused tile"
+        );
+    }
+
     /// Regression: tab titles with long names must stay on a single line and show
     /// a trailing ellipsis rather than wrapping or overflowing the tab bar rect.
     #[test]


### PR DESCRIPTION
No linked GitHub issue. Implements stint task 0387.
This is the follow-up completing the input-router refactor that a prior task partially delivered (see the 0240 task file for the variance note).

## Summary

**Terminal + app-pane input migration (commit 1)**
- The vendored `egui_term` widget no longer reads `ctx.input()` for keyboard: the host takes the frame's Key/Text/Paste/Copy/Cut events out of egui's shared queue *before* the render pass and hands them to the focused terminal via `TerminalView::with_input`. Unfocused terminals get an empty event list; pointer/wheel stays on the normal egui path.
- `App::handle_key` now takes `&PlexiInput` instead of `&egui::InputState`; `dispatch_app_key_events` reads the ownership buffer and claims Escape/ArrowUp from it, carried through every runtime implementor (file browser, text editor, secrets, assistant, WASM/Python panes, CLI renderer).
- `PlexiInput` widened to also take `Event::Copy`/`Event::Cut` (Ime still deliberately excluded); new unit tests plus a HostHarness test proving a real `RawInput` key event reaches a focused app pane through the router.
- **Fixes the terminal Cmd+A bug structurally**: egui's render-time widget machinery (`allocate_painter`'s built-in select-all) consumed `Key::A` before the terminal saw it; the terminal now receives its events before render, so nothing can steal them. Two leftover diagnostic log blocks removed. One targeted `log::info!` trace fires when Cmd+A routes to a focused terminal.

**FocusLayer enum deletion (commit 2)**
- The 15-variant state-bearing `FocusLayer` dispatch enum is deleted. Overlay keyboard + render dispatch now goes through a real `FocusOwner` trait (`handle_key` / `draw`) via stateless per-overlay owner tokens; the two 15-arm matches in `update()` are gone.
- `focus_stack` is now `Vec<FocusKind>` — a fieldless identity discriminant used only for membership/promotion/logging, mapped to its `&'static dyn FocusOwner` at dispatch time.
- Promotion semantics (CapabilityModal/EventConsent/RawWasmReview jump-to-top), QuickNote Cmd+0 preemption, and NotesPicker/NotesTriage forced-Passthrough behavior preserved; all focus log traces kept.

## Scope note

Per-overlay *state extraction* (moving `rename_buffer`, pending queues, etc. into owner structs) was deliberately not done: the per-frame reconcile-from-flags model reads each overlay's visibility flag on `PlexiApp` before the owner is pushed, so state cannot move into owners without duplication. Inverting that model is a separate redesign; the rationale is documented in `src/app/focus.rs` doc comments.

## Test evidence

- cargo test: 1483 passed, 0 failed, 2 ignored — full bin suite, run green after each commit
- New coverage: router unit tests (Copy/Cut taken, Ime left), `raw_key_event_reaches_focused_app_via_router` HostHarness test
- Codex review: unavailable (account usage limit)
- Conclusion: **binary install required** — keyboard/input-ordering behavior in the live terminal backend cannot be exercised headlessly. Per the task's validation contract, this needs interactive verification of real terminal typing (arrow keys, Cmd+A, paste, IME composition) via `just pr-install <PR>` before merge.
