### PR TITLE
fix(host): WASM panes honor Escape-to-close, overlay placement, centered load spinner (stints 0430, 0431, 0432)

### DIFF
--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -1926,7 +1926,18 @@ impl LiveWasmPane {
         let mut consumed = false;
         for event in input.events() {
             match event {
-                egui::Event::Key { .. } => {
+                egui::Event::Key { key, modifiers, .. } => {
+                    // Bare Escape is reserved for the host CloseApp binding
+                    // (keys.rs, `BindingContext::AppActive`). Reporting it
+                    // consumed claims Escape out of the frame's input buffer
+                    // before `poll_actions` can fire CloseApp, so the focused
+                    // WASM pane never closes on Escape. Skip it — never forward
+                    // to the guest, never count toward `consumed`. Cmd+Escape
+                    // (context zoom-out) is already dropped by
+                    // `translate_key_event`.
+                    if *key == egui::Key::Escape && !modifiers.command {
+                        continue;
+                    }
                     if let Some(ke) = translate_key_event(event) {
                         self.inner.push_input(InputEvent::Key(ke));
                     }
@@ -3206,6 +3217,50 @@ mod tests {
         assert!(
             cmd.is_none(),
             "Cmd-chords are host shortcuts, not guest input"
+        );
+    }
+
+    /// Stint 0430: bare Escape is reserved for the host CloseApp binding
+    /// (keys.rs, `BindingContext::AppActive`). A focused WASM pane must report
+    /// `Passthrough` for it so `poll_actions` can fire CloseApp; before the fix
+    /// `handle_key` reported `Consumed` for every key event, claiming Escape out
+    /// of the frame buffer and starving the close. Normal keys stay `Consumed`.
+    #[test]
+    fn handle_key_reserves_bare_escape_for_host_close() {
+        fn disposition(live: &mut LiveWasmPane, event: egui::Event) -> KeyDisposition {
+            let ctx = egui::Context::default();
+            let mut raw = egui::RawInput::default();
+            raw.events.push(event);
+            let mut out = KeyDisposition::Passthrough;
+            let _ = ctx.run(raw, |ctx| {
+                let input = crate::app::input_router::PlexiInput::take_from(ctx);
+                out = live.handle_key(&input);
+            });
+            out
+        }
+
+        let mut live = LiveWasmPane::new(
+            pane(0.0),
+            "wasm-test",
+            StateSnapshot { entries: vec![] },
+            Vec::new(),
+        );
+
+        assert_eq!(
+            disposition(
+                &mut live,
+                egui_key(egui::Key::Escape, true, false, egui::Modifiers::NONE)
+            ),
+            KeyDisposition::Passthrough,
+            "bare Escape must pass through so the host CloseApp binding fires"
+        );
+        assert_eq!(
+            disposition(
+                &mut live,
+                egui_key(egui::Key::W, true, false, egui::Modifiers::NONE)
+            ),
+            KeyDisposition::Consumed,
+            "normal keys are consumed and forwarded to the WASM guest"
         );
     }
 

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -931,7 +931,9 @@ impl LivePythonPane {
                     );
                     self.pending_click_carry = pending_click;
                 }
-                ui.spinner();
+                ui.centered_and_justified(|ui| {
+                    ui.add(egui::Spinner::new());
+                });
                 self.record_render_perf(host_frame_started.elapsed());
                 ui.ctx()
                     .request_repaint_after(std::time::Duration::from_millis(5));
@@ -981,7 +983,9 @@ impl LivePythonPane {
                 );
                 self.pending_click_carry = pending_click;
             }
-            ui.spinner();
+            ui.centered_and_justified(|ui| {
+                ui.add(egui::Spinner::new());
+            });
             self.record_render_perf(host_frame_started.elapsed());
             ui.ctx()
                 .request_repaint_after(std::time::Duration::from_millis(5));
@@ -1043,7 +1047,9 @@ impl LivePythonPane {
                 );
                 self.pending_click_carry = pending_click;
             }
-            ui.spinner();
+            ui.centered_and_justified(|ui| {
+                ui.add(egui::Spinner::new());
+            });
         }
         self.record_render_perf(host_frame_started.elapsed());
         let now = std::time::Instant::now();
@@ -1652,6 +1658,16 @@ fn python_key_events(events: &[egui::Event]) -> Vec<Value> {
             else {
                 return None;
             };
+            // Bare Escape is reserved for the host CloseApp binding (keys.rs,
+            // `BindingContext::AppActive`). Forwarding it to the guest also makes
+            // `handle_key` report `Consumed`, which claims Escape out of the
+            // frame's input buffer before `poll_actions` can fire CloseApp — so
+            // the focused app never closes on Escape. Skip it here, matching the
+            // pre-WASM ProcessApp carve-out. Cmd+Escape (context zoom-out) still
+            // forwards so guests can bind it.
+            if *key == egui::Key::Escape && !modifiers.command {
+                return None;
+            }
             Some(json!({
                 "key": python_key_name(*key),
                 "pressed": pressed,
@@ -3082,6 +3098,37 @@ mod tests {
         assert_eq!(events[0]["pressed"], true);
         assert_eq!(events[1]["key"], "right");
         assert_eq!(events[1]["pressed"], false);
+    }
+
+    /// Stint 0430: bare Escape is reserved for the host CloseApp binding. It must
+    /// never reach the guest — forwarding it makes `handle_key` report `Consumed`,
+    /// which claims Escape out of the frame buffer before `poll_actions` can fire
+    /// CloseApp, so the focused app never closes. Cmd+Escape (context zoom-out) is
+    /// still delivered so guests can bind it.
+    #[test]
+    fn python_key_events_skips_bare_escape_but_forwards_cmd_escape() {
+        let bare_escape = [egui::Event::Key {
+            key: egui::Key::Escape,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: egui::Modifiers::NONE,
+        }];
+        assert!(
+            python_key_events(&bare_escape).is_empty(),
+            "bare Escape must not reach the guest — it drives host CloseApp"
+        );
+
+        let cmd_escape = [egui::Event::Key {
+            key: egui::Key::Escape,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: egui::Modifiers::COMMAND,
+        }];
+        let forwarded = python_key_events(&cmd_escape);
+        assert_eq!(forwarded.len(), 1, "Cmd+Escape still forwards to the guest");
+        assert_eq!(forwarded[0]["key"], "escape");
     }
 
     #[test]

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -255,6 +255,93 @@ impl PlexiApp {
             })
     }
 
+    /// Single placement authority for a freshly-built app pane. Honors the
+    /// layout `hint` identically for every runtime (builtin, Python-WASM, native
+    /// WASM) so no open path can silently diverge:
+    ///
+    /// * `Some("overlay")` — replace the focused pane in place, reusing its pane
+    ///   id and stashing the displaced pane in `overlay_replaced` so closing the
+    ///   app restores it (see `restore_overlay_replacement`). Falls through to
+    ///   the root/split path when the context is empty.
+    /// * any other hint — split beside the focused pane, or install as the tree
+    ///   root when no pane is focused.
+    ///
+    /// `build(pane_id, linked_pane_id, overlay_replaced) -> Pane` constructs the
+    /// runtime-specific pane once its final id is known — overlay reuses the
+    /// focused id; every other path allocates a fresh one via
+    /// [`Self::open_pane_layout`]. Returns the installed pane id, or `None` when
+    /// an overlay was requested against a degenerate focus target (the focused
+    /// tile is not a pane, or its pane is missing from the map); callers treat
+    /// that as a failed launch.
+    fn place_app_pane<F>(
+        &mut self,
+        app_id: &str,
+        group: Option<String>,
+        hint: Option<&str>,
+        share_hint: Option<f32>,
+        build: F,
+    ) -> Option<PaneId>
+    where
+        F: FnOnce(PaneId, Option<PaneId>, Option<Box<Pane>>) -> Pane,
+    {
+        let active = self.active_window;
+
+        if matches!(hint, Some("overlay")) {
+            if let Some(focused_tile) = self.windows[active].focused_pane {
+                let Some(Tile::Pane(focused_pane_id)) =
+                    self.windows[active].tree.tiles.get(focused_tile)
+                else {
+                    log::warn!(
+                        "app::{app_id}: overlay launch skipped — focused tile is not a pane"
+                    );
+                    return None;
+                };
+                let pane_id = *focused_pane_id;
+                let Some(replaced_pane) = self.windows[active].panes.remove(&pane_id) else {
+                    log::warn!(
+                        "app::{app_id}: overlay launch skipped — pane {pane_id} missing from pane map"
+                    );
+                    return None;
+                };
+                let pane = build(pane_id, None, Some(Box::new(replaced_pane)));
+                self.windows[active].panes.insert(pane_id, pane);
+                self.set_window_focused_pane(active, focused_tile);
+                log::info!("app::{app_id}: launched as overlay on pane {pane_id}");
+                return Some(pane_id);
+            }
+            log::info!(
+                "app::{app_id}: overlay requested but empty context — launching as root pane"
+            );
+            // fall through to the root/split path below
+        }
+
+        if self.windows[active].zoomed_pane.take().is_some() {
+            log::info!("app::{app_id}: cleared zoom before launch");
+        }
+
+        // Record which terminal we're splitting from before focus moves.
+        let linked_pane_id = self.focused_terminal_id(active);
+        let share = Self::share_ratio_from_fraction(app_id, share_hint);
+        let (new_id, share, vertical, new_pane_first) =
+            self.open_pane_layout(app_id, group, hint, share);
+        let pane = build(new_id, linked_pane_id, None);
+        self.windows[active].panes.insert(new_id, pane);
+
+        // Empty context: no focused pane means no existing tile to split against —
+        // install the new pane directly as the tree root.
+        if self.windows[active].focused_pane.is_none() {
+            let ctx = &mut self.windows[active];
+            let root_tile = ctx.tree.tiles.insert_pane(new_id);
+            ctx.tree.root = Some(root_tile);
+            ctx.focused_pane = Some(root_tile);
+            log::info!("app::{app_id}: launched as root pane {new_id} (empty context)");
+            return Some(new_id);
+        }
+        let _ = self.split_with_new_pane(new_id, vertical, share, new_pane_first, false);
+        log::info!("app::{app_id}: launched as split pane {new_id}");
+        Some(new_id)
+    }
+
     /// Open a built-in error tile pane when a capability pre-flight check fails.
     /// Uses `AppRuntime::Builtin` — no app runtime is spawned.
     fn open_launch_failed_pane(
@@ -382,39 +469,35 @@ impl PlexiApp {
         let app_id = config.app_id.clone();
         let runtime = crate::host::wasm_python::LivePythonPane::launch(config)
             .map_err(|error| error.to_string())?;
-        let active = self.active_window;
-        let share = Self::share_ratio_from_fraction(&app_id, None);
-        let (new_id, share, vertical, new_pane_first) =
-            self.open_pane_layout(&app_id, None, layout, share);
-        let linked_pane_id = self.focused_terminal_id(active);
-        self.windows[active].panes.insert(
-            new_id,
-            Pane::App(Box::new(crate::host::pane::AppPane {
-                pip_status: None,
-                id: new_id,
-                runtime: crate::host::pane::AppRuntime::Python(Box::new(runtime)),
-                workspace_root,
-                permissions,
-                manifest_id: app_id.clone(),
-                name: app_id.clone(),
-                pane_group: None,
-                linked_pane_id,
-                overlay_replaced: None,
-                hidden: false,
-                agent: None,
-                slots: std::collections::HashMap::new(),
-                semantic_state: Default::default(),
-            })),
-        );
+        let manifest_id = app_id.clone();
+        let name = app_id.clone();
+        let new_id = self
+            .place_app_pane(
+                &app_id,
+                None,
+                layout,
+                None,
+                move |new_id, linked_pane_id, overlay_replaced| {
+                    Pane::App(Box::new(crate::host::pane::AppPane {
+                        pip_status: None,
+                        id: new_id,
+                        runtime: crate::host::pane::AppRuntime::Python(Box::new(runtime)),
+                        workspace_root,
+                        permissions,
+                        manifest_id,
+                        name,
+                        pane_group: None,
+                        linked_pane_id,
+                        overlay_replaced,
+                        hidden: false,
+                        agent: None,
+                        slots: std::collections::HashMap::new(),
+                        semantic_state: Default::default(),
+                    }))
+                },
+            )
+            .ok_or_else(|| format!("overlay launch target unavailable for {app_id}"))?;
         self.hot_reload.watch(new_id, app_dir);
-        if self.windows[active].focused_pane.is_none() {
-            let ctx = &mut self.windows[active];
-            let root = ctx.tree.tiles.insert_pane(new_id);
-            ctx.tree.root = Some(root);
-            ctx.focused_pane = Some(root);
-        } else {
-            let _ = self.split_with_new_pane(new_id, vertical, share, new_pane_first, false);
-        }
         crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
             app_id: app_id.clone(),
             type_id: "python-wasm".to_string(),
@@ -507,10 +590,6 @@ impl PlexiApp {
     ) -> Result<PaneId, String> {
         use crate::host::wasm_pane::{LiveWasmPane, SysinfoStats, WasmPane};
 
-        let active = self.active_window;
-        let share = Self::share_ratio_from_fraction(app_id, None);
-        let (new_id, share, vertical, new_pane_first) =
-            self.open_pane_layout(app_id, None, layout, share);
         let pane = WasmPane::new(app, Box::new(SysinfoStats::new()));
         let pane = if let Some((store, granted, blocked)) = remembered {
             pane.with_remembered_capabilities(workspace_root.clone(), store, granted, blocked)
@@ -518,28 +597,36 @@ impl PlexiApp {
             pane
         };
         let mut live = LiveWasmPane::new(pane, app_id, snapshot, launch_args);
-        live.set_pane_id(new_id);
 
-        let linked_pane_id = self.focused_terminal_id(active);
-        self.windows[active].panes.insert(
-            new_id,
-            Pane::App(Box::new(crate::host::pane::AppPane {
-                pip_status: None,
-                id: new_id,
-                runtime: crate::host::pane::AppRuntime::Wasm(Box::new(live)),
-                workspace_root,
-                permissions,
-                manifest_id: app_id.to_string(),
-                name: app_id.to_string(),
-                pane_group: None,
-                linked_pane_id,
-                overlay_replaced: None,
-                hidden: false,
-                agent: None,
-                slots: std::collections::HashMap::new(),
-                semantic_state: Default::default(),
-            })),
-        );
+        let manifest_id = app_id.to_string();
+        let name = app_id.to_string();
+        let new_id = self
+            .place_app_pane(
+                app_id,
+                None,
+                layout,
+                None,
+                move |new_id, linked_pane_id, overlay_replaced| {
+                    live.set_pane_id(new_id);
+                    Pane::App(Box::new(crate::host::pane::AppPane {
+                        pip_status: None,
+                        id: new_id,
+                        runtime: crate::host::pane::AppRuntime::Wasm(Box::new(live)),
+                        workspace_root,
+                        permissions,
+                        manifest_id,
+                        name,
+                        pane_group: None,
+                        linked_pane_id,
+                        overlay_replaced,
+                        hidden: false,
+                        agent: None,
+                        slots: std::collections::HashMap::new(),
+                        semantic_state: Default::default(),
+                    }))
+                },
+            )
+            .ok_or_else(|| format!("overlay launch target unavailable for {app_id}"))?;
         crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
             app_id: app_id.to_string(),
             type_id: "wasm".to_string(),
@@ -547,15 +634,6 @@ impl PlexiApp {
             timestamp: crate::host::event_log::now_timestamp(),
         });
         log::info!("wasm::{app_id}: spawned pane {new_id}");
-
-        if self.windows[active].focused_pane.is_none() {
-            let ctx = &mut self.windows[active];
-            let root_tile = ctx.tree.tiles.insert_pane(new_id);
-            ctx.tree.root = Some(root_tile);
-            ctx.focused_pane = Some(root_tile);
-            return Ok(new_id);
-        }
-        let _ = self.split_with_new_pane(new_id, vertical, share, new_pane_first, false);
         Ok(new_id)
     }
 
@@ -703,106 +781,42 @@ impl PlexiApp {
         hint: Option<&str>,
         share: Option<f32>,
     ) {
-        let active = self.active_window;
         let app_type_id = app.type_id().to_string();
         let app_name = app.display_name();
-        let new_app_pane = |id: PaneId,
-                            app: Box<dyn App>,
-                            workspace_root: PathBuf,
-                            group: Option<String>,
-                            linked_pane_id: Option<PaneId>,
-                            overlay_replaced: Option<Box<Pane>>| {
-            Pane::App(Box::new(crate::host::pane::AppPane {
-                pip_status: None,
-                id,
-                runtime: crate::host::pane::AppRuntime::Builtin(app),
-                workspace_root,
-                permissions,
-                manifest_id: app_type_id.clone(),
-                name: app_name.clone(),
-                pane_group: group,
-                linked_pane_id,
-                overlay_replaced,
-                hidden: false,
-                agent: None,
-                slots: std::collections::HashMap::new(),
-                semantic_state: Default::default(),
-            }))
-        };
-
-        if matches!(hint, Some("overlay")) {
-            if let Some(focused_tile) = self.windows[active].focused_pane {
-                let Some(Tile::Pane(focused_pane_id)) =
-                    self.windows[active].tree.tiles.get(focused_tile)
-                else {
-                    log::warn!(
-                        "builtin::{app_name}: overlay launch skipped — focused tile is not a pane"
-                    );
-                    return;
-                };
-                let pane_id = *focused_pane_id;
-                let Some(replaced_pane) = self.windows[active].panes.remove(&pane_id) else {
-                    return;
-                };
-                self.windows[active].panes.insert(
-                    pane_id,
-                    new_app_pane(
-                        pane_id,
-                        app,
-                        workspace_root,
-                        group,
-                        None,
-                        Some(Box::new(replaced_pane)),
-                    ),
-                );
-                self.set_window_focused_pane(active, focused_tile);
-                log::info!("builtin::{app_name}: launched as overlay on pane {pane_id}");
-                crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
-                    app_id: app_type_id.clone(),
-                    type_id: app_type_id.clone(),
-                    pane_id,
-                    timestamp: crate::host::event_log::now_timestamp(),
-                });
-                return;
-            }
-            log::info!(
-                "builtin::{app_name}: overlay requested but empty context — launching as root pane"
-            );
-            // fall through to root-pane path below
-        }
-
-        if self.windows[active].zoomed_pane.take().is_some() {
-            log::info!("builtin::{app_name}: cleared zoom before launch");
-        }
-
-        // Record which terminal we're splitting from before focus moves.
-        let linked_pane_id = self.focused_terminal_id(active);
-        let share = Self::share_ratio_from_fraction(&app_type_id, share);
-        let (new_id, share, vertical, new_pane_first) =
-            self.open_pane_layout(&app_type_id, group.clone(), hint, share);
-        self.windows[active].panes.insert(
-            new_id,
-            new_app_pane(new_id, app, workspace_root, group, linked_pane_id, None),
+        let manifest_id = app_type_id.clone();
+        let group_for_pane = group.clone();
+        let placed = self.place_app_pane(
+            &app_type_id,
+            group,
+            hint,
+            share,
+            move |id, linked_pane_id, overlay_replaced| {
+                Pane::App(Box::new(crate::host::pane::AppPane {
+                    pip_status: None,
+                    id,
+                    runtime: crate::host::pane::AppRuntime::Builtin(app),
+                    workspace_root,
+                    permissions,
+                    manifest_id,
+                    name: app_name,
+                    pane_group: group_for_pane,
+                    linked_pane_id,
+                    overlay_replaced,
+                    hidden: false,
+                    agent: None,
+                    slots: std::collections::HashMap::new(),
+                    semantic_state: Default::default(),
+                }))
+            },
         );
-        crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
-            app_id: app_type_id.clone(),
-            type_id: app_type_id.clone(),
-            pane_id: new_id,
-            timestamp: crate::host::event_log::now_timestamp(),
-        });
-
-        // Empty context: no focused pane means no existing tile to split.
-        // Install the new pane directly as the tree root.
-        if self.windows[active].focused_pane.is_none() {
-            let ctx = &mut self.windows[active];
-            let root_tile = ctx.tree.tiles.insert_pane(new_id);
-            ctx.tree.root = Some(root_tile);
-            ctx.focused_pane = Some(root_tile);
-            log::info!("builtin::{app_name}: launched as root pane {new_id} (empty context)");
-            return;
+        if let Some(pane_id) = placed {
+            crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
+                app_id: app_type_id.clone(),
+                type_id: app_type_id.clone(),
+                pane_id,
+                timestamp: crate::host::event_log::now_timestamp(),
+            });
         }
-
-        let _ = self.split_with_new_pane(new_id, vertical, share, new_pane_first, false);
     }
 
     pub(super) fn create_single_pane_tree(
@@ -1807,5 +1821,112 @@ fn sanitize_wasm_path_component(input: &str) -> String {
         "root".to_string()
     } else {
         out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::permissions::AppPermissions;
+    use crate::host::wasm_app::{StateSnapshot, StateStore, WasmApp};
+    use crate::testing::HostHarness;
+
+    fn counter_fixture() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/wasm-fixtures/counter.wasm")
+    }
+
+    /// A loadable native-WASM component and the state snapshot the pane opens
+    /// with. Snapshot is taken before the store moves into the app, mirroring the
+    /// production launch path.
+    fn load_counter() -> (WasmApp, StateSnapshot) {
+        let store = StateStore::ephemeral();
+        let snapshot = store.snapshot();
+        let app = WasmApp::load_ephemeral_run("counter-pane", &counter_fixture(), store)
+            .expect("load counter fixture");
+        (app, snapshot)
+    }
+
+    /// Stint 0431: the native-WASM open path must honor the default `"overlay"`
+    /// placement hint (the layout Cmd+P uses) — replace the focused pane in
+    /// place, reusing its id and stashing the displaced pane for restore — not
+    /// unconditionally split a new pane below. Regression:
+    /// `open_wasm_app_instance` ignored the hint and always split.
+    #[test]
+    fn open_wasm_app_instance_overlay_replaces_focused_pane_in_place() {
+        let mut h = HostHarness::new();
+        let focused = h.add_test_pane();
+        h.focus_pane(focused);
+        let count_before = h.pane_count();
+
+        let (app, snapshot) = load_counter();
+        let pane_id = h
+            .app
+            .open_wasm_app_instance(
+                "counter-pane",
+                app,
+                snapshot,
+                std::env::temp_dir(),
+                AppPermissions::default(),
+                None,
+                Some("overlay"),
+                Vec::new(),
+            )
+            .expect("overlay launch returns the reused pane id");
+
+        assert_eq!(pane_id, focused, "overlay reuses the focused pane's id");
+        assert_eq!(
+            h.pane_count(),
+            count_before,
+            "overlay replaces in place — no extra pane is split"
+        );
+        let stashed_replacement = h.app.windows[0]
+            .panes
+            .get(&focused)
+            .and_then(Pane::as_app)
+            .map(|app| app.overlay_replaced.is_some())
+            .unwrap_or(false);
+        assert!(
+            stashed_replacement,
+            "overlay stashes the displaced pane in overlay_replaced for restore-on-close"
+        );
+    }
+
+    /// Stint 0431: an overlay launch into an empty context (no focused pane)
+    /// must fall through to the root-pane path and install the app as the tree
+    /// root — never a silent no-op.
+    #[test]
+    fn open_wasm_app_instance_overlay_no_focused_pane_launches_root() {
+        let mut h = HostHarness::new();
+        assert!(
+            h.app.windows[0].focused_pane.is_none(),
+            "empty context has no focused pane"
+        );
+
+        let (app, snapshot) = load_counter();
+        let pane_id = h
+            .app
+            .open_wasm_app_instance(
+                "counter-pane",
+                app,
+                snapshot,
+                std::env::temp_dir(),
+                AppPermissions::default(),
+                None,
+                Some("overlay"),
+                Vec::new(),
+            )
+            .expect("overlay with empty context launches as root pane");
+
+        let root = h.app.windows[0].tree.root.expect("root tile installed");
+        assert_eq!(
+            h.app.windows[0].focused_pane,
+            Some(root),
+            "new root pane must be focused"
+        );
+        assert_eq!(
+            h.app.windows[0].tree.tiles.get(root),
+            Some(&Tile::Pane(pane_id)),
+            "root tile must hold the launched wasm pane"
+        );
     }
 }

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -1718,6 +1718,80 @@ fn key_pane_delivers_key_event_and_mutates_guest_view() {
     }
 }
 
