### PR TITLE
component-gallery: compose remaining widgets onto decoder-supported nodes (stint 0407)

### DIFF
--- a/apps/dev/component-gallery/main.py
+++ b/apps/dev/component-gallery/main.py
@@ -97,24 +97,32 @@ _SCROLL = Scrollable(child=Column(children=[]))
 
 
 def update(event) -> list:
+    # Checkbox, Switch, Radio, Slider, Select, TabBar, and Pagination have no
+    # native CPython-WASM node — they compose onto Row/Button trees (stint
+    # 0407), so state changes arrive as UiAction clicks (like Toggle/
+    # Accordion already did), not UiValueChange.
     if isinstance(event, UiValueChange):
         h, v = event.handler_id, event.value
-        if h == "gallery-check":
-            return _set(CHECK, bool(v))
-        if h == "gallery-switch":
-            return _set(SWITCH, bool(v))
-        if h == "gallery-radio":
-            return _set(RADIO, int(v))
-        if h == "gallery-slider":
-            return _set(SLIDER, float(v))
-        if h == "gallery-tabs":
-            return _set(TAB, int(v))
-        if h == "gallery-page":
-            return _set(PAGE, int(v))
         if h == "gallery-note":
             return _set(NOTE, str(v))
     if isinstance(event, UiAction):
         h = event.handler_id
+        if h == "gallery-check":
+            return _set(CHECK, not state.get(CHECK, True))
+        if h == "gallery-switch":
+            return _set(SWITCH, not state.get(SWITCH, False))
+        if h.startswith("gallery-radio:"):
+            return _set(RADIO, int(h.split(":", 1)[1]))
+        if h == "gallery-slider:dec":
+            return _set(SLIDER, max(0.0, state.get(SLIDER, 0.4) - 0.1))
+        if h == "gallery-slider:inc":
+            return _set(SLIDER, min(1.0, state.get(SLIDER, 0.4) + 0.1))
+        if h.startswith("gallery-tabs:"):
+            return _set(TAB, int(h.split(":", 1)[1]))
+        if h == "gallery-page:prev":
+            return _set(PAGE, max(0, state.get(PAGE, 0) - 1))
+        if h == "gallery-page:next":
+            return _set(PAGE, min(4, state.get(PAGE, 0) + 1))
         if h == "gallery-accordion":
             return _set(ACCORDION, not state.get(ACCORDION, True))
         if h == "gallery-modal-open":
@@ -123,6 +131,8 @@ def update(event) -> list:
             return _set(MODAL, False)
         if h == "gallery-select":
             return _set(SELECT, (state.get(SELECT, 0) + 1) % 3)
+        if h.startswith("gallery-select:"):
+            return _set(SELECT, int(h.split(":", 1)[1]))
     return []
 
 

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -417,7 +417,24 @@ class ActionBar(Component):
         self.actions = actions
 
     def to_node(self) -> dict:
-        return {"type": "action_bar", "actions": [{"type": "button", "node_id": action.on_click, "label": action.label, "style": action.style, "disabled": action.disabled} for action in self.actions]}
+        # No native action-bar node — composes onto a Row of Buttons, same as
+        # any other button group. Discovered blocking live component-gallery
+        # verification during stint 0407; `action_bar` was previously
+        # aspirational (see test history) and never had a decode arm.
+        return {
+            "type": "row",
+            "children": [
+                {
+                    "type": "button",
+                    "label": action.label,
+                    "on_click": action.on_click,
+                    "style": action.style,
+                    "disabled": action.disabled,
+                }
+                for action in self.actions
+            ],
+            "gap": SPACE_SM,
+        }
 
 
 @dataclass
@@ -437,6 +454,62 @@ class Spacer(Component):
 
     def to_node(self) -> dict:
         return {"type": "spacer", "size": self.size, "grow": self.grow}
