### PR TITLE
fix(apps): port sudoku to current SDK — canvas size + hit_region drift

### DIFF
--- a/apps/dev/canvas-sidebar/canvas_sidebar.py
+++ b/apps/dev/canvas-sidebar/canvas_sidebar.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import plexi_sdk as sdk
 from plexi_sdk import log
 from plexi_sdk.effects import SetStatus, SetTitle
-from plexi_sdk.events import KeyEvent, UiAction
+from plexi_sdk.events import KeyEvent, Resize, UiAction
 from plexi_sdk.ui import (
     Button,
     Canvas,
@@ -31,15 +31,20 @@ GRID = 8
 _n = GRID
 
 
-def init(_size, _args) -> list:
+def init(size, _args) -> list:
     global _n
     _n = GRID
+    sdk.canvas_width, sdk.canvas_height = size
     log.info("canvas-sidebar: initialized HStack[Canvas grow + Sized sidebar]")
     return [SetTitle("Canvas Sidebar"), SetStatus(f"grid {_n}x{_n}")]
 
 
 def update(event) -> list:
     global _n
+    if isinstance(event, Resize):
+        sdk.canvas_width = event.width
+        sdk.canvas_height = event.height
+        return []
     if isinstance(event, UiAction):
         if event.handler_id == "denser":
             _n = min(24, _n + 1)
@@ -58,9 +63,7 @@ def update(event) -> list:
     return []
 
 
-def _grid_commands() -> list:
-    w = max(1.0, float(sdk.canvas_width or 480.0))
-    h = max(1.0, float(sdk.canvas_height or 360.0))
+def _grid_commands(w, h) -> list:
     cmds: list = [CanvasRect(0, 0, w, h, "#0d0d1a")]
     cell_w = w / _n
     cell_h = h / _n
@@ -94,5 +97,7 @@ def view():
         ),
         width=SIDEBAR_W,
     )
-    canvas = Canvas(_grid_commands(), grow=True)
+    w = max(1.0, float(sdk.canvas_width or 480.0) - SIDEBAR_W - 12.0)
+    h = max(1.0, float(sdk.canvas_height or 360.0))
+    canvas = Canvas(_grid_commands(w, h), width=w, height=h, grow=True)
     return HStack([canvas, sidebar], gap=12)

--- a/apps/dev/canvas-sidebar/canvas_sidebar.py
+++ b/apps/dev/canvas-sidebar/canvas_sidebar.py
@@ -10,7 +10,7 @@ horizontal Stack correctly.
 from __future__ import annotations
 
 import plexi_sdk as sdk
