### PR TITLE
fix(host): grow-canvas height floor overflows the pane on shrink (stint 0390)

### DIFF
--- a/src/host/wasm_render.rs
+++ b/src/host/wasm_render.rs
@@ -289,7 +289,7 @@ fn render_node(
                 ui.available_width().max(1.0)
             };
             let height = if c.grow {
-                ui.available_height().max(c.height)
+                ui.available_height().max(1.0)
             } else {
                 c.height
             };
@@ -385,6 +385,7 @@ fn render_node(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::host::wasm_app::bindings::plexi::platform::types::CanvasNode;
     use crate::host::wasm_app::{InputEvent, StateSnapshot, StateStore, SystemStats, WasmApp};
     use std::path::PathBuf;
 
@@ -416,6 +417,58 @@ mod tests {
         assert_eq!(origin, container.min);
         assert!((sx - 300.0 / 640.0).abs() < f32::EPSILON);
         assert!((sy - 700.0 / 360.0).abs() < f32::EPSILON);
+    }
+
+    // Stint 0390: a grow canvas's height must track the pane like its width
+    // does, not stay floored at the app's declared height. Shrinking the pane
+    // below the declared height previously left the canvas rect taller than
+    // the pane, painting content below the visible edge.
+    #[test]
+    fn grow_canvas_height_tracks_pane_when_shrunk_below_declared_height() {
+        let declared_height = 360.0;
+        let pane_height = 100.0;
+
+        let tree = UiTree {
+            root: 0,
+            nodes: vec![IndexedNode {
+                id: 0,
+                key: String::new(),
+                data: UiNodeData::Canvas(CanvasNode {
+                    width: 0.0,
+                    height: declared_height,
+                    grow: true,
+                    commands: vec![],
+                }),
+            }],
+        };
+
+        let ctx = egui::Context::default();
+        crate::ui::theme::setup_fonts(&ctx);
+        let colors = Colors::from_config(
+            &crate::ui::theme::preset_colors("catppuccin-mocha").expect("preset"),
+        );
+
+        let mut raw_input = egui::RawInput::default();
+        raw_input.screen_rect = Some(egui::Rect::from_min_size(
+            egui::Pos2::ZERO,
+            egui::vec2(200.0, pane_height),
+        ));
+
+        let mut allocated_height = 0.0f32;
+        let _ = ctx.run(raw_input, |ctx| {
+            egui::CentralPanel::default()
+                .frame(egui::Frame::NONE)
+                .show(ctx, |ui| {
+                    let _ = render_ui_tree_with_surface(ui, &tree, &colors, None);
+                    allocated_height = ui.min_rect().height();
+                });
+        });
+
+        assert!(
+            allocated_height <= pane_height + 1.0,
+            "grow canvas allocated {allocated_height}px tall in a {pane_height}px pane, \
+             declared height was {declared_height}px"
+        );
     }
 
     // G4 foundation: a real sysmon view tree (after delivering stats) renders


### PR DESCRIPTION
No linked GitHub issue — tracked as stint task 0390.

## Summary

- `src/host/wasm_render.rs`: a grow-enabled `Canvas` node's height was floored at the app's declared height (`ui.available_height().max(c.height)`) while width honestly tracked the pane (`ui.available_width().max(1.0)`). Shrinking a pane below the declared height still allocated the canvas at the declared height, overflowing the pane bottom — reported as "the balls fall below the viewport" in `apps/balls`.
- Fix: grow canvases now track `ui.available_height().max(1.0)`, mirroring the width branch's non-degenerate floor.
- Added a headless render regression test (`grow_canvas_height_tracks_pane_when_shrunk_below_declared_height`) asserting the allocated canvas rect does not exceed a pane shrunk below the declared canvas height.

## Out of scope (per stint task)

- `apps/balls` ignoring `init(size)`/`Resize` — separate app-level fix.
- Introducing a minimum pane size — clamping is the wrong lever.
- The WIT L1 node-set regression (stint 0389).

## Test evidence

- `cargo test --bin plexi host::wasm_render::` — 4 passed, 0 failed (includes new regression test).
- `just test` — 1485 passed, 0 failed, 2 ignored.
- Conclusion: install skippable — full coverage via headless render test; pure rendering-layout logic with no app-launch/channel/filesystem surface.
- Codex review (`codex review --base alpha`) unavailable — hit usage limit (resets 2026-08-12); not blocking per pipeline (local test suite is the hard gate).