### PR TITLE
assistant build loop: fast app check, zero-discovery skill + tier floor, run UX (stints 0458, 0459, 0460)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,10 @@ There is one comms model with three disjoint planes, each with a single sanction
 
 Later consolidation candidates (left untouched by 0327, not yet unified): notifications (`NotifyAction`), pane slots, `PathChanged` pane-group sync, poll-based "Phase C" delivery, and undo/rollback checkpoints on the event record.
 
+## Capturing Host State
+
+`plexi host screenshot [--pane <id>] [--output <path>]` captures the running host window as a PNG through the real render pipeline (`AppRequest::Screenshot` → `egui::ViewportCommand::Screenshot` → `src/app/screenshot.rs`) — the actual pixels on screen: chrome, terminals, apps, overlays. `--pane` crops to that pane's current rect. Works over the channel socket like every pane command (`PLEXI_SOCKET`/`PLEXI_CHANNEL` rules apply). **Never use macOS `screencapture` or any OS-level capture to inspect a Plexi host** — this command is the sanctioned path, works headless, and needs no screen-recording permission. For pane *semantics* (text, node bounds) use `plexi pane state <id>`; for a not-running-host render of an app, use `plexi app render . --png`.
+
 ## General Rules
 
 - When the user reports a bug, fix what they asked for first.

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -64,14 +64,6 @@ impl PlexiApp {
         if text_surface_focused {
             return;
         }
-        // egui surrenders widget focus on Escape during `begin_pass`, before
-        // this dispatch runs — so on the keypress that leaves a focused
-        // TextInput the gate above is already off. Swallow that Escape so
-        // the AppActive CloseApp binding doesn't close the pane on the same
-        // keypress; the next keystroke routes to the app normally.
-        if previously_focused && input.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
-            log::info!("app_keys: pane {pane_id} Escape left the focused TextInput — swallowed");
-        }
         // The app classifies keys from the frame's ownership-transfer buffer
         // (stint 0387) rather than a second read of `ctx`. If it consumed the
         // key, also claim Escape/ArrowUp out of the buffer so `poll_actions`
@@ -83,6 +75,19 @@ impl PlexiApp {
         if disposition == crate::app::app_trait::KeyDisposition::Consumed {
             input.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
             input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp);
+        }
+        // egui surrenders widget focus on Escape during `begin_pass`, before
+        // this dispatch runs — so on the keypress that leaves a focused
+        // TextInput the gate above is already off. The app has now seen that
+        // Escape through `handle_key` (stint 0460 — e.g. the assistant
+        // interrupts its in-flight turn on the same press that leaves the
+        // composer); claim whatever is left of it out of the buffer so the
+        // AppActive CloseApp binding can't close the pane on the same
+        // keypress.
+        if previously_focused && input.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
+            log::info!(
+                "app_keys: pane {pane_id} Escape left the focused TextInput — delivered to app, CloseApp suppressed"
+            );
         }
     }
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1582,6 +1582,40 @@ impl PlexiApp {
                     );
                 }
             }