-from plexi_sdk import log
+from plexi_sdk import log, theme
 from plexi_sdk.effects import SetStatus, SetTitle
 from plexi_sdk.events import KeyEvent, Resize, UiAction
 from plexi_sdk.ui import (
@@ -19,9 +19,8 @@ from plexi_sdk.ui import (
     CanvasLine,
     CanvasRect,
     Column,
+    Divider,
     HStack,
-    Section,
-    Sized,
     Text,
 )
 
@@ -84,20 +83,21 @@ def _grid_commands(w, h) -> list:
 
 
 def view():
-    sidebar = Sized(
-        Column(
-            [
-                Section("Sidebar"),
-                Text(text=f"Grid: {_n} x {_n}"),
-                Button(label="Denser (+)", on_click="denser"),
-                Button(label="Sparser (-)", on_click="sparser"),
-            ],
-            padding=12,
-            gap=8,
-        ),
-        width=SIDEBAR_W,
+    # Sidebar renders first so egui's horizontal layout reserves its space
+    # before the grow canvas claims the remainder (no fixed-width wrapper
+    # node exists on the live CPython-WASM decode path — see stint 0394).
+    sidebar = Column(
+        [
+            Text(text="SIDEBAR", size=10.0, color=theme.muted, bold=True),
+            Divider(),
+            Text(text=f"Grid: {_n} x {_n}"),
+            Button(label="Denser (+)", on_click="denser"),
+            Button(label="Sparser (-)", on_click="sparser"),
+        ],
+        padding=12,
+        gap=8,
     )
     w = max(1.0, float(sdk.canvas_width or 480.0) - SIDEBAR_W - 12.0)
     h = max(1.0, float(sdk.canvas_height or 360.0))
     canvas = Canvas(_grid_commands(w, h), width=w, height=h, grow=True)
-    return HStack([canvas, sidebar], gap=12)
+    return HStack([sidebar, canvas], gap=12)

--- a/apps/sudoku/main.py
+++ b/apps/sudoku/main.py
@@ -6,9 +6,7 @@ from __future__ import annotations
 import random
 
 import plexi_sdk as sdk
-from plexi_sdk import dim, rgba, state, theme
-
-TRANSPARENT = rgba(0, 0, 0, 0)
+from plexi_sdk import dim, state, theme
 from plexi_sdk.effects import SetState, SetStatus, SetTimer, SetTitle
 from plexi_sdk.events import KeyEvent, MouseEvent, Resize, TimerFired
 from plexi_sdk.ui import (
@@ -176,7 +174,9 @@ def _enter_number(d, num):
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────
 
-def init(_size, _args):
+def init(size, _args):
+    sdk.canvas_width, sdk.canvas_height = size
+    sdk.pane_width, sdk.pane_height = size
     missing = {k: v for k, v in _blank().items() if state.get(k) is None}
     effects = [
         SetTitle("Sudoku"),
@@ -198,10 +198,14 @@ def update(event):
         return []
 
     if isinstance(event, Resize):
+        sdk.canvas_width = event.width
+        sdk.canvas_height = event.height
+        sdk.pane_width = event.width
+        sdk.pane_height = event.height
         return []
 
     if isinstance(event, MouseEvent) and event.pressed:
-        return _mouse(d, event.region)
+        return _mouse(d, event.x, event.y)
 
     if isinstance(event, KeyEvent) and event.pressed:
         return _key(d, event)
@@ -210,20 +214,34 @@ def update(event):
 
 # ── Input handlers ─────────────────────────────────────────────────────────
 
-def _mouse(d, region):
-    if not region:
-        return []
+def _mouse(d, x, y):
     if str(d.get("screen")) != "game":
-        if region.startswith("diff-"):
-            diff = DIFFICULTIES[int(region[5:])]
-            return [SetState(_new_game(diff)), SetStatus(f"{diff.title()} — 00:00")]
+        w = sdk.canvas_width or 800.0
+        h = sdk.canvas_height or 600.0
+        for i, (bx, by, bw, bh) in enumerate(_diff_button_rects(w, h)):
+            if bx <= x < bx + bw and by <= y < by + bh:
+                diff = DIFFICULTIES[i]
+                return [SetState(_new_game(diff)), SetStatus(f"{diff.title()} — 00:00")]
         return []
-    if region.startswith("num-"):
-        return _enter_number(d, int(region[4:]))
-    if region.startswith("cell-"):
-        r, c = (int(v) for v in region[5:].split("-"))
+
+    sidebar_w, cell = _compute_layout()
+    pane_w = sdk.canvas_width or sdk.pane_width or 800.0
+    gw = cell * 9
+    pair_w = gw + 12.0 + sidebar_w
+    ox = max(8.0, (pane_w - pair_w) / 2.0)
+    oy = 8.0
+    sx = ox + gw + 12.0
+
+    if ox <= x < ox + gw and oy <= y < oy + gw:
+        r = max(0, min(8, int((y - oy) // cell)))
+        c = max(0, min(8, int((x - ox) // cell)))
         board = d.get("board", [[0] * 9] * 9)
         return [SetState({"sel_r": r, "sel_c": c, "sel_num": board[r][c]})]
+
+    _, num_rects = _draw_sidebar_canvas(d, sx, oy, sidebar_w, cell)
+    for num, bx, by, bw, bh in num_rects:
+        if bx <= x < bx + bw and by <= y < by + bh:
+            return _enter_number(d, num)
     return []
 
 def _key(d, event):
@@ -342,12 +360,13 @@ def view():
         keys = [("1-9", "fill"), ("n", "notes"), ("p", "pause"), ("r", "restart"), ("m", "menu")]
         footer = FooterKeys(keys)
     screen = str(d.get("screen", "menu"))
+    w, h = sdk.canvas_width, sdk.canvas_height
     if screen != "menu":
         # Single canvas for the entire game body: grid + sidebar drawn together.
         # This avoids HStack grow-distribution fighting with fixed-size children.
-        body = Canvas(_draw_game(d), grow=True)
+        body = Canvas(_draw_game(d), width=w, height=h, grow=True)
     else:
-        body = Canvas(_draw_menu(d), grow=True)
+        body = Canvas(_draw_menu(d), width=w, height=h, grow=True)
 
     return Column([
         AppBar("Sudoku"),
@@ -356,7 +375,26 @@ def view():
     ], padding=0, gap=0, grow=True)
 
 
+# ── Shared drawing helpers ─────────────────────────────────────────────────
+
+def _bordered_rect(x, y, w, h, fill, radius=0.0, border_color=None, border_width=0.0):
+    """CanvasRect no longer takes border_color/border_width; draw the border
+    as an outline rect behind an inset fill rect instead."""
+    if not border_color or border_width <= 0:
+        return [CanvasRect(x, y, w, h, fill, radius=radius)]
+    return [
+        CanvasRect(x, y, w, h, border_color, radius=radius),
+        CanvasRect(x + border_width, y + border_width, w - 2 * border_width, h - 2 * border_width,
+                   fill, radius=max(0.0, radius - border_width)),
+    ]
+
 # ── Menu drawing ───────────────────────────────────────────────────────────
+
+def _diff_button_rects(w, h):
+    bw, bh = 220.0, 64.0
+    bx = (w - bw) / 2
+    by_start = h / 2 - 80.0
+    return [(bx, by_start + i * 80.0, bw, bh) for i in range(3)]
 
 def _draw_menu(d):
     w = sdk.canvas_width
@@ -368,20 +406,16 @@ def _draw_menu(d):
     cmds.append(CanvasText(w / 2, title_y, "SUDOKU", size=36.0, color=theme.fg, bold=True, align="center_center"))
     cmds.append(CanvasText(w / 2, title_y + 40.0, "Choose your difficulty", size=13.0, color=theme.muted, align="center_center"))
 
-    bw, bh = 220.0, 64.0
-    bx = (w - bw) / 2
-    by_start = h / 2 - 80.0
     labels = [("Easy", f"{CLUES['easy']} clues"), ("Medium", f"{CLUES['medium']} clues"), ("Hard", f"{CLUES['hard']} clues")]
     tones = [theme.success, theme.warning, theme.danger]
+    rects = _diff_button_rects(w, h)
 
     for i, (label, subtitle) in enumerate(labels):
-        by = by_start + i * 80.0
+        bx, by, bw, bh = rects[i]
         selected = i == diff_idx
         bg = theme.surface if selected else theme.bg
         border = tones[i] if selected else theme.highlight
-        cmds.append(CanvasRect(bx, by, bw, bh, bg, radius=8.0,
-                               border_color=border, border_width=2.0,
-                               hit_region=f"diff-{i}"))
+        cmds.extend(_bordered_rect(bx, by, bw, bh, bg, radius=8.0, border_color=border, border_width=2.0))
         text_color = tones[i] if selected else theme.fg
         cmds.append(CanvasText(bx + bw / 2, by + 22.0, label, size=17.0, color=text_color, bold=selected, align="center_center"))
         cmds.append(CanvasText(bx + bw / 2, by + 44.0, subtitle, size=11.0, color=theme.muted, align="center_center"))
@@ -434,12 +468,14 @@ def _draw_sidebar_canvas(d, sx, oy, sidebar_w, cell):
     section("NUMBERS")
     gap = 5.0
     bw = bh = max(24.0, (sidebar_w - 2 * gap) / 3.0)
+    num_rects = []
     for i in range(9):
         num = i + 1
         col_i = i % 3
         row_i = i // 3
         bx = sx + col_i * (bw + gap)
         by = y + row_i * (bh + gap)
+        num_rects.append((num, bx, by, bw, bh))
         done_num = counts[num - 1] >= 9
         is_sel = num == sel_num and sel_num != 0
         if done_num:
@@ -448,12 +484,10 @@ def _draw_sidebar_canvas(d, sx, oy, sidebar_w, cell):
             bg, text_col, border = theme.highlight, theme.accent, theme.accent
         else:
             bg, text_col, border = theme.surface, theme.fg, theme.highlight
-        cmds.append(CanvasRect(bx, by, bw, bh, bg, radius=4.0,
-                               border_color=border, border_width=1.0,
-                               hit_region=f"num-{num}"))
+        cmds.extend(_bordered_rect(bx, by, bw, bh, bg, radius=4.0, border_color=border, border_width=1.0))
         cmds.append(CanvasText(bx + bw / 2, by + bh / 2, str(num), size=15.0,
                                color=text_col, bold=not done_num, align="center_center"))
-    return cmds
+    return cmds, num_rects
 
 
 def _draw_game(d):
@@ -466,7 +500,8 @@ def _draw_game(d):
     oy = 8.0
     sx = ox + gw + 12.0
 
-    return _draw_grid(d, cell, ox, oy) + _draw_sidebar_canvas(d, sx, oy, sidebar_w, cell)
+    sidebar_cmds, _ = _draw_sidebar_canvas(d, sx, oy, sidebar_w, cell)
+    return _draw_grid(d, cell, ox, oy) + sidebar_cmds
 
 
 def _draw_grid(d, cell=None, ox=6.0, oy=8.0):
@@ -493,12 +528,6 @@ def _draw_grid(d, cell=None, ox=6.0, oy=8.0):
     cmds.append(CanvasRect(ox - 3, oy - 3, gw + 6, gh + 6, theme.bg_darkest, radius=6.0))
     cmds.append(CanvasRect(ox, oy, gw, gh, theme.bg, radius=4.0))
 
-    # Per-cell hit regions
-    for r in range(9):
-        for c in range(9):
-            cmds.append(CanvasRect(ox + c * cell, oy + r * cell, cell, cell,
-                                   TRANSPARENT, hit_region=f"cell-{r}-{c}"))
-
     # Row + col cross highlight only — no box tint.
     if sel_r >= 0 and sel_c >= 0 and not paused and screen == "game":
         cmds.append(CanvasRect(ox, oy + sel_r * cell, gw, cell, theme.surface))
@@ -513,7 +542,7 @@ def _draw_grid(d, cell=None, ox=6.0, oy=8.0):
 
     # Selected cell — highlight fill + muted border, clearly distinct from box tint
     if sel_r >= 0 and sel_c >= 0 and not paused and screen == "game":
-        cmds.append(CanvasRect(
+        cmds.extend(_bordered_rect(
             ox + sel_c * cell + 1, oy + sel_r * cell + 1, cell - 2, cell - 2,
             theme.highlight, radius=3.0,
             border_color=theme.muted, border_width=2.0,

--- a/apps/sudoku/main.py
+++ b/apps/sudoku/main.py
@@ -214,14 +214,32 @@ def update(event):
 
 # ── Input handlers ─────────────────────────────────────────────────────────
 
+def _hit_rect(x, y, rects):
+    """rects: iterable of (key, rx, ry, rw, rh). Return the first key whose
+    rect contains (x, y), else None. Pure — no state, no drawing."""
+    for key, rx, ry, rw, rh in rects:
+        if rx <= x < rx + rw and ry <= y < ry + rh:
+            return key
+    return None
+
+def _hit_cell(x, y, ox, oy, cell):
+    """Return the (row, col) of the grid cell containing (x, y), else None."""
+    gw = cell * 9
+    if not (ox <= x < ox + gw and oy <= y < oy + gw):
+        return None
+    r = max(0, min(8, int((y - oy) // cell)))
+    c = max(0, min(8, int((x - ox) // cell)))
+    return r, c
+
 def _mouse(d, x, y):
     if str(d.get("screen")) != "game":
         w = sdk.canvas_width or 800.0
         h = sdk.canvas_height or 600.0
-        for i, (bx, by, bw, bh) in enumerate(_diff_button_rects(w, h)):
-            if bx <= x < bx + bw and by <= y < by + bh:
-                diff = DIFFICULTIES[i]
-                return [SetState(_new_game(diff)), SetStatus(f"{diff.title()} — 00:00")]
+        rects = [(i, bx, by, bw, bh) for i, (bx, by, bw, bh) in enumerate(_diff_button_rects(w, h))]
+        idx = _hit_rect(x, y, rects)
+        if idx is not None:
+            diff = DIFFICULTIES[idx]
+            return [SetState(_new_game(diff)), SetStatus(f"{diff.title()} — 00:00")]
         return []
 
     sidebar_w, cell = _compute_layout()
@@ -232,16 +250,16 @@ def _mouse(d, x, y):
     oy = 8.0
     sx = ox + gw + 12.0
 
-    if ox <= x < ox + gw and oy <= y < oy + gw:
-        r = max(0, min(8, int((y - oy) // cell)))
-        c = max(0, min(8, int((x - ox) // cell)))
+    cell_hit = _hit_cell(x, y, ox, oy, cell)
+    if cell_hit is not None:
+        r, c = cell_hit
         board = d.get("board", [[0] * 9] * 9)
         return [SetState({"sel_r": r, "sel_c": c, "sel_num": board[r][c]})]
 
     _, num_rects = _draw_sidebar_canvas(d, sx, oy, sidebar_w, cell)
-    for num, bx, by, bw, bh in num_rects:
-        if bx <= x < bx + bw and by <= y < by + bh:
-            return _enter_number(d, num)
+    num = _hit_rect(x, y, num_rects)
+    if num is not None:
+        return _enter_number(d, num)
     return []
 
 def _key(d, event):

--- a/apps/sudoku/tests/test_sudoku.py
+++ b/apps/sudoku/tests/test_sudoku.py
@@ -1,0 +1,116 @@
+"""Sudoku hit-testing unit tests.
+
+Covers the pure coordinate -> target mapping used by the MouseEvent handler
+(stint 0397/0394) — no host, no subprocess, no canvas rendering required.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "sdk", "python")
+)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import main as sudoku  # noqa: E402
+
+
+def test_diff_button_hit_at_each_center():
+    w, h = 800.0, 600.0
+    rects = sudoku._diff_button_rects(w, h)
+    assert len(rects) == 3
+    for i, (bx, by, bw, bh) in enumerate(rects):
+        indexed = [(j, rx, ry, rw, rh) for j, (rx, ry, rw, rh) in enumerate(rects)]
+        cx, cy = bx + bw / 2, by + bh / 2
+        assert sudoku._hit_rect(cx, cy, indexed) == i
+
+
+def test_diff_button_miss_outside_all_buttons():
+    w, h = 800.0, 600.0
+    rects = [(i, bx, by, bw, bh) for i, (bx, by, bw, bh) in enumerate(sudoku._diff_button_rects(w, h))]
+    assert sudoku._hit_rect(0.0, 0.0, rects) is None
+    assert sudoku._hit_rect(w, h, rects) is None
+
+
+def test_num_button_hit_maps_to_number():
+    d = sudoku._new_game("easy")
+    sidebar_w, cell = 120.0, 40.0
+    _, num_rects = sudoku._draw_sidebar_canvas(d, 500.0, 8.0, sidebar_w, cell)
+    assert len(num_rects) == 9
+    for num, bx, by, bw, bh in num_rects:
+        cx, cy = bx + bw / 2, by + bh / 2
+        assert sudoku._hit_rect(cx, cy, num_rects) == num
+
+
+def test_num_button_miss_between_buttons_returns_none():
+    d = sudoku._new_game("easy")
+    sidebar_w, cell = 120.0, 40.0
+    _, num_rects = sudoku._draw_sidebar_canvas(d, 500.0, 8.0, sidebar_w, cell)
+    assert sudoku._hit_rect(-1000.0, -1000.0, num_rects) is None
+
+
+def test_cell_hit_maps_to_selected_cell():
+    ox, oy, cell = 10.0, 8.0, 40.0
+    for r in range(9):
+        for c in range(9):
+            cx = ox + c * cell + cell / 2
+            cy = oy + r * cell + cell / 2
+            assert sudoku._hit_cell(cx, cy, ox, oy, cell) == (r, c)
+
+
+def test_cell_hit_boundary_is_linear_not_coincidental():
+    """Check several points near cell boundaries, not just centers, to prove
+    the row/col math is a real division, not a fluke that only lines up at
+    one sampled point per cell."""
+    ox, oy, cell = 10.0, 8.0, 40.0
+
+    # Last pixel inside cell (2, 2) still maps to (2, 2).
+    assert sudoku._hit_cell(ox + 2 * cell + cell - 0.01, oy + 2 * cell + cell - 0.01, ox, oy, cell) == (2, 2)
+    # First pixel of the next cell over maps to (2, 3).
+    assert sudoku._hit_cell(ox + 3 * cell, oy + 2 * cell, ox, oy, cell) == (2, 3)
+    # First pixel of the next row down maps to (3, 2).
+    assert sudoku._hit_cell(ox + 2 * cell, oy + 3 * cell, ox, oy, cell) == (3, 2)
+    # Top-left corner of the grid maps to (0, 0).
+    assert sudoku._hit_cell(ox, oy, ox, oy, cell) == (0, 0)
+    # Last pixel of the whole grid maps to (8, 8).
+    assert sudoku._hit_cell(ox + 9 * cell - 0.01, oy + 9 * cell - 0.01, ox, oy, cell) == (8, 8)
+
+
+def test_cell_hit_outside_grid_is_none():
+    ox, oy, cell = 10.0, 8.0, 40.0
+    gw = cell * 9
+    assert sudoku._hit_cell(ox - 1.0, oy, ox, oy, cell) is None
+    assert sudoku._hit_cell(ox, oy - 1.0, ox, oy, cell) is None
+    assert sudoku._hit_cell(ox + gw, oy, ox, oy, cell) is None
+    assert sudoku._hit_cell(ox, oy + gw, ox, oy, cell) is None
+
+
+def test_mouse_menu_click_starts_game_with_clicked_difficulty():
+    sudoku.sdk.canvas_width = 800.0
+    sudoku.sdk.canvas_height = 600.0
+    d = sudoku._blank()
+    bx, by, bw, bh = sudoku._diff_button_rects(800.0, 600.0)[1]
+    effects = sudoku._mouse(d, bx + bw / 2, by + bh / 2)
+    assert len(effects) == 2
+    new_state = effects[0].data
+    assert new_state["screen"] == "game"
+    assert new_state["difficulty"] == "medium"
+
+
+def test_mouse_game_click_selects_cell():
+    sudoku.sdk.canvas_width = 800.0
+    sudoku.sdk.canvas_height = 600.0
+    sudoku.sdk.pane_width = 800.0
+    sudoku.sdk.pane_height = 600.0
+    d = sudoku._new_game("easy")
+    sidebar_w, cell = sudoku._compute_layout()
+    pane_w = sudoku.sdk.canvas_width or sudoku.sdk.pane_width or 800.0
+    gw = cell * 9
+    pair_w = gw + 12.0 + sidebar_w
+    ox = max(8.0, (pane_w - pair_w) / 2.0)
+    oy = 8.0
+    effects = sudoku._mouse(d, ox + cell / 2, oy + cell / 2)
+    assert len(effects) == 1
+    assert effects[0].data == {"sel_r": 0, "sel_c": 0, "sel_num": d["board"][0][0]}

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -385,7 +385,7 @@ class HStack(Component):
         return None
 
     def to_node(self) -> dict:
-        return {"type": "stack", "direction": "horizontal", "children": [child.to_node() for child in self.children], "gap": self.gap, "grow": self.grow}
+        return {"type": "row", "children": [child.to_node() for child in self.children], "gap": self.gap, "grow": self.grow}
 
 
 class Sized(Component):

--- a/src/protocol/events.rs
+++ b/src/protocol/events.rs
@@ -56,11 +56,13 @@ pub enum PlexiEvent {
         /// Current surface rect the app should draw into.
         rect: Rect,
         /// Actual rendered canvas width from the previous frame's component tree.
-        /// Zero on the first frame (no prior render). SDK exposes as sdk.canvas_width.
+        /// Zero on the first frame (no prior render). Not SDK-exposed; apps that
+        /// need their own size track it themselves via `init(size)` + `Resize`.
         #[serde(default)]
         canvas_width: f32,
         /// Actual rendered canvas height from the previous frame's component tree.
-        /// Zero on the first frame (no prior render). SDK exposes as sdk.canvas_height.
+        /// Zero on the first frame (no prior render). Not SDK-exposed; apps that
+        /// need their own size track it themselves via `init(size)` + `Resize`.
         #[serde(default)]
         canvas_height: f32,
     },


### PR DESCRIPTION
No linked GitHub issue — tracked as stint task 0394.

## Summary

- Sudoku crashed unconditionally on its first `view()` (`AttributeError: module 'plexi_sdk' has no attribute 'canvas_width'`). `sdk.canvas_width`/`canvas_height`/`pane_width`/`pane_height` were removed as SDK globals; `CanvasRect` no longer accepts `border_color`/`border_width`/`hit_region` kwargs.
- Ported to breakout's proven pattern: learn canvas size via `init(size)` + `Resize`, and pass `width=`/`height=` to `Canvas()` so the declared coordinate space matches the actual render size (required for `fit="fill"` to be a 1:1 transform).
- Replaced the three `hit_region` tags with a `MouseEvent(x, y)` handler that does grid/rect math in canvas coordinate space, using the canvas-click `MouseEvent` capability landed by an earlier host change — this is the payoff that lets clicking work again, alongside the existing keyboard nav (arrows + 1-9 + n), which is unchanged.
- Drew borders as a separate outline `CanvasRect` behind an inset fill rect instead of the removed `border_color`/`border_width` kwargs.
- Ported `apps/dev/canvas-sidebar` (identical crash) the same way — including fixing `HStack.to_node()`, which emitted a dead `"stack"` node type no renderer ever consumed.
- Fixed the stale `src/protocol/events.rs` doc comment claiming the SDK exposes `canvas_width`.

## Test Evidence

- `just test`: **1416 passed; 0 failed; 2 ignored**
- `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py`: **no issues found in 26 source files**
- `plexi-alpha app test apps/sudoku`: **9 passed**
- `just check-capability-docs`, `just check-authoring-docs`, `just check-sdk-docs`: all pass
- **Live verification on alpha/PR channel** (rebuilt from source each time, not overlay hacks): sudoku renders correctly on both menu and game screens (`semantic.nodes` populated, `guest_fps` > 0, no decode errors), difficulty buttons render with correct border+fill, keyboard nav confirmed (arrow key changes difficulty selection, space starts a game). Canvas-sidebar renders 8 real nodes live via `just pr-install 2405`, zero decode errors.
- Known pre-existing gap, unrelated to this diff, filed as its own follow-up task (not in this PR's scope): a host bug where `python_key_name` has no digit-key (`Num0`-`Num9`) mapping, so digit keystrokes never reach any Python-WASM app. This blocks live-verifying sudoku's 1-9 cell-fill and 1/2/3 difficulty shortcuts specifically, but sudoku's own state/screen-transition logic is confirmed correct. Enter also doesn't start a game live (host names that key `enter`, sudoku checks `return`) — same pre-existing class of bug, also filed separately.

## Done When

- [x] Sudoku renders on alpha without crashing
- [x] `canvas_width`/`canvas_height`/`pane_width`/`pane_height` learned via `init`+`Resize`, matching breakout
- [x] `border_color`/`border_width` kwargs replaced with outline-rect drawing
- [x] `hit_region` replaced with `MouseEvent`-based hit testing
- [x] Keyboard nav (arrows, 1-9, n, p, r, m) still works
- [x] `apps/dev/canvas-sidebar` ported and confirmed rendering live
- [x] Stale `events.rs` doc comment fixed