### PR TITLE
config(ai): default model_medium mimo-v2.5-pro → mimo-v2.5 (stint 0447)

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -63,7 +63,7 @@ backend = "openrouter"
 [ai.openrouter]
 api_key_env  = "OPENROUTER_API_KEY"
 model_low    = "qwen/qwen3.6-flash"
-model_medium = "xiaomi/mimo-v2.5-pro"
+model_medium = "xiaomi/mimo-v2.5"
 model_high   = "anthropic/claude-fable-5"
 ```
 
@@ -173,7 +173,7 @@ backend = "openrouter"         # "openrouter" (cloud) or "ollama" (local)
 [ai.openrouter]
 api_key_env  = "OPENROUTER_API_KEY"
 model_low    = "qwen/qwen3.6-flash"
-model_medium = "xiaomi/mimo-v2.5-pro"
+model_medium = "xiaomi/mimo-v2.5"
 model_high   = "anthropic/claude-fable-5"
 
 # [ai.ollama]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -568,7 +568,7 @@ pub struct OpenRouterBackendConfig {
     pub api_key_env: Option<String>,
     /// Low-tier model. e.g. "qwen/qwen3.6-flash"
     pub model_low: Option<String>,
-    /// Medium-tier model. e.g. "xiaomi/mimo-v2.5-pro"
+    /// Medium-tier model. e.g. "xiaomi/mimo-v2.5"
     pub model_medium: Option<String>,
     /// High-tier model. e.g. "anthropic/claude-fable-5"
     pub model_high: Option<String>,

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -1082,7 +1082,7 @@ mod tests {
             openrouter: Some(OpenRouterBackendConfig {
                 api_key_env: None,
                 model_low: Some("qwen/qwen3.6-flash".to_string()),
-                model_medium: Some("xiaomi/mimo-v2.5-pro".to_string()),
+                model_medium: Some("xiaomi/mimo-v2.5".to_string()),
                 model_high: Some("anthropic/claude-fable-5".to_string()),
             }),
             ollama: None,
@@ -1097,7 +1097,7 @@ mod tests {
         assert_eq!(or_config.model_low.as_deref(), Some("qwen/qwen3.6-flash"));
         assert_eq!(
             or_config.model_medium.as_deref(),
-            Some("xiaomi/mimo-v2.5-pro")
+            Some("xiaomi/mimo-v2.5")
         );
         assert_eq!(
             or_config.model_high.as_deref(),


### PR DESCRIPTION
Downgrades the medium-tier broker default from MiMo v2.5 Pro to plain MiMo v2.5 — Pro-tier cost/latency is unneeded for the medium lane. `xiaomi/mimo-v2.5` verified live on the OpenRouter models API before writing. All 38 broker tests pass.

Stint 0447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)