+
+
+# ── CPython-WASM decode-arm composition helpers ─────────────────────────────
+#
+# `src/host/wasm_python.rs::decode_node_data` only understands the WIT
+# `ui-node-data` variant set (row, column, button, text, progress-bar, badge,
+# text_input, ...). Widgets below have no dedicated variant, so their
+# `to_node()` composes an equivalent tree out of already-supported primitives
+# instead of emitting a bespoke `"type"` the decoder rejects with
+# "unsupported CPython-WASM UINode type: <name>" (stint 0402, 0407).
+
+
+def _toggle_row(node_id: str, label: str, active: bool,
+                 active_label: str, inactive_label: str, disabled: bool) -> dict:
+    """Single on/off control: a state-carrying Button, optionally preceded by
+    a label. Clicking fires `node_id` as an on_click UiAction — callers flip
+    their own boolean state, the same pattern `Toggle`/`Accordion` already use."""
+    chip = {
+        "type": "button",
+        "label": active_label if active else inactive_label,
+        "on_click": node_id,
+        "style": "primary" if active else "secondary",
+        "disabled": disabled,
+    }
+    if not label:
+        return chip
+    return {
+        "type": "row",
+        "children": [{"type": "text", "text": label}, chip],
+        "gap": SPACE_SM,
+    }
+
+
+def _option_row(node_id: str, options: List[str], selected: int, disabled: bool) -> dict:
+    """Single-select control: a Row of Buttons, one per option. Clicking
+    option `i` fires `f"{node_id}:{i}"` as an on_click UiAction."""
+    buttons = [
+        {
+            "type": "button",
+            "label": option,
+            "on_click": f"{node_id}:{i}",
+            "style": "primary" if i == selected else "secondary",
+            "disabled": disabled,
+        }
+        for i, option in enumerate(options)
+    ]
+    return {"type": "row", "children": buttons, "gap": SPACE_SM}
+
+
+def _initials(label: str) -> str:
+    parts = [p for p in label.split() if p]
+    if not parts:
+        return "?"
+    if len(parts) == 1:
+        return parts[0][:2].upper()
+    return (parts[0][0] + parts[-1][0]).upper()
 
 
 @dataclass
@@ -470,7 +543,16 @@ class Tooltip(Component):
     child: Component
 
     def to_node(self) -> dict:
-        return {"type": "tooltip", "text": self.text, "child": self.child.to_node()}
+        # No native hover/tooltip node — the hint is shown as a small caption
+        # under the child instead of appearing on hover.
+        return {
+            "type": "column",
+            "children": [
+                self.child.to_node(),
+                {"type": "text", "text": self.text, "size": TEXT_HINT},
+            ],
+            "gap": SPACE_XS,
+        }
 
 
 @dataclass
@@ -479,7 +561,7 @@ class Avatar(Component):
     size: float = 0.0
 
     def to_node(self) -> dict:
-        return {"type": "avatar", "label": self.label, "size": self.size}
+        return {"type": "badge", "text": _initials(self.label), "color": "neutral"}
 
 
 @dataclass
@@ -489,7 +571,7 @@ class Icon(Component):
     color: str = ""
 
     def to_node(self) -> dict:
-        return {"type": "icon", "name": self.name, "size": self.size, "color": self.color}
+        return {"type": "text", "text": f"[{self.name}]", "size": self.size or TEXT_BODY}
 
 
 @dataclass
@@ -498,7 +580,11 @@ class CodeBlock(Component):
     language: str = ""
 
     def to_node(self) -> dict:
-        return {"type": "code_block", "code": self.code, "language": self.language}
+        children = []
+        if self.language:
+            children.append({"type": "text", "text": self.language, "bold": True, "size": TEXT_HINT})
+        children.append({"type": "text", "text": self.code})
+        return {"type": "column", "children": children, "gap": SPACE_XS}
 
 
 @dataclass
@@ -507,7 +593,24 @@ class Table(Component):
     rows: list[list[str]]
 
     def to_node(self) -> dict:
