### PR TITLE
feat(host): emit canvas-space MouseEvent on canvas click (stint 0397)

### DIFF
--- a/apps/dev/canvas-grid/canvas_grid.py
+++ b/apps/dev/canvas-grid/canvas_grid.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Canvas Grid — POC for stint 0397 canvas coordinate hit-testing.
+
+Click a cell in the grid. The canvas uses fit="contain" so its declared
+360x360 coordinate space is scaled and letterboxed inside the pane — this
+app only works if the host correctly inverts that fit transform before
+delivering MouseEvent, since the app never sees the pane's pixel size.
+"""
+
+from __future__ import annotations
+
+from plexi_sdk import log, state
+from plexi_sdk.effects import SetState, SetStatus, SetTitle
+from plexi_sdk.events import MouseEvent
+from plexi_sdk.ui import AppBar, Canvas, CanvasLine, CanvasRect, CanvasText, Column, FooterKeys
+
+CANVAS_W = 360.0
+CANVAS_H = 360.0
+GRID_COLS = 6
+GRID_ROWS = 6
+CELL_W = CANVAS_W / GRID_COLS
+CELL_H = CANVAS_H / GRID_ROWS
+
+
+def init(_size, _args) -> list:
+    return [
+        SetTitle("Canvas Grid"),
+        SetState({"selected": None, "clicks": 0}),
+    ]
+
+
+def update(event) -> list:
+    if isinstance(event, MouseEvent) and event.pressed:
+        col = int(event.x // CELL_W)
+        row = int(event.y // CELL_H)
+        if not (0 <= col < GRID_COLS and 0 <= row < GRID_ROWS):
+            return []
+        clicks = state.get("clicks", 0) + 1
+        log.info(
+            f"canvas-grid: cell ({col},{row}) from canvas-space "
+            f"({event.x:.1f}, {event.y:.1f})"
+        )
+        return [
+            SetState({"selected": [col, row], "clicks": clicks}),
+            SetStatus(f"cell ({col}, {row}) · {clicks} clicks"),
+        ]
+    return []
+
+
+def view():
+    selected = state.get("selected")
+    clicks = state.get("clicks", 0)
+    return Column(
+        [
+            AppBar("Canvas Grid", f"{clicks} clicks"),
+            Canvas(_draw(selected), width=CANVAS_W, height=CANVAS_H, grow=True, fit="contain"),
+            FooterKeys([("click", "select cell")]),
+        ],
+        padding=0,
+        gap=0,
+        grow=True,
+    )
+
+
+def _draw(selected) -> list:
+    commands: list = [CanvasRect(0, 0, CANVAS_W, CANVAS_H, "#11111b")]
+    if selected is not None:
+        col, row = selected
+        commands.append(
+            CanvasRect(col * CELL_W, row * CELL_H, CELL_W, CELL_H, "#89b4fa55")
+        )
+    for c in range(1, GRID_COLS):
+        x = c * CELL_W
+        commands.append(CanvasLine(x, 0.0, x, CANVAS_H, "#45475a"))
+    for r in range(1, GRID_ROWS):
+        y = r * CELL_H
+        commands.append(CanvasLine(0.0, y, CANVAS_W, y, "#45475a"))
+    if selected is not None:
+        col, row = selected
+        commands.append(
+            CanvasText(
+                col * CELL_W + CELL_W / 2,
+                row * CELL_H + CELL_H / 2,
+                f"{col},{row}",
+                size=14.0,
+                color="#cdd6f4",
+                align="center",
+            )
+        )
+    return commands

--- a/apps/dev/canvas-grid/manifest.toml
+++ b/apps/dev/canvas-grid/manifest.toml
@@ -1,0 +1,15 @@
+schema_version = 1
+
+[app]
+id = "canvas-grid"
+type = "app"
+name = "Canvas Grid"
+version = "0.1.0"
+description = "POC: canvas coordinate hit-testing — click a cell in a fit-scaled grid, logs and highlights the canvas-space cell (stint 0397)."
+entry = "canvas_grid.py"
+watch = true
+
+[app.capabilities]
+capabilities = []
+
+[launch]

--- a/apps/dev/canvas-grid/manifest.toml
+++ b/apps/dev/canvas-grid/manifest.toml
@@ -12,4 +12,7 @@ watch = true
 [app.capabilities]
 capabilities = []
 
+[runtime]
+python_compat = true
+
 [launch]

--- a/sdk/python/plexi_sdk/_v3_runtime.py
+++ b/sdk/python/plexi_sdk/_v3_runtime.py
@@ -112,6 +112,8 @@ class V3AppRuntime:
             self._handle_key(ev)
         elif t == "key_events":
             self._handle_key_events(ev)
+        elif t == "mouse":
+            self._handle_mouse(ev)
         elif t == "timer":
             self._handle_timer(ev)
         elif t == "component_event":
@@ -278,6 +280,16 @@ class V3AppRuntime:
                 handled = True
         if handled:
             _emit({"type": "schedule_render", "after_ms": 16})
+
+    def _handle_mouse(self, ev: dict) -> None:
+        self._dispatch(events.MouseEvent(
+            x=float(ev.get("x", 0.0)),
+            y=float(ev.get("y", 0.0)),
+            button=ev.get("button"),
+            pressed=bool(ev.get("pressed", False)),
+            scroll_x=float(ev.get("scroll_x", 0.0)),
+            scroll_y=float(ev.get("scroll_y", 0.0)),
+        ))
 
     def _handle_timer(self, ev: dict) -> None:
         self._dispatch_timer(

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -964,6 +964,15 @@ impl LivePythonPane {
                     "type": "text_submitted", "id": handler_id, "value": value
                 }));
             }
+            for click in result.canvas_clicks {
+                let _ = self.runtime.send(&json!({
+                    "type": "mouse",
+                    "x": click.x,
+                    "y": click.y,
+                    "button": click.button,
+                    "pressed": click.pressed,
+                }));
+            }
         } else {
             ui.spinner();
         }

--- a/src/host/wasm_render.rs
+++ b/src/host/wasm_render.rs
@@ -26,6 +26,17 @@ pub enum CanvasFit {
     Contain,
 }
 
+/// A canvas click reported in the app's own declared canvas coordinate
+/// space (post `canvas_transform` inversion), not screen pixels. See
+/// `MouseEvent` in `sdk/python/plexi_sdk/events.py`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CanvasClick {
+    pub x: f32,
+    pub y: f32,
+    pub button: Option<&'static str>,
+    pub pressed: bool,
+}
+
 /// Interactions produced by one render pass, to be translated into guest input.
 #[derive(Default, Debug)]
 pub struct RenderResult {
@@ -33,6 +44,8 @@ pub struct RenderResult {
     pub actions: Vec<String>,
     /// `(on_change action, new value)` pairs from edited text inputs.
     pub value_changes: Vec<(String, String)>,
+    /// Canvas clicks, already inverted into the app's declared canvas space.
+    pub canvas_clicks: Vec<CanvasClick>,
     pub canvas_time: std::time::Duration,
 }
 
@@ -385,13 +398,30 @@ fn render_node(
             } else {
                 c.height
             };
-            let (rect, _) =
-                ui.allocate_exact_size(egui::vec2(width, height.max(1.0)), egui::Sense::hover());
+            let (rect, resp) =
+                ui.allocate_exact_size(egui::vec2(width, height.max(1.0)), egui::Sense::click());
             let fit = canvas_fits
                 .and_then(|fits| fits.get(&id))
                 .copied()
                 .unwrap_or_default();
             let (origin, sx, sy) = canvas_transform(rect, c.width, c.height, fit);
+            if resp.clicked() {
+                if let Some(pixel_pos) = resp.interact_pointer_pos() {
+                    let button = if resp.clicked_by(egui::PointerButton::Secondary) {
+                        Some("right")
+                    } else if resp.clicked_by(egui::PointerButton::Middle) {
+                        Some("middle")
+                    } else {
+                        Some("left")
+                    };
+                    out.canvas_clicks.push(CanvasClick {
+                        x: (pixel_pos.x - origin.x) / sx,
+                        y: (pixel_pos.y - origin.y) / sy,
+                        button,
+                        pressed: true,
+                    });
+                }
+            }
             for command in &c.commands {
                 match command {
                     CanvasCommand::Rect(r) => {
@@ -614,6 +644,112 @@ mod tests {
             "grow canvas allocated {allocated_height}px tall in a {pane_height}px pane, \
              declared height was {declared_height}px"
         );
+    }
+
+    // Stint 0397: a click at a known screen pixel inside a scaled `grow`
+    // canvas must arrive as the correct canvas-space coordinate, not the raw
+    // pixel. This is the transform-inversion regression guard — it exercises
+    // the exact `canvas_transform` math the painter uses, inverted.
+    #[test]
+    fn canvas_click_inverts_fit_transform_to_canvas_space() {
+        let declared_width = 360.0;
+        let declared_height = 440.0;
+        let pane_width = 200.0;
+        let pane_height = 400.0;
+
+        let tree = UiTree {
+            root: 0,
+            nodes: vec![IndexedNode {
+                id: 0,
+                key: String::new(),
+                data: UiNodeData::Canvas(CanvasNode {
+                    width: declared_width,
+                    height: declared_height,
+                    grow: true,
+                    commands: vec![],
+                }),
+            }],
+        };
+        let mut fits = HashMap::new();
+        fits.insert(0, CanvasFit::Contain);
+
+        let ctx = egui::Context::default();
+        crate::ui::theme::setup_fonts(&ctx);
+        let colors = Colors::from_config(
+            &crate::ui::theme::preset_colors("catppuccin-mocha").expect("preset"),
+        );
+
+        // sx = sy = 200/360 = 5/9; origin.y = 200 - (440 * 5/9)/2 = 700/9.
+        // A click at screen pixel (50, 100) inverts to canvas space (90, 40).
+        let click_px = egui::pos2(50.0, 100.0);
+        let screen_rect =
+            egui::Rect::from_min_size(egui::Pos2::ZERO, egui::vec2(pane_width, pane_height));
+
+        // Warm-up frame with no input: egui hit-tests a press/release pair
+        // against the *previous* frame's widget rects, so the canvas must
+        // already have been laid out once before a click can resolve.
+        let warmup = egui::RawInput {
+            screen_rect: Some(screen_rect),
+            ..Default::default()
+        };
+        let _ = ctx.run(warmup, |ctx| {
+            egui::CentralPanel::default()
+                .frame(egui::Frame::NONE)
+                .show(ctx, |ui| {
+                    let _ = render_ui_tree_with_canvas_fits(ui, &tree, &colors, None, Some(&fits));
+                });
+        });
+
+        // Move + press + release delivered together as one frame's input,
+        // mirroring the click-simulation pattern proven in `src/ui_tests.rs`
+        // (`PlexiUiHarness` sidebar tests).
+        let click_frame = egui::RawInput {
+            screen_rect: Some(screen_rect),
+            events: vec![
+                egui::Event::PointerMoved(click_px),
+                egui::Event::PointerButton {
+                    pos: click_px,
+                    button: egui::PointerButton::Primary,
+                    pressed: true,
+                    modifiers: egui::Modifiers::default(),
+                },
+                egui::Event::PointerButton {
+                    pos: click_px,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ],
+            ..Default::default()
+        };
+        let mut captured = RenderResult::default();
+        let _ = ctx.run(click_frame, |ctx| {
+            egui::CentralPanel::default()
+                .frame(egui::Frame::NONE)
+                .show(ctx, |ui| {
+                    captured =
+                        render_ui_tree_with_canvas_fits(ui, &tree, &colors, None, Some(&fits));
+                });
+        });
+
+        assert_eq!(
+            captured.canvas_clicks.len(),
+            1,
+            "one click at a known pixel should produce exactly one canvas click"
+        );
+        let click = captured.canvas_clicks[0];
+        assert!(
+            (click.x - 90.0).abs() < 0.01,
+            "expected canvas-space x 90.0, got {}",
+            click.x
+        );
+        assert!(
+            (click.y - 40.0).abs() < 0.01,
+            "expected canvas-space y 40.0, got {}",
+            click.y
+        );
+        assert_eq!(click.button, Some("left"));
+        assert!(click.pressed);
     }
 
     // G4 foundation: a real sysmon view tree (after delivering stats) renders


### PR DESCRIPTION
Stint task: 0397 (no linked GitHub issue)

## Summary

- Canvas nodes sensed only `hover`, so egui click events were silently dropped even though `MouseEvent` has been defined in the SDK/WIT protocol with nothing producing it.
- `wasm_render.rs`: canvas nodes now sense clicks, and the click position is inverted through the exact `canvas_transform` already used to paint the canvas — so the app always receives coordinates in its own declared canvas space, never raw screen pixels. Locked design decision: raw `(x, y)` coordinates only, no `hit_region=` tagging.
- `wasm_python.rs`: canvas clicks are forwarded to the CPython bridge as `{"type": "mouse", ...}` on the same JSON path as `key_events`/`ui_action`.
- `_v3_runtime.py`: decodes `"mouse"` events into `events.MouseEvent` and dispatches to `update()`. `_adapter.py` needed no changes — its generic dataclass decoder already handles `MouseEvent` since it has no nested fields.
- New host test (`canvas_click_inverts_fit_transform_to_canvas_space`) is the transform-inversion regression guard: a click at a known screen pixel inside a scaled `Contain`-fit `grow` canvas must arrive at the exact expected canvas-space coordinate.
- New POC: `apps/dev/canvas-grid` — a 6x6 grid on a `fit="contain"` canvas that highlights and logs the clicked cell, exercising the scaled-canvas path end to end.

## Test evidence

- `just test`: 1416 passed, 0 failed, 2 ignored
- `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py`: no issues found in 26 source files
- `just sdk-smoke`: 68 passed, 1 skipped
- `just check-sdk-docs` / `just check-authoring-docs`: up to date
- `plexi app check apps/dev/canvas-grid --png-dir ...`: passed, renders at 4 sizes including a visibly letterboxed Contain-fit canvas

## Validation

Binary install required — this is a live click/interaction path (egui `Sense::click()`, JSON bridge, Python dispatch) that the headless host test and `plexi app check` cover only partially. Please install via `just pr-install <PR>` and click cells in `apps/dev/canvas-grid` to confirm the correct cell highlights.

Do not merge — awaiting tester validation.