### PR TITLE
fix(apps): pong wasm-poc manifest missing gpu.render/pipe.open capabilities (stint 0386)

### DIFF
--- a/apps/wasm-poc/pong/manifest.toml
+++ b/apps/wasm-poc/pong/manifest.toml
@@ -14,7 +14,7 @@ execution = "local"
 python_compat = false
 
 [app.capabilities]
-capabilities = []
+capabilities = ["gpu.render", "pipe.open"]
 
 [app.capabilities.wasm]
 required = []

--- a/src/host/wasm_app.rs
+++ b/src/host/wasm_app.rs
@@ -781,6 +781,10 @@ mod tests {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/wasm-fixtures/audio-synth.wasm")
     }
 
+    fn pong_fixture() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/wasm-fixtures/pong.wasm")
+    }
+
     fn empty_snapshot() -> StateSnapshot {
         StateSnapshot { entries: vec![] }
     }
@@ -798,6 +802,66 @@ mod tests {
             ]
         );
         Ok(())
+    }
+
+    // Stint 0386: pong is compiled against the `plexi-gpu-app` world, which
+    // unconditionally imports `pipes` and `gpu`. Ground truth is the compiled
+    // component's actual imports (dead-code elimination strips anything the
+    // guest never calls, e.g. pong never touches host-state), not the WIT
+    // world text.
+    #[test]
+    fn inspect_required_grants_maps_component_imports_for_pong() -> wasmtime::Result<()> {
+        let grants = WasmApp::inspect_required_grants(&pong_fixture())?;
+
+        assert_eq!(
+            grants.capability_ids(),
+            vec!["pipe.open".to_string(), "gpu.render".to_string()]
+        );
+        Ok(())
+    }
+
+    // Stint 0386: the manifest-backed launch path (`open_installed_wasm_app_pane`)
+    // derives `Grants` strictly from `apps/wasm-poc/pong/manifest.toml`'s
+    // declared `capabilities` list, then links the component against those
+    // grants. Before the fix, `capabilities = []` meant `pipes`/`gpu` were
+    // never linked, and wasmtime failed at instantiation with an unresolved
+    // import. Parse the real manifest and reproduce that exact derivation to
+    // prove the declared capabilities now satisfy the compiled binary's
+    // actual required imports end to end.
+    #[test]
+    fn pong_manifest_capabilities_satisfy_compiled_component_imports() -> wasmtime::Result<()> {
+        use crate::app::permissions::{parse_capability_strings, Capability};
+        use crate::app::registry::AppManifest;
+
+        let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("apps/wasm-poc/pong/manifest.toml");
+        let manifest_text = std::fs::read_to_string(&manifest_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", manifest_path.display()));
+        let manifest: AppManifest =
+            toml::from_str(&manifest_text).expect("pong manifest.toml parses");
+
+        let declared_caps =
+            parse_capability_strings(&manifest.app.capabilities.capabilities)
+                .expect("pong manifest declares only known capabilities");
+
+        let grants = Grants {
+            state: true,
+            pipes: declared_caps.contains(&Capability::PipeOpen),
+            gpu: declared_caps.contains(&Capability::GpuRender),
+            audio: declared_caps.contains(&Capability::AudioPlayback),
+        };
+        assert!(
+            grants.pipes && grants.gpu,
+            "pong manifest must declare pipe.open and gpu.render"
+        );
+
+        WasmApp::load_with_grants(
+            "com.plexi.pong",
+            &pong_fixture(),
+            StateStore::ephemeral(),
+            grants,
+        )
+        .map(|_| ())
     }
 
     fn host_ctx_with_pipes() -> HostCtx {


### PR DESCRIPTION
No linked GitHub issue — tracked as stint task 0386 (P0).

## Summary

- `apps/wasm-poc/pong/manifest.toml` declared `capabilities = []`, but `pong.wasm` is compiled against the `plexi-gpu-app` WIT world, which unconditionally imports `pipes` and `gpu`. `open_installed_wasm_app_pane` (`src/pane_ops/create.rs:583-608`) derives `Grants` strictly from the manifest's declared `capabilities`, so the manifest-based launch path (`plexi app open apps/wasm-poc/pong`) failed at wasmtime link time with an unresolved import — only the raw-wasm path (which inspects the compiled binary directly) worked.
- Fix: added `capabilities = ["gpu.render", "pipe.open"]`, matching `audio-synth`'s existing correct pattern (`audio.playback`, `pipe.open`).

## Scope item 3 — re-checked the other apps/wasm-poc/* manifests against actual compiled components

Rebuilt all five `apps/wasm-poc/*` components (`just wasm-fixtures`) and inspected the actual compiled component imports with `wasm-tools component wit`, rather than trusting the shared `wit/world.wit` source (every app's `.wit` file declares all four worlds regardless of which one it targets, and doesn't reflect dead-code elimination of unused imports — the WIT world text alone would have been misleading here):

| App | World (`wit_bindgen::generate!`) | Actual compiled imports | Manifest change |
|---|---|---|---|
| pong | `plexi-gpu-app` | `host-log`, `pipes`, `gpu` | **Fixed** — added `gpu.render`, `pipe.open` |
| counter | `plexi-app` | `host-log` only | None — `pipes` import dead-code-eliminated (counter never calls it) |
| sysmon | `plexi-app` | `host-state`, `host-log` | None — same elimination; `state` is unconditionally granted in `create.rs` regardless of declared capabilities |
| python-shim | `plexi-app` | `host-state`, `host-log` | None — same as sysmon |
| audio-synth | `plexi-audio-app` | `host-log`, `pipes`, `audio-rt-control` | None — already correct |

## Test evidence

- Added `inspect_required_grants_maps_component_imports_for_pong` (`src/host/wasm_app.rs`) — locks in the compiled pong component's actual required grants (`pipe.open`, `gpu.render`).
- Added `pong_manifest_capabilities_satisfy_compiled_component_imports` — parses the real `manifest.toml`, derives `Grants` the exact same way `open_installed_wasm_app_pane` does, and loads the compiled fixture end-to-end through `WasmApp::load_with_grants`, proving the manifest-based launch path now succeeds without falling back to the raw-wasm approval prompt. Verified this test fails on the pre-fix manifest (`capabilities = []`) with the same class of error, then passes once restored.
- `cargo test --bin plexi host::wasm_app::tests::` — 10 passed, 0 failed.
- `just test` — 1487 passed, 0 failed, 2 ignored.
- Conclusion: install skippable — the new test exercises the exact manifest→Grants→wasmtime-link path `open_installed_wasm_app_pane` uses, against the real compiled `pong.wasm` fixture, headlessly.
- Codex review (`codex review --base alpha`) unavailable — hit usage limit (resets 2026-08-12); not blocking per pipeline (local test suite is the hard gate).

## Non-Scope (per stint task)

- No changes to the WIT worlds, capability-gating logic in `src/pane_ops/create.rs`, or the raw-wasm approval flow.
- No changes to `src/host/wasm_gpu.rs` or the async staging-ring readback work (stint 0234).