### PR TITLE
chore: throwaway PR for merge-cleanup verification (stint 0405)

### DIFF
--- a/THROWAWAY_0405_VERIFY.md
+++ b/THROWAWAY_0405_VERIFY.md
@@ -1,0 +1,1 @@
+# throwaway file for merge-cleanup verification (stint 0405 tester pass), safe to delete


### PR DESCRIPTION
Throwaway PR opened solely to independently verify stint 0405's merge-cleanup recipe as part of PR #2409 validation. Will be merged and cleaned up immediately, then this note removed. Not a real feature.