-        return {"type": "table", "columns": self.columns, "rows": self.rows}
+        header = {
+            "type": "row",
+            "children": [{"type": "text", "text": col, "bold": True} for col in self.columns],
+            "gap": SPACE_SM,
+        }
+        body_rows = [
+            {
+                "type": "row",
+                "children": [{"type": "text", "text": str(cell)} for cell in row],
+                "gap": SPACE_SM,
+            }
+            for row in self.rows
+        ]
+        return {
+            "type": "column",
+            "children": [header, {"type": "divider"}, *body_rows],
+            "gap": SPACE_XS,
+        }
 
 
 @dataclass
@@ -515,9 +618,21 @@ class KeyValue(Component):
     rows: list[tuple[str, str]]
 
     def to_node(self) -> dict:
-        return {"type": "key_value", "rows": [
-            {"key": key, "value": value} for key, value in self.rows
-        ]}
+        return {
+            "type": "column",
+            "children": [
+                {
+                    "type": "row",
+                    "children": [
+                        {"type": "text", "text": key, "bold": True},
+                        {"type": "text", "text": value},
+                    ],
+                    "gap": SPACE_SM,
+                }
+                for key, value in self.rows
+            ],
+            "gap": SPACE_XS,
+        }
 
 
 @dataclass
@@ -525,7 +640,12 @@ class Breadcrumb(Component):
     items: list[str]
 
     def to_node(self) -> dict:
-        return {"type": "breadcrumb", "items": self.items}
+        children = []
+        for i, item in enumerate(self.items):
+            if i > 0:
+                children.append({"type": "text", "text": "›"})
+            children.append({"type": "text", "text": item})
+        return {"type": "row", "children": children, "gap": SPACE_XS}
 
 
 @dataclass
@@ -535,8 +655,23 @@ class Pagination(Component):
     total: int = 0
 
     def to_node(self) -> dict:
-        return {"type": "pagination", "node_id": self.node_id,
-                "page": self.page, "total": self.total}
+        at_start = self.page <= 0
+        at_end = self.page >= max(0, self.total - 1)
+        return {
+            "type": "row",
+            "children": [
+                {
+                    "type": "button", "label": "‹", "on_click": f"{self.node_id}:prev",
+                    "style": "secondary", "disabled": at_start,
+                },
+                {"type": "text", "text": f"{self.page + 1} / {max(self.total, 1)}"},
+                {
+                    "type": "button", "label": "›", "on_click": f"{self.node_id}:next",
+                    "style": "secondary", "disabled": at_end,
+                },
+            ],
+            "gap": SPACE_SM,
+        }
 
 
 @dataclass
@@ -547,8 +682,17 @@ class Accordion(Component):
     open: bool = False
 
     def to_node(self) -> dict:
-        return {"type": "accordion", "node_id": self.node_id, "title": self.title,
-                "open": self.open, "child": self.child.to_node()}
+        header = {
+            "type": "button",
+            "label": f"{'▾' if self.open else '▸'} {self.title}",
+            "on_click": self.node_id,
+            "style": "secondary",
+            "disabled": False,
+        }
+        children: list = [header]
+        if self.open:
+            children.append(self.child.to_node())
+        return {"type": "column", "children": children, "gap": SPACE_XS}
 
 
 @dataclass
@@ -559,8 +703,7 @@ class Checkbox(Component):
     disabled: bool = False
 
     def to_node(self) -> dict:
-        return {"type": "checkbox", "node_id": self.node_id, "label": self.label,
-                "checked": self.checked, "disabled": self.disabled}
+        return _toggle_row(self.node_id, self.label, self.checked, "☑", "☐", self.disabled)
 
 
 @dataclass
@@ -571,8 +714,7 @@ class Radio(Component):
     disabled: bool = False
 
     def to_node(self) -> dict:
-        return {"type": "radio", "node_id": self.node_id, "options": self.options,
-                "selected": self.selected, "disabled": self.disabled}
+        return _option_row(self.node_id, self.options, self.selected, self.disabled)
 
 
 @dataclass
