### PR TITLE
assistant: pane-open targeting + keyboard/responsive permission modal (stints 0374, 0377, 0378)

### DIFF
--- a/src/app/assistant_host_tools.rs
+++ b/src/app/assistant_host_tools.rs
@@ -52,6 +52,7 @@ impl PlexiApp {
                             .collect::<Vec<_>>()
                     })
                     .unwrap_or_default();
+                let target_pane_id = parsed.get("pane_id").and_then(serde_json::Value::as_u64);
                 match self.assistant_spawn_pane(
                     origin_pane_id,
                     origin_context_id,
@@ -59,6 +60,7 @@ impl PlexiApp {
                     layout,
                     args,
                     cwd,
+                    target_pane_id,
                 ) {
                     Ok(pane_id) => succeeded(
                         serde_json::json!({"ok": true, "pane_id": pane_id, "type_id": type_id}),
@@ -108,6 +110,7 @@ impl PlexiApp {
                             .collect::<Vec<_>>()
                     })
                     .unwrap_or_default();
+                let target_pane_id = parsed.get("pane_id").and_then(serde_json::Value::as_u64);
                 match self.assistant_spawn_pane(
                     origin_pane_id,
                     origin_context_id,
@@ -115,6 +118,7 @@ impl PlexiApp {
                     layout,
                     args,
                     None,
+                    target_pane_id,
                 ) {
                     Ok(pane_id) => {
                         succeeded(serde_json::json!({"ok": true, "pane_id": pane_id, "app": app}))
@@ -138,6 +142,7 @@ impl PlexiApp {
                     layout,
                     Vec::new(),
                     cwd,
+                    None,
                 ) {
                     Ok(pane_id) => {
                         if let Err(error) =
@@ -282,6 +287,20 @@ impl PlexiApp {
         Ok(())
     }
 
+    /// Spawn `type_id` into a new pane, or — when `target_pane_id` is set —
+    /// into the vicinity of that existing pane, which must be an idle
+    /// terminal (an "empty" pane). Targeting an occupied pane (already
+    /// running an app, or a portal) returns a clear `pane_occupied` error
+    /// instead of the opaque `open_..._failed` message a same-pane split
+    /// collision used to produce (stint 0374).
+    ///
+    /// The target's own pane_id is not reused for the new content — the
+    /// new app pane keeps its own freshly allocated id like any other
+    /// spawn, and the target is torn down (with full hot-reload/notification
+    /// cleanup via `close_pane_by_id`) only after the new pane exists. This
+    /// avoids reassigning a live pane's id, which would orphan any
+    /// subscriptions, watchers, or WASM runtime handles already registered
+    /// under the id the new pane launched with.
     fn assistant_spawn_pane(
         &mut self,
         origin_pane_id: u64,
@@ -290,6 +309,7 @@ impl PlexiApp {
         layout: Option<String>,
         args: Vec<String>,
         cwd: Option<std::path::PathBuf>,
+        target_pane_id: Option<u64>,
     ) -> Result<u64, String> {
         if !self.windows.iter().any(|window| {
             window.context_id == origin_context_id && window.panes.contains_key(&origin_pane_id)
@@ -298,6 +318,23 @@ impl PlexiApp {
                 "origin pane {origin_pane_id} is no longer in context {origin_context_id}"
             ));
         }
+        let from_pane_id = if let Some(target_id) = target_pane_id {
+            let Some((target_win, _)) = self.find_pane_in_any_window(target_id) else {
+                return Err(format!("pane_not_found: {target_id}"));
+            };
+            let is_empty_terminal = matches!(
+                self.windows[target_win].panes.get(&target_id),
+                Some(crate::host::pane::Pane::Terminal(_))
+            );
+            if !is_empty_terminal {
+                return Err(format!(
+                    "pane_occupied: pane {target_id} is not an empty terminal pane; only idle terminal panes can be targeted"
+                ));
+            }
+            target_id
+        } else {
+            origin_pane_id
+        };
         let before = self
             .windows
             .iter()
@@ -320,7 +357,7 @@ impl PlexiApp {
             type_id: type_id.to_string(),
             layout,
             args,
-            from_pane_id: Some(origin_pane_id),
+            from_pane_id: Some(from_pane_id),
             request_id: None,
             response_file: None,
             ephemeral: false,
@@ -331,29 +368,44 @@ impl PlexiApp {
             target_context: None,
             name: None,
         });
-        if let Some(created) = self
+        let result = if let Some(created) = self
             .windows
             .iter()
             .flat_map(|window| window.panes.keys().copied())
             .find(|pane_id| !before.contains(pane_id))
         {
-            return Ok(created);
+            Ok(created)
+        } else {
+            let window = self
+                .windows
+                .iter()
+                .find(|window| window.context_id == origin_context_id)
+                .ok_or_else(|| format!("origin context {origin_context_id} closed"))?;
+            let focused = window
+                .focused_pane
+                .and_then(|tile| window.tree.tiles.get(tile))
+                .and_then(|tile| match tile {
+                    egui_tiles::Tile::Pane(id) => Some(*id),
+                    _ => None,
+                });
+            focused
+                .filter(|pane_id| Some(*pane_id) != focused_before)
+                .ok_or_else(|| {
+                    format!("open request for '{type_id}' did not create or focus a pane")
+                })
+        };
+        // Only tear down the retargeted pane once the new content has
+        // actually landed — a failed spawn must leave the target alone
+        // rather than silently deleting it.
+        if let (Ok(created), Some(target_id)) = (&result, target_pane_id) {
+            if *created != target_id {
+                log::info!(
+                    "assistant_spawn_pane: retargeted pane {target_id} closed after '{type_id}' opened in pane {created}"
+                );
+                self.close_pane_by_id(target_id);
+            }
         }
-        let window = self
-            .windows
-            .iter()
-            .find(|window| window.context_id == origin_context_id)
-            .ok_or_else(|| format!("origin context {origin_context_id} closed"))?;
-        let focused = window
-            .focused_pane
-            .and_then(|tile| window.tree.tiles.get(tile))
-            .and_then(|tile| match tile {
-                egui_tiles::Tile::Pane(id) => Some(*id),
-                _ => None,
-            });
-        focused
-            .filter(|pane_id| Some(*pane_id) != focused_before)
-            .ok_or_else(|| format!("open request for '{type_id}' did not create or focus a pane"))
+        result
     }
 
     fn assistant_pane_list(&self) -> serde_json::Value {
@@ -557,6 +609,119 @@ mod tests {
                 .is_some_and(|error| error.contains("echo must be true")),
             "{:?}",
             hidden_echo.error
+        );
+    }
+
+    /// Stint 0374: `host.apps.open`/`host.panes.open` can target an existing
+    /// idle terminal pane instead of always spawning a fresh one — the
+    /// dogfooding bug where targeting pane 105 for calculator returned an
+    /// opaque `open_pane_failed` and the app landed in a brand-new pane.
+    #[test]
+    fn native_open_tools_target_existing_empty_terminal_pane() {
+        let mut harness = HostHarness::new();
+        let origin = harness.add_test_pane();
+        let context = harness.app.windows[0].context_id;
+
+        let terminal = harness.app.handle_assistant_host_tool(
+            "host.terminals.open",
+            &serde_json::json!({"layout": "split_h", "cwd": std::env::temp_dir()}).to_string(),
+            origin,
+            context,
+        );
+        assert!(terminal.error.is_none(), "{:?}", terminal.error);
+        let target_id = serde_json::from_str::<serde_json::Value>(
+            terminal.output_json.as_deref().expect("terminal output"),
+        )
+        .unwrap()["pane_id"]
+            .as_u64()
+            .expect("terminal pane id");
+
+        let opened = harness.app.handle_assistant_host_tool(
+            "host.apps.open",
+            &serde_json::json!({"app": "text-editor", "pane_id": target_id}).to_string(),
+            origin,
+            context,
+        );
+        assert!(opened.error.is_none(), "{:?}", opened.error);
+        let new_id = serde_json::from_str::<serde_json::Value>(
+            opened.output_json.as_deref().expect("open output"),
+        )
+        .unwrap()["pane_id"]
+            .as_u64()
+            .expect("new pane id");
+
+        assert_ne!(
+            new_id, target_id,
+            "targeting reuses the target's slot, not its literal pane_id"
+        );
+        assert!(
+            !harness
+                .app
+                .windows
+                .iter()
+                .any(|window| window.panes.contains_key(&target_id)),
+            "the retargeted terminal pane should be torn down"
+        );
+        assert!(
+            harness
+                .app
+                .windows
+                .iter()
+                .any(|window| window.panes.contains_key(&new_id)),
+            "the new app pane should exist"
+        );
+    }
+
+    #[test]
+    fn native_open_tools_target_occupied_pane_returns_clear_error() {
+        let mut harness = HostHarness::new();
+        let origin = harness.add_test_pane();
+        let context = harness.app.windows[0].context_id;
+        let occupied = harness.add_test_pane();
+
+        let result = harness.app.handle_assistant_host_tool(
+            "host.apps.open",
+            &serde_json::json!({"app": "text-editor", "pane_id": occupied}).to_string(),
+            origin,
+            context,
+        );
+        assert!(
+            result
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("pane_occupied")),
+            "{:?}",
+            result.error
+        );
+        assert!(
+            harness
+                .app
+                .windows
+                .iter()
+                .any(|window| window.panes.contains_key(&occupied)),
+            "an occupied target must not be torn down on rejection"
+        );
+    }
+
+    #[test]
+    fn native_open_tools_target_missing_pane_returns_not_found() {
+        let mut harness = HostHarness::new();
+        let origin = harness.add_test_pane();
+        let context = harness.app.windows[0].context_id;
+
+        let result = harness.app.handle_assistant_host_tool(
+            "host.panes.open",
+            &serde_json::json!({"type_id": "text-editor", "pane_id": 999_999}).to_string(),
+            origin,
+            context,
+        );
+        assert!(
+            result
+                .error
+                .as_deref()
+                .is_some_and(|error| error.contains("pane_not_found")),
+            "{:?}",
+            result.error
         );
     }
 }

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -888,7 +888,7 @@ impl AssistantApp {
             AiTool {
                 name: HOST_TOOL_PANES_OPEN.into(),
                 description: "Open an app or terminal pane by native type id.".into(),
-                input_schema: serde_json::json!({"type":"object","properties":{"type_id":{"type":"string"},"layout":{"type":"string"},"cwd":{"type":"string"},"args":{"type":"array","items":{"type":"string"}}},"required":["type_id"]}),
+                input_schema: serde_json::json!({"type":"object","properties":{"type_id":{"type":"string"},"layout":{"type":"string"},"cwd":{"type":"string"},"args":{"type":"array","items":{"type":"string"}},"pane_id":{"type":"integer","description":"Open into this existing empty terminal pane instead of spawning a new one. The pane must be an idle terminal; occupied panes return an error."}},"required":["type_id"]}),
                 output_schema: serde_json::json!({"type":"object"}),
                 timeout_ms: Some(30_000),
                 read_only: false,
@@ -912,7 +912,7 @@ impl AssistantApp {
             AiTool {
                 name: HOST_TOOL_APPS_OPEN.into(),
                 description: "Open an installed Plexi app in a pane.".into(),
-                input_schema: serde_json::json!({"type":"object","properties":{"app":{"type":"string"},"layout":{"type":"string"},"args":{"type":"array","items":{"type":"string"}}},"required":["app"]}),
+                input_schema: serde_json::json!({"type":"object","properties":{"app":{"type":"string"},"layout":{"type":"string"},"args":{"type":"array","items":{"type":"string"}},"pane_id":{"type":"integer","description":"Open into this existing empty terminal pane instead of spawning a new one. The pane must be an idle terminal; occupied panes return an error."}},"required":["app"]}),
                 output_schema: serde_json::json!({"type":"object"}),
                 timeout_ms: Some(30_000),
                 read_only: false,
@@ -2881,6 +2881,17 @@ impl App for AssistantApp {
         if self.model.overlay_active() {
             if input.key_pressed(egui::Key::Escape) {
                 self.model.cancel_overlay();
+                return KeyDisposition::Consumed;
+            }
+            return KeyDisposition::Passthrough;
+        }
+        // The permission sheet also owns Escape while open — same rationale
+        // as the overlay case above: resolve it as a deny here so `Escape`
+        // never falls through to `CloseApp`, and leave Tab/arrows/Enter in
+        // the buffer for `render.rs`'s `handle_permission_keys` to consume.
+        if self.model.pending_permission.is_some() {
+            if input.key_pressed(egui::Key::Escape) {
+                self.resolve_permission(PermissionChoice::Deny);
                 return KeyDisposition::Consumed;
             }
             return KeyDisposition::Passthrough;

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -78,6 +78,9 @@ pub struct ActiveToolCall {
 pub struct PendingPermission {
     pub tool: String,
     pub input_summary: String,
+    /// Keyboard cursor over `PermissionChoice::ORDER`, so Tab/arrow nav can
+    /// move it and Enter can activate whatever it lands on.
+    pub selected: usize,
 }
 
 /// What the user chose on the permission sheet.
@@ -87,6 +90,17 @@ pub enum PermissionChoice {
     AllowSession,
     AllowAlways,
     Deny,
+}
+
+impl PermissionChoice {
+    /// Left-to-right order the sheet renders its actions in — also the
+    /// Tab/arrow traversal order.
+    pub const ORDER: [PermissionChoice; 4] = [
+        PermissionChoice::AllowOnce,
+        PermissionChoice::AllowSession,
+        PermissionChoice::AllowAlways,
+        PermissionChoice::Deny,
+    ];
 }
 
 /// Live state of an in-flight model turn. Reasoning deltas are carried
@@ -842,11 +856,38 @@ impl AssistantModel {
     }
 
     /// The in-flight turn hit an ask-gated tool: show the permission sheet.
+    /// The cursor starts on `Deny` (`ORDER`'s last slot) — the safe default
+    /// if the user reflexively hits Enter without looking.
     pub fn permission_requested(&mut self, tool: &str, input_summary: &str) {
         self.pending_permission = Some(PendingPermission {
             tool: tool.to_string(),
             input_summary: input_summary.to_string(),
+            selected: PermissionChoice::ORDER.len() - 1,
         });
+    }
+
+    /// Move the permission sheet's keyboard cursor one action right,
+    /// wrapping from the last action back to the first.
+    pub fn permission_move_next(&mut self) {
+        if let Some(pending) = self.pending_permission.as_mut() {
+            pending.selected = (pending.selected + 1) % PermissionChoice::ORDER.len();
+        }
+    }
+
+    /// Move the permission sheet's keyboard cursor one action left,
+    /// wrapping from the first action back to the last.
+    pub fn permission_move_prev(&mut self) {
+        if let Some(pending) = self.pending_permission.as_mut() {
+            let len = PermissionChoice::ORDER.len();
+            pending.selected = (pending.selected + len - 1) % len;
+        }
+    }
+
+    /// The action the permission sheet's keyboard cursor currently sits on.
+    pub fn permission_selected_choice(&self) -> Option<PermissionChoice> {
+        self.pending_permission
+            .as_ref()
+            .map(|pending| PermissionChoice::ORDER[pending.selected])
     }
 
     /// The user decided the pending permission sheet. A denial appends a
@@ -1422,6 +1463,53 @@ mod tests {
         let row = m.turns.last().unwrap();
         assert_eq!(row.status, Some(ToolStatus::Failed));
         assert!(row.text.contains("tool_timeout"));
+    }
+
+    /// Stint 0377: the permission sheet's keyboard cursor starts on Deny
+    /// (the safe default), Tab/arrow-right cycles forward with wraparound,
+    /// and Shift-Tab/arrow-left cycles backward with wraparound.
+    #[test]
+    fn permission_sheet_keyboard_cursor_cycles_with_wraparound() {
+        let mut m = AssistantModel::fresh();
+        m.permission_requested("csv.write_range", "{}");
+        assert_eq!(
+            m.permission_selected_choice(),
+            Some(PermissionChoice::Deny),
+            "cursor starts on the safe default"
+        );
+
+        m.permission_move_next();
+        assert_eq!(
+            m.permission_selected_choice(),
+            Some(PermissionChoice::AllowOnce),
+            "wraps forward from the last action to the first"
+        );
+
+        m.permission_move_prev();
+        assert_eq!(m.permission_selected_choice(), Some(PermissionChoice::Deny));
+
+        m.permission_move_prev();
+        assert_eq!(
+            m.permission_selected_choice(),
+            Some(PermissionChoice::AllowAlways),
+            "wraps backward from the first action to the last"
+        );
+
+        m.permission_move_next();
+        m.permission_move_next();
+        assert_eq!(
+            m.permission_selected_choice(),
+            Some(PermissionChoice::AllowOnce)
+        );
+    }
+
+    #[test]
+    fn permission_sheet_cursor_navigation_is_noop_with_nothing_pending() {
+        let mut m = AssistantModel::fresh();
+        assert!(m.pending_permission.is_none());
+        m.permission_move_next();
+        m.permission_move_prev();
+        assert!(m.permission_selected_choice().is_none());
     }
 
     #[test]

--- a/src/assistant/render.rs
+++ b/src/assistant/render.rs
@@ -163,19 +163,27 @@ impl AssistantRenderer {
                 bottom: style::SPACE_SM as i8,
             }))
             .show_inside(ui, |ui| {
-                if let Some(choice) = Self::draw_permission_sheet(ui, model, colors) {
-                    event = Some(ComposerEvent::Permission(choice));
-                }
                 // Keys first: Enter/Tab/arrows must be consumed before the
                 // TextEdit processes input, or completion renders a one-frame
-                // stale buffer (the autocomplete "glitch"). While an overlay is
-                // open it owns navigation keys and the composer stays inert.
-                if model.overlay_active() {
+                // stale buffer (the autocomplete "glitch"). While the
+                // permission sheet or an overlay is open, it owns navigation
+                // keys and the composer stays inert. The sheet takes
+                // priority over the overlay — a permission ask can interrupt
+                // an open overlay's underlying turn.
+                let permission_pending = model.pending_permission.is_some();
+                if permission_pending {
+                    if let Some(perm_event) = Self::handle_permission_keys(ui, model) {
+                        event = Some(perm_event);
+                    }
+                } else if model.overlay_active() {
                     if let Some(overlay_event) = Self::handle_overlay_keys(ui, model) {
                         event = Some(overlay_event);
                     }
                 } else if let Some(key_event) = Self::handle_composer_keys(ui, model, te_id) {
                     event = Some(key_event);
+                }
+                if let Some(choice) = Self::draw_permission_sheet(ui, model, colors) {
+                    event = Some(ComposerEvent::Permission(choice));
                 }
                 composer_rect = Some(Self::draw_composer(
                     ui,
@@ -185,7 +193,14 @@ impl AssistantRenderer {
                     is_focused,
                     total_h * Self::COMPOSER_MAX_FRACTION,
                 ));
-                if model.overlay_active() {
+                if permission_pending {
+                    HintBar::new(&[
+                        HintGroup::new(&["\u{21e5}"], "navigate"),
+                        HintGroup::new(&["\u{21b5}"], "confirm"),
+                        HintGroup::new(&["Esc"], "deny"),
+                    ])
+                    .show(ui, colors);
+                } else if model.overlay_active() {
                     let mut hints = vec![
                         HintGroup::new(&["\u{2191}", "\u{2193}"], "navigate"),
                         HintGroup::new(&["\u{21b5}"], "confirm"),
@@ -490,12 +505,19 @@ impl AssistantRenderer {
 
     /// Permission sheet for the pending ask-gated tool call, rendered above
     /// the composer. Returns the user's decision, if any, this frame.
+    ///
+    /// Sizing is responsive: the action row wraps onto a second line
+    /// instead of overflowing once the pane is too narrow to fit all four
+    /// buttons, and the summary text wraps within the available width
+    /// rather than clipping — so the sheet scales down to a small pane and
+    /// up to an ultra-wide one without layout breakage.
     fn draw_permission_sheet(
         ui: &mut egui::Ui,
         model: &AssistantModel,
         colors: &Colors,
     ) -> Option<PermissionChoice> {
         let pending = model.pending_permission.as_ref()?;
+        let selected = pending.selected;
         let mut choice = None;
         egui::Frame::new()
             .fill(colors.bg_active)
@@ -509,14 +531,18 @@ impl AssistantRenderer {
                         .size(style::TEXT_CAPTION)
                         .color(colors.accent),
                 );
-                ui.label(
-                    RichText::new(format!(
-                        "assistant (medium) wants to run the app tool '{}'",
-                        pending.tool
-                    ))
-                    .size(style::TEXT_BODY)
-                    .color(colors.text_primary),
-                );
+                ui.scope(|ui| {
+                    ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
+                    ui.set_max_width(ui.available_width());
+                    ui.label(
+                        RichText::new(format!(
+                            "assistant (medium) wants to run the app tool '{}'",
+                            pending.tool
+                        ))
+                        .size(style::TEXT_BODY)
+                        .color(colors.text_primary),
+                    );
+                });
                 if !pending.input_summary.is_empty() {
                     ui.scope(|ui| {
                         ui.set_max_width(ui.available_width());
@@ -524,26 +550,81 @@ impl AssistantRenderer {
                     });
                 }
                 ui.add_space(style::SPACE_XS);
-                ui.horizontal(|ui| {
-                    if chrome_button(ui, "Allow once", ButtonKind::Accent, colors, 0.0).clicked() {
-                        choice = Some(PermissionChoice::AllowOnce);
-                    }
-                    if chrome_button(ui, "Allow this session", ButtonKind::Primary, colors, 0.0)
-                        .clicked()
-                    {
-                        choice = Some(PermissionChoice::AllowSession);
-                    }
-                    if chrome_button(ui, "Always allow", ButtonKind::Primary, colors, 0.0).clicked()
-                    {
-                        choice = Some(PermissionChoice::AllowAlways);
-                    }
-                    if chrome_button(ui, "Deny", ButtonKind::Danger, colors, 0.0).clicked() {
-                        choice = Some(PermissionChoice::Deny);
+                let actions: [(&str, ButtonKind, PermissionChoice); 4] = [
+                    ("Allow once", ButtonKind::Accent, PermissionChoice::AllowOnce),
+                    (
+                        "Allow this session",
+                        ButtonKind::Primary,
+                        PermissionChoice::AllowSession,
+                    ),
+                    (
+                        "Always allow",
+                        ButtonKind::Primary,
+                        PermissionChoice::AllowAlways,
+                    ),
+                    ("Deny", ButtonKind::Danger, PermissionChoice::Deny),
+                ];
+                // `Ui::horizontal_wrapped` reflows buttons onto additional
+                // rows instead of clipping or forcing the frame wider than
+                // the pane, so the sheet stays usable at small window sizes.
+                ui.horizontal_wrapped(|ui| {
+                    for (i, (label, kind, value)) in actions.into_iter().enumerate() {
+                        let resp = chrome_button(ui, label, kind, colors, 0.0);
+                        if i == selected {
+                            ui.painter().rect_stroke(
+                                resp.rect.expand(2.0),
+                                style::RADIUS_MD,
+                                egui::Stroke::new(2.0, colors.accent),
+                                egui::StrokeKind::Outside,
+                            );
+                        }
+                        if resp.clicked() {
+                            choice = Some(value);
+                        }
                     }
                 });
             });
         ui.add_space(style::SPACE_XS);
         choice
+    }
+
+    /// Consume the permission sheet's keyboard-nav keys before the composer
+    /// TextEdit renders, mirroring `handle_overlay_keys`: Tab/Shift-Tab and
+    /// the arrow keys move the focused action, Enter activates it, and Esc
+    /// denies outright (the safe default) rather than merely dismissing the
+    /// sheet, since a pending ask-gated tool call has nothing safe to fall
+    /// back to.
+    fn handle_permission_keys(
+        ui: &mut egui::Ui,
+        model: &mut AssistantModel,
+    ) -> Option<ComposerEvent> {
+        let mut next = false;
+        let mut prev = false;
+        let mut confirm = false;
+        let mut deny = false;
+        ui.input_mut(|input| {
+            next = input.consume_key(egui::Modifiers::NONE, egui::Key::Tab)
+                || input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowRight);
+            prev = input.consume_key(egui::Modifiers::SHIFT, egui::Key::Tab)
+                || input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowLeft);
+            confirm = input.consume_key(egui::Modifiers::NONE, egui::Key::Enter);
+            deny = input.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+        });
+        if next {
+            model.permission_move_next();
+        }
+        if prev {
+            model.permission_move_prev();
+        }
+        if deny {
+            return Some(ComposerEvent::Permission(PermissionChoice::Deny));
+        }
+        if confirm {
+            return model
+                .permission_selected_choice()
+                .map(ComposerEvent::Permission);
+        }
+        None
     }
 
     /// "thoughts" section: the model's reasoning tokens, rendered open and


### PR DESCRIPTION
No linked GitHub issue — tracked as stint tasks 0374, 0377, 0378 (assistant/permission UX cluster).

## Summary

- **0374** — `host.panes.open`/`host.apps.open` accept a `pane_id` param to target an existing idle terminal pane; occupied/missing targets return a clear `pane_occupied`/`pane_not_found` error instead of the previous opaque `open_..._failed`. The target is torn down (full cleanup via `close_pane_by_id`) only after the new app pane successfully lands.
- **0377** — the permission sheet is keyboard-interactable: Tab/Shift-Tab and Left/Right cycle the focused action, Enter activates it, Esc denies (safe default). Escape is claimed before it can fall through to `CloseApp`, mirroring the existing overlay/model-picker Esc-consume pattern.
- **0378** — the permission sheet's action row wraps (`horizontal_wrapped`) and its summary text wraps within the available width instead of clipping, so it scales down to a narrow pane and up to an ultra-wide one without overflow.

## Test evidence

- `cargo test --bin plexi`: 1436 passed, 0 failed, 2 ignored.
- New/targeted tests:
  - `app::assistant_host_tools::tests::native_open_tools_target_existing_empty_terminal_pane`
  - `app::assistant_host_tools::tests::native_open_tools_target_occupied_pane_returns_clear_error`
  - `app::assistant_host_tools::tests::native_open_tools_target_missing_pane_returns_not_found`
  - `assistant::model::tests::permission_sheet_keyboard_cursor_cycles_with_wraparound`
  - `assistant::model::tests::permission_sheet_cursor_navigation_is_noop_with_nothing_pending`
- `mypy sdk/python/plexi_sdk/`: no issues.
- `just check-docs`: all docs up to date, no regen needed (diff doesn't touch CLI/config/SDK/capability surfaces).
- No TOML scene added for the permission sheet: like the existing `/permissions` manager scene, the ask-gated sheet can't be seeded through the scene runner's production input paths (it requires a live tool call reaching an "Ask" decision, not a slash command) — same precedent already documented in `tests/scenes/assistant-permissions.toml`. Coverage is Rust model tests for the state machine.
- **Binary install required** for 0377/0378 (keyboard nav + responsive layout are visual/interaction behavior with no scene coverage): validate with `just pr-install <PR>` then drive `plexi-pr-<PR>` — trigger an ask-gated tool call, confirm Tab/Shift-Tab/arrows/Enter/Esc work with no mouse, and resize the pane narrow/ultra-wide to confirm the sheet reflows without clipping. 0374 has full harness coverage (install optional for that half).

## Stints

`.stint/tasks/0374-app-open-pane-targeting.md`, `.stint/tasks/0377-permission-modal-keyboard-nav.md`, `.stint/tasks/0378-permission-modal-responsive-sizing.md`