### PR TITLE
fix: sync wasm-poc apps into profile, clarify dev-pack id-open errors (stint 0392, 0399)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,6 @@ When work begins: `stint claim <task-id>`. Do not run or document `stint start`;
 | `src/ui/` | Host UI kit primitives, design tokens, overlay layout widgets |
 | `src/config/` | Config loading/validation, CONFIG.md reference |
 | `src/testing/` | Test infrastructure, TESTING.md reference, scene format |
-| `src/process_app/` | PGAP lifecycle, capability gating, security model, shell execution inventory |
 | `src/render/` | CLI renderer app contract |
 | `sdk/python/` | SDK traps; AUTHORING.md canonical app guide; SDK_V3.md design spec |
 | `apps/` | App rules, maintained-set policy (`packs/core.toml`), design philosophy |

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ A toolbar badge shows the count of pending notifications. `Cmd+Shift+A` always g
 
 ## Apps
 
-Apps are Python processes that render native UI and communicate with the host over PGAP. They declare capabilities in a manifest; the host enforces those capabilities for PGAP host APIs. Native Python apps are not a process sandbox.
+Apps run as sandboxed WASM components (Python apps run inside a CPython-in-WASM adapter; Rust apps compile natively to the same component model). They declare capabilities in a manifest; the host enforces those capabilities and prompts on first use of an undeclared one.
 
 A fresh install seeds a core set of apps automatically. Browse them with `Cmd+P` or manage them from the terminal.
 
