### PR TITLE
fix(apps): snake food truly random; balls restored to live-dims click-driven behavior (stints 0433, 0434)

### DIFF
--- a/apps/balls/balls.py
+++ b/apps/balls/balls.py
@@ -1,33 +1,30 @@
 #!/usr/bin/env python3
-"""Balls — SDK v3 runtime-state canvas physics demo."""
+"""Balls — elastic circle collision physics demo.
+
+Runs against live pane dimensions each frame: walls track pane resizes, so
+balls fall into freed space when a pane below closes. Absolute pixel radii,
+1:1 canvas (fill mode with live width/height), click to add a ball at the
+cursor, click a ball to remove it.
+"""
 
 from __future__ import annotations
 
 import math
 import random
 
-from plexi_sdk import log
+from plexi_sdk import dim, log, theme
 from plexi_sdk.effects import SetSchedulerMode, SetStatus, SetTitle
-from plexi_sdk.events import KeyEvent, RenderFrame
-from plexi_sdk.ui import (
-    AppBar,
-    Canvas,
-    CanvasCircle,
-    CanvasRect,
-    CanvasText,
-    Column,
-    FooterKeys,
-)
+from plexi_sdk.events import MouseEvent, RenderFrame, Resize
+from plexi_sdk.ui import Canvas, CanvasCircle, CanvasRect, CanvasText
 
-CANVAS_W = 640.0
-CANVAS_H = 360.0
 TARGET_FPS = 60
 TARGET_DT = 1.0 / TARGET_FPS
-GRAVITY = 300.0
-DAMPING = 0.78
-FRICTION = 0.995
+MAX_DT = 0.05  # cap to avoid tunnelling on first frame / tab-back
+GRAVITY = 300.0  # px/s^2
+DAMPING = 0.78  # energy retained on wall bounce
+FRICTION = 0.995  # per-frame horizontal friction on floor contact
 MAX_BALLS = 50