@@ -583,8 +725,7 @@ class Switch(Component):
     disabled: bool = False
 
     def to_node(self) -> dict:
-        return {"type": "switch", "node_id": self.node_id, "label": self.label,
-                "on": self.on, "disabled": self.disabled}
+        return _toggle_row(self.node_id, self.label, self.on, "on", "off", self.disabled)
 
 
 @dataclass
@@ -596,8 +737,24 @@ class Slider(Component):
     disabled: bool = False
 
     def to_node(self) -> dict:
-        return {"type": "slider", "node_id": self.node_id, "value": self.value,
-                "min": self.min, "max": self.max, "disabled": self.disabled}
+        span = self.max - self.min
+        fraction = max(0.0, min(1.0, (self.value - self.min) / span)) if span > 0 else 0.0
+        return {
+            "type": "row",
+            "children": [
+                {
+                    "type": "button", "label": "-", "on_click": f"{self.node_id}:dec",
+                    "style": "secondary", "disabled": self.disabled,
+                },
+                {"type": "progress-bar", "value": fraction, "max": 1.0,
+                 "label": f"{self.value:.2f}"},
+                {
+                    "type": "button", "label": "+", "on_click": f"{self.node_id}:inc",
+                    "style": "secondary", "disabled": self.disabled,
+                },
+            ],
+            "gap": SPACE_SM,
+        }
 
 
 @dataclass
@@ -608,8 +765,14 @@ class Select(Component):
     placeholder: str = ""
 
     def to_node(self) -> dict:
-        return {"type": "select", "node_id": self.node_id, "options": self.options,
-                "selected": self.selected, "placeholder": self.placeholder}
+        row = _option_row(self.node_id, self.options, self.selected, False)
+        if not self.placeholder:
+            return row
+        return {
+            "type": "column",
+            "children": [{"type": "text", "text": self.placeholder, "size": TEXT_HINT}, row],
+            "gap": SPACE_XS,
+        }
 
 
 @dataclass
@@ -619,8 +782,14 @@ class DateTimePicker(Component):
     mode: str = "datetime"
 
     def to_node(self) -> dict:
-        return {"type": "date_time_picker", "node_id": self.node_id,
-                "value": self.value, "mode": self.mode}
+        return {
+            "type": "TextInput",
+            "value": self.value,
+            "placeholder": self.mode,
+            "on_change": self.node_id,
+            "on_submit": self.node_id,
+            "password": False,
+        }
 
 
 @dataclass
@@ -630,8 +799,9 @@ class Progress(Component):
     indeterminate: bool = False
 
     def to_node(self) -> dict:
-        return {"type": "progress", "value": self.value, "label": self.label,
-                "indeterminate": self.indeterminate}
+        if self.indeterminate:
+            return {"type": "spinner", "label": self.label}
+        return {"type": "progress-bar", "value": self.value, "max": 1.0, "label": self.label}
 
 
 @dataclass
@@ -649,7 +819,19 @@ class Banner(Component):
     title: str = ""
 
     def to_node(self) -> dict:
-        return {"type": "banner", "text": self.text, "tone": self.tone, "title": self.title}
+        badge_color = self.tone if self.tone in ("accent", "success", "warning", "danger") else "neutral"
+        children = []
+        if self.title:
+            children.append({"type": "text", "text": self.title, "bold": True})
+        children.append({"type": "text", "text": self.text})
+        return {
+            "type": "row",
+            "children": [
+                {"type": "badge", "text": self.tone or "info", "color": badge_color},
+                {"type": "column", "children": children, "gap": 0.0},
+            ],
+            "gap": SPACE_SM,
+        }
 
 
 @dataclass
@@ -659,8 +841,7 @@ class TabBar(Component):
     active: int = 0
 
     def to_node(self) -> dict:
-        return {"type": "tabs", "node_id": self.node_id, "tabs": self.tabs,
-                "active": self.active}
+        return _option_row(self.node_id, self.tabs, self.active, False)
 
 
 @dataclass