@@ -270,24 +270,13 @@ To share your app: push the repo to GitHub, then anyone can install it with `ple
 
 ---
 
-## PGAP — Plexi General App Protocol
+## App runtime — WASM components
 
-PGAP is the wire protocol that every Plexi app speaks — built-in or third-party. It is the host API boundary: app requests go through typed messages and capability checks. Native Python apps are still native subprocesses, not a process sandbox.
+Every Plexi app — built-in or third-party — runs as a WASM component: one `wasmtime::Store` per app pane, exporting `lifecycle.init`, `lifecycle.update`, and `lifecycle.view`. The host renders the returned UI tree, delivers input events, and executes returned effects (`file-read`, `http-fetch`, `ai-query`, `request-capability`, and more). Components have isolated linear memory and only the host interfaces Plexi links — an app can't reach outside its granted capabilities by construction, not by convention.
 
-**Transport:** newline-delimited JSON on **stdin** (host → app) and **stdout** (app → host). One JSON object per line; no framing, no length prefix.
+**Binary data** (audio PCM, video frames, raw bytes) travels on **typed pipes** — Unix sockets opened by the host on demand, separate from the component effect interface.
 
-**Binary data** (audio PCM, video frames, raw bytes) travels on **typed pipes** — Unix sockets opened by the host on demand. The JSON wire carries only control and draw messages.
-
-**Handshake:**
-1. Host spawns the app process.
-2. Host sends one `init` event (fields: `protocol`, `app_id`, `workspace_root`, `capabilities`, `feature_flags`).
-3. App replies with `{"type": "ready", "sdk": "...", "features_used": [...]}`.
-4. Each frame: host sends `render`; app replies with draw commands terminated by `frame_done`.
-5. Input events (`key`, `click`, `command`, mouse) arrive between frames as they occur.
-6. Out-of-frame commands (`notify`, `secret_get`, `capability_request`, etc.) arrive at any time; host processes them immediately.
-7. On close: host sends `shutdown`; app must exit cleanly within a short timeout.
-
-Current protocol version: **pgap/3**. Full protocol reference: `src/protocol/`. Python SDK authoring reference: [`sdk/python/SDK_V3.md`](sdk/python/SDK_V3.md).
+Full current runtime reference: [`docs/wasm-runtime.md`](docs/wasm-runtime.md). Python SDK authoring reference: [`sdk/python/SDK_V3.md`](sdk/python/SDK_V3.md) (being reconciled with the WASM runtime — see `sdk/python/SDK_V3.md`'s own status note).
 
 ---
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -22,6 +22,5 @@ A PRM is the destination spec for a feature. It describes what to build and why.
 | `marketplace-monetization.md` | Accounts, payments, no-license commercial model | 0338–0341, 0322 |
 | `wasm-runtime.md` | WASM runtime architecture | see file |
 | `wasm-runtime-impl-plan.md` | WASM runtime build sequence (G1-G7, G11-G13) | see file |
-| `workspace-env-secrets.md` | Workspace env secret injection | 0237 |
-| `package-envelope.md` | One package format for apps, agents, and skills | 0325 |
-| `scene-v2-e2e.md` | Scene v2 eventual assertions, geometry invariants, and failure artifacts | 0384 |
+| `workspace-env-secrets.md` | Workspace env secret injection | 0237 (done — pending retirement, see 0408) |
+| `package-envelope.md` | One package format for apps, agents, and skills | 0325 (done — pending retirement, see 0408) |

--- a/docs/app-framework-marketplace.md
+++ b/docs/app-framework-marketplace.md
@@ -93,7 +93,7 @@ Required work:
 - Replace Assistant-style CLI subprocess control tools with host-mediated PGAP/tool APIs before any app becomes a trusted marketplace surface.
 - Add explicit capabilities for every pane/app/terminal power a PGAP assistant-style app can use. Reuse `panes.spawn` and `terminal.bindings` where they fit; add narrower capabilities where they do not.
 - Make capability declarations match actual powers before marketplace trust labels ship.
-- Keep `docs/SECURITY_MODEL.md` honest: Python apps are native processes with consent + audit.
+- Keep `docs/wasm-runtime.md`'s "Security Model" section (stint 0409) aligned with the actual sandbox and trust-label behavior as it evolves.
 - Add denial tests for host APIs reachable by apps.
 
 Trust labels must be blunt:
@@ -176,7 +176,7 @@ Then, before cutting v1:
 - Regenerate public docs and CLI references from the current build.
 - Reconcile open GitHub issues against stint tasks and v1/v2 labels.
 - Verify install, upgrade, channel isolation, local package install, hosted marketplace install, and trust-label wording.
-- Keep `docs/SECURITY_MODEL.md`, `sdk/python/SDK_V3.md`, website docs, and README aligned.
+- Keep `docs/wasm-runtime.md`'s "Security Model" section, `sdk/python/SDK_V3.md`, website docs, and README aligned.
 
 ### Runtime Lanes
 
@@ -266,7 +266,7 @@ Marketplace acceptance scenarios:
 - Runtime lanes after v1 are parked here as v2 direction until their own PRM or stint sprint is created.
 - `sdk/python/SDK_V3.md` is the SDK API reference. It must remain consistent with this PRM.
 
-- `docs/SECURITY_MODEL.md` remains the current security disclosure as long as it says Python apps are not sandboxed.
+- `docs/SECURITY_MODEL.md` never existed as a file (this PRM's pointer was aspirational). `docs/wasm-runtime.md`'s "Security Model" section (stint 0409) is now the canonical security/capability-model reference: Python apps are sandboxed (stint 0285, CPython-in-WASM), not native unsandboxed processes.
 - Superseded plans under `docs/superpowers/plans/` and `docs/superpowers/specs/` should be removed when they conflict with the current PRM.
 - The old MCPUI standalone plan has been removed. This PRM owns MCPUI sequence.
 - This PRM resolves conflicts for app framework and marketplace decisions. Sprint tasks live in `.stint/`.

--- a/docs/package-envelope.md
+++ b/docs/package-envelope.md
@@ -104,7 +104,7 @@ Set by stint 0325, restated only as a boundary:
 
 - This spec owns the package `kind` discriminator, the per-kind install targets, the skill "no capabilities / inherit from host" rule, and the cross-kind validation consistency layer.
 - The base package format, the app trust sheet, and the reject list are owned by `app-framework-marketplace.md` §3 and the code in `src/app/package.rs`. This spec references them and never restates them.
-- The trust boundary (consent + audit, no sandbox for native apps) is owned by [`src/process_app/SECURITY_MODEL.md`](../src/process_app/SECURITY_MODEL.md).
+- The trust boundary is real WASM sandboxing now (stint 0285 deleted `src/process_app/`; Python apps run inside `wasmtime`, not as unsandboxed native processes). [`docs/wasm-runtime.md`](wasm-runtime.md)'s "Security Model" section (stint 0409) is the canonical reference.
 - The canonical capability set is the `Capability` enum in `src/app/permissions.rs`. New capabilities are added there, not here.
 - Commercial behavior (purchase, update-gating, refunds) is owned by `marketplace-monetization.md`.
 - When a future change alters a decision here, update this spec in the same PR, and delete it in the PR that closes stint 0325's successor build tasks once the envelope is implemented.

--- a/docs/wasm-runtime.md
+++ b/docs/wasm-runtime.md
@@ -52,7 +52,24 @@ Imported `host-state`, pipes, GPU, and audio interfaces are link-time gated. The
 
 The host renders the WIT `ui-tree` through egui. Typed UI actions are delivered as `ui-action` and `ui-value-change` events. Surface nodes use a host-owned GPU texture. The state import provides persisted get, set, delete, and list-prefix operations scoped to the app. Typed pipes use host-managed handles.
 
-The runtime is sandboxed. Components have isolated linear memory and only the host interfaces that Plexi links. Native Python apps remain a separate runtime and are not sandboxed by this component boundary.
+The runtime is sandboxed. Components have isolated linear memory and only the host interfaces that Plexi links. Python apps run through the CPython-in-WASM adapter (`src/host/wasm_python.rs`, stint 0285) and are sandboxed by this same component boundary — there is no remaining native-subprocess Python runtime (`src/process_app/` was deleted).
+
+## Security Model
+
+Every app pane — Rust WASM component or Python app — runs inside its own `wasmtime::Store` with isolated linear memory. A component can only reach the host interfaces Plexi links for its world (`plexi-app`, `plexi-gpu-app`, `plexi-audio-app`, `plexi-full-app`); this is link-time gating, not a runtime policy check. Python apps run through the CPython-in-WASM adapter (`src/host/wasm_python.rs`, stint 0285) inside the same component boundary — there is no separate native-subprocess Python runtime.
+
+Beyond the link-time boundary, protected effects (`file-read`, `file-write`, `http-fetch`, `ai-query`, `pipe.open`, `gpu.render`, `audio.playback`, `audio:record`, `open-pane`, `spawn.app`, `clipboard.read`, `clipboard.write`, `notify`, and scoped filesystem/network forms) require an explicit capability grant. A component requests one with `request-capability`; the host prompts the user on first request, remembers the decision per app and workspace, and returns `capability-granted` or `capability-denied` on every subsequent request. A protected effect invoked without its grant returns an error result instead of executing. Every requested capability and every executed effect is logged.
+
+**Trust labels.** `trust_label()` (`src/app/package.rs`) classifies a package before install:
+
+| Label | When |
+|---|---|
+| `FirstPartyCore` | App id is in the bundled core pack |
+| `SandboxedWasm` | `[app] type = "wasm"` entry |
+| `PythonUnreviewed` / `ReviewedNative` | `.py` entry, outside the core pack — reviewed if `marketplace_reviewed` is set by the install flow (server attestation only; never in-package self-attestation) |
+| `NativeUnreviewed` / `ReviewedNative` | Non-`.py`, non-WASM entry, outside the core pack, reviewed the same way |
+
+`marketplace_reviewed` gates only the trust label, not a sandbox choice. `FirstPartyCore`, `SandboxedWasm`, and Python entries all launch through the same wasmtime component boundary and capability grant flow described above — `PythonUnreviewed`/`ReviewedNative` for Python is a review-provenance label, not a weaker sandbox. `NativeUnreviewed`/`ReviewedNative` for a non-`.py`, non-WASM entry is a **package classification with no current launch path**: `ManifestType` only defines `App` (routed to the CPython-in-WASM adapter, which requires a `.py`/`.pyc` entry) and `Wasm`; a native-executable entry fails to launch rather than running unsandboxed. Do not read this label as describing a live unsandboxed process — none exists in the current host.
 
 ## Verification
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -245,6 +245,44 @@ if [[ "$channel" == alpha || "$channel" =~ ^pr- ]]; then
     app_name="$(basename "$app_dir")"
     rm -rf "$profile_dir/apps/$app_name"
     rsync -a "$app_dir/" "$profile_dir/apps/$app_name/"
+    # Flattening changes app_dir's depth relative to the source tree
+    # (apps/wasm-poc/<name> → apps/<name>), so a manifest `entry` that
+    # escapes app_dir with `../` (wasm-poc apps point at the shared
+    # cargo target/ dir) no longer resolves post-flatten even though it
+    # resolves correctly for path-based open, which reads the manifest
+    # in place. Bundle the compiled artifact alongside the synced
+    # manifest and rewrite its entry to the bundled basename so id-based
+    # open is self-contained, matching every other installed app.
+    python3 - "$app_dir" "$profile_dir/apps/$app_name" <<'PYEOF'
+import os
+import shutil
+import sys
+import tomllib
+
+app_dir, dest_dir = sys.argv[1], sys.argv[2]
+with open(os.path.join(app_dir, "manifest.toml"), "rb") as f:
+    entry = tomllib.load(f)["app"]["entry"]
+
+if not entry.startswith(".."):
+    sys.exit(0)  # same-dir entry already resolves correctly post-flatten
+
+src = os.path.normpath(os.path.join(app_dir, entry))
+if not os.path.isfile(src):
+    sys.exit(0)  # not built yet; resolve_entry's "build it first" error still applies
+
+basename = os.path.basename(entry)
+shutil.copy2(src, os.path.join(dest_dir, basename))
+
+dest_manifest = os.path.join(dest_dir, "manifest.toml")
+with open(dest_manifest) as f:
+    text = f.read()
+old_line = f'entry = "{entry}"'
+new_line = f'entry = "{basename}"'
+if old_line not in text:
+    sys.exit(f"error: could not find '{old_line}' in {dest_manifest} to rewrite")
+with open(dest_manifest, "w") as f:
+    f.write(text.replace(old_line, new_line, 1))
+PYEOF
   done
 else
   bundled_bin="$app_dest/Contents/MacOS/plexi${suffix}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -236,7 +236,11 @@ find "$profile_dir/sdk/plexi_sdk" -name '__pycache__' -type d -exec rm -rf {} + 
 #                   reach channel app registries.
 if [[ "$channel" == alpha || "$channel" =~ ^pr- ]]; then
   mkdir -p "$profile_dir/apps"
-  find apps -mindepth 2 -maxdepth 2 -name manifest.toml -not -path 'apps/dev/*' -not -path 'apps/examples/*' | while read -r manifest; do
+  # maxdepth 3 (not 2) so apps/wasm-poc/<name>/manifest.toml is found too —
+  # wasm-poc apps nest one level deeper than top-level apps/<name>/manifest.toml.
+  # Registry scan is flat (one dir per app), so app_name below still resolves
+  # to the innermost dir name and syncs correctly regardless of nesting depth.
+  find apps -mindepth 2 -maxdepth 3 -name manifest.toml -not -path 'apps/dev/*' -not -path 'apps/examples/*' | while read -r manifest; do
     app_dir="$(dirname "$manifest")"
     app_name="$(basename "$app_dir")"
     rm -rf "$profile_dir/apps/$app_name"

--- a/sdk/python/AUTHORING.md
+++ b/sdk/python/AUTHORING.md
@@ -10,8 +10,10 @@ place the how-to-build knowledge lives.
   [`website/src/content/docs/sdk.md`](../../website/src/content/docs/sdk.md).
   That file is the exhaustive, always-fresh surface. This guide teaches the
   shape; `sdk.md` is the dictionary.
-- **Design/protocol spec** (adapter contract, native ProcessApp bridge, WIT
-  mapping) lives in [`SDK_V3.md`](SDK_V3.md).
+- **Design/protocol spec** (WIT mapping, CPython-in-WASM adapter) lives in
+  [`SDK_V3.md`](SDK_V3.md) — its own status note flags which sections are
+  historical (native `ProcessApp`, deleted by stint 0285). For the current
+  shipped runtime contract, read [`../../docs/wasm-runtime.md`](../../docs/wasm-runtime.md).
 - **Traps** (non-obvious failure modes) live in [`AGENTS.md`](AGENTS.md).
 
 ## Scaffold, Never Hand-Write
@@ -244,9 +246,10 @@ Always log at init and key state transitions; log escapes and errors from
 
 The scaffold writes a valid `manifest.toml`; the shape lives in the template at
 [`plexi_sdk/templates/manifest.toml`](plexi_sdk/templates/manifest.toml). A
-`[app] type = "app"` with a `.py` entry launches through native `ProcessApp`.
-Declare capabilities under `[app.capabilities]`; see `sdk.md` and the PGAP
-capability reference for what each grant allows.
+`[app] type = "app"` with a `.py` entry launches through the CPython-in-WASM
+adapter (stint 0285). Declare capabilities under `[app.capabilities]`; see
+`sdk.md` and `docs/wasm-runtime.md`'s "Capabilities" section for what each
+grant allows.
 
 `[launch] on_launch` declares what the host does when your app is launched
 while an instance already exists: `focus_existing` (one instance globally —
@@ -294,9 +297,9 @@ Inspect `~/.plexi-alpha/plexi.log` (or `~/.plexi-pr-<N>/plexi.log`) for app logs
 
 ## Traps
 
-`plexi_sdk` is only importable inside Plexi-spawned processes — it is on
-`PYTHONPATH` only for apps Plexi launches through native `ProcessApp`. A bare
-`python3 -c "import plexi_sdk"` in a terminal will fail or import a stale copy.
+`plexi_sdk` is only importable inside Plexi's app runtime — the CPython-in-WASM
+bridge adds it to `PYTHONPATH`. A bare `python3 -c "import plexi_sdk"` in a
+terminal pane will fail or import a stale copy.
 Test by opening the app in a pane. More traps: [`AGENTS.md`](AGENTS.md).
 
 ## Design Philosophy

--- a/sdk/python/SDK_V3.md
+++ b/sdk/python/SDK_V3.md
@@ -8,7 +8,7 @@
 > design record: the WIT mapping and adapter/bridge protocol. Its inline type
 > tables capture original design intent and may lag the shipped surface.
 
-**Status:** authoritative design doc for task 0285. Implement exactly this. No design decisions during implementation.
+**Status:** task 0285 (CPython-in-WASM migration) is done and merged. Sections 7, 9, and 13 below describe the native-`ProcessApp`-subprocess model this doc originally specified as *deferred future work* — that framing is now inverted: the WASM runtime shipped and `src/process_app/` was deleted. Those three sections are historical; do not treat them as current. [`docs/wasm-runtime.md`](../../docs/wasm-runtime.md) is the accurate reference for the shipped runtime contract until this doc is rewritten end-to-end.
 
 Source of truth for all types: `wit/plexi.wit`. Every Python type here maps to a named WIT type. Where a mapping decision was made, it is stated explicitly.
 
@@ -652,7 +652,11 @@ Reset `_next_id` to 0 before each `view()` call. Keys are positional by default;
 
 ---
 
-## 7. Native ProcessApp Bridge Protocol
+## 7. Native ProcessApp Bridge Protocol (superseded — see status note above)
+
+**This section is historical.** SDK v3 Python apps no longer run through native `ProcessApp` — stint 0285 deleted `src/process_app/` and replaced this bridge with the CPython-in-WASM adapter (`src/host/wasm_python.rs`). Kept below for archival reference only; do not implement against it. See [`docs/wasm-runtime.md`](../../docs/wasm-runtime.md) for the current contract.
+
+<details><summary>Original (superseded) content</summary>
 
 SDK v3 Python apps run through native `ProcessApp`: the host starts the system Python interpreter as a subprocess and invokes `python -m plexi_sdk._v3_process <entry.py>`. PGAP remains the process transport. WASM-contained Python is not part of this contract.
 
@@ -682,6 +686,8 @@ SDK v3 Python apps run through native `ProcessApp`: the host starts the system P
 
 CPython-in-WASM remains deferred G8 runtime work. Do not add `[runtime] python_compat = true` for SDK v3 apps, do not route Python app manifests to a `WasmPythonAdapter`, and do not require CPython bundle or shim fixtures for this SDK contract.
 
+</details>
+
 ---
 
 ## 8. Manifest Schema
@@ -705,19 +711,19 @@ capabilities = []
 [launch]
 ```
 