-_runtime: dict | None = None
+BG = "#0d0d1a"
 PALETTE = [
     "#f38ba8",
     "#a6e3a1",
@@ -37,68 +34,110 @@ PALETTE = [
     "#94e2d5",
     "#fab387",
     "#74c7ec",
+    "#b4befe",
+    "#eba0ac",
+    "#a6adc8",
+    "#cdd6f4",
 ]
 
+_runtime: dict | None = None
 
-def _initial(count: int = 10) -> dict:
-    rng = random.Random(7)
+
+def _new_ball(
+    x: float,
+    y: float,
+    idx: int,
+    vx: float | None = None,
+    vy: float | None = None,
+) -> dict:
+    radius = random.uniform(14.0, 44.0)
+    return {
+        "x": x,
+        "y": y,
+        "vx": random.uniform(-180.0, 180.0) if vx is None else vx,
+        "vy": random.uniform(-250.0, -60.0) if vy is None else vy,
+        "r": radius,
+        "color": PALETTE[idx % len(PALETTE)],
+    }
+
+
+def _initial(w: float, h: float, count: int) -> dict:
+    count = max(1, min(count, MAX_BALLS))
     balls = []
-    for idx in range(max(1, min(count, MAX_BALLS))):
-        radius = rng.uniform(14.0, 36.0)
-        balls.append(
-            {
-                "x": rng.uniform(radius, CANVAS_W - radius),
-                "y": rng.uniform(radius, CANVAS_H * 0.55),
-                "vx": rng.uniform(-180.0, 180.0),
-                "vy": rng.uniform(-250.0, -60.0),
-                "r": radius,
-                "color": PALETTE[idx % len(PALETTE)],
-            }
-        )
-    return {"balls": balls, "ticks": 0}
+    for idx in range(count):
+        ball = _new_ball(0.0, 0.0, idx)
+        ball["x"] = random.uniform(ball["r"], max(ball["r"], w - ball["r"]))
+        ball["y"] = random.uniform(ball["r"], max(ball["r"], h * 0.6))
+        balls.append(ball)
+    return {"balls": balls, "w": w, "h": h}
 
 
 def _sim() -> dict:
     global _runtime
     if _runtime is None:
-        _runtime = _initial()
+        _runtime = _initial(640.0, 360.0, 10)
     return _runtime
 
 
 def init(size, args) -> list:
     global _runtime
+    w, h = size
     count = 10
     if args:
         try:
             count = int(args[0])
         except (TypeError, ValueError):
             count = 10
-    _runtime = _initial(count)
+    _runtime = _initial(w, h, count)
     effects: list = [
         SetTitle("Balls"),
         SetSchedulerMode("continuous", fps=TARGET_FPS),
         SetStatus(f"{len(_runtime['balls'])} balls"),
     ]
-    log.info("balls: SDK v3 canvas initialized")
+    log.info(f"balls: init complete, spawned {len(_runtime['balls'])} balls")
     return effects
 
 
 def update(event) -> list:
-    if isinstance(event, KeyEvent):
-        if event.key in ("+", "plus", "equals"):
-            _sim()["balls"].extend(_initial(1)["balls"])
-        elif event.key in ("-", "minus") and len(_sim()["balls"]) > 1:
-            _sim()["balls"].pop()
+    data = _sim()
+
+    if isinstance(event, Resize):
+        data["w"] = event.width
+        data["h"] = event.height
         return []
-    if not isinstance(event, RenderFrame):
+
+    if isinstance(event, MouseEvent) and event.pressed:
+        return _click(data, event.x, event.y)
+
+    if isinstance(event, RenderFrame):
+        dt = event.elapsed if event.elapsed > 0 else TARGET_DT
+        _step(data, min(dt, MAX_DT))
         return []
-    dt = event.elapsed if event.elapsed > 0 else TARGET_DT
-    _step(_sim(), min(dt, TARGET_DT * 2.0))
+
     return []
 
 
-def _step(data: dict, dt: float = TARGET_DT) -> dict:
+def _click(data: dict, x: float, y: float) -> list:
     balls = data["balls"]
+    # Topmost ball is drawn last, so hit-test from the end.
+    for i in range(len(balls) - 1, -1, -1):
+        ball = balls[i]
+        if (x - ball["x"]) ** 2 + (y - ball["y"]) ** 2 <= ball["r"] ** 2:
+            balls.pop(i)
+            log.info(f"balls: removed ball at ({x:.0f}, {y:.0f}), count={len(balls)}")
+            return [SetStatus(f"{len(balls)} balls")]
+    if len(balls) < MAX_BALLS:
+        balls.append(_new_ball(x, y, len(balls), vy=random.uniform(-300.0, -120.0)))
+        log.info(f"balls: spawned ball at ({x:.0f}, {y:.0f}), count={len(balls)}")
+        return [SetStatus(f"{len(balls)} balls")]
+    return []
+
+
+def _step(data: dict, dt: float) -> None:
+    balls = data["balls"]
+    w = data["w"]
+    h = data["h"]
+
     for ball in balls:
         ball["vy"] += GRAVITY * dt
         ball["x"] += ball["vx"] * dt
@@ -109,23 +148,21 @@ def _step(data: dict, dt: float = TARGET_DT) -> dict:
         if ball["x"] - radius < 0:
             ball["x"] = radius
             ball["vx"] = abs(ball["vx"]) * DAMPING
-        elif ball["x"] + radius > CANVAS_W:
-            ball["x"] = CANVAS_W - radius
+        elif ball["x"] + radius > w:
+            ball["x"] = w - radius
             ball["vx"] = -abs(ball["vx"]) * DAMPING
         if ball["y"] - radius < 0:
             ball["y"] = radius
             ball["vy"] = abs(ball["vy"]) * DAMPING
-        elif ball["y"] + radius > CANVAS_H:
-            ball["y"] = CANVAS_H - radius
+        elif ball["y"] + radius > h:
+            ball["y"] = h - radius
             ball["vy"] = -abs(ball["vy"]) * DAMPING
             ball["vx"] *= FRICTION
 
-    for i in range(len(balls)):
-        for j in range(i + 1, len(balls)):
+    n = len(balls)
+    for i in range(n):
+        for j in range(i + 1, n):
             _collide(balls[i], balls[j])
-
-    data["ticks"] += 1
-    return data
 
 
 def _collide(a: dict, b: dict) -> None:
@@ -141,8 +178,9 @@ def _collide(a: dict, b: dict) -> None:
     else:
         dist = 0.0
         nx, ny = 1.0, 0.0
+
     overlap = min_dist - dist
-    am = a["r"] * a["r"]
+    am = a["r"] * a["r"]  # mass proportional to area (uniform density)
     bm = b["r"] * b["r"]
     total = am + bm
     a["x"] -= nx * overlap * bm / total
@@ -164,36 +202,37 @@ def _collide(a: dict, b: dict) -> None:
 
 def view():
     data = _sim()
-    count = len(data["balls"])
-    return Column(
-        [
-            AppBar("Balls", f"{count} balls"),
-            Canvas(_draw(data), width=CANVAS_W, height=CANVAS_H, grow=True),
-            FooterKeys([("+", "add"), ("-", "remove")]),
-        ],
-        padding=0,
-        gap=0,
-        grow=True,
-    )
+    w = data["w"]
+    h = data["h"]
+    return Canvas(_draw(data), width=w, height=h, grow=True)
 
 
 def _draw(data: dict) -> list:
-    commands: list = [CanvasRect(0, 0, CANVAS_W, CANVAS_H, "#0d0d1a")]
-    for ball in data["balls"]:
+    w = data["w"]
+    h = data["h"]
+    balls = data["balls"]
+    commands: list = [CanvasRect(0.0, 0.0, w, h, BG)]
+    for ball in balls:
         commands.append(
-            CanvasCircle(ball["x"] + 3.0, ball["y"] + 4.0, ball["r"], "#00000055")
+            CanvasCircle(ball["x"] + 3.0, ball["y"] + 4.0, ball["r"], dim("#000000", 60))
         )
-    for ball in data["balls"]:
+    for ball in balls:
         commands.append(CanvasCircle(ball["x"], ball["y"], ball["r"], ball["color"]))
         commands.append(
             CanvasCircle(
                 ball["x"] - ball["r"] * 0.28,
                 ball["y"] - ball["r"] * 0.28,
                 max(3.0, ball["r"] * 0.28),
-                "#ffffff66",
+                dim("#ffffff", 90),
             )
         )
     commands.append(
-        CanvasText(12.0, 18.0, f"ticks {data['ticks']}", size=11.0, color="#a6adc8")
+        CanvasText(
+            12.0,
+            18.0,
+            f"{len(balls)} balls — click to add · click ball to remove",
+            size=12.0,
+            color=theme.muted,
+        )
     )
     return commands

--- a/apps/balls/tests/test_balls_v3.py
+++ b/apps/balls/tests/test_balls_v3.py
@@ -8,15 +8,19 @@ import sys
 sys.path.insert(
     0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "sdk", "python")
 )
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "dev", "balls"))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from plexi_sdk.events import RenderFrame  # noqa: E402
+from plexi_sdk.events import MouseEvent, RenderFrame, Resize  # noqa: E402
 
 import balls  # noqa: E402
 
 