+            crate::app_protocol::AppRequest::Screenshot {
+                pane_id,
+                output_path,
+                response_file,
+            } => {
+                log::info!(
+                    "pane_ipc: kind=screenshot pane_id={pane_id:?} output_path={output_path}"
+                );
+                // Validate a pane target up front so the CLI fails fast on a
+                // bad id; the rect itself is resolved at capture time.
+                let unknown_pane = pane_id
+                    .is_some_and(|id| self.find_pane_in_any_window(id).is_none());
+                if unknown_pane {
+                    let response = serde_json::json!({
+                        "error": format!("pane {} not found", pane_id.unwrap_or_default())
+                    });
+                    if let Err(e) = std::fs::write(response_file, response.to_string()) {
+                        log::error!(
+                            "pane_ipc: screenshot: could not write response file {response_file:?}: {e}"
+                        );
+                    }
+                } else {
+                    self.pending_screenshots
+                        .push(crate::app::screenshot::PendingScreenshot {
+                            pane_id: *pane_id,
+                            output_path: output_path.clone(),
+                            response_file: response_file.clone(),
+                        });
+                    self.ctx.send_viewport_cmd(egui::ViewportCommand::Screenshot(
+                        egui::UserData::default(),
+                    ));
+                    self.ctx.request_repaint();
+                }
+            }
             crate::app_protocol::AppRequest::GetPaneState {
                 pane_id,
                 response_file,

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1291,6 +1291,30 @@ impl PlexiApp {
                             term.backend
                                 .process_command(egui_term::BackendCommand::Write(bytes));
                             Ok(serde_json::json!({"ok": true}))
+                        } else if pane.as_app_mut().is_some()
+                            && text_input_focused
+                            && key.eq_ignore_ascii_case("escape")
+                        {
+                            // Escape parity with a live keypress (stint 0460):
+                            // a replayed raw Escape lands mid-frame, after the
+                            // dispatch gate already ran, so it would fall
+                            // through to the AppActive CloseApp binding and
+                            // destroy the pane. Deliver it to the app's
+                            // handle_key instead — the assistant interrupts
+                            // its in-flight turn — and never replay it raw.
+                            let app_pane = pane.as_app_mut().expect("checked above");
+                            match super::drive_native_pane_key(&mut app_pane.runtime, key) {
+                                Ok(disposition) => {
+                                    log::info!(
+                                        "pane_ipc: key_pane: pane {pane_id} Escape delivered to app (text surface focused, CloseApp suppressed, result={disposition:?})"
+                                    );
+                                    Ok(serde_json::json!({
+                                        "ok": true,
+                                        "disposition": "text_input_escape",
+                                    }))
+                                }
+                                Err(e) => Err(e),
+                            }
                         } else if pane.as_app_mut().is_some() && text_input_focused {
                             match super::key_str_to_egui_raw_input(key) {
                                 Some(raw) => {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,6 +12,7 @@ pub mod host_version;
 pub mod http;
 pub mod image_viewer_app;
 pub(crate) mod input_owner;
+pub(crate) mod screenshot;
 pub(crate) mod input_router;
 pub(crate) mod launch_spec;
 mod lifecycle;
@@ -167,6 +168,9 @@ pub struct PlexiApp {
     /// Repaint-cause diagnostics sample window (#2019): start instant and
     /// frame count. `None` until the first frame opens a window.
     pub(crate) frame_diag_window: Option<(std::time::Instant, u32)>,
+    /// Screenshot requests (`plexi host screenshot`) awaiting the viewport
+    /// capture that `AppRequest::Screenshot` triggered (stint 0461).
+    pub(crate) pending_screenshots: Vec<crate::app::screenshot::PendingScreenshot>,
     /// Last window title sent via `ViewportCommand::Title`. egui's
     /// `send_viewport_cmd` unconditionally requests a repaint, so sending the
     /// title every frame creates a self-sustaining repaint loop (60fps
@@ -1270,6 +1274,7 @@ impl PlexiApp {
                     pending_context_close: None,
                     frame_tick,
                     frame_diag_window: None,
+                    pending_screenshots: Vec::new(),
                     last_sent_window_title: None,
                     permission_store_dir: crate::config::config_dir(),
                     renaming_window: None,
@@ -1516,6 +1521,7 @@ impl PlexiApp {
             pending_context_close: None,
             frame_tick,
             frame_diag_window: None,
+            pending_screenshots: Vec::new(),
             last_sent_window_title: None,
             permission_store_dir: crate::config::config_dir(),
             renaming_window: None,
@@ -1933,6 +1939,7 @@ impl PlexiApp {
                 pending_context_close: None,
                 frame_tick,
                 frame_diag_window: None,
+            pending_screenshots: Vec::new(),
                 last_sent_window_title: None,
                 permission_store_dir: {
                     let dir = std::env::temp_dir()
@@ -2322,6 +2329,10 @@ impl eframe::App for PlexiApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         self.frame_tick
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        // Viewport captures requested by `plexi host screenshot` arrive as
+        // raw-input events; fulfill queued requests before anything else
+        // consumes this frame's input (stint 0461).
+        self.fulfill_pending_screenshots(ctx);
         // Repaint-cause diagnostics (#2019): count this frame, attribute
         // input-carrying frames to UserInput, and flush one summary per
         // 10s sample window.

--- a/src/app/screenshot.rs
+++ b/src/app/screenshot.rs
@@ -1,0 +1,176 @@
+//! Live-host screenshot capture (`plexi host screenshot`, stint 0461).
+//!
+//! The CLI sends `AppRequest::Screenshot`; the handler queues a
+//! [`PendingScreenshot`] and asks egui for a viewport capture
+//! (`ViewportCommand::Screenshot`). The wgpu backend reads the real
+//! swapchain back and delivers it as `egui::Event::Screenshot` in a later
+//! frame's raw input, where [`PlexiApp::fulfill_pending_screenshots`] crops,
+//! encodes, and writes the PNG plus the CLI response file. This captures the
+//! pixels the user actually sees — chrome, terminals, apps, overlays — with
+//! no OS-level screen capture involved.
+
+use super::PlexiApp;
+
+#[derive(Debug)]
+pub struct PendingScreenshot {
+    /// Crop to this pane's screen rect; `None` captures the whole window.
+    pub pane_id: Option<u64>,
+    pub output_path: String,
+    pub response_file: String,
+}
+
+impl PlexiApp {
+    /// Drain any `Event::Screenshot` deliveries from this frame's raw input
+    /// and fulfill every queued request with the captured image.
+    pub(crate) fn fulfill_pending_screenshots(&mut self, ctx: &egui::Context) {
+        if self.pending_screenshots.is_empty() {
+            return;
+        }
+        let images: Vec<std::sync::Arc<egui::ColorImage>> = ctx.input(|i| {
+            i.raw
+                .events
+                .iter()
+                .filter_map(|event| match event {
+                    egui::Event::Screenshot { image, .. } => Some(image.clone()),
+                    _ => None,
+                })
+                .collect()
+        });
+        let Some(image) = images.last() else {
+            return;
+        };
+        let pixels_per_point = ctx.pixels_per_point();
+        for request in std::mem::take(&mut self.pending_screenshots) {
+            let result = self.write_screenshot(&request, image, pixels_per_point);
+            let response = match &result {
+                Ok((width, height)) => serde_json::json!({
+                    "ok": true,
+                    "path": request.output_path,
+                    "width": width,
+                    "height": height,
+                }),
+                Err(error) => {
+                    log::warn!(
+                        "screenshot: pane_id={:?} output={} failed: {error}",
+                        request.pane_id,
+                        request.output_path
+                    );
+                    serde_json::json!({ "error": error })
+                }
+            };
+            if let Err(error) =
+                std::fs::write(&request.response_file, response.to_string())
+            {
+                log::warn!(
+                    "screenshot: could not write response file {}: {error}",
+                    request.response_file
+                );
+            }
+        }
+    }
+
+    fn write_screenshot(
+        &mut self,
+        request: &PendingScreenshot,
+        image: &egui::ColorImage,
+        pixels_per_point: f32,
+    ) -> Result<(u32, u32), String> {
+        let region = match request.pane_id {
+            None => None,
+            Some(pane_id) => {
+                let Some((win_idx, tile_id)) = self.find_pane_in_any_window(pane_id) else {
+                    return Err(format!("pane {pane_id} not found"));
+                };
+                let Some(rect) = self.windows[win_idx].tree.tiles.rect(tile_id) else {
+                    return Err(format!(
+                        "pane {pane_id}: no known screen rect (pane has not rendered yet)"
+                    ));
+                };
+                Some(rect)
+            }
+        };
+        let cropped = crop_color_image(image, region, pixels_per_point)?;
+        let (width, height) = (cropped.width() as u32, cropped.height() as u32);
+        let mut rgba = Vec::with_capacity(cropped.pixels.len() * 4);
+        for pixel in &cropped.pixels {
+            rgba.extend_from_slice(&pixel.to_array());
+        }
+        let buffer = image::RgbaImage::from_raw(width, height, rgba)
+            .ok_or_else(|| "could not assemble RGBA buffer from capture".to_string())?;
+        if let Some(parent) = std::path::Path::new(&request.output_path).parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("could not create {}: {e}", parent.display()))?;
+        }
+        buffer
+            .save_with_format(&request.output_path, image::ImageFormat::Png)
+            .map_err(|e| format!("could not write {}: {e}", request.output_path))?;
+        log::info!(
+            "screenshot: wrote {}x{} png to {} (pane_id={:?})",
+            width,
+            height,
+            request.output_path,
+            request.pane_id
+        );
+        Ok((width, height))
+    }
+}
+
+/// Crop a captured frame to `region` (logical points; `None` = full frame).
+/// The capture is in physical pixels, so the rect scales by
+/// `pixels_per_point` and clamps to the frame bounds.
+fn crop_color_image(
+    image: &egui::ColorImage,
+    region: Option<egui::Rect>,
+    pixels_per_point: f32,
+) -> Result<egui::ColorImage, String> {
+    let Some(rect) = region else {
+        return Ok(image.clone());
+    };
+    let (frame_w, frame_h) = (image.width(), image.height());
+    let x0 = ((rect.min.x * pixels_per_point).floor().max(0.0) as usize).min(frame_w);
+    let y0 = ((rect.min.y * pixels_per_point).floor().max(0.0) as usize).min(frame_h);
+    let x1 = ((rect.max.x * pixels_per_point).ceil().max(0.0) as usize).min(frame_w);
+    let y1 = ((rect.max.y * pixels_per_point).ceil().max(0.0) as usize).min(frame_h);
+    if x1 <= x0 || y1 <= y0 {
+        return Err(format!(
+            "pane rect {rect:?} is outside the captured frame ({frame_w}x{frame_h} px)"
+        ));
+    }
+    let mut pixels = Vec::with_capacity((x1 - x0) * (y1 - y0));
+    for y in y0..y1 {
+        pixels.extend_from_slice(&image.pixels[y * frame_w + x0..y * frame_w + x1]);
+    }
+    Ok(egui::ColorImage {
+        size: [x1 - x0, y1 - y0],
+        pixels,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::crop_color_image;
+
+    #[test]
+    fn crop_scales_by_pixels_per_point_and_clamps_to_frame() {
+        let mut image = egui::ColorImage::new([100, 80], egui::Color32::BLACK);
+        // Mark a known pixel inside the crop region: logical (10,5) @2x = (20,10).
+        image.pixels[10 * 100 + 20] = egui::Color32::WHITE;
+        let rect = egui::Rect::from_min_max(egui::pos2(10.0, 5.0), egui::pos2(30.0, 25.0));
+        let cropped = crop_color_image(&image, Some(rect), 2.0).expect("valid crop");
+        assert_eq!(cropped.size, [40, 40]);
+        assert_eq!(cropped.pixels[0], egui::Color32::WHITE);
+
+        // A rect hanging past the frame edge clamps instead of failing.
+        let edge = egui::Rect::from_min_max(egui::pos2(45.0, 35.0), egui::pos2(60.0, 50.0));
+        let clamped = crop_color_image(&image, Some(edge), 2.0).expect("clamped crop");
+        assert_eq!(clamped.size, [10, 10]);
+
+        // Fully outside the frame is a loud error.
+        let outside = egui::Rect::from_min_max(egui::pos2(60.0, 45.0), egui::pos2(70.0, 50.0));
+        assert!(crop_color_image(&image, Some(outside), 2.0).is_err());
+
+        // No region = full frame.
+        let full = crop_color_image(&image, None, 2.0).expect("full frame");
+        assert_eq!(full.size, [100, 80]);
+    }
+}

--- a/src/assistant/builtin/build-plexi-app.md
+++ b/src/assistant/builtin/build-plexi-app.md
@@ -1,14 +1,16 @@
 ---
 name: build-plexi-app
 description: Build a small Plexi app (game, timer, counter, tool) when the user asks to build, create, make, or write an app or game
+tier: high
 ---
 Build the app as a real Plexi app, never as a loose script run from a terminal. The whole flow runs on your embedded authoring tools — host.build.run for lifecycle commands and host.files.* for code. Never open a terminal pane for your own build work; terminals are only for commands the user asked to watch.
 
+The complete SDK API reference is appended to this prompt. It is authoritative and current. Never read, list, or grep `plexi_sdk` sources or any SDK file to "learn the API" — every component, event, effect, and state call you need is already below. Spending tool calls on SDK discovery is a bug.
+
 1. Scaffold: host.build.run {"args": ["app", "init", "<kebab-name>"]}. Its stdout names the app directory it created; use that path exactly, never guess it. Add "--global" only if the user wants the app outside this workspace — workspace apps hot-reload while global apps do not. If exit_code is nonzero (e.g. a name collision), never edit whatever already exists at that path — it was not scaffolded by you and may have no build tooling available. Retry `app init` with a different kebab-name, or if collisions persist, show the user the exact error text and stop.
-2. Learn the SDK from the scaffold: host.files.list the app directory, then host.files.read the generated `AGENTS.md` and `main.py`. Follow them exactly; do not guess the SDK API. Use host.files.grep to find SDK symbols instead of reading whole files.
-3. Write the app with host.files.write on `main.py`. Keep the first version small and working: `view()` returns a tree of `plexi_sdk.ui` widgets, `update(event)` handles `UiAction` by `handler_id`, state changes go through the `SetState` effect. Make every interaction keyboard-reachable. Use host.files.edit for follow-up fixes instead of rewriting the file — each edit returns a diff the user sees.
-4. Validate: host.build.run {"args": ["app", "check", "<app-dir>"]}. Read its stdout/stderr from the result. It must pass; fix every error it reports before opening the app.
-5. Open the app with the host tool host.apps.open (app = the kebab name) as soon as the first check passes. A workspace app hot-reloads in its open pane on every save, so keep iterating with host.files.edit and the user watches it converge. Re-run app check after meaningful changes.
-6. Tell the user the app is open and how to use it.
+2. Write the app with a single host.files.write of `main.py`, composed straight from the SDK reference — no exploratory list/read/grep first. Keep the first version small and working: `view()` returns a tree of `plexi_sdk.ui` widgets, `update(event)` handles `UiAction` by `handler_id`, state changes go through the `SetState` effect. Make every interaction keyboard-reachable. Use host.files.edit for follow-up fixes instead of rewriting the file — each edit returns a diff the user sees.
+3. Validate: host.build.run {"args": ["app", "check", "<app-dir>"]}. Read its stdout/stderr from the result. It must pass; fix every error it reports before opening the app. Fix from the check output alone — re-read `main.py` only when an edit needs context the check output doesn't show.
+4. Open the app with the host tool host.apps.open (app = the kebab name) as soon as the first check passes. A workspace app hot-reloads in its open pane on every save, so keep iterating with host.files.edit and the user watches it converge. Re-run app check after meaningful changes.
+5. Tell the user the app is open and how to use it.
 
 If a step fails, show the user the exact error and fix it. Do not fall back to a plain terminal script unless the user explicitly asks for one.

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -220,11 +220,13 @@ impl ToolCallHooks for AssistantToolHooks {
                 }
             }
         }
+        // Compact one-liner for the running row; the multi-line key/value
+        // detail is stashed for the finished row's caret body (stint 0460).
         let input_summary = summarize_input(input_json);
         self.in_flight_inputs
             .lock()
             .unwrap()
-            .insert(name.to_string(), input_summary.clone());
+            .insert(name.to_string(), tool_input_detail(input_json));
         let _ = self.flow_tx.send(ToolFlowEvent::Started {
             tool: name.to_string(),
             input_summary,
@@ -295,9 +297,15 @@ mod output_preview_tests {
         let preview = tool_output_preview(output);
         assert_eq!(preview, "stdout: line one\nline two\nstderr: boom");
 
-        // No liftable string fields → raw JSON, still bounded.
-        let raw = r#"{"ok": true, "count": 3}"#;
-        assert_eq!(tool_output_preview(raw), raw);
+        // No liftable string fields → pretty-printed JSON, one field per line.
+        let pretty = tool_output_preview(r#"{"ok": true, "count": 3}"#);
+        assert!(pretty.contains("\n"), "must break into lines: {pretty}");
+        assert!(pretty.contains("\"count\": 3"));
+
+        // Input detail: one key per line, string values unquoted.
+        let detail =
+            super::tool_input_detail(r#"{"path": "/tmp/x.py", "sizes": [480, 320]}"#);
+        assert_eq!(detail, "path: /tmp/x.py\nsizes: [480,320]");
 
         // Oversized output keeps head and tail lines around a marker line.
         let big = format!(r#"{{"stdout": "{}"}}"#, "x\\n".repeat(2000));
@@ -335,8 +343,9 @@ fn format_setting_ids(ids: &[String]) -> String {
 /// `\n` escapes), falling back to the raw JSON when nothing liftable exists.
 fn tool_output_preview(output_json: &str) -> String {
     const FIELDS: &[&str] = &["stdout", "stderr", "content", "text", "message", "error"];
+    let parsed = serde_json::from_str::<serde_json::Value>(output_json).ok();
     let mut sections = Vec::new();
-    if let Ok(value) = serde_json::from_str::<serde_json::Value>(output_json) {
+    if let Some(value) = &parsed {
         for field in FIELDS {
             if let Some(text) = value.get(field).and_then(serde_json::Value::as_str) {
                 if !text.trim().is_empty() {
@@ -345,12 +354,35 @@ fn tool_output_preview(output_json: &str) -> String {
             }
         }
     }
+    // No liftable string field: pretty-print the JSON so it breaks into
+    // lines instead of one endless run that overflows the pane.
     let raw = if sections.is_empty() {
-        output_json.to_string()
+        parsed
+            .as_ref()
+            .and_then(|value| serde_json::to_string_pretty(value).ok())
+            .unwrap_or_else(|| output_json.to_string())
     } else {
         sections.join("\n")
     };
     bounded_head_tail_multiline(&raw, TOOL_OUTPUT_PREVIEW_BUDGET)
+}
+
+/// Multi-line `key: value` rendering of a tool call's input for the caret
+/// body — string values keep their real newlines, non-strings print as
+/// compact JSON. Falls back to the raw input when it isn't a JSON object.
+fn tool_input_detail(input_json: &str) -> String {
+    let detail = match serde_json::from_str::<serde_json::Value>(input_json) {
+        Ok(serde_json::Value::Object(map)) if !map.is_empty() => map
+            .iter()
+            .map(|(key, value)| match value {
+                serde_json::Value::String(text) => format!("{key}: {text}"),
+                other => format!("{key}: {other}"),
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => input_json.to_string(),
+    };
+    bounded_head_tail_multiline(&detail, TOOL_OUTPUT_PREVIEW_BUDGET)
 }
 
 /// Head/tail bounding that keeps newlines — for block previews. The omission

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -239,7 +239,7 @@ impl ToolCallHooks for AssistantToolHooks {
             detail: tool_render_detail(name, output_json),
             input_summary: self.in_flight_inputs.lock().unwrap().remove(name),
             output_preview: output_json
-                .map(|output| bounded_head_tail(output, TOOL_OUTPUT_PREVIEW_BUDGET))
+                .map(|output| tool_output_preview(output))
                 .filter(|preview| !preview.is_empty()),
         });
     }
@@ -285,6 +285,28 @@ mod render_detail_tests {
     }
 }
 
+#[cfg(test)]
+mod output_preview_tests {
+    use super::tool_output_preview;
+
+    #[test]
+    fn lifts_string_fields_with_real_newlines_and_falls_back_to_raw_json() {
+        let output = r#"{"ok": true, "exit_code": 1, "stdout": "line one\nline two", "stderr": "boom"}"#;
+        let preview = tool_output_preview(output);
+        assert_eq!(preview, "stdout: line one\nline two\nstderr: boom");
+
+        // No liftable string fields → raw JSON, still bounded.
+        let raw = r#"{"ok": true, "count": 3}"#;
+        assert_eq!(tool_output_preview(raw), raw);
+
+        // Oversized output keeps head and tail lines around a marker line.
+        let big = format!(r#"{{"stdout": "{}"}}"#, "x\\n".repeat(2000));
+        let bounded = tool_output_preview(&big);
+        assert!(bounded.chars().count() <= super::TOOL_OUTPUT_PREVIEW_BUDGET + 40);
+        assert!(bounded.contains("chars omitted"));
+    }
+}
+
 /// Compact single-line summary of a tool input for sheets and audit lines.
 fn summarize_input(input_json: &str) -> String {
     let flat: String = input_json.split_whitespace().collect::<Vec<_>>().join(" ");
@@ -305,6 +327,55 @@ fn format_setting_ids(ids: &[String]) -> String {
             .collect::<Vec<_>>()
             .join(", ")
     }
+}
+
+/// Human-readable preview of a tool call's output: meaningful string fields
+/// lifted out of the result JSON with their real newlines preserved (a
+/// command's stdout reads as the lines it printed, not one flattened run of
+/// `\n` escapes), falling back to the raw JSON when nothing liftable exists.
+fn tool_output_preview(output_json: &str) -> String {
+    const FIELDS: &[&str] = &["stdout", "stderr", "content", "text", "message", "error"];
+    let mut sections = Vec::new();
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(output_json) {
+        for field in FIELDS {
+            if let Some(text) = value.get(field).and_then(serde_json::Value::as_str) {
+                if !text.trim().is_empty() {
+                    sections.push(format!("{field}: {}", text.trim_end()));
+                }
+            }
+        }
+    }
+    let raw = if sections.is_empty() {
+        output_json.to_string()
+    } else {
+        sections.join("\n")
+    };
+    bounded_head_tail_multiline(&raw, TOOL_OUTPUT_PREVIEW_BUDGET)
+}
+
+/// Head/tail bounding that keeps newlines — for block previews. The omission
+/// marker sits on its own line so surviving head/tail lines stay intact.
+fn bounded_head_tail_multiline(text: &str, budget: usize) -> String {
+    let chars = text.chars().collect::<Vec<_>>();
+    if chars.len() <= budget {
+        return text.to_string();
+    }
+    if budget < 12 {
+        return chars.into_iter().take(budget).collect();
+    }
+    let mut keep = budget;
+    for _ in 0..2 {
+        let omitted = chars.len().saturating_sub(keep);
+        let marker_len = format!("\n[{omitted} chars omitted]\n").chars().count();
+        keep = budget.saturating_sub(marker_len);
+    }
+    let head = keep.div_ceil(2);
+    let tail = keep.saturating_sub(head);
+    let omitted = chars.len().saturating_sub(head + tail);
+    let mut out = chars.iter().take(head).collect::<String>();
+    out.push_str(&format!("\n[{omitted} chars omitted]\n"));
+    out.extend(chars.iter().skip(chars.len() - tail));
+    out
 }
 
 fn bounded_head_tail(text: &str, budget: usize) -> String {
@@ -1420,14 +1491,6 @@ impl AssistantApp {
             self.execute_effects(effects);
             return;
         };
-        let tier = self.session_overrides.model_tier.unwrap_or_else(|| {
-            if self.settings.model.tier.source.scope == settings::SettingsScope::Default {
-                agent.default_tier
-            } else {
-                self.settings.model.tier.value
-            }
-        });
-        let concrete_model = agent.model_routes.for_tier(tier).cloned();
         let effort = self.model.effort_override.or(agent.effort);
         let selected_skill = self.pending_skill.take().or_else(|| {
             self.skill_registry
@@ -1435,6 +1498,32 @@ impl AssistantApp {
                 .or_else(|| self.skill_registry.app_build_fallback(&prompt, &agent.skills))
                 .cloned()
         });
+        // Session tier, with a skill-declared floor (stint 0459): a skill that
+        // knows its work needs a stronger model (frontmatter `tier:`) raises a
+        // *default-sourced* tier for the turns it drives. An explicit user
+        // choice — `/model` session override or a configured tier — always
+        // wins; only the installed default is escalated.
+        let tier_is_default_sourced = self.session_overrides.model_tier.is_none()
+            && self.settings.model.tier.source.scope == settings::SettingsScope::Default;
+        let mut tier = self.session_overrides.model_tier.unwrap_or_else(|| {
+            if tier_is_default_sourced {
+                agent.default_tier
+            } else {
+                self.settings.model.tier.value
+            }
+        });
+        if let Some(floor) = selected_skill.as_ref().and_then(|skill| skill.tier) {
+            if tier_is_default_sourced && floor > tier {
+                log::info!(
+                    "assistant[{conversation_id}]: skill '{}' raised default tier {} -> {} (skill-tier-floor)",
+                    selected_skill.as_ref().map(|s| s.name.as_str()).unwrap_or("?"),
+                    settings::model_tier_name(tier),
+                    settings::model_tier_name(floor),
+                );
+                tier = floor;
+            }
+        }
+        let concrete_model = agent.model_routes.for_tier(tier).cloned();
         let is_app_build_turn = selected_skill
             .as_ref()
             .is_some_and(|skill| skill.name == skills::APP_BUILD_SKILL_NAME);

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -88,6 +88,9 @@ pub struct ActiveToolCall {
     pub tool: String,
     /// Compact summary of the call's input, shown on the running row.
     pub input_summary: String,
+    /// When the call started, so the running row can show elapsed time — a
+    /// long `app check` reads as progress instead of a hang (stint 0460).
+    pub started: std::time::Instant,
 }
 
 /// Everything the model needs to commit a completed tool call as a
@@ -876,6 +879,7 @@ impl AssistantModel {
         self.active_tools.push(ActiveToolCall {
             tool: tool.to_string(),
             input_summary: input_summary.to_string(),
+            started: std::time::Instant::now(),
         });
     }
 

--- a/src/assistant/render.rs
+++ b/src/assistant/render.rs
@@ -387,42 +387,50 @@ impl AssistantRenderer {
             .default_open(failed)
             .show(ui, |ui| {
                 if let Some(input) = &turn.input_summary {
-                    ui.label(
-                        RichText::new(format!("in  {input}"))
-                            .size(style::TEXT_CAPTION)
-                            .monospace()
-                            .color(colors.text_dim),
-                    );
+                    Self::draw_preview_block(ui, colors, "in", input);
                 }
                 if let Some(output) = &turn.output_preview {
-                    // Output previews carry real newlines (stint 0460) —
-                    // render line-by-line in a framed block like the diff
-                    // view so command output reads as the lines it printed.
-                    egui::Frame::new()
-                        .fill(colors.bg_active)
-                        .corner_radius(style::RADIUS_MD)
-                        .inner_margin(egui::Margin::symmetric(
-                            style::SPACE_SM as i8,
-                            style::SPACE_XS as i8,
-                        ))
-                        .show(ui, |ui| {
-                            ui.spacing_mut().item_spacing.y = 0.0;
-                            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
-                            for line in output.lines() {
-                                ui.label(
-                                    RichText::new(line)
-                                        .size(style::TEXT_CAPTION)
-                                        .monospace()
-                                        .color(colors.text_dim),
-                                );
-                            }
-                        });
+                    Self::draw_preview_block(ui, colors, "out", output);
                 }
                 if let Some(diff) = &turn.detail {
                     Self::draw_diff_block(ui, colors, diff);
                 }
             });
         ui.add_space(style::SPACE_SM);
+    }
+
+    /// A labeled multi-line preview (tool input/output, stint 0460): real
+    /// newlines render as separate rows inside a framed block that fills the
+    /// available width, and long rows wrap instead of clipping at the pane
+    /// edge.
+    fn draw_preview_block(ui: &mut egui::Ui, colors: &Colors, label: &str, body: &str) {
+        ui.label(
+            RichText::new(label)
+                .size(style::TEXT_HINT)
+                .monospace()
+                .color(colors.text_dim),
+        );
+        egui::Frame::new()
+            .fill(colors.bg_active)
+            .corner_radius(style::RADIUS_MD)
+            .inner_margin(egui::Margin::symmetric(
+                style::SPACE_SM as i8,
+                style::SPACE_XS as i8,
+            ))
+            .show(ui, |ui| {
+                ui.set_width(ui.available_width());
+                ui.spacing_mut().item_spacing.y = 0.0;
+                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
+                for line in body.lines() {
+                    ui.label(
+                        RichText::new(line)
+                            .size(style::TEXT_CAPTION)
+                            .monospace()
+                            .color(colors.text_dim),
+                    );
+                }
+            });
+        ui.add_space(style::SPACE_XS);
     }
 
     /// A unified diff rendered line-by-line: additions in the success hue,

--- a/src/assistant/render.rs
+++ b/src/assistant/render.rs
@@ -395,15 +395,28 @@ impl AssistantRenderer {
                     );
                 }
                 if let Some(output) = &turn.output_preview {
-                    ui.scope(|ui| {
-                        ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
-                        ui.label(
-                            RichText::new(format!("out {output}"))
-                                .size(style::TEXT_CAPTION)
-                                .monospace()
-                                .color(colors.text_dim),
-                        );
-                    });
+                    // Output previews carry real newlines (stint 0460) —
+                    // render line-by-line in a framed block like the diff
+                    // view so command output reads as the lines it printed.
+                    egui::Frame::new()
+                        .fill(colors.bg_active)
+                        .corner_radius(style::RADIUS_MD)
+                        .inner_margin(egui::Margin::symmetric(
+                            style::SPACE_SM as i8,
+                            style::SPACE_XS as i8,
+                        ))
+                        .show(ui, |ui| {
+                            ui.spacing_mut().item_spacing.y = 0.0;
+                            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
+                            for line in output.lines() {
+                                ui.label(
+                                    RichText::new(line)
+                                        .size(style::TEXT_CAPTION)
+                                        .monospace()
+                                        .color(colors.text_dim),
+                                );
+                            }
+                        });
                 }
                 if let Some(diff) = &turn.detail {
                     Self::draw_diff_block(ui, colors, diff);
@@ -542,10 +555,22 @@ impl AssistantRenderer {
         colors: &Colors,
         active: &super::model::ActiveToolCall,
     ) {
-        let line = if active.input_summary.is_empty() {
-            format!("⟳ {} — running…", active.tool)
+        // Braille spinner keyed to wall clock — the assistant already
+        // repaints continuously while a turn is in flight, so this animates
+        // without extra repaint requests. Elapsed seconds make a long tool
+        // call (a 60s+ `app check`) read as progress, not a hang.
+        const FRAMES: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+        let elapsed = active.started.elapsed();
+        let frame = FRAMES[(elapsed.as_millis() / 100) as usize % FRAMES.len()];
+        let elapsed_label = if elapsed.as_secs() >= 2 {
+            format!(" · {}s", elapsed.as_secs())
         } else {
-            format!("⟳ {} {} — running…", active.tool, active.input_summary)
+            String::new()
+        };
+        let line = if active.input_summary.is_empty() {
+            format!("{frame} {}{elapsed_label}", active.tool)
+        } else {
+            format!("{frame} {} {}{elapsed_label}", active.tool, active.input_summary)
         };
         ui.scope(|ui| {
             ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
@@ -556,6 +581,8 @@ impl AssistantRenderer {
                     .color(colors.accent),
             );
         });
+        ui.ctx()
+            .request_repaint_after(std::time::Duration::from_millis(100));
         ui.add_space(style::SPACE_SM);
     }
 

--- a/src/assistant/skills.rs
+++ b/src/assistant/skills.rs
@@ -50,6 +50,10 @@ pub struct SkillDefinition {
     pub instructions: String,
     pub source: SkillSource,
     pub path: PathBuf,
+    /// Optional model-tier floor (frontmatter `tier:`). When the session tier
+    /// is still the installed default, dispatch escalates to at least this
+    /// tier for turns that load the skill; an explicit user tier always wins.
+    pub tier: Option<crate::app_protocol::ModelTier>,
 }
 
 #[derive(Debug, Default)]
@@ -215,12 +219,24 @@ fn parse_skill_text(text: &str, source: SkillSource, path: &Path) -> Result<Skil
     if name.is_empty() || description.is_empty() || instructions.trim().is_empty() {
         return Err("name, description, and instructions must be non-empty".to_string());
     }
+    let tier = match value("tier").as_deref() {
+        None => None,
+        Some("low") => Some(crate::app_protocol::ModelTier::Low),
+        Some("medium") => Some(crate::app_protocol::ModelTier::Medium),
+        Some("high") => Some(crate::app_protocol::ModelTier::High),
+        Some(other) => {
+            return Err(format!(
+                "frontmatter tier must be low, medium, or high — got '{other}'"
+            ))
+        }
+    };
     Ok(SkillDefinition {
         name,
         description,
         instructions: instructions.trim().to_string(),
         source,
         path: path.to_path_buf(),
+        tier,
     })
 }
 
@@ -262,6 +278,49 @@ mod tests {
             .all()
             .iter()
             .all(|skill| skill.source == SkillSource::Builtin));
+    }
+
+    #[test]
+    fn tier_frontmatter_parses_and_rejects_unknown_values() {
+        let skill = parse_skill_text(
+            "---\nname: deploy\ndescription: deploy a release\ntier: high\n---\nbody",
+            SkillSource::User,
+            Path::new("x"),
+        )
+        .expect("valid tier");
+        assert_eq!(skill.tier, Some(crate::app_protocol::ModelTier::High));
+
+        let no_tier = parse_skill_text(
+            "---\nname: deploy\ndescription: deploy a release\n---\nbody",
+            SkillSource::User,
+            Path::new("x"),
+        )
+        .expect("tier is optional");
+        assert_eq!(no_tier.tier, None);
+
+        let err = parse_skill_text(
+            "---\nname: deploy\ndescription: deploy a release\ntier: turbo\n---\nbody",
+            SkillSource::User,
+            Path::new("x"),
+        )
+        .expect_err("unknown tier must fail loudly");
+        assert!(err.contains("turbo"), "{err}");
+    }
+
+    #[test]
+    fn builtin_app_build_skill_declares_a_high_tier_floor() {
+        let root = tempfile::tempdir().unwrap();
+        let registry = SkillRegistry::load(root.path(), root.path());
+        let skill = registry.get(APP_BUILD_SKILL_NAME).expect("builtin present");
+        assert_eq!(
+            skill.tier,
+            Some(crate::app_protocol::ModelTier::High),
+            "app builds must escalate off a default-sourced weak tier"
+        );
+        assert!(
+            !skill.instructions.contains("host.files.grep to find SDK symbols"),
+            "the skill must not instruct SDK discovery — the API reference is embedded"
+        );
     }
 
     #[test]
@@ -381,10 +440,12 @@ mod tests {
             instructions: "do it".into(),
             source: SkillSource::User,
             path: PathBuf::new(),
+            tier: None,
         };
         let docs = SkillDefinition {
             name: "docs".into(), description: "Write and revise product documentation with clear examples and accurate command references.".into(),
             instructions: "write".into(), source: SkillSource::User, path: PathBuf::new(),
+            tier: None,
         };
         let registry = SkillRegistry {
             skills: vec![release, docs],
@@ -412,6 +473,7 @@ mod tests {
             instructions: "do it".into(),
             source: SkillSource::User,
             path: PathBuf::new(),
+            tier: None,
         };
         let registry = SkillRegistry {
             skills: vec![make("release-a"), make("release-b")],

--- a/src/cli/app_check.rs
+++ b/src/cli/app_check.rs
@@ -249,7 +249,12 @@ pub fn app_check_cli(path: &str, sizes: &[String], png_dir: Option<&str>) -> i32
     }
     let launch_config = is_python_entry.then(|| python_launch_config(&manifest, &entry_path, app_dir));
 
-    for (width, height) in render_sizes {
+    // A guest that fails to boot fails identically at every size; stop after
+    // the first boot failure instead of paying the probe cost 4 more times
+    // (stint 0458 — a broken first draft is the assistant loop's hot path).
+    let mut render_boot_failed = false;
+    let total_sizes = render_sizes.len();
+    for (index, (width, height)) in render_sizes.into_iter().enumerate() {
         let label = format!("{width}x{height}");
         let Some(launch_config) = &launch_config else {
             continue;
@@ -284,7 +289,17 @@ pub fn app_check_cli(path: &str, sizes: &[String], png_dir: Option<&str>) -> i32
                     }
                 }
             }
-            Err(e) => errors.push(format!("render {label} — {e}")),
+            Err(e) => {
+                errors.push(format!("render {label} — {e}"));
+                render_boot_failed = true;
+                let remaining = total_sizes - index - 1;
+                if remaining > 0 {
+                    println!(
+                        "skip render — {remaining} remaining size(s) skipped after {label} failed to boot"
+                    );
+                }
+                break;
+            }
         }
     }
 
@@ -298,7 +313,9 @@ pub fn app_check_cli(path: &str, sizes: &[String], png_dir: Option<&str>) -> i32
                     .unwrap_or(&fixture.path)
                     .display()
             );
-            if let Some(launch_config) = &launch_config {
+            if render_boot_failed {
+                println!("skip seeded probe — app failed to boot during render checks");
+            } else if let Some(launch_config) = &launch_config {
                 run_seeded_state_and_action_probe(
                     &manifest,
                     launch_config,

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -859,6 +859,18 @@ pub enum HostCmd {
         #[arg(long)]
         json: bool,
     },
+    /// Capture the running host window as a PNG through the real render
+    /// pipeline — the pixels the user actually sees, no OS screen capture.
+    ///
+    /// Example: plexi host screenshot --pane 3 --output /tmp/pane3.png
+    Screenshot {
+        /// Crop the capture to this pane's current screen rect
+        #[arg(long)]
+        pane: Option<u64>,
+        /// Where to write the PNG (default: <profile>/screenshots/<timestamp>.png)
+        #[arg(long, short = 'o')]
+        output: Option<String>,
+    },
 }
 
 /// `plexi account <cmd>` — marketplace account management.

--- a/src/cli/host.rs
+++ b/src/cli/host.rs
@@ -633,6 +633,86 @@ pub fn host_status_cli(json: bool) -> i32 {
     0
 }
 
+/// `plexi host screenshot [--pane <id>] [--output <path>]` — capture the
+/// live host window (optionally cropped to one pane) through the real
+/// render pipeline. Prints the written PNG path on success.
+pub fn host_screenshot_cli(pane: Option<u64>, output: Option<&str>) -> i32 {
+    let id = uuid::Uuid::new_v4();
+    let output_path = match output {
+        Some(path) => path.to_string(),
+        None => {
+            let stamp = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or_default();
+            crate::config::config_dir()
+                .join("screenshots")
+                .join(format!("host-{stamp}.png"))
+                .to_string_lossy()
+                .into_owned()
+        }
+    };
+    let response_file = crate::config::config_dir()
+        .join(format!("screenshot-response-{id}.json"))
+        .to_string_lossy()
+        .into_owned();
+    log::info!("host_screenshot:cli: pane={pane:?} output_path={output_path}");
+
+    let code = super::send_to_socket(serde_json::json!({
+        "type": "screenshot",
+        "pane_id": pane,
+        "output_path": output_path,
+        "response_file": response_file,
+    }));
+    if code != 0 {
+        return code;
+    }
+
+    // The capture round-trips through the GPU (request frame -> readback ->
+    // next frame's input), so allow a little longer than plain state reads.
+    let response_path = std::path::PathBuf::from(&response_file);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        if response_path.exists() {
+            let content = match std::fs::read_to_string(&response_path) {
+                Ok(content) => content,
+                Err(e) => {
+                    eprintln!("error: could not read response file: {e}");
+                    return 1;
+                }
+            };
+            let _ = std::fs::remove_file(&response_path);
+            match serde_json::from_str::<serde_json::Value>(&content) {
+                Ok(v) if v.get("error").is_some() => {
+                    eprintln!(
+                        "error: {}",
+                        v["error"].as_str().unwrap_or("screenshot failed")
+                    );
+                    return 1;
+                }
+                Ok(v) => {
+                    println!(
+                        "{} ({}x{})",
+                        v["path"].as_str().unwrap_or(&output_path),
+                        v["width"],
+                        v["height"]
+                    );
+                    return 0;
+                }
+                Err(e) => {
+                    eprintln!("error: malformed screenshot response: {e}");
+                    return 1;
+                }
+            }
+        }
+        if std::time::Instant::now() >= deadline {
+            eprintln!("error: timed out waiting for screenshot response");
+            return 1;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -532,7 +532,7 @@ pub use events::{
     events_subscribe_cli, EmitArgs,
 };
 pub use doctor::doctor_cli;
-pub use host::{host_start_cli, host_status_cli, host_stop_cli};
+pub use host::{host_screenshot_cli, host_start_cli, host_status_cli, host_stop_cli};
 pub use install::{
     install_cli, install_pack_cli, install_workspace_pack_cli, plexi_uninstall_cli,
     self_update_cli, update_cli,

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -469,6 +469,13 @@ impl WasmPythonRuntime {
     pub fn drain_stderr(&self) -> String {
         String::from_utf8_lossy(&self.stderr.drain()).into_owned()
     }
+
+    /// Whether the guest thread has exited (crash, clean exit, or failed
+    /// boot). Buffered stdout may still hold undrained messages after this
+    /// turns true — drain once more before treating the guest as gone.
+    pub fn is_finished(&self) -> bool {
+        self.thread.as_ref().is_none_or(std::thread::JoinHandle::is_finished)
+    }
 }
 
 impl Drop for WasmPythonRuntime {
@@ -595,6 +602,24 @@ impl HeadlessPythonSession {
                 if matches(&message) {
                     return Ok(());
                 }
+            }
+            if self.runtime.is_finished() {
+                // The guest may have flushed final messages between the drain
+                // above and exiting — drain once more before declaring death.
+                for message in self.runtime.drain_messages()? {
+                    if matches(&message) {
+                        return Ok(());
+                    }
+                }
+                let stderr = self.runtime.drain_stderr();
+                return Err(WasmPythonError::BridgeJson(format!(
+                    "app exited before responding{}",
+                    if stderr.trim().is_empty() {
+                        String::new()
+                    } else {
+                        format!("\n  stderr:\n{stderr}")
+                    }
+                )));
             }
             if std::time::Instant::now() > deadline {
                 let stderr = self.runtime.drain_stderr();
@@ -3922,6 +3947,39 @@ mod tests {
                     if *x == 41.0 && *y == 42.0
             )
         )));
+    }
+
+    #[test]
+    fn headless_frame_fails_fast_when_the_guest_dies_at_import() {
+        let app = tempdir().expect("app dir");
+        std::fs::write(
+            app.path().join("main.py"),
+            "raise RuntimeError('broken on purpose')\n",
+        )
+        .expect("write app");
+        let config = PythonLaunchConfig {
+            app_id: "test.broken-guest".to_string(),
+            app_dir: app.path().to_path_buf(),
+            entry: app.path().join("main.py"),
+            module_name: "main".to_string(),
+            launch_args: Vec::new(),
+            workspace_root: app.path().to_path_buf(),
+            capabilities: Vec::new(),
+            allowed_hosts: Vec::new(),
+        };
+        let started = std::time::Instant::now();
+        let err = run_headless_frame(&config, (480.0, 320.0), None)
+            .expect_err("an entry that raises at import must fail the headless probe");
+        let elapsed = started.elapsed();
+        let message = format!("{err:?}");
+        assert!(
+            message.contains("app exited before responding"),
+            "must take the guest-death fast path, not the {HEADLESS_DEFAULT_TIMEOUT:?} timeout: {message}"
+        );
+        assert!(
+            elapsed < HEADLESS_DEFAULT_TIMEOUT,
+            "broken guest must fail before the poll timeout, took {elapsed:?}"
+        );
     }
 
     fn python_shim_fixture() -> PathBuf {

--- a/src/main.rs
+++ b/src/main.rs
@@ -618,6 +618,9 @@ fn main() -> eframe::Result {
                         )),
                         HostCmd::Stop => std::process::exit(cli::host_stop_cli()),
                         HostCmd::Status { json } => std::process::exit(cli::host_status_cli(json)),
+                        HostCmd::Screenshot { pane, output } => std::process::exit(
+                            cli::host_screenshot_cli(pane, output.as_deref()),
+                        ),
                     },
                     Commands::Notify {
                         title,

--- a/src/plexi_ai/backend/openrouter.rs
+++ b/src/plexi_ai/backend/openrouter.rs
@@ -85,6 +85,48 @@ struct PartialToolCall {
     arguments: String,
 }
 
+/// Tool name as sent on the wire. Both the OpenAI function-calling spec and
+/// Anthropic's tool schema require `^[a-zA-Z0-9_-]{1,128}$` — Plexi's dotted
+/// host-tool names (`host.files.read`) only ever worked because some
+/// providers are lenient. Anthropic-family providers hard-reject them with
+/// `tools.0.custom.name: String should match pattern ...`, which is exactly
+/// how the 2026-07-19 mid-conversation model switch to claude died. Encode
+/// on the way out, decode via the reverse map on the way back in.
+fn wire_tool_name(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Rewrite every tool name inside an OpenAI-format message to its wire form:
+/// `tool_calls[].function.name` on assistant messages and the optional
+/// `name` on tool-result messages. History replay must match the tools
+/// array or strict providers reject the whole request.
+fn sanitize_message_tool_names(message: &mut serde_json::Value) {
+    if let Some(calls) = message
+        .get_mut("tool_calls")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        for call in calls {
+            if let Some(name) = call["function"]["name"].as_str() {
+                call["function"]["name"] = serde_json::Value::String(wire_tool_name(name));
+            }
+        }
+    }
+    if message.get("role").and_then(serde_json::Value::as_str) == Some("tool") {
+        if let Some(name) = message.get("name").and_then(serde_json::Value::as_str) {
+            let wire = wire_tool_name(name);
+            message["name"] = serde_json::Value::String(wire);
+        }
+    }
+}
+
 /// Worker: calls OpenRouter SSE endpoint and delivers events to `tx`.
 fn stream_openrouter(
     api_key: String,
@@ -111,6 +153,15 @@ fn stream_openrouter(
         }));
     }
     messages.extend(request.messages.iter().cloned());
+    for message in &mut messages {
+        sanitize_message_tool_names(message);
+    }
+    // wire name -> real dotted name, for decoding the model's tool calls.
+    let tool_name_map: HashMap<String, String> = request
+        .tools
+        .iter()
+        .map(|t| (wire_tool_name(&t.name), t.name.clone()))
+        .collect();
 
     let mut body = serde_json::json!({
         "model": model,
@@ -130,7 +181,7 @@ fn stream_openrouter(
                 serde_json::json!({
                     "type": "function",
                     "function": {
-                        "name": t.name,
+                        "name": wire_tool_name(&t.name),
                         "description": t.description,
                         "parameters": t.input_schema
                     }
@@ -300,7 +351,9 @@ fn stream_openrouter(
                 .into_values()
                 .map(|p| RawToolCall {
                     id: p.id,
-                    name: p.name,
+                    // Decode the wire name back to the real dotted tool name;
+                    // a name outside the map passes through untouched.
+                    name: tool_name_map.get(&p.name).cloned().unwrap_or(p.name),
                     arguments: p.arguments,
                 })
                 .collect();
@@ -374,6 +427,38 @@ fn apply_reasoning_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tool_names_are_wire_safe_and_history_is_sanitized() {
+        // Dotted host-tool names must encode to the provider-required
+        // `^[a-zA-Z0-9_-]{1,128}$` pattern and decode back via the map.
+        assert_eq!(wire_tool_name("host.files.read"), "host_files_read");
+        assert_eq!(wire_tool_name("already_safe-name"), "already_safe-name");
+
+        let mut assistant_msg = serde_json::json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "host.build.run", "arguments": "{}"}
+            }]
+        });
+        sanitize_message_tool_names(&mut assistant_msg);
+        assert_eq!(
+            assistant_msg["tool_calls"][0]["function"]["name"],
+            serde_json::json!("host_build_run")
+        );
+
+        let mut tool_msg = serde_json::json!({
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "name": "host.build.run",
+            "content": "ok"
+        });
+        sanitize_message_tool_names(&mut tool_msg);
+        assert_eq!(tool_msg["name"], serde_json::json!("host_build_run"));
+    }
 
     #[test]
     fn explicit_reasoning_effort_is_encoded_in_payload() {

--- a/src/plexi_ai/backend/openrouter.rs
+++ b/src/plexi_ai/backend/openrouter.rs
@@ -170,11 +170,25 @@ fn stream_openrouter(
         Ok(r) => r,
         Err(ureq::Error::Status(status, error_resp)) => {
             let body = error_resp.into_string().unwrap_or_default();
-            // Try to parse OpenRouter error shape: {"error":{"code":N,"message":"…"}}
-            let msg = serde_json::from_str::<serde_json::Value>(&body)
-                .ok()
-                .and_then(|v| v["error"]["message"].as_str().map(|s| s.to_string()))
-                .unwrap_or_else(|| body.clone());
+            // OpenRouter error shape: {"error":{"code":N,"message":"…",
+            // "metadata":{"raw":"<the upstream provider's actual error>"}}}.
+            // "Provider returned error" alone is undiagnosable — always
+            // surface metadata.raw when present and log the full body.
+            log::warn!("openrouter: http {status} error body: {body}");
+            let parsed = serde_json::from_str::<serde_json::Value>(&body).ok();
+            let message = parsed
+                .as_ref()
+                .and_then(|v| v["error"]["message"].as_str())
+                .map(str::to_string);
+            let provider_raw = parsed
+                .as_ref()
+                .and_then(|v| v["error"]["metadata"]["raw"].as_str())
+                .map(str::to_string);
+            let msg = match (message, provider_raw) {
+                (Some(message), Some(raw)) => format!("{message} — provider detail: {raw}"),
+                (Some(message), None) => message,
+                (None, _) => body.clone(),
+            };
             let _ = tx.send(StreamEvent::Error(format!(
                 "openrouter http error {status}: {msg}"
             )));

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -481,6 +481,20 @@ pub enum AppRequest {
     /// Host writes `{"error":"..."}` if the pane is not found.
     GetPaneState { pane_id: u64, response_file: String },
 
+    /// Capture the live host window as a PNG through the real render
+    /// pipeline (`egui::ViewportCommand::Screenshot` — actual rendered
+    /// pixels, not a re-render). With `pane_id`, the image is cropped to
+    /// that pane's current screen rect. Sent by `plexi host screenshot`.
+    /// Host writes the PNG to `output_path` and
+    /// `{"ok":true,"path":...,"width":...,"height":...}` (or
+    /// `{"error":"..."}`) to `response_file`.
+    Screenshot {
+        #[serde(default)]
+        pane_id: Option<u64>,
+        output_path: String,
+        response_file: String,
+    },
+
     /// Dispatch a semantic action to an app pane. Sent by `plexi app action <pane_id> <action> [args...]`.
     /// Host delivers `PlexiEvent::Action { action, args }` to the target app pane.
     /// Writes `{"ok":true}` or `{"error":"..."}` to `response_file`.

--- a/src/protocol/primitives.rs
+++ b/src/protocol/primitives.rs
@@ -74,7 +74,7 @@ pub struct AiTool {
 ///   - `Low`    → Haiku
 ///   - `Medium` → Sonnet
 ///   - `High`   → Opus
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum ModelTier {
     Low,

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1369,8 +1369,8 @@ mod tests {
             crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path());
 
         let mut write_tool = Turn::tool("host.files.write", ToolStatus::Succeeded);
-        write_tool.input_summary = Some(r#"{"path": "main.py"}"#.to_string());
-        write_tool.output_preview = Some(r#"{"ok": true, "bytes": 512}"#.to_string());
+        write_tool.input_summary = Some("path: main.py".to_string());
+        write_tool.output_preview = Some("{\n  \"ok\": true,\n  \"bytes\": 512\n}".to_string());
         write_tool.detail =
             Some("--- a/main.py\n+++ b/main.py\n@@ -1,1 +1,2 @@\n-pass\n+print(\"hi\")\n".to_string());
         let mut check_tool = Turn::tool("plexi.app_check", ToolStatus::Succeeded);

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1379,6 +1379,11 @@ mod tests {
         let mut failed_tool =
             Turn::tool("host.build.run — exit 1: mypy error", ToolStatus::Failed);
         failed_tool.input_summary = Some(r#"{"cmd": "app check"}"#.to_string());
+        // Multi-line output preview (stint 0460): real newlines render as a
+        // framed block, so a command's output reads as the lines it printed.
+        failed_tool.output_preview = Some(
+            "stdout: ✓ manifest — fish-game\n✗ types — mypy found errors:\nmain.py:12: error: \"UiValueChange\" has no attribute \"payload\"\n✗ app check failed — 1 error(s)".to_string(),
+        );
 
         assistant.model.turns = vec![
             Turn::now(TurnRole::User, "Build a simple number guessing game as a Plexi app."),
@@ -1394,6 +1399,12 @@ mod tests {
                 "The Guessing Game app is open! Type a number and press Enter.",
             ),
         ];
+        // An in-flight tool call so the animated running row (spinner +
+        // elapsed seconds, stint 0460) is on the screenshot too.
+        assistant.model.streaming.in_flight = true;
+        assistant
+            .model
+            .tool_call_started("host.build.run", r#"{"args": ["app", "check", "fish-game"]}"#);
 
         let mut h = PlexiUiHarness::new_sized(1000.0, 720.0);
         h.step();


### PR DESCRIPTION
Stint tasks: 0458, 0459, 0460, 0461 (no linked GitHub issues).

Forensics of the 2026-07-19 fish-game alpha run (one prompt, ~8 min, ~45 tool calls, two 76-second silent stalls, an invisible provider failure at the end) found five infrastructure defects; this bundle fixes all of them and adds the live-capture command requested mid-session.

## Summary

**0458 — cli/app-check: fail fast on a broken guest**
- The headless probe detects guest-thread death instead of spinning the full 15s timeout; the error carries guest stderr.
- After the first render-size boot failure the remaining sizes and seeded/action probes are skipped with an explicit note. Broken-app check: 76s → ~2s. Passing path unchanged.

**0459 — assistant: no SDK re-discovery, tier floor**
- build-plexi-app no longer instructs grep-based SDK discovery (the generated API reference is already injected); authoring is a single write, fixes come from check output.
- Skills may declare a tier floor in frontmatter; dispatch escalates only a default-sourced session tier (explicit /model or configured tier always wins). build-plexi-app declares high.

**0460 — assistant run UX**
- One Escape press interrupts an in-flight turn: live path via the dispatch gate (the leave-the-field Escape is delivered to handle_key before CloseApp suppression), CLI path via KeyPane parity (replayed raw events land after the gate and used to close the pane).
- Active tool row animates: braille spinner + elapsed seconds.
- Tool caret bodies get labeled full-width in/out blocks: key/value input detail, stdout/stderr/content lifted with real newlines, pretty-printed JSON fallback, line-aware head/tail bounding.
- OpenRouter errors surface error.metadata.raw and warn-log the full body — which immediately diagnosed the mystery 400: **Anthropic-family providers reject dotted tool names** (`host.files.read` fails `^[a-zA-Z0-9_-]{1,128}$`). Tool names are now encoded to wire-safe form on the way out (tools array + replayed history) and decoded on the way back. This is why switching model mid-conversation to claude appeared to be ignored.

**0461 — host/cli: live screenshot through the render pipeline**
- New command: capture the running host window (or one pane, `--pane <id>`) as a PNG via `AppRequest::Screenshot` → `egui::ViewportCommand::Screenshot` — real swapchain pixels, no OS screen capture, no permission prompt. Root AGENTS.md documents it as the only sanctioned way to inspect live host pixels.

## Test evidence

- cargo test --bin plexi: 1529 passed, 6 failed — the same 6 pre-existing environment failures as clean alpha.
- New coverage: broken-guest fast-fail probe test, tier frontmatter parse/reject + builtin-floor contract tests, wire-name encode/sanitize tests, multi-line preview tests, crop scale/clamp test, updated transcript screenshot test (PNG reviewed and deleted).
- Live E2E on the PR build, same prompt as the baseline run: **8 tool calls (was ~45), zero SDK-discovery greps, failing checks 2.2s (was 76s), ~3–5 min wall clock (was ~8) with most of the remainder being model latency and permission sheets.** Generated game verified playing via pane-cropped live screenshots; Escape interrupt confirmed cancelling an in-flight turn without closing the pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5q9JbE5qbNM6MA4rQPdSu