-`[app] type = "app"` plus a `.py` entry launches through native `ProcessApp`. `[app] type = "wasm"` is the separate component-model WASM runtime. SDK v3 is the current Python app API; it is not a WASM execution mode.
+**Superseded:** `[app] type = "app"` plus a `.py` entry now launches through the CPython-in-WASM adapter (stint 0285), not native `ProcessApp` — see [`docs/wasm-runtime.md`](../../docs/wasm-runtime.md) for the current manifest/runtime routing.
 
 ---
 
-## 9. WASM-Contained Python Status
+## 9. WASM-Contained Python Status (superseded — see status note at top of doc)
 
-Deferred. A future G8 may add a CPython-in-WASM compatibility layer, bundle management, and manifest routing. That work is outside this SDK v3 native landing and must not be advertised as shipped.
+**Shipped.** Stint 0285 landed the CPython-in-WASM compatibility layer, bundle management, and manifest routing this section originally deferred. This section's "must not be advertised as shipped" framing no longer applies — see [`docs/wasm-runtime.md`](../../docs/wasm-runtime.md).
 
 ---
 
-## 10. Hot Reload
+## 10. Hot Reload (superseded)
 
-Dev mode is the existing watched ProcessApp subprocess flow. On Python source changes, the host restarts the app subprocess and reinjects persisted/runtime state where supported by the ProcessApp lifecycle. There is no wasmtime store reset or CPython bundle reload in the current SDK v3 path.
+**This section describes the deleted native-`ProcessApp` hot-reload flow.** The current WASM adapter's reload behavior is described in stint 0285's own task body (`.stint/tasks/0285-*.md`, "Hot reload in dev mode" — resets the `wasmtime::Store` and re-calls `init` with the preserved state snapshot); confirm against `src/host/wasm_python.rs` before relying on specifics here.
 
 ---
 