-def test_render_frame_steps_physics_and_view_has_canvas() -> None:
-    data = balls._initial(2)
+def _one_ball(x: float, y: float, r: float) -> dict:
+    return {"x": x, "y": y, "vx": 0.0, "vy": 0.0, "r": r, "color": "#ffffff"}
+
+
+def test_render_frame_steps_physics_and_view_is_bare_canvas() -> None:
+    data = balls._initial(640.0, 360.0, 2)
     start_y = data["balls"][0]["y"]
     balls._runtime = data
 
@@ -24,13 +28,12 @@ def test_render_frame_steps_physics_and_view_has_canvas() -> None:
     stepped = balls._runtime
 
     assert effects == []
-    assert stepped["ticks"] == 1
     assert stepped["balls"][0]["y"] != start_y
-    canvas = balls.view().to_node()["children"][1]
+    canvas = balls.view().to_node()
     assert canvas["type"] == "canvas"
-    assert {"type": "rect", "x": 0, "y": 0, "w": balls.CANVAS_W, "h": balls.CANVAS_H,
-            "fill": "#0d0d1a", "radius": 0.0} in canvas["commands"]
-    assert any(cmd["type"] == "circle" and "cx" in cmd and "r" in cmd for cmd in canvas["commands"])
+    assert canvas["fit"] == "fill"
+    assert canvas["width"] == 640.0 and canvas["height"] == 360.0
+    assert any(cmd["type"] == "circle" for cmd in canvas["commands"])
 
 
 def test_init_uses_continuous_scheduler_not_timers() -> None:
@@ -43,3 +46,36 @@ def test_init_uses_continuous_scheduler_not_timers() -> None:
         for effect in effects
     )
     assert not any(type(effect).__name__ == "SetTimer" for effect in effects)
+
+
+def test_click_empty_adds_ball_at_cursor_click_ball_removes() -> None:
+    balls._runtime = {"balls": [_one_ball(100.0, 100.0, 20.0)], "w": 640.0, "h": 360.0}
+
+    # Click empty space -> add a ball at the exact cursor position.
+    balls.update(MouseEvent(x=400.0, y=300.0, pressed=True))
+    assert len(balls._runtime["balls"]) == 2
+    added = balls._runtime["balls"][-1]
+    assert (added["x"], added["y"]) == (400.0, 300.0)
+
+    # Click inside the original ball's circle hitbox -> remove it.
+    balls.update(MouseEvent(x=100.0, y=100.0, pressed=True))
+    remaining = balls._runtime["balls"]
+    assert len(remaining) == 1
+    assert (remaining[0]["x"], remaining[0]["y"]) == (400.0, 300.0)
+
+
+def test_resize_moves_walls_to_live_dims() -> None:
+    balls._runtime = {"balls": [_one_ball(100.0, 100.0, 20.0)], "w": 640.0, "h": 360.0}
+    balls.update(Resize(width=1000.0, height=800.0))
+    assert balls._runtime["w"] == 1000.0
+    assert balls._runtime["h"] == 800.0
+
+
+def test_floor_bounce_uses_live_height() -> None:
+    # A ball resting past a shrunken floor is pushed back onto the new floor.
+    balls._runtime = {"balls": [_one_ball(100.0, 350.0, 20.0)], "w": 640.0, "h": 360.0}
+    balls._runtime["balls"][0]["vy"] = 100.0
+    balls.update(Resize(width=640.0, height=200.0))
+    balls.update(RenderFrame(frame_id=1, elapsed=balls.TARGET_DT))
+    ball = balls._runtime["balls"][0]
+    assert ball["y"] <= 200.0 - ball["r"] + 1e-6

