### PR TITLE
fix(sdk): Tabs/Grid/Toggle/ProgressBar emit decoder-unsupported node types (stint 0402)

### DIFF
--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -2325,20 +2325,15 @@ class Tabs:
         for i, (label, _content) in enumerate(self.tabs):
             bold = i == self.active
             tab_buttons.append({
-                "type": "interactive",
-                "node_id": f"tab_{i}",
-                "child": {
-                    "type": "text",
-                    "text": label,
-                    "bold": bold,
-                },
-                "on_click": True,
-                "on_hover": False,
+                "type": "button",
+                "label": label,
+                "on_click": f"tab_{i}",
+                "style": "primary" if bold else "secondary",
+                "disabled": False,
             })
 
         tab_bar: dict = {
-            "type": "stack",
-            "direction": "horizontal",
+            "type": "row",
             "children": tab_buttons,
             "gap": SPACE_SM,
         }
@@ -2354,8 +2349,7 @@ class Tabs:
             children.append(active_content)
 
         return {
-            "type": "stack",
-            "direction": "vertical",
+            "type": "column",
             "children": children,
             "gap": 0.0,
         }
@@ -2405,15 +2399,13 @@ class Grid:
             for child in row_items:
                 row_nodes.append(child.to_node() if hasattr(child, "to_node") else child)
             rows.append({
-                "type": "stack",
-                "direction": "horizontal",
+                "type": "row",
                 "children": row_nodes,
                 "gap": self.gap,
             })
 
         return {
-            "type": "stack",
-            "direction": "vertical",
+            "type": "column",
             "children": rows,
             "gap": self.gap,
         }
@@ -2422,7 +2414,8 @@ class Grid:
 class Toggle:
     """On/off toggle switch (L1 sugar).
 
-    Renders as an Interactive node with a horizontal stack indicator.
+    Renders as a Button whose label carries the on/off state; clicking it
+    fires `node_id` as the on_click handler.
 
     Example::
 
@@ -2436,21 +2429,22 @@ class Toggle:
         self.label = label
 
     def to_node(self) -> dict:
+        state_button: dict = {
+            "type": "button",
+            "label": "on" if self.value else "off",
+            "on_click": self.node_id,
+            "style": "primary" if self.value else "secondary",
+            "disabled": False,
+        }
+        if not self.label:
+            return state_button
         return {
-            "type": "interactive",
-            "node_id": self.node_id,
-            "child": {
-                "type": "stack",
-                "direction": "horizontal",
-                "children": [
-                    {"type": "text", "text": self.label} if self.label else
-                    {"type": "text", "text": ""},
-                    {"type": "text", "text": "on" if self.value else "off"},
-                ],
-                "gap": SPACE_SM,
-            },
-            "on_click": True,
-            "on_hover": False,
+            "type": "row",
+            "children": [
+                {"type": "text", "text": self.label},
+                state_button,
+            ],
+            "gap": SPACE_SM,
         }
 
 
@@ -2480,14 +2474,11 @@ class Clickable:
 
 
 class ProgressBar:
-    """Horizontal progress bar (L0 decomposition).
-
-    Decomposes to a horizontal Stack with a filled portion and an empty
-    portion sized proportionally to ``value / max_value``.
+    """Horizontal progress bar backed by the host's native progress-bar node.
 
     Example::
 
-        bar = ProgressBar(0.75, color="accent")
+        bar = ProgressBar(0.75)
         ctx.render_tree(bar.to_node())
     """
 
@@ -2495,37 +2486,16 @@ class ProgressBar:
         self,
         value: float,
         max_value: float = 1.0,
-        color: str = "",
     ) -> None:
         self.value = value
         self.max_value = max_value
-        self.color = color
 
     def to_node(self) -> dict:
         safe_max = self.max_value if self.max_value > 0 else 1.0
-        ratio = max(0.0, min(1.0, self.value / safe_max))
-        empty_ratio = 1.0 - ratio
-
-        filled: dict = {
-            "type": "text",
-            "text": "█" * max(1, round(ratio * 20)),
-            "color": self.color or "accent",
-        }
-        empty: dict = {
-            "type": "text",
-            "text": "░" * max(0, round(empty_ratio * 20)),
-            "color": "dim",
-        }
-
-        children: list = [filled]
-        if empty_ratio > 0:
-            children.append(empty)
-
         return {
-            "type": "stack",
-            "direction": "horizontal",
-            "children": children,
-            "gap": 0.0,
+            "type": "progress-bar",
+            "value": self.value,
+            "max": safe_max,
         }
 
 

