### PR TITLE
assistant: interactive model picker + permissions manager (stints 0372, 0373)

### DIFF
--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -2865,6 +2865,26 @@ impl App for AssistantApp {
     }
 
     fn handle_key(&mut self, input: &crate::app::input_router::PlexiInput) -> KeyDisposition {
+        // The model/agent picker and permissions manager own Escape while
+        // open: this runs before `poll_actions`, which binds plain Escape to
+        // `CloseApp` when the assistant's app surface is focused
+        // (`src/host/keys.rs` `AppActive` context). Without claiming it here
+        // first, Escape falls through and destroys the pane instead of just
+        // closing the overlay — the same precedent `dispatch_app_key_events`
+        // already documents for file-browser search-mode Escape. Returning
+        // `Passthrough` for every other key (including ArrowUp) leaves them
+        // in the frame's input buffer for `render.rs`'s `handle_overlay_keys`
+        // to consume during the render pass — `Consumed` here would make
+        // `dispatch_app_key_events` strip ArrowUp out of the buffer too
+        // (it claims Escape *and* ArrowUp together on any `Consumed`
+        // disposition), starving the overlay's own up-navigation.
+        if self.model.overlay_active() {
+            if input.key_pressed(egui::Key::Escape) {
+                self.model.cancel_overlay();
+                return KeyDisposition::Consumed;
+            }
+            return KeyDisposition::Passthrough;
+        }
         if input.key_pressed(egui::Key::Escape) && self.model.streaming.in_flight {
             self.interrupt_in_flight_turn();
             return KeyDisposition::Consumed;

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -47,7 +47,10 @@ use crate::plexi_ai::tool_dispatch::{
 };
 
 use audit::{AuditEvent, AuditLog};
-use model::{AssistantEffect, AssistantModel, PermissionChoice, TurnRole};
+use model::{
+    AgentChoice, AssistantEffect, AssistantModel, AssistantOverlay, GrantRow, PermissionChoice,
+    TurnRole,
+};
 use render::{AssistantRenderer, ComposerEvent, MarkdownTextCache};
 use settings::{AssistantSettings, SessionOverrides, SettingsLoadError, SettingsLoader};
 use skills::{SkillDefinition, SkillRegistry};
@@ -556,11 +559,11 @@ impl AssistantApp {
                 AssistantEffect::ShowContext => self.cmd_show_context(),
                 AssistantEffect::ShowHooks => self.cmd_show_hooks(),
                 AssistantEffect::InvokeSkill { name, args } => self.cmd_invoke_skill(&name, &args),
-                AssistantEffect::ListPermissions => self.cmd_list_permissions(),
+                AssistantEffect::OpenPermissionsManager => self.open_permissions_manager(),
                 AssistantEffect::RevokeGrant { target_id } => self.cmd_revoke(&target_id),
                 AssistantEffect::ShowAudit => self.cmd_show_audit(),
                 AssistantEffect::ShowSettings => self.cmd_show_settings(),
-                AssistantEffect::ShowModelSetting => self.cmd_show_model_setting(),
+                AssistantEffect::OpenModelPicker => self.open_model_picker(),
                 AssistantEffect::SetSessionModel(tier) => self.set_session_model(tier),
                 AssistantEffect::ListAgents => self.cmd_list_agents(),
                 AssistantEffect::SwitchAgent(id) => self.cmd_switch_agent(&id),
@@ -1620,6 +1623,28 @@ impl AssistantApp {
         duration: GrantDuration,
         source: GrantSource,
     ) {
+        self.record_grant_with_decision(
+            actor_id,
+            actor_scope,
+            target_type,
+            target,
+            duration,
+            source,
+            Decision::Allow,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn record_grant_with_decision(
+        &mut self,
+        actor_id: &str,
+        actor_scope: ActorScope,
+        target_type: TargetType,
+        target: &str,
+        duration: GrantDuration,
+        source: GrantSource,
+        decision: Decision,
+    ) {
         // Canonicalize to match `PermissionRequest`'s workspace normalization
         // (macOS tempdirs resolve `/var` → `/private/var`).
         let workspace_root = self
@@ -1635,7 +1660,7 @@ impl AssistantApp {
             target_id: target.to_string(),
             resource_scope: ResourceScope::Workspace,
             resource_id: None,
-            decision: Decision::Allow,
+            decision,
             duration,
             source,
             created_at: std::time::SystemTime::now()
@@ -2276,32 +2301,37 @@ impl AssistantApp {
         self.execute_effects(effects);
     }
 
-    fn cmd_show_model_setting(&mut self) {
-        self.reload_settings();
+    /// The model tier that would drive the next turn: a session/user override
+    /// wins, otherwise the active agent's default. `reload_settings` must have
+    /// run so `self.settings` is current.
+    fn resolved_model_tier(&self) -> ModelTier {
         let configured = &self.settings.model.tier;
-        let (tier, source) = if self.session_overrides.model_tier.is_some()
+        if self.session_overrides.model_tier.is_some()
             || configured.source.scope != settings::SettingsScope::Default
         {
-            (configured.value, configured.source.description())
+            configured.value
         } else if let Some(agent) = self.active_agent() {
-            (
-                agent.default_tier,
-                format!("agent `{}` [{}]", agent.id, agent.source.label()),
-            )
+            agent.default_tier
         } else {
-            (configured.value, configured.source.description())
-        };
-        log::info!(
-            "assistant: /model showing {} from {}",
-            settings::model_tier_name(tier),
-            source
-        );
-        let effects = self.model.push_info(format!(
-            "Model tier: `{}` ({}).",
-            settings::model_tier_name(tier),
-            source
-        ));
-        self.execute_effects(effects);
+            configured.value
+        }
+    }
+
+    /// `/model` (no args): open the interactive model/agent picker.
+    fn open_model_picker(&mut self) {
+        self.reload_settings();
+        self.reload_agents();
+        let current_tier = self.resolved_model_tier();
+        let tiers = vec![ModelTier::Low, ModelTier::Medium, ModelTier::High];
+        let agents = self
+            .agent_registry
+            .agents()
+            .map(|agent| AgentChoice {
+                id: agent.id.clone(),
+                display_name: agent.display_name.clone(),
+            })
+            .collect();
+        self.model.open_model_picker(current_tier, tiers, agents);
     }
 
     fn cmd_show_settings(&mut self) {
@@ -2598,11 +2628,11 @@ impl AssistantApp {
         self.execute_effects(effects);
     }
 
-    /// `/permissions`: persisted grants for the assistant actor.
-    fn cmd_list_permissions(&mut self) {
+    /// Persisted grants attributable to the assistant actor (connector tools,
+    /// host tools, and shared event streams), as editable overlay rows.
+    fn assistant_grant_rows(&self) -> Vec<GrantRow> {
         let connector_actor_id = self.connector_actor().0;
-        let lines: Vec<String> = self
-            .grant_store
+        self.grant_store
             .records()
             .iter()
             .filter(|r| {
@@ -2614,30 +2644,135 @@ impl AssistantApp {
                         || (r.target_type == TargetType::AppEventStream
                             && r.actor_id == ASSISTANT_ACTOR_ID))
             })
-            .map(|r| {
-                format!(
-                    "{} = {} ({:?}, {:?})",
-                    r.target_id,
-                    r.decision.as_str(),
-                    r.duration,
-                    r.source
-                )
+            .map(|r| GrantRow {
+                target_id: r.target_id.clone(),
+                decision: r.decision,
             })
+            .collect()
+    }
+
+    /// `/permissions` and `/revoke` (no args): open the permissions manager.
+    fn open_permissions_manager(&mut self) {
+        let grants = self.assistant_grant_rows();
+        self.model.open_permissions_manager(grants);
+    }
+
+    /// Apply the permissions manager's edited rows (Enter). Only rows whose
+    /// decision changed touch the grant store: Ask reverts a target to the
+    /// posture default (delete), Allow/Deny re-record the existing grant's
+    /// metadata with the new decision. Every write is audited.
+    fn apply_permission_grants(&mut self, rows: Vec<GrantRow>) {
+        let current: std::collections::HashMap<String, Decision> = self
+            .assistant_grant_rows()
+            .into_iter()
+            .map(|r| (r.target_id, r.decision))
             .collect();
-        log::info!(
-            "assistant: /permissions — {} grant(s) for assistant",
-            lines.len()
-        );
-        let text = if lines.is_empty() {
-            "No persisted grants for the assistant. Tool calls will ask.".to_string()
+        let mut changed = 0usize;
+        for row in rows {
+            if current.get(&row.target_id) == Some(&row.decision) {
+                continue;
+            }
+            let actor_id = if row.target_id.starts_with("app.") || row.target_id.starts_with("host.")
+            {
+                self.connector_actor().0
+            } else {
+                ASSISTANT_ACTOR_ID.to_string()
+            };
+            match row.decision {
+                Decision::Ask => {
+                    let removed =
+                        self.grant_store
+                            .revoke(ActorType::Agent, &actor_id, &row.target_id);
+                    let unsubscribed = self.unsubscribe_stream(&row.target_id);
+                    if removed > 0 {
+                        self.grant_store.save();
+                    }
+                    self.audit.append(&AuditEvent::now(
+                        "revoke",
+                        &row.target_id,
+                        "revoked",
+                        &format!(
+                            "{removed} grant(s), {unsubscribed} subscription(s) removed via permissions manager"
+                        ),
+                    ));
+                }
+                Decision::Allow | Decision::Deny => {
+                    // Rows are built only from existing persisted grants, so
+                    // each has a record whose metadata we mirror with the new
+                    // decision.
+                    let meta = self
+                        .grant_store
+                        .records()
+                        .iter()
+                        .find(|r| {
+                            r.actor_type == ActorType::Agent
+                                && r.actor_id == actor_id
+                                && r.target_id == row.target_id
+                        })
+                        .map(|r| (r.target_type, r.actor_scope, r.duration, r.source));
+                    let Some((target_type, actor_scope, duration, source)) = meta else {
+                        log::warn!(
+                            "assistant: permissions manager skipped '{}' — no existing grant to re-record",
+                            row.target_id
+                        );
+                        continue;
+                    };
+                    self.record_grant_with_decision(
+                        &actor_id,
+                        actor_scope,
+                        target_type,
+                        &row.target_id,
+                        duration,
+                        source,
+                        row.decision,
+                    );
+                    self.grant_store.save();
+                    self.audit.append(&AuditEvent::now(
+                        "permission_set",
+                        &row.target_id,
+                        row.decision.as_str(),
+                        "via permissions manager",
+                    ));
+                }
+            }
+            changed += 1;
+            log::info!(
+                "assistant: permission '{}' set to {} via picker",
+                row.target_id,
+                row.decision.as_str()
+            );
+        }
+        let text = if changed == 0 {
+            "No permission changes.".to_string()
         } else {
-            format!(
-                "Assistant grants:\n{}\nUse /revoke <target_id> to remove one.",
-                lines.join("\n")
-            )
+            format!("Updated {changed} permission(s).")
         };
         let effects = self.model.push_info(text);
         self.execute_effects(effects);
+    }
+
+    /// Confirm the open overlay (Enter): dispatch the selection through the
+    /// same handlers the text commands use, then close.
+    fn confirm_overlay(&mut self) {
+        match std::mem::take(&mut self.model.overlay) {
+            AssistantOverlay::ModelPicker {
+                selected,
+                tiers,
+                agents,
+                ..
+            } => {
+                if selected < tiers.len() {
+                    self.set_session_model(tiers[selected]);
+                } else if let Some(choice) = agents.get(selected - tiers.len()) {
+                    let id = choice.id.clone();
+                    self.cmd_switch_agent(&id);
+                }
+            }
+            AssistantOverlay::PermissionsManager { grants, .. } => {
+                self.apply_permission_grants(grants);
+            }
+            AssistantOverlay::None => {}
+        }
     }
 
     /// `/revoke <target_id>`: remove persisted grants for one target. Event
@@ -2775,6 +2910,7 @@ impl App for AssistantApp {
                 self.execute_effects(effects);
             }
             Some(ComposerEvent::Permission(choice)) => self.resolve_permission(choice),
+            Some(ComposerEvent::OverlayConfirm) => self.confirm_overlay(),
             None => {}
         }
         if compact_visible_this_frame && self.run_pending_compaction() {
@@ -3786,12 +3922,21 @@ enabled = ["allowed.tool"]
         let tools_row = &app.model.turns.last().unwrap().text;
         assert!(tools_row.contains("app.view.tool — allow"), "{tools_row}");
 
+        // `/permissions` now opens the interactive manager, populated from the
+        // grant store, instead of dumping text.
         app.model.composer = "/permissions".to_string();
         let effects = app.model.submit();
         app.execute_effects(effects);
-        let perms_row = &app.model.turns.last().unwrap().text;
-        assert!(perms_row.contains("app.view.tool = allow"), "{perms_row}");
+        let AssistantOverlay::PermissionsManager { grants, .. } = &app.model.overlay else {
+            panic!("expected the permissions manager overlay to be open");
+        };
+        assert!(
+            grants.iter().any(|g| g.target_id == "app.view.tool"),
+            "seeded grant is listed: {grants:?}"
+        );
+        app.model.cancel_overlay();
 
+        // `/revoke <target_id>` keeps its fast-path text behavior.
         app.model.composer = "/revoke app.view.tool".to_string();
         let effects = app.model.submit();
         app.execute_effects(effects);
@@ -3814,6 +3959,92 @@ enabled = ["allowed.tool"]
         );
 
         tool_dispatch::unregister(9104);
+    }
+
+    #[test]
+    fn permissions_manager_set_to_block_persists_and_audits() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = test_app(ws.path());
+        seed_grant(&mut app, "app.view.tool", Decision::Allow);
+
+        app.model.composer = "/permissions".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+
+        // Cycle the row Allow -> Ask -> Deny, then apply.
+        app.model.overlay_cycle_decision();
+        app.model.overlay_cycle_decision();
+        app.confirm_overlay();
+
+        assert!(!app.model.overlay_active());
+        let record = app
+            .grant_store
+            .records()
+            .iter()
+            .find(|r| r.target_id == "app.view.tool")
+            .expect("grant still persisted after set-to-block");
+        assert_eq!(record.decision, Decision::Deny);
+
+        let audited = app
+            .audit
+            .tail(5)
+            .into_iter()
+            .any(|e| e.kind == "permission_set" && e.target == "app.view.tool" && e.decision == "deny");
+        assert!(audited, "block change must be audited");
+    }
+
+    #[test]
+    fn permissions_manager_set_to_ask_revokes_and_audits() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = test_app(ws.path());
+        seed_grant(&mut app, "app.view.tool", Decision::Allow);
+
+        // `/revoke` (no args) opens the same manager as `/permissions`.
+        app.model.composer = "/revoke".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        assert!(matches!(
+            app.model.overlay,
+            AssistantOverlay::PermissionsManager { .. }
+        ));
+
+        // Allow -> Ask reverts to the posture default: the record is deleted.
+        app.model.overlay_cycle_decision();
+        app.confirm_overlay();
+
+        assert!(
+            app.grant_store.records().is_empty(),
+            "set-to-ask removes the persisted grant"
+        );
+        let audited = app
+            .audit
+            .tail(5)
+            .into_iter()
+            .any(|e| e.kind == "revoke" && e.target == "app.view.tool");
+        assert!(audited, "revert-to-ask must be audited");
+    }
+
+    #[test]
+    fn permissions_manager_cancel_leaves_grants_untouched() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = test_app(ws.path());
+        seed_grant(&mut app, "app.view.tool", Decision::Allow);
+
+        app.model.composer = "/permissions".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+
+        app.model.overlay_cycle_decision(); // edit in-flight, then cancel
+        app.model.cancel_overlay();
+
+        assert!(!app.model.overlay_active());
+        let record = app
+            .grant_store
+            .records()
+            .iter()
+            .find(|r| r.target_id == "app.view.tool")
+            .expect("grant untouched after cancel");
+        assert_eq!(record.decision, Decision::Allow);
     }
 
     // ── Phase D3: event subscriptions + delivery bridge ───────────────────────
@@ -4506,7 +4737,7 @@ enabled = ["allowed.tool"]
     }
 
     #[test]
-    fn model_without_args_shows_the_resolved_tier_and_source() {
+    fn model_without_args_opens_picker_on_resolved_tier() {
         let ws = tempfile::tempdir().unwrap();
         let settings_path = ws.path().join("agents/settings.toml");
         std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
@@ -4517,8 +4748,53 @@ enabled = ["allowed.tool"]
         let effects = app.model.submit();
         app.execute_effects(effects);
 
-        let output = &app.model.turns.last().unwrap().text;
-        assert!(output.contains("`low`") && output.contains("user"));
+        // The picker opens with the cursor on the resolved tier (low, index 0)
+        // and the current agent listed. No text row is pushed.
+        assert!(app.model.turns.is_empty(), "picker opens instead of a text row");
+        let AssistantOverlay::ModelPicker {
+            selected,
+            current_tier,
+            tiers,
+            agents,
+            ..
+        } = &app.model.overlay
+        else {
+            panic!("expected the model picker overlay to be open");
+        };
+        assert_eq!(*current_tier, ModelTier::Low);
+        assert_eq!(*selected, 0);
+        assert_eq!(tiers.len(), 3);
+        assert!(
+            agents.iter().any(|a| a.id == "default"),
+            "the default agent is listed"
+        );
+    }
+
+    #[test]
+    fn model_picker_confirm_sets_the_selected_tier() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = test_app(ws.path());
+
+        app.model.composer = "/model".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+
+        // Default resolves to `medium` (index 1); one step down lands on
+        // `high` (index 2). Confirm follows the same path as `/model high`.
+        assert_eq!(app.model.overlay_selected(), 1);
+        app.model.overlay_move_down();
+        assert_eq!(app.model.overlay_selected(), 2);
+        app.confirm_overlay();
+
+        assert!(!app.model.overlay_active(), "overlay closes on confirm");
+        assert_eq!(app.session_overrides.model_tier, Some(ModelTier::High));
+        assert!(app
+            .model
+            .turns
+            .last()
+            .unwrap()
+            .text
+            .contains("Model tier set to"));
     }
 
     #[test]

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -141,8 +141,9 @@ pub enum AssistantEffect {
         name: String,
         args: String,
     },
-    /// `/permissions`: list persisted grants for the assistant actor.
-    ListPermissions,
+    /// `/permissions` and `/revoke` (no args): open the interactive
+    /// permissions manager overlay over the composer.
+    OpenPermissionsManager,
     /// `/revoke <target_id>`: remove persisted grants for one target.
     RevokeGrant {
         target_id: String,
@@ -151,8 +152,8 @@ pub enum AssistantEffect {
     ShowAudit,
     /// `/settings` and `/config`: show the resolved Assistant settings.
     ShowSettings,
-    /// `/model`: show the resolved model tier and its source.
-    ShowModelSetting,
+    /// `/model` (no args): open the interactive model/agent picker overlay.
+    OpenModelPicker,
     /// `/model low|medium|high`: override the model tier for this session.
     SetSessionModel(ModelTier),
     ListAgents,
@@ -174,6 +175,45 @@ pub enum AssistantEffect {
     /// thread waiting on a permission reply. The late outcome is dropped by
     /// the stale-conversation guard in `finish_turn`.
     CancelTurn,
+}
+
+/// One agent the model/agent picker can switch to.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentChoice {
+    pub id: String,
+    pub display_name: String,
+}
+
+/// One editable row in the permissions manager: a persisted grant target and
+/// the decision currently selected for it (cycled in-place, applied on Enter).
+#[derive(Debug, Clone, PartialEq)]
+pub struct GrantRow {
+    pub target_id: String,
+    pub decision: crate::broker::Decision,
+}
+
+/// A modal overlay the composer renders above itself. Distinct from the
+/// filter-as-you-type slash-command picker (`picker_selected`/`picker_active`),
+/// which has its own text-driven lifecycle.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum AssistantOverlay {
+    #[default]
+    None,
+    /// `/model`: pick a session model tier or switch the active agent. The
+    /// flattened selection runs over `tiers` first, then `agents`.
+    ModelPicker {
+        selected: usize,
+        current_tier: ModelTier,
+        active_agent_id: String,
+        tiers: Vec<ModelTier>,
+        agents: Vec<AgentChoice>,
+    },
+    /// `/permissions` and `/revoke`: review persisted grants and re-decide
+    /// each one (Space cycles Allow/Ask/Block), applied on Enter.
+    PermissionsManager {
+        selected: usize,
+        grants: Vec<GrantRow>,
+    },
 }
 
 fn new_conversation_id() -> String {
@@ -217,6 +257,8 @@ pub struct AssistantModel {
     /// Shell-style composer history cursor over prior user turns. `None`
     /// means normal editing; `Some(0)` is the newest user message.
     history_cursor: Option<usize>,
+    /// Modal picker/manager overlay currently open over the composer.
+    pub overlay: AssistantOverlay,
 }
 
 impl AssistantModel {
@@ -238,6 +280,7 @@ impl AssistantModel {
             effort_override: None,
             compaction: CompactionState::Idle,
             history_cursor: None,
+            overlay: AssistantOverlay::None,
         }
     }
 
@@ -295,6 +338,115 @@ impl AssistantModel {
             .strip_prefix('/')
             .unwrap_or("")
             .to_string()
+    }
+
+    /// True while a modal picker/manager overlay is open over the composer.
+    pub fn overlay_active(&self) -> bool {
+        !matches!(self.overlay, AssistantOverlay::None)
+    }
+
+    /// Open the model/agent picker. `current_tier` is the resolved session
+    /// tier; the cursor lands on its row. Callers pass the full tier list and
+    /// the current agent roster.
+    pub fn open_model_picker(
+        &mut self,
+        current_tier: ModelTier,
+        tiers: Vec<ModelTier>,
+        agents: Vec<AgentChoice>,
+    ) {
+        let selected = tiers.iter().position(|t| *t == current_tier).unwrap_or(0);
+        log::info!(
+            "assistant[{}]: model picker opened, current tier={current_tier:?}, {} tier(s), {} agent(s)",
+            self.conversation_id,
+            tiers.len(),
+            agents.len()
+        );
+        self.overlay = AssistantOverlay::ModelPicker {
+            selected,
+            current_tier,
+            active_agent_id: self.active_agent_id.clone(),
+            tiers,
+            agents,
+        };
+    }
+
+    /// Open the permissions manager over the persisted grants for the actor.
+    pub fn open_permissions_manager(&mut self, grants: Vec<GrantRow>) {
+        log::info!(
+            "assistant[{}]: permissions manager opened, {} grant(s)",
+            self.conversation_id,
+            grants.len()
+        );
+        self.overlay = AssistantOverlay::PermissionsManager {
+            selected: 0,
+            grants,
+        };
+    }
+
+    /// Total selectable rows in the open overlay.
+    pub fn overlay_len(&self) -> usize {
+        match &self.overlay {
+            AssistantOverlay::None => 0,
+            AssistantOverlay::ModelPicker { tiers, agents, .. } => tiers.len() + agents.len(),
+            AssistantOverlay::PermissionsManager { grants, .. } => grants.len(),
+        }
+    }
+
+    /// The overlay's current cursor row (0 when no overlay is open).
+    pub fn overlay_selected(&self) -> usize {
+        match &self.overlay {
+            AssistantOverlay::None => 0,
+            AssistantOverlay::ModelPicker { selected, .. }
+            | AssistantOverlay::PermissionsManager { selected, .. } => *selected,
+        }
+    }
+
+    /// Move the cursor up one row (clamped at the top).
+    pub fn overlay_move_up(&mut self) {
+        match &mut self.overlay {
+            AssistantOverlay::ModelPicker { selected, .. }
+            | AssistantOverlay::PermissionsManager { selected, .. } => {
+                *selected = selected.saturating_sub(1);
+            }
+            AssistantOverlay::None => {}
+        }
+    }
+
+    /// Move the cursor down one row (clamped at the last row).
+    pub fn overlay_move_down(&mut self) {
+        let len = self.overlay_len();
+        match &mut self.overlay {
+            AssistantOverlay::ModelPicker { selected, .. }
+            | AssistantOverlay::PermissionsManager { selected, .. } => {
+                if *selected + 1 < len {
+                    *selected += 1;
+                }
+            }
+            AssistantOverlay::None => {}
+        }
+    }
+
+    /// Space in the permissions manager: cycle the selected grant's decision
+    /// Allow → Ask → Block → Allow. No-op for other overlays.
+    pub fn overlay_cycle_decision(&mut self) {
+        use crate::broker::Decision;
+        if let AssistantOverlay::PermissionsManager { selected, grants } = &mut self.overlay {
+            if let Some(row) = grants.get_mut(*selected) {
+                row.decision = match row.decision {
+                    Decision::Allow => Decision::Ask,
+                    Decision::Ask => Decision::Deny,
+                    Decision::Deny => Decision::Allow,
+                };
+            }
+        }
+    }
+
+    /// Close the overlay without applying anything (Esc).
+    pub fn cancel_overlay(&mut self) {
+        if self.overlay_active() {
+            log::info!("assistant[{}]: overlay cancelled", self.conversation_id);
+            self.overlay = AssistantOverlay::None;
+        }
     }
 
     /// Submit the composer. Returns the effects to execute. Blank input is a
@@ -526,7 +678,7 @@ impl AssistantModel {
             "skills" => vec![AssistantEffect::ListSkills],
             "context" => vec![AssistantEffect::ShowContext],
             "hooks" => vec![AssistantEffect::ShowHooks],
-            "permissions" => vec![AssistantEffect::ListPermissions],
+            "permissions" => vec![AssistantEffect::OpenPermissionsManager],
             "audit" => vec![AssistantEffect::ShowAudit],
             "settings" | "config" => vec![AssistantEffect::ShowSettings],
             "resume" if cmd.args.is_empty() => vec![AssistantEffect::ListConversations],
@@ -547,7 +699,7 @@ impl AssistantModel {
                 vec![AssistantEffect::CompactConversation]
             }
             "export" => vec![AssistantEffect::ExportConversation],
-            "model" if cmd.args.is_empty() => vec![AssistantEffect::ShowModelSetting],
+            "model" if cmd.args.is_empty() => vec![AssistantEffect::OpenModelPicker],
             "model" => {
                 let tier = match cmd.args.as_str() {
                     "low" => Some(ModelTier::Low),
@@ -621,21 +773,10 @@ impl AssistantModel {
                     }]
                 }
             },
-            "revoke" => {
-                if cmd.args.is_empty() {
-                    self.turns.push(Turn::now(
-                        TurnRole::Error,
-                        "Usage: /revoke <target_id> — see /permissions for target ids.",
-                    ));
-                    vec![AssistantEffect::SessionWrite {
-                        conversation_id: self.conversation_id.clone(),
-                    }]
-                } else {
-                    vec![AssistantEffect::RevokeGrant {
-                        target_id: cmd.args.clone(),
-                    }]
-                }
-            }
+            "revoke" if cmd.args.is_empty() => vec![AssistantEffect::OpenPermissionsManager],
+            "revoke" => vec![AssistantEffect::RevokeGrant {
+                target_id: cmd.args.clone(),
+            }],
             name => vec![AssistantEffect::InvokeSkill {
                 name: name.to_string(),
                 args: cmd.args.clone(),
@@ -1063,7 +1204,7 @@ mod tests {
         );
         assert_eq!(
             submitted(&mut m, "/permissions"),
-            vec![AssistantEffect::ListPermissions]
+            vec![AssistantEffect::OpenPermissionsManager]
         );
         assert_eq!(
             submitted(&mut m, "/audit"),
@@ -1075,12 +1216,13 @@ mod tests {
                 target_id: "app.csv.write_range".to_string()
             }]
         );
+        // Bare /revoke opens the permissions manager (same as /permissions),
+        // not a usage error.
+        assert_eq!(
+            submitted(&mut m, "/revoke"),
+            vec![AssistantEffect::OpenPermissionsManager]
+        );
         assert!(m.turns.is_empty(), "views answer via the pane shell");
-
-        // Bare /revoke is a usage error row, not an effect.
-        let effects = submitted(&mut m, "/revoke");
-        assert!(matches!(&effects[0], AssistantEffect::SessionWrite { .. }));
-        assert_eq!(m.turns.last().unwrap().role, TurnRole::Error);
     }
 
     #[test]
@@ -1131,12 +1273,77 @@ mod tests {
     }
 
     #[test]
-    fn model_without_args_requests_the_resolved_setting() {
+    fn model_without_args_opens_the_picker() {
         let mut model = AssistantModel::fresh();
 
         let effects = submitted(&mut model, "/model");
 
-        assert_eq!(effects, vec![AssistantEffect::ShowModelSetting]);
+        assert_eq!(effects, vec![AssistantEffect::OpenModelPicker]);
+    }
+
+    #[test]
+    fn model_picker_overlay_navigates_and_cancels() {
+        let mut model = AssistantModel::fresh();
+        model.open_model_picker(
+            ModelTier::Medium,
+            vec![ModelTier::Low, ModelTier::Medium, ModelTier::High],
+            vec![AgentChoice {
+                id: "default".to_string(),
+                display_name: "Plexi Assistant".to_string(),
+            }],
+        );
+        // Cursor lands on the current tier (medium = index 1).
+        assert_eq!(model.overlay_selected(), 1);
+        assert_eq!(model.overlay_len(), 4); // 3 tiers + 1 agent
+
+        model.overlay_move_down();
+        assert_eq!(model.overlay_selected(), 2); // high
+        model.overlay_move_down();
+        assert_eq!(model.overlay_selected(), 3); // agent row
+        model.overlay_move_down();
+        assert_eq!(model.overlay_selected(), 3, "clamps at the last row");
+
+        model.overlay_move_up();
+        model.overlay_move_up();
+        model.overlay_move_up();
+        model.overlay_move_up();
+        assert_eq!(model.overlay_selected(), 0, "clamps at the first row");
+
+        model.cancel_overlay();
+        assert!(!model.overlay_active());
+    }
+
+    #[test]
+    fn permissions_overlay_cycles_decisions() {
+        use crate::broker::Decision;
+        let mut model = AssistantModel::fresh();
+        model.open_permissions_manager(vec![
+            GrantRow {
+                target_id: "app.a.read".to_string(),
+                decision: Decision::Allow,
+            },
+            GrantRow {
+                target_id: "app.b.write".to_string(),
+                decision: Decision::Ask,
+            },
+        ]);
+        assert_eq!(model.overlay_selected(), 0);
+
+        // Space cycles the selected row: Allow -> Ask -> Deny -> Allow.
+        model.overlay_cycle_decision();
+        model.overlay_cycle_decision();
+        let AssistantOverlay::PermissionsManager { grants, .. } = &model.overlay else {
+            panic!("expected permissions manager");
+        };
+        assert_eq!(grants[0].decision, Decision::Deny);
+        assert_eq!(grants[1].decision, Decision::Ask, "other rows untouched");
+
+        model.overlay_move_down();
+        model.overlay_cycle_decision();
+        let AssistantOverlay::PermissionsManager { grants, .. } = &model.overlay else {
+            panic!("expected permissions manager");
+        };
+        assert_eq!(grants[1].decision, Decision::Deny);
     }
 
     #[test]

--- a/src/assistant/render.rs
+++ b/src/assistant/render.rs
@@ -21,8 +21,13 @@ use crate::ui::list::ListRow;
 use crate::ui::style;
 use crate::ui::theme::Colors;
 
+use crate::app_protocol::ModelTier;
+use crate::broker::Decision;
+
 use super::commands;
-use super::model::{AssistantModel, CompactionState, PermissionChoice, ToolStatus, TurnRole};
+use super::model::{
+    AssistantModel, AssistantOverlay, CompactionState, PermissionChoice, ToolStatus, TurnRole,
+};
 
 /// What the composer asked the pane shell to do this frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -30,6 +35,27 @@ pub enum ComposerEvent {
     Submit,
     /// The user decided the pending permission sheet.
     Permission(PermissionChoice),
+    /// Enter pressed in an open picker/manager overlay: apply the selection.
+    OverlayConfirm,
+}
+
+/// Row label for a model tier.
+fn model_tier_label(tier: ModelTier) -> &'static str {
+    match tier {
+        ModelTier::Low => "low",
+        ModelTier::Medium => "medium",
+        ModelTier::High => "high",
+    }
+}
+
+/// Row label for a permission decision — "block" reads clearer than "deny" in
+/// the manager (matches the Space-cycle affordance).
+fn decision_label(decision: Decision) -> &'static str {
+    match decision {
+        Decision::Allow => "allow",
+        Decision::Ask => "ask",
+        Decision::Deny => "block",
+    }
 }
 
 /// Stateless renderer for the Assistant pane.
@@ -142,8 +168,13 @@ impl AssistantRenderer {
                 }
                 // Keys first: Enter/Tab/arrows must be consumed before the
                 // TextEdit processes input, or completion renders a one-frame
-                // stale buffer (the autocomplete "glitch").
-                if let Some(key_event) = Self::handle_composer_keys(ui, model, te_id) {
+                // stale buffer (the autocomplete "glitch"). While an overlay is
+                // open it owns navigation keys and the composer stays inert.
+                if model.overlay_active() {
+                    if let Some(overlay_event) = Self::handle_overlay_keys(ui, model) {
+                        event = Some(overlay_event);
+                    }
+                } else if let Some(key_event) = Self::handle_composer_keys(ui, model, te_id) {
                     event = Some(key_event);
                 }
                 composer_rect = Some(Self::draw_composer(
@@ -154,15 +185,27 @@ impl AssistantRenderer {
                     is_focused,
                     total_h * Self::COMPOSER_MAX_FRACTION,
                 ));
-                let mut hints = vec![
-                    HintGroup::new(&["\u{21b5}"], "send"),
-                    HintGroup::new(&["\u{21e7}", "\u{21b5}"], "newline"),
-                    HintGroup::new(&["/"], "commands"),
-                ];
-                if model.streaming.in_flight {
-                    hints.push(HintGroup::new(&["Esc"], "stop"));
+                if model.overlay_active() {
+                    let mut hints = vec![
+                        HintGroup::new(&["\u{2191}", "\u{2193}"], "navigate"),
+                        HintGroup::new(&["\u{21b5}"], "confirm"),
+                        HintGroup::new(&["Esc"], "cancel"),
+                    ];
+                    if matches!(model.overlay, AssistantOverlay::PermissionsManager { .. }) {
+                        hints.push(HintGroup::new(&["Space"], "cycle"));
+                    }
+                    HintBar::new(&hints).show(ui, colors);
+                } else {
+                    let mut hints = vec![
+                        HintGroup::new(&["\u{21b5}"], "send"),
+                        HintGroup::new(&["\u{21e7}", "\u{21b5}"], "newline"),
+                        HintGroup::new(&["/"], "commands"),
+                    ];
+                    if model.streaming.in_flight {
+                        hints.push(HintGroup::new(&["Esc"], "stop"));
+                    }
+                    HintBar::new(&hints).show(ui, colors);
                 }
-                HintBar::new(&hints).show(ui, colors);
             });
 
         egui::CentralPanel::default()
@@ -173,8 +216,10 @@ impl AssistantRenderer {
                 Self::draw_transcript(ui, model, md_cache, text_cache, colors);
             });
 
-        if model.picker_active() {
-            if let Some(rect) = composer_rect {
+        if let Some(rect) = composer_rect {
+            if model.overlay_active() {
+                Self::draw_overlay_popup(ui, model, pane_id, colors, rect, picker_max_h);
+            } else if model.picker_active() {
                 Self::draw_picker_popup(ui, model, te_id, pane_id, colors, rect, picker_max_h);
             }
         }
@@ -795,6 +840,175 @@ impl AssistantRenderer {
         if let Some(name) = clicked {
             Self::complete_command(ui.ctx(), model, te_id, name, "click");
         }
+    }
+
+    /// Consume overlay navigation keys before the composer TextEdit renders.
+    /// Arrows move the cursor, Enter confirms (returned to the shell), Esc
+    /// cancels, and Space cycles a decision — but only in the permissions
+    /// manager, so Space keeps inserting literal spaces everywhere else.
+    fn handle_overlay_keys(ui: &mut egui::Ui, model: &mut AssistantModel) -> Option<ComposerEvent> {
+        let is_perms = matches!(model.overlay, AssistantOverlay::PermissionsManager { .. });
+        let mut up = false;
+        let mut down = false;
+        let mut confirm = false;
+        let mut cancel = false;
+        let mut cycle = false;
+        ui.input_mut(|input| {
+            up = input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp);
+            down = input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowDown);
+            confirm = input.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
+            cancel = input.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+            if is_perms {
+                cycle = input.consume_key(egui::Modifiers::NONE, egui::Key::Space);
+            }
+        });
+        if up {
+            model.overlay_move_up();
+        }
+        if down {
+            model.overlay_move_down();
+        }
+        if cycle {
+            model.overlay_cycle_decision();
+        }
+        if cancel {
+            model.cancel_overlay();
+            return None;
+        }
+        confirm.then_some(ComposerEvent::OverlayConfirm)
+    }
+
+    /// The model/agent picker and permissions manager share the slash-command
+    /// picker's floating geometry: an `Area` anchored above the composer,
+    /// growing upward, with a scrollable `ListRow` body clamped to `max_h`.
+    fn draw_overlay_popup(
+        ui: &egui::Ui,
+        model: &AssistantModel,
+        pane_id: egui::Id,
+        colors: &Colors,
+        composer_rect: egui::Rect,
+        max_h: f32,
+    ) {
+        let row_count = model.overlay_len().max(1);
+        let selected = model.overlay_selected();
+        let row_gap = ui.spacing().item_spacing.y;
+        let content_h =
+            row_count as f32 * style::LIST_ROW_H + row_count.saturating_sub(1) as f32 * row_gap;
+        let list_h = content_h.min(max_h.max(0.0));
+        let margin = style::SPACE_XS;
+        let popup_h = list_h + 2.0 * margin + 2.0;
+        let pos = composer_rect.left_top() - egui::vec2(0.0, style::SPACE_XS + popup_h);
+
+        egui::Area::new(pane_id.with("assistant_overlay"))
+            .fixed_pos(pos)
+            .order(egui::Order::Foreground)
+            .show(ui.ctx(), |ui| {
+                ui.set_width(composer_rect.width());
+                egui::Frame::new()
+                    .fill(colors.bg_active)
+                    .stroke(egui::Stroke::new(1.0, colors.border))
+                    .corner_radius(style::RADIUS_MD)
+                    .inner_margin(egui::Margin::same(margin as i8))
+                    .show(ui, |ui| {
+                        ui.set_width(ui.available_width());
+                        egui::ScrollArea::vertical()
+                            .id_salt("assistant_overlay_scroll")
+                            .max_height(list_h)
+                            .min_scrolled_height(list_h)
+                            .auto_shrink([false, true])
+                            .show(ui, |ui| match &model.overlay {
+                                AssistantOverlay::ModelPicker {
+                                    current_tier,
+                                    active_agent_id,
+                                    tiers,
+                                    agents,
+                                    ..
+                                } => Self::draw_model_picker_rows(
+                                    ui,
+                                    colors,
+                                    selected,
+                                    *current_tier,
+                                    active_agent_id,
+                                    tiers,
+                                    agents,
+                                ),
+                                AssistantOverlay::PermissionsManager { grants, .. } => {
+                                    Self::draw_permissions_rows(ui, colors, selected, grants)
+                                }
+                                AssistantOverlay::None => {}
+                            });
+                    });
+            });
+    }
+
+    fn draw_model_picker_rows(
+        ui: &mut egui::Ui,
+        colors: &Colors,
+        selected: usize,
+        current_tier: ModelTier,
+        active_agent_id: &str,
+        tiers: &[ModelTier],
+        agents: &[super::model::AgentChoice],
+    ) {
+        Self::overlay_section_label(ui, colors, "Model tier");
+        for (i, tier) in tiers.iter().enumerate() {
+            let mut row = ListRow::new(model_tier_label(*tier)).selected(i == selected);
+            if *tier == current_tier {
+                row = row.chip("current");
+            }
+            let resp = row.show(ui, colors);
+            if i == selected {
+                resp.scroll_into_view(ui, true);
+            }
+        }
+        Self::overlay_section_label(ui, colors, "Agent");
+        for (j, agent) in agents.iter().enumerate() {
+            let idx = tiers.len() + j;
+            let mut row = ListRow::new(&agent.display_name)
+                .secondary(&agent.id)
+                .selected(idx == selected);
+            if agent.id == active_agent_id {
+                row = row.chip("active");
+            }
+            let resp = row.show(ui, colors);
+            if idx == selected {
+                resp.scroll_into_view(ui, true);
+            }
+        }
+    }
+
+    fn draw_permissions_rows(
+        ui: &mut egui::Ui,
+        colors: &Colors,
+        selected: usize,
+        grants: &[super::model::GrantRow],
+    ) {
+        if grants.is_empty() {
+            ui.label(
+                RichText::new("No grants yet — tool calls will ask.")
+                    .size(style::TEXT_HINT)
+                    .color(colors.text_dim),
+            );
+            return;
+        }
+        for (i, grant) in grants.iter().enumerate() {
+            let resp = ListRow::new(&grant.target_id)
+                .secondary(decision_label(grant.decision))
+                .selected(i == selected)
+                .show(ui, colors);
+            if i == selected {
+                resp.scroll_into_view(ui, true);
+            }
+        }
+    }
+
+    fn overlay_section_label(ui: &mut egui::Ui, colors: &Colors, label: &str) {
+        ui.add_space(style::SPACE_XS);
+        ui.label(
+            RichText::new(label)
+                .size(style::TEXT_HINT)
+                .color(colors.text_dim),
+        );
     }
 
     /// The growable composer; returns its outer rect so the picker popup can

--- a/tests/scenes/assistant-permissions.toml
+++ b/tests/scenes/assistant-permissions.toml
@@ -1,0 +1,32 @@
+# Native Assistant permissions-manager overlay. `/permissions` (no args) opens
+# the interactive manager instead of dumping text. With no persisted grants it
+# shows its empty state; Esc closes it. (Seeded-grant cycle/apply behavior is
+# covered by Rust #[test]s — the scene format can't seed the grant store.)
+size = [1280.0, 800.0]
+
+[[steps]]
+open = { kind = "builtin", id = "assistant", as = "assistant" }
+
+[[steps]]
+run_steps = 2
+
+[[steps]]
+text = { target = "assistant", value = "/permissions" }
+
+[[steps]]
+key = { target = "assistant", value = "enter" }
+
+[[steps]]
+run_steps = 3
+
+[[steps]]
+assert_label = { target = "assistant", label = "No grants yet — tool calls will ask." }
+
+[[steps]]
+shot = "assistant-permissions.png"
+
+[[steps]]
+key = { target = "assistant", value = "escape" }
+
+[[steps]]
+run_steps = 2

--- a/tests/scenes/assistant-permissions.toml
+++ b/tests/scenes/assistant-permissions.toml
@@ -30,3 +30,9 @@ key = { target = "assistant", value = "escape" }
 
 [[steps]]
 run_steps = 2
+
+# Regression: escape must close only the overlay, not the whole pane (see
+# assistant-settings.toml for the same check on the /model picker — this
+# manager shares the exact same key-handling path).
+[[steps]]
+assert = { target = "assistant", exists = true, focused = true, pane_count = 1 }

--- a/tests/scenes/assistant-settings.toml
+++ b/tests/scenes/assistant-settings.toml
@@ -23,6 +23,8 @@ run_steps = 3
 [[steps]]
 assert_label = { target = "assistant", label = "Assistant settings" }
 
+# /model (no args) now opens the interactive tier/agent picker instead of
+# printing static text. Enter opens it; a tier row is visible.
 [[steps]]
 text = { target = "assistant", value = "/model" }
 
@@ -33,7 +35,20 @@ key = { target = "assistant", value = "enter" }
 run_steps = 3
 
 [[steps]]
-assert_label = { target = "assistant", label = "Model tier: " }
+assert_label = { target = "assistant", label = "medium" }
 
 [[steps]]
 shot = "assistant-settings.png"
+
+# Arrow down to the next tier and confirm; the session tier is applied.
+[[steps]]
+key = { target = "assistant", value = "down" }
+
+[[steps]]
+key = { target = "assistant", value = "enter" }
+
+[[steps]]
+run_steps = 3
+
+[[steps]]
+assert_label = { target = "assistant", label = "Model tier set to " }

--- a/tests/scenes/assistant-settings.toml
+++ b/tests/scenes/assistant-settings.toml
@@ -52,3 +52,29 @@ run_steps = 3
 
 [[steps]]
 assert_label = { target = "assistant", label = "Model tier set to " }
+
+# Regression: escape inside the picker must close only the overlay, not the
+# whole pane. Escape has a plain host binding (CloseApp, AppActive context)
+# that previously fired because the picker never claimed the key before
+# `poll_actions` saw it — the pane was destroyed instead of the overlay
+# closing.
+[[steps]]
+text = { target = "assistant", value = "/model" }
+
+[[steps]]
+key = { target = "assistant", value = "enter" }
+
+[[steps]]
+run_steps = 3
+
+[[steps]]
+key = { target = "assistant", value = "escape" }
+
+[[steps]]
+run_steps = 3
+
+[[steps]]
+assert = { target = "assistant", exists = true, focused = true, pane_count = 1 }
+
+[[steps]]
+assert_label = { target = "assistant", label = "Model tier set to " }


### PR DESCRIPTION
No linked GitHub issue — tracked via stint tasks 0372 and 0373 (`.stint/`).

## Summary

**Stint 0372 — `/model` interactive picker**
- `/model` (no args) now opens an arrow-key picker over model tier (low/medium/high) and the active agent, instead of printing static text.
- Enter applies through the same `set_session_model`/agent-switch paths the old text command used; Esc cancels. `/model low|medium|high` explicit-arg fast path is unchanged.

**Stint 0373 — interactive permissions manager**
- `/revoke` and `/permissions` (no args) now open a shared permissions manager listing persisted grants.
- Space cycles a grant's decision (Allow → Ask → Block), Enter applies. Writes go through the existing `grant_store`/audit path — Ask reverts to the posture default (revoke), Allow/Block re-record the grant with the new decision. `/revoke <target_id>` explicit-arg fast path is unchanged.
- Both overlays reuse the existing slash-command picker's `Area`/`ScrollArea`/`ListRow` geometry rather than a new component.

## Test evidence

- `cargo test --bin plexi`: 1431 passed, 0 failed, 2 ignored (includes new/updated overlay unit tests and the `scene_suite` TOML scenes).
- `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py`: no issues found (26 source files) — diff doesn't touch the SDK, run for gate completeness.
- `cargo build`: clean (only pre-existing unrelated warnings in other modules).
- Docs regen: not applicable — diff is scoped to `src/assistant/` and `tests/scenes/`, no CLI/config/SDK/capability surface touched.
- Conclusion: binary install recommended before merge — this is user-visible host UI (new keyboard-driven overlay, egui rendering) not fully exercisable from headless scene assertions alone. Validate with `just pr-install <PR>` and drive `/model` and `/revoke`/`/permissions` in a real pane.

## Done When

- [x] `/model` opens an interactive picker; arrow keys navigate; Enter applies; Esc cancels
- [x] `/revoke` and `/permissions` (no args) open an interactive permissions manager; Space cycles Allow/Ask/Block; Enter applies via existing grant_store/audit path
- [x] Both surfaces reuse one picker component
- [x] `cargo test --bin plexi` green
- [x] New/updated TOML scene + Rust `#[test]` coverage for picker navigation/selection and grant list/cycle/revoke