### PR TITLE
feat(apps): logs v2 — colored row-per-entry tail, true follow-freeze; FooterKeys standardized (stints 0449, 0452)

### DIFF
--- a/apps/calc/calc.py
+++ b/apps/calc/calc.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from plexi_sdk import log, state
 from plexi_sdk.effects import SetState, SetStatus, SetTitle
 from plexi_sdk.events import KeyEvent, UiAction
-from plexi_sdk.ui import Button, Column, Component, Spacer, Text
+from plexi_sdk.ui import Button, Column, Component, FooterKeys, Spacer, Text
 
 BUTTON_ROWS = [
     ["C", "+/-", "%", "/"],
@@ -74,9 +74,14 @@ def view():
             Text(data["display"], size=28.0, bold=True, align="end", truncate=True),
             *[ButtonRow(row) for row in BUTTON_ROWS],
             Spacer(grow=True),
-            Text(
-                "0-9 input. Operators queue. Enter equals. Backspace deletes.",
-                size=11.0,
+            FooterKeys(
+                [
+                    ("0-9", "input"),
+                    ("+ - * /", "operators"),
+                    ("↩", "equals"),
+                    ("⌫", "delete"),
+                    ("esc", "clear"),
+                ]
             ),
         ],
         gap=8.0,

--- a/apps/logs/logs.py
+++ b/apps/logs/logs.py
@@ -8,6 +8,13 @@ through the capability-gated `read_host_log` host effect (`logs.read`): the host
 owns path resolution and tails the file; this app owns parsing, filtering, and
 presentation. A log it cannot reach renders an explicit error, never a blank
 pane.
+
+Each parsed entry renders as its own row node — timestamp, a color-coded level
+badge, module, and message — so the delta protocol re-serializes only the rows
+that actually change (a quiet pane emits near-empty deltas). Follow ON keeps
+polling and shows the newest entry at the top; follow OFF freezes the visible
+tail entirely (polling stops, fresh results are dropped) so the view holds still
+for reading.
 """
 
 from __future__ import annotations
@@ -24,9 +31,16 @@ from plexi_sdk.events import (
     UiValueChange,
 )
 from plexi_sdk.ui import (
+    SPACE_SM,
+    SPACE_XS,
+    TEXT_HINT,
     AppBar,
+    Badge,
+    BadgeColor,
     Column,
+    Component,
     FooterKeys,
+    HStack,
     Scrollable,
     Spacer,
     TabBar,
@@ -38,11 +52,23 @@ POLL_MS = 2_000
 TIMER_ID = 1
 MAX_LINES = 500
 TAIL_BYTES = 256 * 1024
-VISIBLE_LINES = 28
 LEVELS = ["ALL", "ERROR", "WARN", "INFO", "DEBUG"]
 LEVEL_KEY = {"a": "ALL", "e": "ERROR", "w": "WARN", "i": "INFO", "d": "DEBUG"}
 LEVEL_TAB = "logs-level"
 SEARCH_INPUT = "logs-search"
+
+# Each level maps to a semantic badge color the host decoder understands
+# (`decode_badge_color` in src/host/wasm_python.rs). Badges are the only tree
+# node that carries color — plain Text nodes drop their color field — so the
+# level badge is where severity color lives. Unknown levels fall back to
+# neutral rather than being dropped.
+NEUTRAL: BadgeColor = "neutral"
+LEVEL_COLOR: dict[str, BadgeColor] = {
+    "ERROR": "danger",
+    "WARN": "warning",
+    "INFO": "accent",
+    "DEBUG": "neutral",
+}
 
 LOG_RE = re.compile(
     r"^\[(\d{4}-\d{2}-\d{2} (\d{2}:\d{2}:\d{2}))\] \[(\w+)\] \[([^\]]+)\] (.*)$"
@@ -54,8 +80,8 @@ DEFAULT_STATE = {
     "filter": "ALL",
     "query": "",
     "searching": False,
-    "offset": 0,
     "follow": True,
+    "pending_force": False,
     "error": None,
     "loaded": False,
 }
@@ -80,21 +106,21 @@ def update(event) -> list:
         return _apply_log_result(data, event)
 
     if isinstance(event, TimerFired) and event.id == TIMER_ID:
-        # Live tail: ask the host for a fresh tail every poll. Lines update when
-        # the HostLogResult arrives; nothing to render until then.
-        return [ReadHostLog(TAIL_BYTES)]
+        # Live tail only while following. Frozen (follow off) means the poll
+        # stops entirely — no fresh read, so the visible tail cannot move.
+        if data["follow"]:
+            return [ReadHostLog(TAIL_BYTES)]
+        return []
 
     if isinstance(event, UiAction) and event.handler_id.startswith(LEVEL_TAB + ":"):
         index = _tab_index(event.handler_id)
         if index is None:
             return []
         data["filter"] = LEVELS[index]
-        data["offset"] = 0
         return [SetState(data), SetStatus(_status(data))]
 
     if isinstance(event, UiValueChange) and event.handler_id == SEARCH_INPUT:
         data["query"] = event.value
-        data["offset"] = 0
         data["follow"] = False
         return [SetState(data), SetStatus(_status(data))]
 
@@ -106,39 +132,28 @@ def update(event) -> list:
         if key == "escape":
             data["searching"] = False
             data["query"] = ""
-            data["offset"] = 0
             data["follow"] = True
-            return [SetState(data), SetStatus(_status(data))]
+            return [SetState(data), SetStatus(_status(data)), ReadHostLog(TAIL_BYTES)]
         return []
 
     if key in LEVEL_KEY:
         data["filter"] = LEVEL_KEY[key]
-        data["offset"] = 0
     elif key == "/":
         data["searching"] = True
         data["follow"] = False
     elif key == "escape" and data["query"]:
         data["query"] = ""
-        data["offset"] = 0
         data["follow"] = True
-    elif key in ("down", "j", "ArrowDown"):
-        data["offset"] = min(_max_offset(data), data["offset"] + 1)
-        data["follow"] = False
-    elif key in ("up", "k", "ArrowUp"):
-        data["offset"] = max(0, data["offset"] - 1)
-        data["follow"] = False
-    elif key == "g":
-        data["offset"] = 0
-        data["follow"] = True
-    elif key == "G":
-        data["offset"] = _max_offset(data)
-        data["follow"] = False
     elif key == "f":
         data["follow"] = not data["follow"]
         if data["follow"]:
-            data["offset"] = 0
+            # Resuming follow: catch up immediately instead of waiting for the
+            # next poll tick.
+            return [SetState(data), SetStatus(_status(data)), ReadHostLog(TAIL_BYTES)]
     elif key == "r":
-        # Force a fresh read now, independent of the poll timer.
+        # Force one fresh read now, even while frozen. `pending_force` lets the
+        # incoming result bypass the follow-off freeze exactly once.
+        data["pending_force"] = True
         return [SetState(data), ReadHostLog(TAIL_BYTES)]
     else:
         return []
@@ -148,7 +163,7 @@ def update(event) -> list:
 def view():
     data = _state()
     subtitle = "Search" if data["searching"] else _subtitle(data)
-    children = [
+    children: list[Component] = [
         AppBar("Logs", subtitle),
         TabBar(LEVEL_TAB, LEVELS, active=LEVELS.index(data["filter"])),
     ]
@@ -163,13 +178,12 @@ def view():
         )
     children.extend(
         [
-            Scrollable(Text(_visible_text(data), size=11.0)),
+            Scrollable(_body(data)),
             Spacer(grow=True),
             FooterKeys(
                 [
                     ("a/e/w/i/d", "level"),
                     ("/", "search"),
-                    ("j/k", "scroll"),
                     ("f", "follow"),
                     ("r", "refresh"),
                 ]
@@ -188,8 +202,8 @@ def _state() -> dict:
     if data["filter"] not in LEVELS:
         data["filter"] = "ALL"
     data["query"] = str(data.get("query") or "")
-    data["offset"] = max(0, int(data.get("offset") or 0))
     data["follow"] = bool(data.get("follow"))
+    data["pending_force"] = bool(data.get("pending_force"))
     data["searching"] = bool(data.get("searching"))
     data["loaded"] = bool(data.get("loaded"))
     error = data.get("error")
@@ -208,17 +222,25 @@ def _apply_log_result(data: dict, result: HostLogResult) -> list:
         data["error"] = result.error
         data["lines"] = []
         data["loaded"] = True
+        data["pending_force"] = False
         log.warn(f"logs: host log unavailable: {result.error}")
         return [SetState(data), SetStatus(_status(data))]
+
+    forced = data["pending_force"]
+    data["pending_force"] = False
+    # Follow-freeze: once loaded, a fresh tail is only applied while following
+    # or when an explicit refresh (`r`) forced this read. Otherwise the visible
+    # tail holds still.
+    if was_loaded and not had_error and not data["follow"] and not forced:
+        return []
+
     content = result.content.decode("utf-8", errors="replace") if result.content else ""
     lines = _parse_log(content)
-    if was_loaded and not had_error and lines == previous_lines:
+    if was_loaded and not had_error and not forced and lines == previous_lines:
         return []  # unchanged tail — skip the repaint
     data["error"] = None
     data["lines"] = lines
     data["loaded"] = True
-    if data["follow"]:
-        data["offset"] = 0
     return [SetState(data), SetStatus(_status(data))]
 
 
@@ -226,8 +248,14 @@ def _parse_log(content: str) -> list[dict]:
     parsed = []
     for raw in reversed(content.splitlines()[-MAX_LINES:]):
         item = _parse(raw)
-        if item:
-            parsed.append(item)
+        if item is None:
+            stripped = raw.rstrip()
+            if not stripped:
+                continue
+            # Unparseable line: keep it, rendered as a plain full-width message
+            # row. Never dropped — a malformed line is still signal.
+            item = {"time": "", "level": "", "target": "", "message": stripped}
+        parsed.append(item)
     return parsed
 
 
@@ -261,34 +289,49 @@ def _filtered(data: dict) -> list[dict]:
     return lines
 
 
-def _visible_text(data: dict) -> str:
+def _body(data: dict) -> Component:
+    """The scrollable tail: one row per entry, or a placeholder message."""
+    lines = [] if data["error"] else _filtered(data)
+    if data["error"] or not lines:
+        return Text(_placeholder_text(data), size=TEXT_HINT)
+    return Column([_row(line) for line in lines], gap=SPACE_XS)
+
+
+def _row(line: dict) -> Component:
+    """One log entry as a row of separated fields.
+
+    Parseable entries lay out as ``time · LEVEL badge · module · message``; the
+    badge is the sole color-carrying node. Unparseable entries collapse to a
+    single full-width message so nothing is silently dropped.
+    """
+    level = line["level"]
+    if not level:
+        message: list[Component] = [Text(line["message"], size=TEXT_HINT)]
+        return HStack(message, gap=SPACE_SM)
+    fields: list[Component] = [
+        Text(line["time"], size=TEXT_HINT),
+        Badge(level, color=LEVEL_COLOR.get(level, NEUTRAL)),
+        Text(line["target"], size=TEXT_HINT),
+        Text(line["message"], size=TEXT_HINT),
+    ]
+    return HStack(fields, gap=SPACE_SM)
+
+
+def _placeholder_text(data: dict) -> str:
     if data["error"]:
         location = f" ({data['path']})" if data["path"] else ""
         return f"Cannot read host log{location}:\n{data['error']}"
-    lines = _filtered(data)
-    if not lines:
-        if not data["loaded"]:
-            return "Loading host log…"
-        where = f" at {data['path']}" if data["path"] else ""
-        return f"No log entries{where}"
-    offset = min(data["offset"], _max_offset(data))
-    visible = lines[offset : offset + VISIBLE_LINES]
-    return "\n".join(
-        f"{line['time']} {line['level']:<5} {line['target']:<24} {line['message']}"
-        for line in visible
-    )
-
-
-def _max_offset(data: dict) -> int:
-    return max(0, len(_filtered(data)) - VISIBLE_LINES)
+    if not data["loaded"]:
+        return "Loading host log…"
+    where = f" at {data['path']}" if data["path"] else ""
+    return f"No log entries{where}"
 
 
 def _subtitle(data: dict) -> str:
     parts = [data["filter"]]
     if data["query"]:
         parts.append(f"/{data['query']}")
-    if data["follow"]:
-        parts.append("follow")
+    parts.append("follow" if data["follow"] else "frozen")
     return " · ".join(parts)
 
 

--- a/apps/logs/tests/test_app.py
+++ b/apps/logs/tests/test_app.py
@@ -115,18 +115,121 @@ def test_apply_log_result_error_surfaces_not_blank():
     assert data["error"] == "open /x: denied"
     assert data["lines"] == []
     assert data["loaded"] is True
-    text = app._visible_text(data)
+    text = app._placeholder_text(data)
     assert "Cannot read host log" in text
     assert "open /x: denied" in text
 
 
-def test_visible_text_shows_path_when_reachable_but_empty():
+def test_placeholder_text_shows_path_when_reachable_but_empty():
     app = _load_app_module()
-    text = app._visible_text(
+    text = app._placeholder_text(
         {**app.DEFAULT_STATE, "path": "/home/u/.plexi-alpha/plexi.log", "loaded": True}
     )
     assert "No log entries" in text
     assert "/home/u/.plexi-alpha/plexi.log" in text
+
+
+# ── Row rendering ─────────────────────────────────────────────────────────────
+
+
+def test_parseable_row_carries_level_colored_badge():
+    app = _load_app_module()
+    row = app._row(
+        {"time": "10:11:12", "level": "ERROR", "target": "app::todo", "message": "boom"}
+    ).to_node()
+    badges = [c for c in row["children"] if c.get("type") == "badge"]
+    assert len(badges) == 1
+    assert badges[0]["text"] == "ERROR"
+    assert badges[0]["color"] == "danger"
+    texts = [c["text"] for c in row["children"] if c.get("type") == "text"]
+    assert texts == ["10:11:12", "app::todo", "boom"]
+
+
+def test_each_level_gets_a_distinct_badge_color():
+    app = _load_app_module()
+    colors = {lvl: app.LEVEL_COLOR[lvl] for lvl in ("ERROR", "WARN", "INFO", "DEBUG")}
+    assert len(set(colors.values())) == 4
+
+
+def test_unparseable_line_kept_as_full_width_message_row():
+    app = _load_app_module()
+    lines = app._parse_log("this is not a log line\n")
+    assert lines == [{"time": "", "level": "", "target": "", "message": "this is not a log line"}]
+    row = app._row(lines[0]).to_node()
+    assert not [c for c in row["children"] if c.get("type") == "badge"]
+    assert [c["text"] for c in row["children"] if c.get("type") == "text"] == [
+        "this is not a log line"
+    ]
+
+
+# ── Follow-freeze ─────────────────────────────────────────────────────────────
+
+
+def _newer_log():
+    return (
+        "[2026-07-02 01:46:18] [INFO] [plexi::config] loaded config\n"
+        "[2026-07-02 01:46:19] [ERROR] [app::todo] save failed\n"
+        "[2026-07-02 01:46:20] [WARN] [app::todo] retrying\n"
+        "[2026-07-02 01:46:21] [INFO] [app::todo] recovered\n"
+    )
+
+
+def test_follow_off_freezes_tail_dropping_new_results():
+    app = _load_app_module()
+    data = dict(app.DEFAULT_STATE)
+    app._apply_log_result(
+        data, HostLogResult(content=THREE_LINE_LOG.encode(), path="/x/plexi.log", error=None)
+    )
+    frozen = [dict(ln) for ln in data["lines"]]
+    data["follow"] = False
+    effects = app._apply_log_result(
+        data, HostLogResult(content=_newer_log().encode(), path="/x/plexi.log", error=None)
+    )
+    assert effects == []  # fresh tail dropped
+    assert data["lines"] == frozen  # visible tail unchanged
+
+
+def test_forced_refresh_bypasses_freeze_once():
+    app = _load_app_module()
+    data = dict(app.DEFAULT_STATE)
+    app._apply_log_result(
+        data, HostLogResult(content=THREE_LINE_LOG.encode(), path="/x/plexi.log", error=None)
+    )
+    data["follow"] = False
+    data["pending_force"] = True  # what pressing `r` sets
+    app._apply_log_result(
+        data, HostLogResult(content=_newer_log().encode(), path="/x/plexi.log", error=None)
+    )
+    assert data["pending_force"] is False  # consumed
+    assert "recovered" in [ln["message"] for ln in data["lines"]]
+
+
+def test_follow_on_keeps_applying_new_results():
+    app = _load_app_module()
+    data = dict(app.DEFAULT_STATE)  # follow defaults True
+    app._apply_log_result(
+        data, HostLogResult(content=THREE_LINE_LOG.encode(), path="/x/plexi.log", error=None)
+    )
+    app._apply_log_result(
+        data, HostLogResult(content=_newer_log().encode(), path="/x/plexi.log", error=None)
+    )
+    assert "recovered" in [ln["message"] for ln in data["lines"]]
+
+
+def test_timer_poll_suppressed_while_frozen():
+    app = _load_app_module()
+    from plexi_sdk import _v3_state
+    from plexi_sdk._v3_state import StateSnapshot
+    from plexi_sdk.effects import ReadHostLog
+    from plexi_sdk.events import TimerFired
+
+    # follow off → no ReadHostLog effect on the poll tick (tail is frozen).
+    _v3_state._state = StateSnapshot({**app.DEFAULT_STATE, "follow": False, "loaded": True}, {})
+    assert app.update(TimerFired(id=app.TIMER_ID)) == []
+    # follow on → the poll re-reads the tail.
+    _v3_state._state = StateSnapshot({**app.DEFAULT_STATE, "follow": True, "loaded": True}, {})
+    effects = app.update(TimerFired(id=app.TIMER_ID))
+    assert any(isinstance(e, ReadHostLog) for e in effects)
 
 
 # ── End-to-end lifecycle through the read_host_log effect ─────────────────────
@@ -140,6 +243,18 @@ def test_boots_and_populates_from_host_log(tmp_path):
         assert _last_status(h) == "3 lines"
         trees = [c for c in h._events_seen if c.get("type") == "component_tree"]
         assert "save failed" in json.dumps(trees[-1])
+
+
+def test_boots_renders_colored_level_badges(tmp_path):
+    log_path = tmp_path / "plexi.log"
+    log_path.write_text(THREE_LINE_LOG)
+    with AppHarness(str(APP), width=800, height=600, host_log_path=str(log_path)) as h:
+        h.run(2)
+        trees = [c for c in h._events_seen if c.get("type") == "component_tree"]
+        blob = json.dumps(trees[-1])
+        assert '"badge"' in blob
+        assert '"danger"' in blob  # ERROR row badge
+        assert '"warning"' in blob  # WARN row badge
 
 
 def test_level_key_narrows_status_count(tmp_path):

--- a/apps/permissions/main.py
+++ b/apps/permissions/main.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from plexi_sdk import log, state
 from plexi_sdk.effects import RequestCapability, SetState, SetStatus, SetTitle
 from plexi_sdk.events import CapabilityDenied, CapabilityGranted, KeyEvent, UiAction
-from plexi_sdk.ui import Button, Column, SelectList, Spacer, Text
+from plexi_sdk.ui import Button, Column, FooterKeys, SelectList, Spacer, Text
 
 DEFAULT_STATE = {
     "grants": [],
@@ -165,7 +165,7 @@ def _list_view(data: dict):
             Spacer(grow=True),
             Button("Open", "permissions:detail", disabled=not rows),
             Button("Reload", "permissions:reload"),
-            Text("j/k selects. Enter opens. r reloads.", size=11.0),
+            FooterKeys([("j/k", "select"), ("↩", "open"), ("r", "reload")]),
         ],
         gap=8.0,
         grow=True,
@@ -194,7 +194,7 @@ def _detail_view(data: dict):
                 disabled=not data["can_manage"],
             ),
             Button("Back", "permissions:back"),
-            Text("x revokes. Esc returns.", size=11.0),
+            FooterKeys([("x", "revoke"), ("esc", "back")]),
         ],
         gap=8.0,
         grow=True,

--- a/apps/stats/stats.py
+++ b/apps/stats/stats.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from plexi_sdk import state
 from plexi_sdk.effects import PersistState, SetStatus, SetTimer, SetTitle
 from plexi_sdk.events import FocusChanged, KeyEvent, TimerFired
-from plexi_sdk.ui import AppBar, Column, SelectList, Spacer, Text
+from plexi_sdk.ui import AppBar, Column, FooterKeys, SelectList, Spacer, Text
 
 DAY_START_HOUR = 4
 IDLE_THRESHOLD_SECS = 15 * 60
@@ -70,7 +70,7 @@ def view():
             Text("No focus events yet.", size=16.0, bold=True),
             Text("Stats will fill in as Plexi sends focus-change events.", size=12.0),
             Spacer(grow=True),
-            Text("r refreshes.", size=11.0),
+            FooterKeys([("r", "refresh")]),
         ], grow=True)
 
     rows = [

--- a/apps/todo/todo.py
+++ b/apps/todo/todo.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from plexi_sdk import state
 from plexi_sdk.effects import PersistState, SetStatus, SetTitle
 from plexi_sdk.events import KeyEvent, UiAction, UiValueChange
-from plexi_sdk.ui import AppBar, Button, Column, SelectList, Spacer, Text, TextInput
+from plexi_sdk.ui import AppBar, Button, Column, FooterKeys, SelectList, Spacer, Text, TextInput
 
 DEFAULT_TODO_STATE = {
     "items": [],
@@ -146,7 +146,7 @@ def view():
             Button("Add", "todo-add:submit", style="primary", disabled=not data["draft"].strip()),
             Button("Cancel", "todo-add:cancel", style="ghost"),
             Spacer(grow=True),
-            Text("Enter saves. Esc cancels.", size=11.0),
+            FooterKeys([("↩", "save"), ("esc", "cancel")]),
         ], grow=True)
 
     rows = [
@@ -167,5 +167,5 @@ def view():
         Button("Add item", "todo-add:start", style="primary"),
         Button("Toggle selected", "todo-toggle", disabled=not rows),
         Button("Delete selected", "todo-delete", style="danger", disabled=not rows),
-        Text("Up/down select. Space toggles. a adds. d deletes.", size=11.0),
+        FooterKeys([("↑/↓", "select"), ("space", "toggle"), ("a", "add"), ("d", "delete")]),
     ], grow=True)


### PR DESCRIPTION
- **logs (0449)**: the single Text-blob wall replaced with row-per-entry rendering — timestamp, colored level Badge (ERROR/WARN/INFO/DEBUG on theme semantic roles), module, message as separated fields; unparseable lines render as plain rows, never dropped. Follow OFF now freezes the visible tail (new tail results are not applied); follow ON polls and pins to newest.
- **footers (0452)**: calc's hand-rolled key legend converted to the shared FooterKeys; same conversion applied to permissions, stats, and todo.

Orchestrator-verified independently: app check green for all five touched apps; 21 logs app tests pass; seeded PNG render inspected — colored badge rows exactly as specced; calc footer now matches logs. Screenshots deleted after review.

Stints 0449, 0452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)