### PR TITLE
fix(host): python_key_name digit mapping + Enter/return key-name mismatch (stint 0400, 0403)

### DIFF
--- a/apps/sudoku/main.py
+++ b/apps/sudoku/main.py
@@ -272,7 +272,7 @@ def _key(d, event):
             return [SetState({"diff_idx": (idx - 1) % 3})]
         if key in ("down", "j"):
             return [SetState({"diff_idx": (idx + 1) % 3})]
-        if key in ("return", "space"):
+        if key in ("enter", "space"):
             new = _new_game(DIFFICULTIES[idx])
             return [SetState(new), SetStatus(f"{DIFFICULTIES[idx].title()} — 00:00")]
         if key == "1":

--- a/sdk/python/AUTHORING.md
+++ b/sdk/python/AUTHORING.md
@@ -200,13 +200,14 @@ adding on press and removing on release; do not toggle state on every event.
 
 | Physical key | `event.key` |
 |---|---|
-| Enter / Return | `"return"` |
+| Enter / Return | `"enter"` |
 | Escape | `"escape"` |
 | Backspace | `"backspace"` |
 | Space | `"space"` |
 | Arrow keys | `"up"` / `"down"` / `"left"` / `"right"` |
 | Tab | `"tab"` |
 | Letters | `"a"`–`"z"` (lowercase) |
+| Digits (main row or numpad) | `"0"`–`"9"` |
 | Plus / Minus / Equals | `"plus"` / `"minus"` / `"equals"` |
 | Function keys | `"f1"`–`"f12"` |
 

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -1530,6 +1530,16 @@ fn python_key_name(key: egui::Key) -> String {
         egui::Key::Backspace => "backspace".to_string(),
         egui::Key::Escape => "escape".to_string(),
         egui::Key::Space => "space".to_string(),
+        egui::Key::Num0 => "0".to_string(),
+        egui::Key::Num1 => "1".to_string(),
+        egui::Key::Num2 => "2".to_string(),
+        egui::Key::Num3 => "3".to_string(),
+        egui::Key::Num4 => "4".to_string(),
+        egui::Key::Num5 => "5".to_string(),
+        egui::Key::Num6 => "6".to_string(),
+        egui::Key::Num7 => "7".to_string(),
+        egui::Key::Num8 => "8".to_string(),
+        egui::Key::Num9 => "9".to_string(),
         other => format!("{other:?}").to_ascii_lowercase(),
     }
 }
@@ -2946,6 +2956,28 @@ mod tests {
     fn python_keys_use_sdk_lowercase_names() {
         assert_eq!(python_key_name(egui::Key::ArrowDown), "down");
         assert_eq!(python_key_name(egui::Key::Escape), "escape");
+        assert_eq!(python_key_name(egui::Key::Enter), "enter");
+    }
+
+    #[test]
+    fn python_key_name_maps_digit_keys_to_plain_digits() {
+        assert_eq!(python_key_name(egui::Key::Num0), "0");
+        assert_eq!(python_key_name(egui::Key::Num1), "1");
+        assert_eq!(python_key_name(egui::Key::Num2), "2");
+        assert_eq!(python_key_name(egui::Key::Num3), "3");
+        assert_eq!(python_key_name(egui::Key::Num4), "4");
+        assert_eq!(python_key_name(egui::Key::Num5), "5");
+        assert_eq!(python_key_name(egui::Key::Num6), "6");
+        assert_eq!(python_key_name(egui::Key::Num7), "7");
+        assert_eq!(python_key_name(egui::Key::Num8), "8");
+        assert_eq!(python_key_name(egui::Key::Num9), "9");
+    }
+
+    #[test]
+    fn python_key_name_fallback_matches_documented_punctuation_names() {
+        assert_eq!(python_key_name(egui::Key::Plus), "plus");
+        assert_eq!(python_key_name(egui::Key::Minus), "minus");
+        assert_eq!(python_key_name(egui::Key::Equals), "equals");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Bundles stint 0400 (P1) and stint 0403 (P2) — same subsystem, both bugs in `python_key_name` in `src/host/wasm_python.rs`.

- **0400**: `python_key_name` had no match arms for `egui::Key::Num0`..`Num9`. Digit keys fell through to the Debug-derived catch-all, producing `"num2"` instead of `"2"`. Every Python-WASM app checking a digit key (e.g. sudoku's `if key in "123456789"`) silently never matched. Added explicit `Num0..Num9 -> "0".."9"` arms.
- **0403**: sudoku's difficulty-menu handler checked `key in ("return", "space")`, but the host has always emitted `"enter"` for the Enter key. Most other core apps (wikipedia, csv_viewer, permissions, calc, github-issues, tetris) already defensively check both `"return"` and `"enter"` — strong evidence `"enter"` is the de-facto, working convention. Fixed sudoku to check `"enter"` instead of `"return"`.
- Corrected `sdk/python/AUTHORING.md`'s key reference table, which documented Enter as `"return"` (stale/wrong) and didn't list the digit-key convention at all. Now documents `"enter"` and `"0"`-`"9"`.
- Verified no other host arms are needed: punctuation keys (`Plus`/`Minus`/`Equals`), `Tab`, letters, and function keys all already produce the correct lowercase name via the Debug-derived fallback (their egui `Debug` output already matches the documented SDK convention) — only the digit variants diverged.

## Test plan

- [x] New unit tests: `python_key_name_maps_digit_keys_to_plain_digits` (Num0..Num9 -> "0".."9"), `python_key_name_fallback_matches_documented_punctuation_names` (Plus/Minus/Equals still correct via fallback), extended `python_keys_use_sdk_lowercase_names` with an Enter assertion. Verified red before the fix, green after.
- [x] `cargo test --bin plexi`: **1418 passed; 0 failed; 2 ignored.**
- [x] `just check-docs`: all docs checks pass, including `check-authoring-docs` (AUTHORING.md verified consistent with the SDK).
- [x] **Live-verified** on a freshly-installed `plexi-alpha` build of this branch (binary install required — keyboard/app-launch behavior only observable in the running host):
  - Opened `sudoku`, pressed `enter` on the difficulty menu — screen transitioned from the difficulty-select canvas to the live grid (title/difficulty buttons replaced by board digits). Confirms 0403.
  - Selected an empty cell via arrow-key navigation, pressed digit key `3` — the digit was written into the board and rendered on canvas at that cell (previously "num3" would never have matched sudoku's digit handler, so nothing would render). Confirms 0400.

Stint tasks: `0400`, `0403`. No linked GitHub issues.

Not merging — a tester validates the PR build first (`just pr-install <PR#>` from this worktree, then drive with `plexi-pr-<PR#>`).