### PR TITLE
fix: dead-code cleanup, merge-cleanup completeness, rapid pane-key regression (stint 0396, 0405, 0404)

### DIFF
--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -7,7 +7,7 @@
 #   scripts/merge-pr.sh rebase <BRANCH>        rebase feature branch on origin/alpha + force-push
 #   scripts/merge-pr.sh squash <PR>            squash-merge only
 #   scripts/merge-pr.sh sync                   reset local alpha to origin/alpha (safe — fails if unexpected commits)
-#   scripts/merge-pr.sh cleanup <PR> <BRANCH>  channel-clean + wtp remove + remote branch delete
+#   scripts/merge-pr.sh cleanup <PR> <BRANCH>  remove all local and remote branch artifacts
 #   scripts/merge-pr.sh close <ISSUE> <PR>     strip pipeline labels + close issue + append ship log
 #   scripts/merge-pr.sh close-stints <PR> <ID...>
 #
@@ -54,11 +54,37 @@ do_sync() {
 do_cleanup() {
     local PR="$1"
     local BRANCH="$2"
+    local WORKTREE_PATH="$ROOT/worktrees/$BRANCH"
     echo "==> Cleaning up PR #$PR artifacts"
     rm -f "test_pr${PR}.py"
     just channel-clean "pr-${PR}" 2>/dev/null || true
-    wtp remove "$BRANCH" --force --with-branch 2>/dev/null || true
-    git push origin --delete "$BRANCH" 2>/dev/null || true
+
+    if git worktree list --porcelain | grep -Fqx "worktree $WORKTREE_PATH"; then
+        git worktree remove --force "$WORKTREE_PATH"
+    fi
+    git worktree prune
+    if [ -e "$WORKTREE_PATH" ]; then
+        echo "ERROR: cleanup left worktree directory: $WORKTREE_PATH" >&2
+        exit 1
+    fi
+    if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+        git branch -D "$BRANCH"
+    fi
+    if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+        echo "ERROR: cleanup left local branch: $BRANCH" >&2
+        exit 1
+    fi
+    if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+        git push origin --delete "$BRANCH"
+    fi
+    if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+        echo "ERROR: cleanup left remote branch: origin/$BRANCH" >&2
+        exit 1
+    fi
+    if git worktree list --porcelain | grep -Fqx "worktree $WORKTREE_PATH"; then
+        echo "ERROR: cleanup left registered worktree: $WORKTREE_PATH" >&2
+        exit 1
+    fi
     echo "==> Reaping finished merged worktrees (clean + fully pushed only)"
     just reap-merged-worktrees 2>/dev/null || true
     echo "==> Sweeping stale worktree build artifacts"

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -503,9 +503,8 @@ pub fn pane_info_cli(previous: Option<u64>) -> i32 {
                             return 1;
                         }
                         let mut obj = v;
-                        obj["socket"] = serde_json::Value::String(
-                            socket_path.to_string_lossy().into_owned(),
-                        );
+                        obj["socket"] =
+                            serde_json::Value::String(socket_path.to_string_lossy().into_owned());
                         let channel =
                             crate::config::build_channel().unwrap_or_else(|| "main".to_string());
                         obj["channel"] = serde_json::Value::String(channel);
@@ -629,7 +628,7 @@ pub fn pane_key_cli(pane_id: u64, key: &str) -> i32 {
         .to_string_lossy()
         .into_owned();
     log::info!(
-        "pane_key:cli: pane_id={pane_id} key_chars={} response_file={response_file:?}",
+        "pane_key:cli: pane_id={pane_id} key={key:?} key_chars={} response_file={response_file:?}",
         key.chars().count()
     );
     let code = send_to_socket(serde_json::json!({

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -567,9 +567,7 @@ impl HeadlessPythonSession {
             "size": [size.0, size.1],
         }))?;
         let mut session = Self { runtime };
-        session.wait_for(|message| {
-            message.get("type").and_then(Value::as_str) == Some("ready")
-        })?;
+        session.wait_for(|message| message.get("type").and_then(Value::as_str) == Some("ready"))?;
         Ok(session)
     }
 
@@ -586,9 +584,7 @@ impl HeadlessPythonSession {
             message.get("type").and_then(Value::as_str) == Some("frame_done")
         })?;
         let raw = tree_json.ok_or_else(|| {
-            WasmPythonError::BridgeJson(
-                "app emitted frame_done with no component_tree".to_string(),
-            )
+            WasmPythonError::BridgeJson("app emitted frame_done with no component_tree".to_string())
         })?;
         decode_ui_tree_value(&raw)
     }
@@ -1423,10 +1419,24 @@ impl LivePythonPane {
         if events.is_empty() {
             crate::app::app_trait::KeyDisposition::Passthrough
         } else {
-            let _ = self.runtime.send(&json!({
+            for event in &events {
+                log::info!(
+                    "app::{}: received key at Python host boundary key={} pressed={}",
+                    self.app_id,
+                    event["key"].as_str().unwrap_or("<missing>"),
+                    event["pressed"].as_bool().unwrap_or(false),
+                );
+            }
+            if let Err(error) = self.runtime.send(&json!({
                 "type": "key_events",
                 "events": events,
-            }));
+            })) {
+                log::error!(
+                    "app::{}: send key events to CPython WASM: {error}",
+                    self.app_id
+                );
+                self.error = Some(error.to_string());
+            }
             crate::app::app_trait::KeyDisposition::Consumed
         }
     }

--- a/src/platform/frame_diag.rs
+++ b/src/platform/frame_diag.rs
@@ -39,8 +39,6 @@ pub enum RepaintCause {
     EdgePulse,
     /// CRT feature effect (~60fps while enabled).
     CrtEffect,
-    /// Image cache load completion (background thread).
-    ImageCacheCompletion,
     /// 100ms poll while a file drag hovers the window.
     FileDragPoll,
     /// 100ms widget pulse/poll animations (copy feedback, quick-note loading).
@@ -52,7 +50,7 @@ pub enum RepaintCause {
 }
 
 /// All variants, in declaration order. Indexes into [`COUNTERS`].
-const ALL_CAUSES: [RepaintCause; 16] = [
+const ALL_CAUSES: [RepaintCause; 15] = [
     RepaintCause::AppIdlePoll,
     RepaintCause::AppClick,
     RepaintCause::AppScheduleRender,
@@ -64,7 +62,6 @@ const ALL_CAUSES: [RepaintCause; 16] = [
     RepaintCause::PaneSwapAnim,
     RepaintCause::EdgePulse,
     RepaintCause::CrtEffect,
-    RepaintCause::ImageCacheCompletion,
     RepaintCause::FileDragPoll,
     RepaintCause::WidgetPulse,
     RepaintCause::QuitConfirm,
@@ -88,7 +85,6 @@ impl RepaintCause {
             RepaintCause::PaneSwapAnim => "pane_swap_anim",
             RepaintCause::EdgePulse => "edge_pulse",
             RepaintCause::CrtEffect => "crt_effect",
-            RepaintCause::ImageCacheCompletion => "image_cache_completion",
             RepaintCause::FileDragPoll => "file_drag_poll",
             RepaintCause::WidgetPulse => "widget_pulse",
             RepaintCause::QuitConfirm => "quit_confirm",

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -44,12 +44,6 @@ fn add_test_pane_appears_in_snapshot() {
 /// the render loop at the display refresh rate (uncapped when occluded).
 /// An idle, settled frame must not request an immediate repaint.
 
-
-
-
-
-
-
 #[test]
 fn two_test_panes_have_distinct_ids() {
     let mut h = HostHarness::new();
@@ -77,6 +71,44 @@ struct TextInputProbe {
     enter_handled: bool,
     enter_rendered: bool,
     consume_enter: bool,
+}
+
+#[derive(Default)]
+struct KeyBurstProbe {
+    received: Vec<String>,
+}
+
+impl crate::app::app_trait::App for KeyBurstProbe {
+    fn type_id(&self) -> &'static str {
+        "key-burst-probe"
+    }
+
+    fn display_name(&self) -> String {
+        "Key Burst Probe".to_string()
+    }
+
+    fn ui(&mut self, _ui: &mut egui::Ui, _ctx: &crate::app::app_trait::AppRenderContext<'_>) {}
+
+    fn handle_key(
+        &mut self,
+        input: &crate::app::input_router::PlexiInput,
+    ) -> crate::app::app_trait::KeyDisposition {
+        for event in input.events() {
+            if let egui::Event::Key {
+                key, pressed: true, ..
+            } = event
+            {
+                let name = format!("{key:?}").to_ascii_lowercase();
+                let name = name.strip_prefix("arrow").unwrap_or(&name).to_string();
+                self.received.push(name);
+            }
+        }
+        crate::app::app_trait::KeyDisposition::Consumed
+    }
+
+    fn serialize_state(&self) -> Option<serde_json::Value> {
+        Some(serde_json::json!({ "received": self.received }))
+    }
 }
 
 impl crate::app::app_trait::App for TextInputProbe {
@@ -209,6 +241,41 @@ fn consumed_native_key_is_not_replayed_into_render_input() {
     assert_eq!(state["enter_rendered"], false);
 }
 
+#[test]
+fn rapid_pane_key_burst_delivers_every_press_in_order() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.open_builtin_app_pane(
+        Box::<KeyBurstProbe>::default(),
+        AppPermissions::builtin(),
+        tmp.path().to_path_buf(),
+        None,
+        Some("split_h"),
+        None,
+    );
+    let pane_id = h.state().open_panes[0];
+    h.run_frames(2);
+
+    let intended = [
+        "right", "down", "left", "up", "right", "right", "down", "left",
+    ];
+    for (index, key) in intended.iter().enumerate() {
+        h.inject_ipc(AppRequest::KeyPane {
+            pane_id,
+            key: (*key).to_string(),
+            response_file: Some(temp_response(tmp.path(), &format!("rapid-key-{index}"))),
+        });
+    }
+    h.run_frames(1);
+
+    let state = h.app.windows[0]
+        .panes
+        .get(&pane_id)
+        .and_then(Pane::as_app)
+        .and_then(|pane| pane.runtime.serialize_state())
+        .expect("burst probe state");
+    assert_eq!(state["received"], serde_json::json!(intended));
+}
 
 /// Stint 0387: a real keyboard event injected via `RawInput` must reach the
 /// focused app pane's `handle_key` through the migrated `PlexiInput`
@@ -696,8 +763,6 @@ fn workspace_clean_slots_removes_unregistered_files_for_reused_pane_ids() {
 /// Regression guard for PR #392: `push_nav` and `pop_nav` commands must be
 /// processed so the host nav stack tracks depth correctly.
 
-
-
 #[test]
 fn set_pane_title_unknown_pane_id_does_not_panic() {
     // Injects SetPaneTitle for a pane_id that doesn't exist.
@@ -1121,13 +1186,6 @@ fn text_input_overlay_focus_wins_after_central_panel_steal() {
 /// stable `capability_secret_input` Id so the post-CentralPanel block can
 /// target it by name.
 
-
-
-
-
-
-
-
 #[test]
 fn portal_context_state_refreshes_when_child_context_changes() {
     let mut h = HostHarness::new();
@@ -1303,9 +1361,9 @@ fn click_pane_delivers_canvas_space_coordinate_through_fit_contain_transform() {
             .panes
             .get(&pane_id)
             .and_then(Pane::as_app)
-            .is_some_and(|pane| {
-                matches!(&pane.runtime, AppRuntime::Python(p) if p.has_rendered_tree())
-            });
+            .is_some_and(
+                |pane| matches!(&pane.runtime, AppRuntime::Python(p) if p.has_rendered_tree()),
+            );
         if rendered {
             break;
         }
@@ -1347,7 +1405,13 @@ fn click_pane_delivers_canvas_space_coordinate_through_fit_contain_transform() {
     let click_y = local_origin_y + target_canvas_y * scale;
 
     let response_file = temp_response(tmp.path(), "click-pane");
-    h.inject_click(pane_id, click_x, click_y, "left", Some(response_file.clone()));
+    h.inject_click(
+        pane_id,
+        click_x,
+        click_y,
+        "left",
+        Some(response_file.clone()),
+    );
     h.run_frames(1);
 
     let response = read_json_response(&response_file);


### PR DESCRIPTION
## Summary

Bundles three disjoint, independent stint tasks into one PR (no file overlap):

- **stint 0396** — deletes the orphaned `RepaintCause::ImageCacheCompletion` (variant decl, all-causes list, string-label arm) in `src/platform/frame_diag.rs`, left behind when `image_cache.rs` was deleted in stint 0389. `git grep ImageCacheCompletion` returns zero hits.
- **stint 0405** — `just merge-cleanup <PR#> <BRANCH>` (`scripts/merge-pr.sh do_cleanup`) now explicitly checks and force-removes the worktree, prunes, and verifies + fails loudly (exact path/branch printed, nonzero exit) if the on-disk dir, local branch, or remote branch survive. Reproduced on a throwaway worktree/branch (`feature/throwaway-0405-test`) before and after — all four artifacts (git worktree registry entry, on-disk dir, local branch, remote branch) are confirmed gone after a single run.
- **stint 0404** — instruments the Python-app key-intake boundary (`src/host/wasm_python.rs::LivePythonPane::handle_key`, ~line 1421) with `log::info!` per received key, and surfaces `runtime.send()` failures via `log::error!` + `self.error` instead of silently swallowing them (`let _ = ...`). Adds a `HostHarness` regression test (`rapid_pane_key_burst_delivers_every_press_in_order`) that injects an 8-key rapid burst via `AppRequest::KeyPane` in a single frame and asserts every press is delivered to the app in order, none dropped.

Traced the full delivery path end-to-end (CLI ack-wait → `pane_ipc_rx` mpsc queue, fully drained every frame → `AppendableStdin` push (unbounded, append-only) → Python `_v3_runtime.run()` `readline()` loop, one message at a time → `_handle_key_events` dispatch) — no coalescing or drop point found in the current code at any of those hops; the new test locks that in as a permanent regression guard.

## Test plan
- [x] `git grep ImageCacheCompletion` → zero hits
- [x] `cargo build --workspace` → clean
- [x] `just test` (full `cargo test --bin plexi`) → 1421 passed, 0 failed, 2 ignored
- [x] `just check-docs` → all generators report up to date (no diff)
- [x] `scripts/merge-pr.sh cleanup` manually reproduced on a throwaway worktree/branch — all four artifacts confirmed removed
- [ ] Tester: install `plexi-pr-<N>` and validate per `just pr-install <N>` (binary install not required for 0396/0405/0404 — pure logic + tooling changes with direct harness/live-repro coverage above, but a tester pass is still expected per pipeline)

Do not merge — a tester validates this PR before merge.