### PR TITLE
feat(sdk,render): token-driven default spacing — declarative apps look right with zero layout code (stint 0445)

### DIFF
--- a/apps/csv_viewer/csv_viewer.py
+++ b/apps/csv_viewer/csv_viewer.py
@@ -184,7 +184,6 @@ def _list_view(data: dict):
             FooterKeys([("j/k", "select"), ("enter", "open"), ("r", "refresh")]),
         ],
         grow=True,
-        padding=0,
     )
 
 
@@ -209,7 +208,6 @@ def _detail_view(data: dict):
             FooterKeys([("j/k", "rows"), ("h/l", "cols"), ("esc", "back")]),
         ],
         grow=True,
-        padding=0,
     )
 
 

--- a/apps/github-issues/main.py
+++ b/apps/github-issues/main.py
@@ -140,7 +140,6 @@ def view():
                 Spacer(grow=True),
             ],
             grow=True,
-            padding=0,
         )
     if data["view"] == "detail":
         return _detail_view(data)
@@ -275,7 +274,6 @@ def _list_view(data: dict):
             ),
         ],
         grow=True,
-        padding=0,
     )
 
 
@@ -308,7 +306,6 @@ def _detail_view(data: dict):
             FooterKeys([("esc", "back")]),
         ],
         grow=True,
-        padding=0,
     )
 
 

--- a/apps/kraken/main.py
+++ b/apps/kraken/main.py
@@ -89,7 +89,6 @@ def view():
             FooterKeys([("j/k", "select"), ("r", "refresh"), ("timer", "auto")]),
         ],
         grow=True,
-        padding=0,
     )
 
 

--- a/apps/logs/logs.py
+++ b/apps/logs/logs.py
@@ -176,7 +176,7 @@ def view():
             ),
         ]
     )
-    return Column(children, grow=True, padding=0)
+    return Column(children, grow=True)
 
 
 def _state() -> dict:

--- a/apps/wikipedia/wikipedia.py
+++ b/apps/wikipedia/wikipedia.py
@@ -218,7 +218,6 @@ def _search_view(data: dict):
             FooterKeys([("enter", "search")]),
         ],
         grow=True,
-        padding=0,
     )
 
 
@@ -237,7 +236,6 @@ def _results_view(data: dict):
             FooterKeys([("j/k", "select"), ("enter", "open"), ("esc", "search")]),
         ],
         grow=True,
-        padding=0,
     )
 
 
@@ -252,7 +250,6 @@ def _article_view(data: dict):
             FooterKeys([("esc", "results")]),
         ],
         grow=True,
-        padding=0,
     )
 
 

--- a/sdk/python/AUTHORING.md
+++ b/sdk/python/AUTHORING.md
@@ -188,9 +188,27 @@ set (`wit/plexi.wit`) is the single, live UI node language; there is no
 separate legacy renderer for it to diverge from. L0 is deprecated and its
 `_l0` fallbacks are gone; the `Raw` escape hatch stays.
 
-Keep the root shell padded: `Column([...], grow=True, padding=SPACE_MD)` or
-larger. Never `padding=0` on the root — app bars and footers render full-bleed
-while body content stays inset.
+### Spacing is good by default
+
+You write no layout code to look right. The host fills in its standard spacing
+wherever your tree declares none, and any explicit value you set wins:
+
+- **Root content inset.** A declarative tree is automatically inset from the
+  pane edge (horizontal `SPACE_XL`, vertical `SPACE_MD`). App bars and footer
+  keys still render full-bleed — only body content is inset — so a
+  `Column([AppBar(...), ...body..., FooterKeys(...)])` needs no layout code.
+  You no longer set root padding: `Column(padding=...)` does not affect the
+  declarative tree (it survives only for legacy canvas-mode layout).
+- **Inter-child spacing.** Leave `gap` unset on `Column`/`HStack` and the host
+  spaces children (columns get `SPACE_MD`, rows get the tighter `SPACE_SM`).
+  Pass an explicit `gap=` to override; `gap=0` packs children flush.
+- **Button targets.** Buttons get a comfortable minimum click/touch size, so
+  single-glyph buttons (calculator keys, toolbar chips) are never cramped.
+
+Full-bleed pixel apps opt out automatically: a grow `Canvas` or a GPU
+`Surface` anywhere in the tree tells the host the app owns every pixel, so no
+inset is applied (games, visualizers, video). A fixed-size `Canvas` is ordinary
+flow content and stays inset.
 
 Canvas apps bypass the host WCAG contrast check. Use `theme.fg` for canvas text
 and reserve `dim()`/`theme.muted` for fills, or text fails contrast.