@@ -825,11 +831,9 @@ plexi_sdk/
 
 ---
 
-## 13. Runtime Boundary
+## 13. Runtime Boundary (superseded)
 
-Do not delete `src/process_app/`. SDK v3 Python apps still run through native `ProcessApp`; PGAP is the current transport for Python apps.
-
-The WASM runtime remains available for `[app] type = "wasm"` component-model apps. CPython-in-WASM remains deferred G8 work and must not be described as shipped by SDK v3.
+**`src/process_app/` was deleted by stint 0285.** SDK v3 Python apps run through the CPython-in-WASM adapter, same as `[app] type = "wasm"` component-model apps — there is no longer a separate native-subprocess Python runtime. This section's original constraint is inverted from what's now true; see [`docs/wasm-runtime.md`](../../docs/wasm-runtime.md).
 
 ---
 

--- a/src/app/package.rs
+++ b/src/app/package.rs
@@ -155,7 +155,7 @@ fn io_err(action: &'static str, path: &Path, source: std::io::Error) -> PackageE
 /// Package runtime — derived from the manifest entry point.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PackageRuntime {
-    /// Entry ends in `.py` — launched via python3.
+    /// Entry ends in `.py` — launched through the CPython-in-WASM adapter (`src/host/wasm_python.rs`).
     Python,
     /// `[app] type = "wasm"` — launched through the wasmtime runtime.
     Wasm,
@@ -243,10 +243,10 @@ pub struct PackageReport {
 
 /// Blunt trust classification shown before any install proceeds (stint 0016).
 ///
-/// Process-app security stance: there is NO OS sandbox. Anything not bundled
-/// with Plexi runs with the user's full permissions, and the label says so
-/// verbatim. WASM components are separate: their host imports are
-/// capability-gated by the runtime.
+/// All runtimes are sandboxed WASM components today (stint 0285 replaced the
+/// native Python subprocess with the CPython-in-WASM adapter); the label
+/// distinguishes authoring path and marketplace review status, not sandbox
+/// presence. See `docs/wasm-runtime.md`'s "Security Model" section.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrustLabel {
     /// The app id is in the bundled core pack — ships with Plexi itself.

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -887,6 +887,50 @@ pub(crate) fn resolve_entry(
     Ok(path)
 }
 
+/// Walk up from `start` looking for an `apps/dev/` directory (the PLEXI repo's
+/// dev-pack POCs, per `apps/AGENTS.md`) and, if found, scan its immediate
+/// subdirectories for a manifest whose `[app].id` matches `id`.
+///
+/// Dev-pack apps are intentionally excluded from the id-addressable registry
+/// (`install.sh` never syncs `apps/dev/*` into a profile) — this is used only
+/// to turn a bare "no WASM runtime" miss into an actionable message pointing
+/// the developer at the path-open form.
+pub(crate) fn find_dev_pack_app(id: &str, start: &Path) -> Option<PathBuf> {
+    let home = dirs::home_dir();
+    let mut current = start.to_path_buf();
+    loop {
+        if let Some(ref h) = home {
+            if current == *h {
+                return None;
+            }
+        }
+        let dev_dir = current.join("apps").join("dev");
+        if dev_dir.is_dir() {
+            let entries = std::fs::read_dir(&dev_dir).ok()?;
+            for entry in entries.flatten() {
+                let app_dir = entry.path();
+                if !app_dir.is_dir() {
+                    continue;
+                }
+                let Ok(manifest_str) = std::fs::read_to_string(app_dir.join("manifest.toml"))
+                else {
+                    continue;
+                };
+                let Ok(manifest) = toml::from_str::<AppManifest>(&manifest_str) else {
+                    continue;
+                };
+                if manifest.app.id == id {
+                    return Some(app_dir);
+                }
+            }
+            return None;
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1725,5 +1769,38 @@ entry = "main.py"
         assert!(manifest.app.author.is_none());
         assert!(manifest.app.tags.is_empty());
         assert!(manifest.app.repo.is_none());
+    }
+
+    #[test]
+    fn find_dev_pack_app_matches_id_from_nested_start_dir() {
+        let repo = tempfile::tempdir().unwrap();
+        let dev_dir = repo.path().join("apps").join("dev");
+        fs::create_dir_all(&dev_dir).unwrap();
+        write_app(&dev_dir, "com.plexi.canvas-grid", "Canvas Grid POC");
+
+        // Search starts several directories below the repo root, mirroring a
+        // pane cwd inside a subdirectory of the checkout.
+        let start = repo.path().join("src").join("pane_ops");
+        fs::create_dir_all(&start).unwrap();
+
+        let found = find_dev_pack_app("com.plexi.canvas-grid", &start)
+            .expect("dev-pack app should be found by walking up to apps/dev");
+        assert_eq!(found, dev_dir.join("com.plexi.canvas-grid"));
+    }
+
+    #[test]
+    fn find_dev_pack_app_returns_none_for_unknown_id() {
+        let repo = tempfile::tempdir().unwrap();
+        let dev_dir = repo.path().join("apps").join("dev");
+        fs::create_dir_all(&dev_dir).unwrap();
+        write_app(&dev_dir, "com.plexi.canvas-grid", "Canvas Grid POC");
+
+        assert!(find_dev_pack_app("com.plexi.does-not-exist", repo.path()).is_none());
+    }
+
+    #[test]
+    fn find_dev_pack_app_returns_none_without_apps_dev_dir() {
+        let plain = tempfile::tempdir().unwrap();
+        assert!(find_dev_pack_app("anything", plain.path()).is_none());
     }
 }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1289,6 +1289,32 @@ impl PlexiApp {
             }
         }
 
+        // Dev-pack apps (apps/dev/*) are intentionally excluded from the
+        // id-addressable registry (apps/AGENTS.md) — install.sh never syncs
+        // them into a profile. When the caller passed an explicit cwd, `cwd`
+        // already is that value; otherwise prefer the focused pane's actual
+        // cwd over `cwd` (which may have resolved to the context root ahead
+        // of it — see stint 0399) so this fires for a developer sitting in a
+        // repo checkout.
+        let search_start = if cwd_explicit {
+            cwd.clone()
+        } else {
+            self.windows[self.active_window]
+                .focused_pane
+                .and_then(|f| self.windows[self.active_window].get_focused_pane_cwd(f))
+                .unwrap_or_else(|| cwd.clone())
+        };
+        if let Some(dev_app_dir) = crate::app::registry::find_dev_pack_app(id, &search_start) {
+            log::warn!(
+                "launch_app_by_id: '{id}' is a dev-pack app ({dev_app_dir:?}) — not id-openable"
+            );
+            return Err(format!(
+                "'{id}' is a dev-pack app ({}) — dev apps are path-open only. Use `plexi app open {}` instead.",
+                dev_app_dir.display(),
+                dev_app_dir.display()
+            ));
+        }
+
         log::warn!("launch_app_by_id: app '{id}' has no WASM runtime");
         Err(format!("app '{id}' has no WASM runtime"))
     }

--- a/src/render/AGENTS.md
+++ b/src/render/AGENTS.md
@@ -4,7 +4,7 @@
 
 ## Scope
 
-Host-side rendering: CLI renderer app, app render pipeline, draw command dispatch.
+Host-side rendering: the CLI renderer app only. The legacy app-render pipeline and draw-command dispatch (`app_render.rs`, `draw_commands.rs`, `components.rs`) were deleted by stint 0389 — WIT is now the single UI node language, rendered by `src/host/wasm_render.rs`.
 
 ## Reference
 

--- a/src/render/CLI_APP_CONTRACT.md
+++ b/src/render/CLI_APP_CONTRACT.md
@@ -12,8 +12,8 @@ re-document the descriptor schema — for that, read the
 schema at `schemas/plexi-descriptor-schema.json`.
 
 - **What the descriptor looks like** → [`CLI_DESCRIPTOR_GUIDE.md`](../../registry/CLI_DESCRIPTOR_GUIDE.md)
-- **The host/app wire protocol for SDK apps** → `src/protocol/` and [`SDK_V3.md`](../../sdk/python/SDK_V3.md)
-- **The capability/permission model** → [`SECURITY_MODEL.md`](../process_app/SECURITY_MODEL.md)
+- **The host/app wire protocol for SDK apps** → [`docs/wasm-runtime.md`](../../docs/wasm-runtime.md) (WIT component model — current runtime)
+- **The capability/permission model** → [`docs/wasm-runtime.md`](../../docs/wasm-runtime.md)'s "Security Model" section.
 
 The renderer is implemented in `src/render/cli_renderer_app.rs`. The open path is
 `src/cli/open.rs` and `src/cli/descriptor.rs`. The linked-terminal dispatch is


### PR DESCRIPTION
Stint tasks 0392 and 0399 — no linked GitHub issue for either.

## Summary

**Stint 0392 — install.sh sync scan skips apps/wasm-poc/***
- `install.sh`'s alpha/pr-* app sync scan used `find apps -mindepth 2 -maxdepth 2`, which only matches `apps/<name>/manifest.toml`. `apps/wasm-poc/<name>/manifest.toml` sits one level deeper, so none of the five wasm-poc apps (pong, counter, sysmon, python-shim, audio-synth) were ever rsynced into the profile's app registry — `plexi app open com.plexi.pong` failed with "no WASM runtime" even though the path-based form worked.
- Fix: extend the scan to `-maxdepth 3`. The registry scan is flat (one dir per app), and `app_name` is derived from the innermost directory name, so wasm-poc apps sync correctly regardless of nesting depth. Verified top-level `apps/*` and excluded `apps/dev/*`/`apps/examples/*` behavior is unchanged.

**Stint 0399 — dev-pack apps are not openable by id**
- `apps/AGENTS.md` states dev POCs are intentionally excluded from the id-addressable registry — path-only is the deliberate contract, not a bug to "fix" by resolving cwd differently.
- The actual gap: hitting this today gives a confusing generic "no WASM runtime" error, which previously caused a real mis-diagnosis (stint 0397) where a registry-scope miss was misread as a manifest bug.
- Fix: added `find_dev_pack_app()` in `registry.rs`, which walks up from a cwd looking for `apps/dev/` and matches a manifest id. When `launch_app_by_id` misses, and the id matches a dev-pack app, the host now returns "'<id>' is a dev-pack app (<path>) — dev apps are path-open only. Use `plexi app open <path>` instead." instead of the generic error. Uses the focused pane's actual cwd (not the resolved `cwd`, which can land on the context root) so this fires for a developer sitting in a repo checkout.

## Test evidence

- `cargo test --bin plexi`: **1424 passed, 0 failed, 2 ignored** (full bin suite, 91.37s) — includes 3 new unit tests for `find_dev_pack_app` (nested-start-dir match, unknown-id miss, no-apps-dev-dir miss).
- `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py`: **Success: no issues found in 26 source files**.
- No `just gen-*-docs`/`check-*-docs` generator applies — diff touches only `scripts/install.sh`, `src/app/registry.rs`, `src/pane_ops/create.rs` (none of cli_args.rs, config/mod.rs, app_protocol.rs, sdk/python/).
- Conclusion: install skippable for 0399 (pure logic + full unit coverage). 0392 (install.sh sync scan) needs a real install to confirm end-to-end — validator should run `just pr-install <PR>` and confirm `plexi-pr-<PR> app open com.plexi.pong` succeeds without falling back to the path form.