@@ -670,8 +851,13 @@ class EmptyState(Component):
     icon: str = ""
 
     def to_node(self) -> dict:
-        return {"type": "empty_state", "title": self.title,
-                "description": self.description, "icon": self.icon}
+        children = []
+        if self.icon:
+            children.append({"type": "text", "text": self.icon, "size": TEXT_TITLE})
+        children.append({"type": "text", "text": self.title, "bold": True})
+        if self.description:
+            children.append({"type": "text", "text": self.description})
+        return {"type": "column", "children": children, "gap": SPACE_XS, "align": "center"}
 
 
 @dataclass
@@ -680,7 +866,13 @@ class Skeleton(Component):
     height: float = 0.0
 
     def to_node(self) -> dict:
-        return {"type": "skeleton", "rows": self.rows, "height": self.height}
+        return {
+            "type": "column",
+            "children": [
+                {"type": "badge", "text": "", "color": "neutral"} for _ in range(max(0, self.rows))
+            ],
+            "gap": SPACE_XS,
+        }
 
 
 @dataclass
@@ -690,8 +882,17 @@ class Modal(Component):
     child: Component
 
     def to_node(self) -> dict:
-        return {"type": "modal", "node_id": self.node_id, "title": self.title,
-                "child": self.child.to_node()}
+        # No native overlay node — renders inline, framed by its title and a
+        # divider, in the position the app places it in the tree.
+        return {
+            "type": "column",
+            "children": [
+                {"type": "text", "text": self.title, "bold": True},
+                {"type": "divider"},
+                self.child.to_node(),
+            ],
+            "gap": SPACE_SM,
+        }
 
 
 @dataclass
@@ -895,7 +1096,14 @@ class Section(Component):
         ctx.rect(x, line_y, w, 1.0, theme.highlight)
 
     def to_node(self) -> dict:
-        return {"type": "section", "title": self.title}
+        return {
+            "type": "column",
+            "children": [
+                {"type": "text", "text": self.title.upper(), "bold": True, "size": TEXT_HINT},
+                {"type": "divider"},
+            ],
+            "gap": SPACE_XS,
+        }
 
 
 @dataclass
@@ -1553,7 +1761,9 @@ class Card(Component):
             if node is None:
                 return None
             children.append(node)
-        return {"type": "card", "children": children, "padding": self.padding}
+        # No native bordered/padded container node — renders as a plain
+        # Column; background/border/padding styling is dropped.
+        return {"type": "column", "children": children, "gap": self.gap}
 
 
 @dataclass
@@ -1649,13 +1859,16 @@ class TextEdit(Component):
         return self._submitted
 
     def to_node(self) -> dict:
+        # No native multiline text-editor node — composes onto the single-line
+        # TextInput primitive. `multiline`/`max_length` have no host-side
+        # equivalent yet and are dropped.
         return {
-            "type": "text_edit",
-            "node_id": self.node_id,
-            "placeholder": self.placeholder,
+            "type": "TextInput",
             "value": self.value,
-            "multiline": self.multiline,
-            "max_length": self.max_length,
+            "placeholder": self.placeholder,
+            "on_change": self.node_id,
+            "on_submit": self.node_id,
+            "password": False,
         }
 
 

--- a/sdk/python/tests/test_new_components.py
+++ b/sdk/python/tests/test_new_components.py
@@ -2,7 +2,41 @@
 
 import pytest
 
-from plexi_sdk.ui import ActionBar, Button, Tabs, Grid, Toggle, Clickable, ProgressBar, TextEdit, Column
+from plexi_sdk.ui import (
+    Accordion,
+    ActionBar,
+    Avatar,
+    Banner,
+    Breadcrumb,
+    Button,
+    Card,
+    Checkbox,
+    Clickable,
+    CodeBlock,
+    Column,
+    DateTimePicker,
+    EmptyState,
+    Grid,
+    Icon,
+    KeyValue,
+    Modal,
+    Pagination,
+    Progress,
+    ProgressBar,
+    Radio,
+    Section,
+    Select,
+    Skeleton,
+    Slider,
+    Switch,
+    TabBar,
+    Table,
+    Tabs,
+    Text,
+    TextEdit,
+    Toggle,
+    Tooltip,
+)
 
 
 # ── helpers ────────────────────────────────────────────────────────────────
