### PR TITLE
fix(apps): breakout locks to sustainable 30fps with dt-correct physics until 0438 lands (stint 0446)

### DIFF
--- a/apps/breakout/breakout.py
+++ b/apps/breakout/breakout.py
@@ -11,7 +11,7 @@ from plexi_sdk.effects import SetSchedulerMode, SetStatus, SetTitle
 from plexi_sdk.events import KeyEvent, RenderFrame, Resize
 from plexi_sdk.ui import Canvas, CanvasCircle, CanvasRect, CanvasText, Column, FooterKeys
 
-TARGET_FPS = 60
+TARGET_FPS = 30
 TARGET_DT = 1.0 / TARGET_FPS
 
 BRICK_COLS = 10
@@ -156,6 +156,9 @@ def init(size, args) -> list:
     _runtime = _initial()
     effects: list = [
         SetTitle("Breakout"),
+        # Locked to a sustainable 30 fps until stint 0438 (diffed tree updates)
+        # restores a jitter-free 60 fps. Physics is dt-based, so gameplay speed
+        # is unchanged at this rate.
         SetSchedulerMode("continuous", fps=TARGET_FPS),
         SetStatus(f"Score: 0 | Lives: {STARTING_LIVES}"),
     ]
@@ -184,7 +187,9 @@ def update(event) -> list:
         if data["state"] != "playing":
             return []
         dt = event.elapsed if event.elapsed > 0 else TARGET_DT
-        effects = _step(data, min(dt, TARGET_DT * 2.0))
+        # Cap a single physics step at one nominal frame so a jitter dip can't
+        # push the ball far enough to tunnel through a brick row.
+        effects = _step(data, min(dt, TARGET_DT))
         return effects
 
     return []

--- a/apps/breakout/tests/test_breakout.py
+++ b/apps/breakout/tests/test_breakout.py
@@ -102,6 +102,37 @@ def test_brick_collision_removes_brick_and_scores() -> None:
     assert first_brick["alive"] is False
 
 
+def test_ball_displacement_per_second_is_tick_rate_independent() -> None:
+    """Physics is dt-based, so 1 real second of travel covers the same distance
+    whether ticked at 30 fps or the old 60 fps. Guards the 0446 fps lock against
+    a future regression that reintroduces fixed per-tick increments."""
+
+    def _travel(fps: int) -> tuple[float, float]:
+        sdk.pane_width = sdk.canvas_width = 2000.0
+        sdk.pane_height = sdk.canvas_height = 2000.0
+        breakout._keys_held.clear()
+        data = breakout._initial()
+        breakout._runtime = data
+        for brick in data["bricks"]:
+            brick["alive"] = False  # remove collisions; measure free flight
+        data["ball_attached"] = False
+        data["ball_x"] = data["ball_y"] = 1000.0
+        data["ball_vx"] = 100.0
+        data["ball_vy"] = -100.0
+        start_x, start_y = data["ball_x"], data["ball_y"]
+        dt = 1.0 / fps
+        for _ in range(fps):  # fps frames of 1/fps == exactly one real second
+            breakout._step(data, dt)
+        return data["ball_x"] - start_x, data["ball_y"] - start_y
+
+    dx_30, dy_30 = _travel(30)
+    dx_60, dy_60 = _travel(60)
+
+    # vx=100, vy=-100 px/s over 1.0 s -> (+100, -100) at either tick rate.
+    assert abs(dx_30 - 100.0) < 1e-6 and abs(dy_30 + 100.0) < 1e-6
+    assert abs(dx_30 - dx_60) < 1e-6 and abs(dy_30 - dy_60) < 1e-6
+
+
 def test_view_returns_canvas_with_correct_structure() -> None:
     _reset()
     node = breakout.view().to_node()


### PR DESCRIPTION
Breakout requested 60fps the CPython-WASM guest sustains at only ~55 with jitter dips (0438 baseline); variable 45-60 reads choppier than a locked rate. Now requests 30fps.

- Physics was already dt-based (velocities in px/sec, dt = real elapsed), so gameplay speed is unchanged; new test proves ball displacement per real second is identical at 30 and 60fps stepping.
- Anti-tunneling clamp tightened from 2*TARGET_DT to TARGET_DT so the max single physics step stays exactly 1/30s (10px < 17px brick height) — same tunneling safety as the old 60fps build.
- Comment references stint 0438 (diffed tree updates) as what restores 60.

Answer to "do we have a frame-lock system": yes — per-app `SetSchedulerMode(fps=N)`, honored host-side with fixed-cadence deadlines; apps just need to request sustainable rates.

`plexi app check` green; `plexi app test` 13 passed.

Stint 0446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)