--- a/sdk/python/tests/test_hstack_sized.py
+++ b/sdk/python/tests/test_hstack_sized.py
@@ -8,8 +8,7 @@ from plexi_sdk.ui import Canvas, HStack, Sized, Text
 def test_hstack_to_node_horizontal_stack() -> None:
     node = HStack([Text(text="a"), Text(text="b")], gap=12.0).to_node()
     assert node is not None
-    assert node["type"] == "stack"
-    assert node["direction"] == "horizontal"
+    assert node["type"] == "row"
     assert node["gap"] == 12.0
     assert len(node["children"]) == 2
 

--- a/sdk/python/tests/test_new_components.py
+++ b/sdk/python/tests/test_new_components.py
@@ -20,19 +20,17 @@ class _TextNode:
 # ── Tabs ───────────────────────────────────────────────────────────────────
 
 
-def test_tabs_to_node_returns_stack() -> None:
+def test_tabs_to_node_returns_column() -> None:
     a = _TextNode("Panel A")
     b = _TextNode("Panel B")
     tabs = Tabs([("Tab 1", a), ("Tab 2", b)], active=0)
     node = tabs.to_node()
     assert isinstance(node, dict)
-    assert node["type"] == "stack"
-    assert node["direction"] == "vertical"
+    assert node["type"] == "column"
     # Must have at least the tab bar and the active content
     assert len(node["children"]) == 2
     tab_bar = node["children"][0]
-    assert tab_bar["type"] == "stack"
-    assert tab_bar["direction"] == "horizontal"
+    assert tab_bar["type"] == "row"
     assert len(tab_bar["children"]) == 2
 
 
@@ -45,21 +43,22 @@ def test_tabs_active_tab_content_is_correct() -> None:
     assert active_content["text"] == "Panel B"
 
 
-def test_tabs_empty_produces_stack() -> None:
+def test_tabs_empty_produces_column() -> None:
     node = Tabs([]).to_node()
-    assert node["type"] == "stack"
+    assert node["type"] == "column"
     # Only the tab bar; no content child
-    assert node["children"][0]["type"] == "stack"
+    assert node["children"][0]["type"] == "row"
 
 
-def test_tabs_active_button_is_bold() -> None:
+def test_tabs_active_button_is_primary_style() -> None:
     a = _TextNode("A")
     b = _TextNode("B")
     tabs = Tabs([("First", a), ("Second", b)], active=0)
     node = tabs.to_node()
     tab_buttons = node["children"][0]["children"]
-    assert tab_buttons[0]["child"]["bold"] is True
-    assert tab_buttons[1]["child"]["bold"] is False
+    assert tab_buttons[0]["type"] == "button"
+    assert tab_buttons[0]["style"] == "primary"
+    assert tab_buttons[1]["style"] == "secondary"
 
 
 # ── Grid ───────────────────────────────────────────────────────────────────
@@ -68,14 +67,12 @@ def test_tabs_active_button_is_bold() -> None:
 def test_grid_2col_has_correct_rows() -> None:
     items = [_TextNode(str(i)) for i in range(4)]
     node = Grid(2, items).to_node()
-    assert node["type"] == "stack"
-    assert node["direction"] == "vertical"
+    assert node["type"] == "column"
     # 4 items / 2 columns = 2 rows
     assert len(node["children"]) == 2
-    # Each row is a horizontal stack with 2 children
+    # Each row is a row node with 2 children
     for row in node["children"]:
-        assert row["type"] == "stack"
-        assert row["direction"] == "horizontal"
+        assert row["type"] == "row"
         assert len(row["children"]) == 2
 
 
@@ -105,21 +102,25 @@ def test_grid_single_column() -> None:
 # ── Toggle ─────────────────────────────────────────────────────────────────
 
 
-def test_toggle_to_node_has_node_id() -> None:
+def test_toggle_with_label_wraps_button_in_row() -> None:
     toggle = Toggle("dark_mode", value=True, label="Dark mode")
     node = toggle.to_node()
     assert isinstance(node, dict)
-    assert node.get("node_id") == "dark_mode"
+    assert node["type"] == "row"
+    label_node, state_button = node["children"]
+    assert label_node == {"type": "text", "text": "Dark mode"}
+    assert state_button["on_click"] == "dark_mode"
 
 
-def test_toggle_on_click_is_true() -> None:
+def test_toggle_without_label_is_bare_button() -> None:
     node = Toggle("t", value=False).to_node()
-    assert node["on_click"] is True
+    assert node["type"] == "button"
+    assert node["on_click"] == "t"
 
 
-def test_toggle_type_is_interactive() -> None:
-    node = Toggle("t", value=False).to_node()
-    assert node["type"] == "interactive"
+def test_toggle_label_reflects_value() -> None:
+    assert Toggle("t", value=True).to_node()["label"] == "on"
+    assert Toggle("t", value=False).to_node()["label"] == "off"
 
 
 # ── Clickable ──────────────────────────────────────────────────────────────