@@ -189,14 +223,17 @@ def test_textedit_is_component() -> None:
 
 
 def test_textedit_to_node_fields() -> None:
+    # TextEdit has no dedicated CPython-WASM decode arm (stint 0407); it
+    # composes onto the native TextInput node. multiline/max_length have no
+    # host-side equivalent yet and are dropped.
     te = TextEdit("notes", placeholder="Write here", value="hello", multiline=True, max_length=500)
     assert te.to_node() == {
-        "type": "text_edit",
-        "node_id": "notes",
-        "placeholder": "Write here",
+        "type": "TextInput",
         "value": "hello",
-        "multiline": True,
-        "max_length": 500,
+        "placeholder": "Write here",
+        "on_change": "notes",
+        "on_submit": "notes",
+        "password": False,
     }
 
 
@@ -206,8 +243,8 @@ def test_textedit_nested_in_column_is_native() -> None:
     node = col.to_node()
     assert node is not None
     child_node = node["children"][0]
-    assert child_node["type"] == "text_edit"
-    assert child_node["node_id"] == "body"
+    assert child_node["type"] == "TextInput"
+    assert child_node["on_change"] == "body"
 
 
 def test_textedit_measure() -> None:
@@ -218,7 +255,11 @@ def test_textedit_measure() -> None:
 # ── ActionBar ─────────────────────────────────────────────────────────────
 
 