+/// Stint 0430: bare Escape on a focused WASM/Python pane must close it. The
+/// Escape→CloseApp binding (keys.rs, `BindingContext::AppActive`) fires in
+/// `poll_actions` only when the focused app's `handle_key` did NOT consume the
+/// key. `LivePythonPane::handle_key` used to report `Consumed` for bare Escape
+/// (`python_key_events` forwarded it), which claimed Escape out of the frame's
+/// input buffer before `poll_actions` ran — so the pane never closed. Drive a
+/// real subprocess pane and a genuine Escape `RawInput` through a live frame
+/// and assert the pane closes.
+#[test]
+fn bare_escape_closes_focused_python_wasm_pane() {
+    let mut h = HostHarness::new();
+
+    let app_dir =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("apps/dev/key-event-probe");
+    h.app
+        .launch_app_by_path_with_layout(&app_dir.to_string_lossy(), None, None, &[])
+        .expect("launch key-event-probe");
+    let pane_id = *h
+        .state()
+        .open_panes
+        .last()
+        .expect("a pane appears after launching key-event-probe");
+
+    // Real subprocess: poll for its first committed render before driving input.
+    let start = std::time::Instant::now();
+    loop {
+        h.run_frames(1);
+        let rendered = h.app.windows[h.app.active_window]
+            .panes
+            .get(&pane_id)
+            .and_then(Pane::as_app)
+            .is_some_and(
+                |pane| matches!(&pane.runtime, AppRuntime::Python(p) if p.has_rendered_tree()),
+            );
+        if rendered {
+            break;
+        }
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(30),
+            "key-event-probe did not render its first frame in time"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+    h.focus_pane(pane_id);
+    h.run_frames(1);
+    assert!(
+        h.state().open_panes.contains(&pane_id),
+        "pane must be open and focused before the Escape press"
+    );
+
+    // Drive a genuine bare Escape through a real frame's RawInput. The focused
+    // Python pane's handle_key returns Passthrough for it, so poll_actions fires
+    // CloseApp within this same frame.
+    h.frame(egui::RawInput {
+        screen_rect: Some(egui::Rect::from_min_size(
+            egui::Pos2::ZERO,
+            egui::vec2(1280.0, 800.0),
+        )),
+        events: vec![egui::Event::Key {
+            key: egui::Key::Escape,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: egui::Modifiers::NONE,
+        }],
+        ..Default::default()
+    });
+
+    assert!(
+        !h.state().open_panes.contains(&pane_id),
+        "bare Escape on a focused Python-WASM pane must close it (Escape→CloseApp)"
+    );
+}
+
 /// Stint 0426 root cause: `PlexiApp::pending_pane_clicks` is removed from its
 /// map by the render dispatcher (`tiling.rs`/`render.rs`) *before* calling
 /// `AppRuntime::ui`, so `LivePythonPane::ui` is a queued click's only chance


### PR DESCRIPTION
Three regressions from the CPython-in-WASM migration (c2a8c76d), verified root causes:

- **Escape-to-close (0430):** WASM Python and native WASM panes forwarded bare Escape to the guest and returned Consumed, starving the Escape→CloseApp binding. Restored the pre-WASM carve-out in both runtimes: bare Escape is never forwarded and never counts toward Consumed. End-to-end harness test drives a real Escape through a live Python-WASM pane and asserts it closes.
- **Overlay placement (0431):** default "overlay" hint was ignored by both WASM open paths (always split Below). Extracted one shared `place_app_pane` authority (overlay-replace-in-place / root / split, info-logged) and routed builtin, Python-WASM, and native-WASM opens through it. Bonus: overlay-launched Python apps now get their hot-reload watcher (old path returned before watching).
- **Spinner (0432):** the three pre-first-frame loading states used bare `ui.spinner()` at the top-left cursor; now `centered_and_justified`.

`cargo build` clean; full suite 1488 passed / 6 pre-existing environment-dependent failures (identical baseline set on alpha). Rebased on alpha post-#2422–#2425.

Stints 0430, 0431, 0432.

🤖 Generated with [Claude Code](https://claude.com/claude-code)