@@ -159,43 +160,23 @@ def test_clickable_on_hover_is_false() -> None:
 
 def test_progress_bar_to_node() -> None:
     node = ProgressBar(0.5, 1.0).to_node()
-    assert isinstance(node, dict)
-    assert node["type"] == "stack"
+    assert node == {"type": "progress-bar", "value": 0.5, "max": 1.0}
 
 
-def test_progress_bar_direction_horizontal() -> None:
+def test_progress_bar_default_max() -> None:
     node = ProgressBar(0.5).to_node()
-    assert node["direction"] == "horizontal"
+    assert node["max"] == 1.0
 
 
-def test_progress_bar_full_has_one_child() -> None:
-    node = ProgressBar(1.0, 1.0).to_node()
-    # 100% filled: empty ratio is 0, so only the filled child
-    assert len(node["children"]) == 1
-    assert node["children"][0]["type"] == "text"
+def test_progress_bar_zero_max_falls_back_to_one() -> None:
+    node = ProgressBar(0.5, max_value=0.0).to_node()
+    assert node["max"] == 1.0
 
 
-def test_progress_bar_zero_has_two_children() -> None:
-    # 0% filled still produces filled (at least 1 char) + empty
-    node = ProgressBar(0.0, 1.0).to_node()
-    assert len(node["children"]) == 2
-
-
-def test_progress_bar_clamps_above_max() -> None:
+def test_progress_bar_passes_raw_value_through() -> None:
+    # The host clamps for rendering; the SDK just forwards value/max.
     node = ProgressBar(2.0, 1.0).to_node()
-    assert len(node["children"]) == 1  # 100%, no empty portion
-
-
-def test_progress_bar_custom_color() -> None:
-    node = ProgressBar(0.5, color="danger").to_node()
-    filled = node["children"][0]
-    assert filled["color"] == "danger"
-
-
-def test_progress_bar_default_color() -> None:
-    node = ProgressBar(0.5).to_node()
-    filled = node["children"][0]
-    assert filled["color"] == "accent"
+    assert node["value"] == 2.0
 
 
 # ── TextEdit ───────────────────────────────────────────────────────────────
@@ -269,3 +250,42 @@ def test_action_bar_to_node_is_semantic_action_bar() -> None:
 def test_action_bar_rejects_non_button_actions() -> None:
     with pytest.raises(TypeError, match="ActionBar actions\\[0\\] must be a Button"):
         ActionBar([TextEdit("not-a-button")])
+
+
+# ── CPython-WASM decoder drift guard ────────────────────────────────────────
+#
+# Mirrors the `match kind { ... }` arms of `decode_node_data` in
+# `src/host/wasm_python.rs` (stint 0402). A widget whose to_node() emits a
+# type outside this set crashes any live CPython-WASM app that uses it with
+# "unsupported CPython-WASM UINode type: <name>" — silent until run live.
+# Keep this set in sync with the Rust match by hand; it is deliberately not
+# derived from the SDK's own output, since that would make the guard
+# tautological.
+_DECODER_SUPPORTED_ROOT_TYPES = {
+    "row", "column", "button", "text", "progress-bar",
+}
+
+
+@pytest.mark.parametrize(
+    "widget_factory",
+    [
+        lambda: Tabs([("Tab 1", _TextNode("Panel A")), ("Tab 2", _TextNode("Panel B"))], active=0),
+        lambda: Tabs([]),
+        lambda: Grid(2, [_TextNode("a"), _TextNode("b"), _TextNode("c")]),
+        lambda: Grid(1, [_TextNode("a")]),
+        lambda: Toggle("dark_mode", value=True),
+        lambda: Toggle("dark_mode", value=True, label="Dark mode"),
+        lambda: ProgressBar(0.5),
+    ],
+    ids=[
+        "tabs", "tabs-empty", "grid", "grid-single-col",
+        "toggle-no-label", "toggle-with-label", "progress_bar",
+    ],
+)
+def test_v3_5_uinode_widgets_emit_decoder_supported_root_type(widget_factory) -> None:
+    node = widget_factory().to_node()
+    assert node["type"] in _DECODER_SUPPORTED_ROOT_TYPES, (
+        f"{node['type']!r} has no CPython-WASM decode arm in "
+        "src/host/wasm_python.rs decode_node_data — this widget will crash "
+        "any live Python-WASM app that renders it"
+    )