--- a/apps/snake/snake.py
+++ b/apps/snake/snake.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import random
+
 from plexi_sdk import log, state
 from plexi_sdk.effects import SetState, SetStatus, SetTimer, SetTitle
 from plexi_sdk.events import KeyEvent, TimerFired
@@ -135,22 +137,24 @@ def _advance(data: dict) -> dict:
     data["snake"].insert(0, head)
     if head == data["food"]:
         data["score"] += 1
-        data["food"] = _next_food(data["snake"], data["score"])
+        data["food"] = _next_food(data["snake"])
         log.info(f"snake: score={data['score']}")
     else:
         data["snake"].pop()
     return data
 
 
-def _next_food(snake: list[list[int]], score: int) -> list[int]:
+def _next_food(snake: list[list[int]]) -> list[int]:
     occupied = {tuple(cell) for cell in snake}
-    start = (score * 17 + len(snake) * 7) % (COLS * ROWS)
-    for offset in range(COLS * ROWS):
-        idx = (start + offset) % (COLS * ROWS)
-        cell = [idx % COLS, idx // COLS]
-        if tuple(cell) not in occupied:
-            return cell
-    return [-1, -1]
+    free = [
+        [c, r]
+        for r in range(ROWS)
+        for c in range(COLS)
+        if (c, r) not in occupied
+    ]
+    if not free:
+        return [-1, -1]
+    return random.choice(free)
 
 
 def view():

--- a/apps/snake/tests/test_snake_v3.py
+++ b/apps/snake/tests/test_snake_v3.py
@@ -50,3 +50,23 @@ def test_key_changes_direction_and_view_has_canvas() -> None:
     canvas = snake.view().children[1].to_node()
     assert canvas["type"] == "canvas"
     assert any(cmd["type"] == "rect" and "w" in cmd and "h" in cmd for cmd in canvas["commands"])
+
+
+def test_next_food_is_random_and_lands_on_free_cell() -> None:
+    body = [[13, 10], [12, 10], [11, 10]]
+    occupied = {tuple(cell) for cell in body}
+    results = set()
+    for _ in range(50):
+        food = snake._next_food(body)
+        assert 0 <= food[0] < snake.COLS
+        assert 0 <= food[1] < snake.ROWS
+        assert tuple(food) not in occupied
+        results.add(tuple(food))
+    # The old deterministic spawn returned one fixed cell for a fixed board;
+    # uniform random over ~500 free cells must produce more than one result.
+    assert len(results) > 1
+
+
+def test_next_food_full_board_returns_sentinel() -> None:
+    full = [[c, r] for r in range(snake.ROWS) for c in range(snake.COLS)]
+    assert snake._next_food(full) == [-1, -1]


### PR DESCRIPTION
- snake: `_next_food` was a deterministic `(score*17+len*7) % 520` walk — exactly +24 cells (down 1, left 2) per meal. Now uniform `random.choice` over free cells, board-full sentinel kept. Standalone check over 10 meals shows non-constant deltas.
- balls: restored pre-L1-migration behavior (reference d9415df5) in the v3 idiom — physics against live pane dims (walls track resizes; balls fall into freed space), absolute 14–44px radii (no stretch-scaling), click-to-add / click-ball-to-remove via MouseEvent (real-pixel circle hitboxes, +/- keys removed), chrome deleted for a single dim HUD line, 60fps continuous.
- test fix: apps/balls/tests pointed its sys.path at apps/dev/balls — it was testing the dev POC. Repointed to the maintained app and rewrote for the restored behavior.

Validation: `plexi app check` green for both (all 4 render sizes); `plexi app test` 4+5 passed; balls headless PNG renders correctly; Pyright clean. Pre-existing note: `app render --png` panics on any AppBar-chrome app (font binding), unrelated.

Stints 0433, 0434.

🤖 Generated with [Claude Code](https://claude.com/claude-code)