--- a/sdk/python/plexi_sdk/_adapter.py
+++ b/sdk/python/plexi_sdk/_adapter.py
@@ -170,25 +170,31 @@ def _normalize_node_data(data: dict[str, Any], key: str, flatten) -> dict[str, A
         child_ids = [
             flatten(child, f"{key}/{idx}") for idx, child in enumerate(children)
         ]
-        return {
+        out: dict[str, Any] = {
             "type": "Column",
             "children": child_ids,
-            "gap": data.get("gap", 0.0),
             "align": data.get("align", "start"),
             "grow": data.get("grow", False),
         }
+        # Carry gap only when the app set one: absence lets the host apply its
+        # default inter-child spacing, an explicit value (including 0) wins.
+        if data.get("gap") is not None:
+            out["gap"] = data["gap"]
+        return out
     if node_type in ("row", "Row"):
         children = data.get("children", [])
         child_ids = [
             flatten(child, f"{key}/{idx}") for idx, child in enumerate(children)
         ]
-        return {
+        out = {
             "type": "Row",
             "children": child_ids,
-            "gap": data.get("gap", 0.0),
             "align": data.get("align", "start"),
             "grow": data.get("grow", False),
         }
+        if data.get("gap") is not None:
+            out["gap"] = data["gap"]
+        return out
     if node_type == "button":
         return {
             "type": "Button",

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -368,7 +368,7 @@ class Button(Component):
 
 
 class HStack(Component):
-    def __init__(self, children: list[Component], gap: float = 0.0, grow: bool = False) -> None:
+    def __init__(self, children: list[Component], gap: "float | None" = None, grow: bool = False) -> None:
         if any(not isinstance(child, Component) for child in children):
             raise TypeError("HStack children must be Component instances")
         self.children = children
@@ -391,7 +391,12 @@ class HStack(Component):
             if node is None:
                 return None
             children.append(node)
-        return {"type": "row", "children": children, "gap": self.gap, "grow": self.grow}
+        node: dict = {"type": "row", "children": children, "grow": self.grow}
+        # Emit gap only when set so the host can distinguish "unset" (apply the
+        # default row spacing) from an explicit "gap=0" (pack flush).
+        if self.gap is not None:
+            node["gap"] = self.gap
+        return node
 
 
 class Sized(Component):
@@ -2217,15 +2222,20 @@ class Column(Component):
     measures fixed-height children first, then distributes leftover space to
     any `Spacer(grow=True)` descendants at the top level.
 
-    Padding defaults to `SPACE_XL` (24px) on the sides and bottom, and
-    `SPACE_SM` (8px) on the top. Pass `padding=0` for full-width content
-    (e.g. apps whose children manage their own horizontal margins).
-    Override top-only with `padding_top=`.
+    Spacing is good by default: leave `gap` unset and the host applies its
+    standard inter-child spacing; pass an explicit `gap=` (including `gap=0`
+    to pack children flush) to override. The root's *content padding* is owned
+    by the host too — a declarative tree is inset automatically, and app bars /
+    footers stay full-bleed — so apps need no layout code to look right.
+
+    `padding` / `padding_top` only affect the legacy canvas-mode layout
+    (`measure`/`render`); they are ignored by the declarative tree, whose inset
+    the host owns.
     """
     children: List[Component]
     padding: float = SPACE_XL
     padding_top: Optional[float] = None
-    gap: float = SPACE_MD
+    gap: Optional[float] = None
     align: str = "start"
     grow: bool = False
     key: str = ""
@@ -2243,13 +2253,20 @@ class Column(Component):
     def _pad_top(self) -> float:
         return self.padding_top if self.padding_top is not None else SPACE_SM
 
+    @property
+    def _gap(self) -> float:
+        """Resolved gap for canvas-mode layout math. The declarative tree omits
+        gap when unset so the host applies its default; canvas-mode has no host,
+        so it falls back to `SPACE_MD` here."""
+        return self.gap if self.gap is not None else SPACE_MD
+
     def measure(self, avail_w: float) -> float:
         inner_w = avail_w - 2 * self.padding
         total = 0.0
         for i, c in enumerate(self.children):
             total += c.measure(inner_w)
             if i < len(self.children) - 1:
-                total += self.gap
+                total += self._gap
         return total + self._pad_top + self.padding
 
     def render(self, ctx, x: float, y: float, w: float, h: float) -> None:
@@ -2259,7 +2276,7 @@ class Column(Component):
         inner_h = h - self._pad_top - self.padding
 
         heights = [c.measure(inner_w) for c in self.children]
-        gap_total = self.gap * max(0, len(self.children) - 1)
+        gap_total = self._gap * max(0, len(self.children) - 1)
         fixed_used = sum(heights) + gap_total
 
         grow_indices = [i for i, c in enumerate(self.children) if c.is_grow()]
@@ -2280,7 +2297,7 @@ class Column(Component):
             child._render_clipped(ctx, inner_x, cursor, inner_w, ch)
             cursor += ch
             if i < len(self.children) - 1:
-                cursor += self.gap
+                cursor += self._gap
 
     def to_node(self) -> "dict | None":
         children = []
@@ -2289,13 +2306,17 @@ class Column(Component):
             if node is None:
                 return None
             children.append(node)
-        return {
+        node: dict = {
             "type": "column",
             "children": children,
-            "gap": self.gap,
-            "padding_top": self._pad_top,
-            "padding": self.padding,
+            "align": self.align,
+            "grow": self.grow,
         }
+        # Emit gap only when the app set one, so the host can tell "unset"
+        # (apply the default) from an explicit "gap=0" (pack flush).
+        if self.gap is not None:
+            node["gap"] = self.gap
+        return node
 
 
 # ── Public render entry point ──────────────────────────────────────────────

--- a/sdk/python/tests/test_hstack_sized.py
+++ b/sdk/python/tests/test_hstack_sized.py
@@ -7,7 +7,7 @@ usable in canvas mode only (measure()/render()/is_grow()).
 
 import pytest
 
-from plexi_sdk.ui import Canvas, HStack, Sized, Text
+from plexi_sdk.ui import Canvas, Column, HStack, Sized, Text
 
 
 def test_hstack_to_node_horizontal_stack() -> None:
@@ -16,6 +16,21 @@ def test_hstack_to_node_horizontal_stack() -> None:
     assert node["type"] == "row"
     assert node["gap"] == 12.0
     assert len(node["children"]) == 2
+
+
+def test_containers_omit_gap_when_unset_but_keep_explicit_zero() -> None:
+    """Good-by-default spacing (stint 0445): an unset gap is omitted from the
+    wire so the host applies its default; an explicit ``gap=0`` is preserved so
+    the host packs children flush. The two must stay distinguishable."""
+    assert "gap" not in HStack([Text(text="a")]).to_node()
+    assert HStack([Text(text="a")], gap=0.0).to_node()["gap"] == 0.0
+
+    col_default = Column([Text(text="a")]).to_node()
+    assert col_default is not None
+    assert "gap" not in col_default
+    col_flush = Column([Text(text="a")], gap=0.0).to_node()
+    assert col_flush is not None
+    assert col_flush["gap"] == 0.0
 
 
 def test_hstack_fails_loud_when_a_child_has_no_tree_node() -> None:

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -2659,7 +2659,10 @@ fn decode_node_data(value: &Value) -> Result<UiNodeData, WasmPythonError> {
         })),
         "Column" | "column" => Ok(UiNodeData::Column(ColumnNode {
             children: u32_list(value, "children")?,
-            gap: optional_f32(value, "gap")?.unwrap_or(0.0),
+            // Default inter-child spacing when the app declares none. Absence
+            // means "use the good default"; an explicit `gap: 0.0` still wins
+            // and packs children flush (stint 0445).
+            gap: optional_f32(value, "gap")?.unwrap_or(crate::ui::style::SPACE_MD),
             align: decode_alignment(
                 value
                     .get("align")
@@ -2712,7 +2715,9 @@ fn decode_node_data(value: &Value) -> Result<UiNodeData, WasmPythonError> {
         })),
         "Row" | "row" => Ok(UiNodeData::Row(RowNode {
             children: u32_list(value, "children")?,
-            gap: optional_f32(value, "gap")?.unwrap_or(0.0),
+            // Rows sit tighter than columns by default; absence uses the token,
+            // an explicit `gap: 0.0` still packs children flush (stint 0445).
+            gap: optional_f32(value, "gap")?.unwrap_or(crate::ui::style::SPACE_SM),
             align: decode_alignment(
                 value
                     .get("align")
@@ -3283,6 +3288,50 @@ mod tests {
         assert!(error
             .to_string()
             .contains("unsupported CPython-WASM UINode type: Accordion"));
+    }
+
+    // Stint 0445: good-by-default inter-child spacing. When an app declares no
+    // `gap`, the decoder fills in the design-token default; an explicit value
+    // (including `0.0`, meaning "pack flush") always wins over the default.
+    #[test]
+    fn container_gap_defaults_when_unset_and_explicit_value_wins() {
+        let col_default = decode_node_data(&json!({"type": "column", "children": []}))
+            .expect("decode column");
+        let UiNodeData::Column(c) = col_default else {
+            panic!("expected column");
+        };
+        assert_eq!(
+            c.gap,
+            crate::ui::style::SPACE_MD,
+            "an unset column gap must fall back to the SPACE_MD token"
+        );
+
+        let row_default =
+            decode_node_data(&json!({"type": "row", "children": []})).expect("decode row");
+        let UiNodeData::Row(r) = row_default else {
+            panic!("expected row");
+        };
+        assert_eq!(
+            r.gap,
+            crate::ui::style::SPACE_SM,
+            "an unset row gap must fall back to the SPACE_SM token"
+        );
+
+        let col_zero =
+            decode_node_data(&json!({"type": "column", "children": [], "gap": 0.0}))
+                .expect("decode column");
+        let UiNodeData::Column(c) = col_zero else {
+            panic!("expected column");
+        };
+        assert_eq!(c.gap, 0.0, "an explicit gap=0 must pack children flush");
+
+        let row_explicit =
+            decode_node_data(&json!({"type": "row", "children": [], "gap": 20.0}))
+                .expect("decode row");
+        let UiNodeData::Row(r) = row_explicit else {
+            panic!("expected row");
+        };
+        assert_eq!(r.gap, 20.0, "an explicit row gap must be honored verbatim");
     }
 
     #[test]

--- a/src/host/wasm_render.rs
+++ b/src/host/wasm_render.rs
@@ -71,19 +71,59 @@ pub fn render_ui_tree_with_canvas_fits(
     surface_key: Option<crate::ui::focus::SurfaceKey>,
 ) -> RenderResult {
     let mut out = RenderResult::default();
-    render_node(
-        ui,
-        &tree.nodes,
-        tree.root,
-        colors,
-        &mut out,
-        0,
-        surface,
-        canvas_fits,
-        pending_click,
-        surface_key,
-    );
+    let render_root = |ui: &mut egui::Ui, out: &mut RenderResult| {
+        render_node(
+            ui,
+            &tree.nodes,
+            tree.root,
+            colors,
+            out,
+            0,
+            surface,
+            canvas_fits,
+            pending_click,
+            surface_key,
+        );
+    };
+    // Good-by-default spacing (stint 0445): a declarative app with no layout
+    // code should not render flush against the pane edge. Wrap the whole tree
+    // in the host UI kit's standard content inset so body content, app bars,
+    // and footers all get comfortable breathing room. Full-bleed pixel apps (a
+    // grow Canvas or a GPU Surface anywhere in the tree) own their own layout
+    // and are exempt.
+    if tree_wants_content_padding(&tree.nodes) {
+        egui::Frame::NONE
+            .inner_margin(root_content_inset())
+            .show(ui, |ui| render_root(ui, &mut out));
+    } else {
+        render_root(ui, &mut out);
+    }
     out
+}
+
+/// The host UI kit's standard content inset for a declarative app's root.
+/// `SPACE_XL` horizontal matches the breathing room modal bodies get; the
+/// slightly tighter `SPACE_MD` top/bottom keeps short apps from feeling
+/// bottom-heavy. All values come from `crate::ui::style` design tokens.
+fn root_content_inset() -> egui::Margin {
+    egui::Margin {
+        left: style::SPACE_XL as i8,
+        right: style::SPACE_XL as i8,
+        top: style::SPACE_MD as i8,
+        bottom: style::SPACE_MD as i8,
+    }
+}
+
+/// A tree earns the default content inset unless it is a full-bleed pixel app:
+/// a grow `Canvas` (games, visualizers) or a GPU `Surface` (video/3D output)
+/// anywhere in the tree signals the app owns every pixel, so the host must not
+/// inset it. A fixed-size `Canvas` is treated as ordinary flow content.
+fn tree_wants_content_padding(nodes: &[IndexedNode]) -> bool {
+    !nodes.iter().any(|n| match &n.data {
+        UiNodeData::Canvas(c) => c.grow,
+        UiNodeData::Surface(_) => true,
+        _ => false,
+    })
 }
 
 /// Headless render of a `UiTree` to PNG bytes via `egui_kittest`'s wgpu
@@ -258,7 +298,11 @@ fn render_node(
             let label = RichText::new(&b.label).color(colors.text_on(fill));
             let btn = egui::Button::new(label)
                 .fill(fill)
-                .corner_radius(style::RADIUS_SM);
+                .corner_radius(style::RADIUS_SM)
+                // Comfortable minimum click/touch target so single-glyph
+                // buttons (calculator keys, toolbar chips) aren't cramped.
+                // Content-sized labels grow past this floor as usual.
+                .min_size(egui::vec2(style::BUTTON_H_MD, style::BUTTON_H_MD));
             let synthetic_click = !b.disabled && node_click_matches(pending_click, id);
             if ui.add_enabled(!b.disabled, btn).clicked() || synthetic_click {
                 out.actions.push(b.on_click.clone());
@@ -621,9 +665,207 @@ fn render_node(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::host::wasm_app::bindings::plexi::platform::types::CanvasNode;
+    use crate::host::wasm_app::bindings::plexi::platform::types::{
+        ButtonNode, CanvasNode, CanvasRect, ColumnNode, SurfaceNode, TextNode,
+    };
     use crate::host::wasm_app::{InputEvent, StateSnapshot, StateStore, SystemStats, WasmApp};
     use std::path::PathBuf;
+
+    fn node(id: u32, data: UiNodeData) -> IndexedNode {
+        IndexedNode {
+            id,
+            key: String::new(),
+            data,
+        }
+    }
+
+    /// Bounding box of everything painted when `tree` renders into a `pane`-sized
+    /// screen. Used to observe where the good-by-default content inset places
+    /// real content vs. where a full-bleed app draws.
+    fn painted_bounds(tree: &UiTree, pane: egui::Vec2) -> egui::Rect {
+        let ctx = egui::Context::default();
+        crate::ui::theme::setup_fonts(&ctx);
+        let colors = Colors::from_config(
+            &crate::ui::theme::preset_colors("catppuccin-mocha").expect("preset"),
+        );
+        let raw = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(egui::Pos2::ZERO, pane)),
+            ..Default::default()
+        };
+        let output = ctx.run(raw, |ctx| {
+            egui::CentralPanel::default()
+                .frame(egui::Frame::NONE)
+                .show(ctx, |ui| {
+                    let _ = render_ui_tree_with_surface(ui, tree, &colors, None, None);
+                });
+        });
+        let mut bounds = egui::Rect::NOTHING;
+        for clipped in output.shapes {
+            let r = clipped.shape.visual_bounding_rect();
+            if r.is_finite() && r.is_positive() {
+                bounds = bounds.union(r);
+            }
+        }
+        bounds
+    }
+
+    // Stint 0445: a declarative flow app (no grow Canvas / Surface) earns the
+    // host's standard content inset, so its content never renders flush against
+    // the pane edge, and buttons get a comfortable minimum click target.
+    #[test]
+    fn flow_root_is_inset_and_buttons_meet_minimum_size() {
+        let tree = UiTree {
+            root: 0,
+            nodes: vec![node(
+                0,
+                UiNodeData::Button(ButtonNode {
+                    label: "X".to_string(),
+                    on_click: "x".to_string(),
+                    style: ButtonStyle::Primary,
+                    disabled: false,
+                }),
+            )],
+        };
+        let bounds = painted_bounds(&tree, egui::vec2(400.0, 300.0));
+        assert!(
+            bounds.min.x >= style::SPACE_XL - 0.5,
+            "flow content left edge {} should be inset by ~SPACE_XL ({})",
+            bounds.min.x,
+            style::SPACE_XL
+        );
+        assert!(
+            bounds.min.y >= style::SPACE_MD - 0.5,
+            "flow content top edge {} should be inset by ~SPACE_MD ({})",
+            bounds.min.y,
+            style::SPACE_MD
+        );
+        assert!(
+            bounds.height() >= style::BUTTON_H_MD - 0.5,
+            "button height {} should meet the minimum target ({})",
+            bounds.height(),
+            style::BUTTON_H_MD
+        );
+    }
+
+    // A grow Canvas signals a full-bleed pixel app; the host must not inset it,
+    // so its drawing reaches the pane edge.
+    #[test]
+    fn grow_canvas_app_is_not_inset() {
+        let fill = Color {
+            r: 255,
+            g: 0,
+            b: 0,
+            a: 255,
+        };
+        let tree = UiTree {
+            root: 0,
+            nodes: vec![node(
+                0,
+                UiNodeData::Canvas(CanvasNode {
+                    width: 100.0,
+                    height: 100.0,
+                    grow: true,
+                    commands: vec![CanvasCommand::Rect(CanvasRect {
+                        x: 0.0,
+                        y: 0.0,
+                        width: 100.0,
+                        height: 100.0,
+                        radius: 0.0,
+                        fill,
+                    })],
+                }),
+            )],
+        };
+        let bounds = painted_bounds(&tree, egui::vec2(400.0, 300.0));
+        assert!(
+            bounds.min.x <= 1.0 && bounds.min.y <= 1.0,
+            "full-bleed canvas should reach the pane origin, got {:?}",
+            bounds.min
+        );
+    }
+
+    #[test]
+    fn content_padding_exemption_tracks_full_bleed_nodes() {
+        let flow = vec![
+            node(
+                0,
+                UiNodeData::Column(ColumnNode {
+                    children: vec![1],
+                    gap: 0.0,
+                    align: Alignment::Start,
+                    grow: false,
+                }),
+            ),
+            node(
+                1,
+                UiNodeData::Text(TextNode {
+                    text: "hi".to_string(),
+                    size: None,
+                    bold: false,
+                    color: None,
+                    truncate: false,
+                    align: Alignment::Start,
+                }),
+            ),
+        ];
+        assert!(
+            tree_wants_content_padding(&flow),
+            "a text/column tree is flow content and wants the inset"
+        );
+
+        let mut with_grow_canvas = flow.clone();
+        with_grow_canvas[1] = node(
+            1,
+            UiNodeData::Canvas(CanvasNode {
+                width: 10.0,
+                height: 10.0,
+                grow: true,
+                commands: vec![],
+            }),
+        );
+        assert!(
+            !tree_wants_content_padding(&with_grow_canvas),
+            "a grow canvas makes the app full-bleed"
+        );
+
+        let mut with_fixed_canvas = flow.clone();
+        with_fixed_canvas[1] = node(
+            1,
+            UiNodeData::Canvas(CanvasNode {
+                width: 10.0,
+                height: 10.0,
+                grow: false,
+                commands: vec![],
+            }),
+        );
+        assert!(
+            tree_wants_content_padding(&with_fixed_canvas),
+            "a fixed-size canvas is ordinary flow content and still wants the inset"
+        );
+
+        let mut with_surface = flow.clone();
+        with_surface[1] = node(
+            1,
+            UiNodeData::Surface(SurfaceNode {
+                width: 8,
+                height: 8,
+                texture_handle: None,
+            }),
+        );
+        assert!(
+            !tree_wants_content_padding(&with_surface),
+            "a GPU surface makes the app full-bleed"
+        );
+    }
+
+    #[test]
+    fn root_content_inset_uses_design_tokens() {
+        let inset = root_content_inset();
+        assert_eq!(inset.left, style::SPACE_XL as i8);
+        assert_eq!(inset.right, style::SPACE_XL as i8);
+        assert_eq!(inset.top, style::SPACE_MD as i8);
+        assert_eq!(inset.bottom, style::SPACE_MD as i8);
+    }
 
     fn fixture() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/wasm-fixtures/sysmon.wasm")


### PR DESCRIPTION
Calculator (and every minimal declarative app) rendered flush against the pane edge with no spacing defaults. Spacing is now infrastructure:

- Root content inset (SPACE_XL/SPACE_MD) applied by the render layer to flow apps; grow-Canvas/Surface and AppBar/FooterKeys chrome stay full-bleed structurally (chrome paints to clip_rect, so bars stay edge-to-edge while body content insets).
- Column gap SPACE_MD, Row gap SPACE_SM as decoder defaults — honest unset-vs-zero: the SDK omits gap from the wire when unset, explicit gap=0 stays flush (locked by host decode + SDK tests).
- Button minimum 32x32 target (BUTTON_H_MD floor).
- All tokens from src/ui/style.rs, no new constants. Documented as contract in AUTHORING.md.
- padding=0 compensation DELETED from csv_viewer, github-issues, kraken, wikipedia, logs.
- Geometry tests: root inset, canvas exemption, full-bleed tracking, gap defaults, button minimums.

Rebased over #2429; the duplicate PNG font-bootstrap fix resolved in favor of the merged version.

Gates: cargo build clean; cargo test 6 known environment failures only; SDK pytest 221 passed; all 14 maintained apps `app check` green with PNG-verified layouts (calc inset with 32px keys; chrome apps full-bleed bars + inset body; canvas games exempt).

Stint 0445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)