--- a/website/src/content/docs/sdk.md
+++ b/website/src/content/docs/sdk.md
@@ -637,7 +637,8 @@ Example::
 
 On/off toggle switch (L1 sugar).
 
-Renders as an Interactive node with a horizontal stack indicator.
+Renders as a Button whose label carries the on/off state; clicking it
+fires `node_id` as the on_click handler.
 
 Example::
 
@@ -655,14 +656,11 @@ Example::
 
 ### `ProgressBar`
 
-Horizontal progress bar (L0 decomposition).
-
-Decomposes to a horizontal Stack with a filled portion and an empty
-portion sized proportionally to ``value / max_value``.
+Horizontal progress bar backed by the host's native progress-bar node.
 
 Example::
 
-    bar = ProgressBar(0.75, color="accent")
+    bar = ProgressBar(0.75)
     ctx.render_tree(bar.to_node())
 
 ## Testing


### PR DESCRIPTION
No linked GitHub issue — tracked as stint task 0402.

## Summary

`Tabs`, `Grid`, `Toggle`, and `ProgressBar` in `sdk/python/plexi_sdk/ui.py` all
composed via `{"type": "stack"}` — the same dead type `HStack` emitted before
stint 0394 fixed it (PR #2405) — and `Tabs`/`Toggle` additionally wrapped
content in `{"type": "interactive"}`. Neither `"stack"` nor `"interactive"`
has a decode arm in `decode_node_data` (`src/host/wasm_python.rs`), and
`"interactive"` isn't in the WIT `ui-node-data` variant (`wit/plexi.wit`) at
all — confirmed by reading both files directly, not by grep. Both crash any
live CPython-WASM app that renders these widgets with `unsupported
CPython-WASM UINode type: <name>`, silent until run live.

- **Tabs/Grid**: compose from `row`/`column` instead of `stack`.
- **Tabs/Toggle**: tab and toggle controls are now `Button` nodes (`label` +
  `on_click` + `style`) instead of `Interactive`-wrapped text — `Interactive`
  isn't a real node type, and `Button` already covers the click-target need.
- **ProgressBar**: emits the decoder's existing native `progress-bar` arm
  instead of hand-rendering block-character text. Drops the `color`
  constructor param, which the decoder has never read from JSON (dead since
  introduction — confirmed by reading the decode arm).
- Adds a drift-guard test (`test_v3_5_uinode_widgets_emit_decoder_supported_root_type`)
  asserting every root type these four widgets can emit is in the decoder's
  supported set, so this class of bug can't silently reach a live host again
  for this widget set.
- Fixes `test_hstack_sized.py`'s stale assertion — it still expected `"stack"`
  after 0394 already changed `HStack` to emit `"row"`.

**Scope note:** no maintained/core app used these four widgets (confirmed via
constructor-call grep, not just import grep — `component-gallery` imports
`TabBar`/`Progress`, a separate older widget set, not `Tabs`/`ProgressBar`).
`Sized`, `Section`, `ActionBar`, and `Clickable` remain unfixed — no live
consumer today (`Sized`/`Section`'s only real usage was already removed in
0394; `ActionBar`/`Clickable` are untouched, dev-only via
`apps/dev/component-gallery`). `ActionBar` in particular emits `"action_bar"`,
also with no decoder or WIT support — a real, separate gap worth its own
stint task since it's not marked as the newer PGAP v3.5 widget set the other
four are.

## Test evidence

- `uv run pytest sdk/python` (from `sdk/python/`): **149 passed, 1 skipped**
  (full suite, unrelated to just the touched files).
- `uv run mypy plexi_sdk/ui.py tests/test_new_components.py`: 5 pre-existing
  errors, identical count/lines on `HEAD~1` — zero new errors introduced.
- `cargo test --bin plexi`: **1420 passed, 0 failed, 2 ignored** (one
  unrelated `assistant::` test flaked once under full-suite parallelism,
  confirmed to pass in isolation and on a clean re-run of the full suite).
- `just check-sdk-docs` / `check-authoring-docs` / `check-cli-docs` /
  `check-config-docs` / `check-capability-docs` / `check-docs-coverage`: all
  green (`sdk.md` regenerated via `just gen-sdk-docs` for the two changed
  docstrings).
- Live verification: built `target/debug/plexi` directly from this worktree
  (the installed `plexi-alpha` binary's baked-in `CARGO_MANIFEST_DIR` points
  at an already-deleted worktree from a merged stint, so `plexi-alpha`/`app
  render`/`app check` all hang — an unrelated, pre-existing environment
  issue, reproduced on an untouched app). Live GUI verification via
  `just pr-install <this PR>` still pending — will confirm in a follow-up
  comment.

## Do not merge

Per request — open for review only.