-def test_action_bar_to_node_is_semantic_action_bar() -> None:
+def test_action_bar_to_node_composes_row_of_buttons() -> None:
+    # ActionBar has no dedicated CPython-WASM decode arm; "action_bar" was
+    # never handled by decode_node_data, so it crashed the whole tree the
+    # first time a live app rendered it (discovered during stint 0407's
+    # component-gallery sweep). Composes onto a Row of Buttons instead.
     bar = ActionBar(
         [
             Button("Save", "save", style="primary"),
@@ -228,19 +269,19 @@ def test_action_bar_to_node_is_semantic_action_bar() -> None:
 
     node = bar.to_node()
 
-    assert node["type"] == "action_bar"
-    assert node["actions"] == [
+    assert node["type"] == "row"
+    assert node["children"] == [
         {
             "type": "button",
-            "node_id": "save",
             "label": "Save",
+            "on_click": "save",
             "style": "primary",
             "disabled": False,
         },
         {
             "type": "button",
-            "node_id": "cancel",
             "label": "Cancel",
+            "on_click": "cancel",
             "style": "ghost",
             "disabled": False,
         },
@@ -262,7 +303,8 @@ def test_action_bar_rejects_non_button_actions() -> None:
 # derived from the SDK's own output, since that would make the guard
 # tautological.
 _DECODER_SUPPORTED_ROOT_TYPES = {
-    "row", "column", "button", "text", "progress-bar",
+    "row", "column", "button", "text", "progress-bar", "badge",
+    "divider", "spinner", "TextInput",
 }
 
 
@@ -283,6 +325,67 @@ _DECODER_SUPPORTED_ROOT_TYPES = {
     ],
 )
 def test_v3_5_uinode_widgets_emit_decoder_supported_root_type(widget_factory) -> None:
+    node = widget_factory().to_node()
+    assert node["type"] in _DECODER_SUPPORTED_ROOT_TYPES, (
+        f"{node['type']!r} has no CPython-WASM decode arm in "
+        "src/host/wasm_python.rs decode_node_data — this widget will crash "
+        "any live Python-WASM app that renders it"
+    )
+
+
+# ── stint 0407: remaining component-gallery widgets ─────────────────────────
+#
+# These widgets had no CPython-WASM decode arm at all (Checkbox, Switch,
+# Radio, Slider, Select, DateTimePicker, TextEdit, Breadcrumb, TabBar,
+# Pagination, Banner, Progress, Skeleton, KeyValue, Table, CodeBlock, Card,
+# Avatar, Icon, Tooltip, Accordion, EmptyState, Modal, Section) plus ActionBar
+# (discovered live-blocking the whole gallery tree). Each now composes onto
+# an already-decoder-supported root type.
+@pytest.mark.parametrize(
+    "widget_factory",
+    [
+        lambda: Checkbox("c", label="I agree", checked=True),
+        lambda: Checkbox("c"),
+        lambda: Switch("s", label="Notifications", on=False),
+        lambda: Switch("s"),
+        lambda: Radio("r", options=["Low", "Medium", "High"], selected=1),
+        lambda: Slider("sl", value=0.4),
+        lambda: Select("se", options=["Red", "Green", "Blue"], selected=0, placeholder="Pick"),
+        lambda: Select("se", options=["Red", "Green", "Blue"]),
+        lambda: DateTimePicker("d", value="2026-01-01", mode="date"),
+        lambda: TextEdit("te", value="hi"),
+        lambda: Breadcrumb(items=["Home", "Apps", "Gallery"]),
+        lambda: TabBar("tb", tabs=["Overview", "Details"], active=0),
+        lambda: Pagination("p", page=0, total=5),
+        lambda: Banner("Saved.", tone="success", title="Success"),
+        lambda: Progress(value=0.5, label="Upload"),
+        lambda: Progress(indeterminate=True, label="Syncing"),
+        lambda: Skeleton(rows=3),
+        lambda: KeyValue(rows=[("Region", "us-east-1")]),
+        lambda: Table(columns=["Name"], rows=[["Ada"]]),
+        lambda: CodeBlock(code="x = 1", language="python"),
+        lambda: Card(children=[Text("hi")]),
+        lambda: Avatar(label="Ian Burke"),
+        lambda: Icon(name="gear"),
+        lambda: Tooltip(text="hint", child=Text("hover me")),
+        lambda: Accordion("a", title="Advanced", child=Text("hidden"), open=True),
+        lambda: Accordion("a", title="Advanced", child=Text("hidden"), open=False),
+        lambda: EmptyState(title="No results", description="Try again", icon="∅"),
+        lambda: Modal("m", title="Confirm", child=Text("Are you sure?")),
+        lambda: Section("Buttons"),
+        lambda: ActionBar([Button("Save", "save")]),
+    ],
+    ids=[
+        "checkbox-labeled", "checkbox-bare", "switch-labeled", "switch-bare",
+        "radio", "slider", "select-with-placeholder", "select-bare",
+        "date-time-picker", "text-edit", "breadcrumb", "tab-bar", "pagination",
+        "banner", "progress", "progress-indeterminate", "skeleton", "key-value",
+        "table", "code-block", "card", "avatar", "icon", "tooltip",
+        "accordion-open", "accordion-closed", "empty-state", "modal", "section",
+        "action-bar",
+    ],
+)
+def test_stint_0407_widgets_emit_decoder_supported_root_type(widget_factory) -> None:
     node = widget_factory().to_node()
     assert node["type"] in _DECODER_SUPPORTED_ROOT_TYPES, (
         f"{node['type']!r} has no CPython-WASM decode arm in "

--- a/tests/scenes/component-gallery.toml
+++ b/tests/scenes/component-gallery.toml
@@ -1,0 +1,32 @@
+# Component Gallery through the production CPython-in-WASM launch path
+# (stint 0407). Regression guard for decode_node_data drift: every widget in
+# apps/dev/component-gallery/main.py must render without the app crashing on
+# "unsupported CPython-WASM UINode type". A single unsupported node fails the
+# whole tree decode, so this scene fails loudly the moment any widget's
+# to_node() emits a type the decoder doesn't understand.
+size = [1000.0, 900.0]
+suite = true
+
+[[steps]]
+open = { kind = "process", path = "apps/dev/component-gallery", as = "gallery" }
+
+[[steps]]
+wait_app_frame = { target = "gallery", timeout_s = 15.0 }
+
+[[steps]]
+run_steps = 5
+
+[[steps]]
+assert = { target = "gallery", pane_count = 1, lifecycle = "running", tree_contains = "Component Gallery" }
+
+[[steps]]
+assert = { target = "gallery", tree_contains = "I agree" }
+
+[[steps]]
+assert = { target = "gallery", tree_contains = "Notifications" }
+
+[[steps]]
+assert = { target = "gallery", tree_contains = "Environment" }
+
+[[steps]]
+shot = "component-gallery.png"


### PR DESCRIPTION
Stint task 0407 (no linked GitHub issue — `.stint/` is authoritative).

## Summary

- Stint 0402 (PR #2408) fixed four `ui.py` widgets (Tabs/Grid/Toggle/ProgressBar) that emitted the dead `{"type": "stack"}` node, but deliberately left the rest of `apps/dev/component-gallery`'s widget set out of scope. This PR is that remainder.
- `Checkbox, Switch, Radio, Slider, Select, DateTimePicker, TextEdit, Breadcrumb, TabBar, Pagination, Banner, Progress, Skeleton, KeyValue, Table, CodeBlock, Card, Avatar, Icon, Tooltip, Accordion, EmptyState, Modal, Section` had no CPython-WASM decode arm in `decode_node_data` — each crashed the *entire* render tree with `"unsupported CPython-WASM UINode type"` the moment a live app used them (one bad node fails the whole tree decode, not just that widget).
- Live-verifying the gallery through the real launch path also turned up `ActionBar` as unhandled — it isn't in 0402's original candidate list, but since it's used directly in `main.py`'s top-level layout, its being broken blocked the entire gallery from rendering at all. Fixed it too.
- Every widget now composes onto already-decoder-supported primitives (`row`/`column`/`button`/`text`/`badge`/`divider`/`spinner`/`progress-bar`/`TextInput`) — same pattern 0402 established, no Rust host changes. Interactive widgets that previously implied a value-carrying node (Checkbox/Switch/Radio/Slider/Select/TabBar/Pagination) now fire click-based `UiAction` events instead of `UiValueChange`, matching the `Toggle`/`Accordion` composition pattern already in the codebase; `component-gallery`'s `update()` is rewired to match.

## Test evidence

- `cargo test --bin plexi`: **1425 passed, 0 failed, 2 ignored** (full bin suite, includes `scenes::tests::scene_suite`).
- New scene `tests/scenes/component-gallery.toml` opens the gallery through the real CPython-WASM launch path (`open = { kind = "process", ... }`) and asserts it renders (`lifecycle = "running"`, `tree_contains` on several widget labels) — this is the regression guard against future decode-arm drift; a single unsupported node type fails the whole tree.
- `sdk/python`: `uv run pytest` — **178 passed, 2 skipped**. `test_new_components.py`'s decoder-drift-guard parametrize extended from 7 to 36 cases covering all 29 touched widgets.
- `just check-sdk-docs` / `just check-authoring-docs`: both up to date, no regen needed.
- `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py`: clean.
- Conclusion: **install skippable — full coverage.** The scene test exercises the exact live-render path (real CPython-WASM launch, real decode_node_data) that was broken; PlexiUiHarness headless rendering is equivalent to an installed binary for this class of change (no OS-level PTY/window-manager surface touched).

## Non-scope

- The `plexi app check` decode-arm lint 0402 floated is still not implemented — tracked separately if still wanted.
- Card/Modal/Tooltip/Skeleton/etc. render with reduced visual fidelity (no border, no true overlay, no hover) since there's no native node for these yet — decode/render without crashing was the bar for this stint, not pixel-parity with the original design intent.