### PR TITLE
assistant: never-frozen streaming — tool-arg generation progress + animated beat everywhere (stint 0467)

### DIFF
--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -42,6 +42,12 @@ use crate::plexi_ai::CancelToken;
 enum StreamDelta {
     Answer(String),
     Reasoning(String),
+    /// The model is generating a tool call (name once known, cumulative
+    /// argument chars) — drives the transcript's generation-progress row.
+    ToolProgress {
+        name: Option<String>,
+        arg_chars: usize,
+    },
 }
 use crate::plexi_ai::tool_dispatch::{
     HostToolHandler, ToolCallHooks, ToolCallResult, ToolDispatcher,
@@ -1645,6 +1651,12 @@ impl AssistantApp {
                     let owned = match delta {
                         TurnDelta::Text(chunk) => StreamDelta::Answer(chunk.to_string()),
                         TurnDelta::Reasoning(chunk) => StreamDelta::Reasoning(chunk.to_string()),
+                        TurnDelta::ToolCallProgress { name, arg_chars } => {
+                            StreamDelta::ToolProgress {
+                                name: name.map(str::to_string),
+                                arg_chars,
+                            }
+                        }
                     };
                     let _ = delta_tx.send(owned);
                 });
@@ -1718,6 +1730,9 @@ impl AssistantApp {
                 match delta {
                     StreamDelta::Answer(chunk) => self.model.apply_answer_delta(&chunk),
                     StreamDelta::Reasoning(chunk) => self.model.apply_reasoning_delta(&chunk),
+                    StreamDelta::ToolProgress { name, arg_chars } => {
+                        self.model.apply_tool_progress(name, arg_chars);
+                    }
                 }
             }
         }

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -152,6 +152,20 @@ pub struct StreamingState {
     /// flushed when a tool call started (stint 0455). `finish_turn` strips
     /// this prefix from the broker's final text so only the tail commits.
     pub committed_answer: String,
+    /// The model is currently generating a tool call (stint 0467) — the
+    /// longest otherwise-silent stretch of an app-build turn. Cleared when
+    /// the finished call dispatches (`tool_call_started`) or the turn ends.
+    pub tool_progress: Option<ToolArgProgress>,
+}
+
+/// Live tool-call generation progress: the tool name once the stream has
+/// delivered it, cumulative argument chars, and when generation began so the
+/// row can show real elapsed time.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ToolArgProgress {
+    pub name: Option<String>,
+    pub arg_chars: usize,
+    pub started: std::time::Instant,
 }
 
 /// Observable lifecycle for `/compact`. This deliberately records feedback,
@@ -839,10 +853,42 @@ impl AssistantModel {
         }
     }
 
-    /// Append an answer text delta from the streaming turn.
+    /// Append an answer text delta from the streaming turn. Text arriving
+    /// means the model is no longer mid-tool-call, so stale generation
+    /// progress is dropped.
     pub fn apply_answer_delta(&mut self, chunk: &str) {
         if self.streaming.in_flight {
             self.streaming.partial_answer.push_str(chunk);
+            self.streaming.tool_progress = None;
+        }
+    }
+
+    /// Record tool-call generation progress (stint 0467). The start instant
+    /// survives updates so the row's elapsed time is the real generation
+    /// time; the name upgrades from `None` once the stream delivers it.
+    pub fn apply_tool_progress(&mut self, name: Option<String>, arg_chars: usize) {
+        if !self.streaming.in_flight {
+            return;
+        }
+        match &mut self.streaming.tool_progress {
+            Some(progress) => {
+                if name.is_some() {
+                    progress.name = name;
+                }
+                progress.arg_chars = arg_chars;
+            }
+            None => {
+                log::info!(
+                    "assistant[{}]: tool-call generation started ({})",
+                    self.conversation_id,
+                    name.as_deref().unwrap_or("name pending")
+                );
+                self.streaming.tool_progress = Some(ToolArgProgress {
+                    name,
+                    arg_chars,
+                    started: std::time::Instant::now(),
+                });
+            }
         }
     }
 
@@ -876,6 +922,9 @@ impl AssistantModel {
     /// above nothing and below every tool call (stint 0455).
     pub fn tool_call_started(&mut self, tool: &str, input_summary: &str) {
         self.flush_streamed_segment();
+        // Generation is over — the finished call is dispatching; the running
+        // tool row takes over as the animated element.
+        self.streaming.tool_progress = None;
         self.active_tools.push(ActiveToolCall {
             tool: tool.to_string(),
             input_summary: input_summary.to_string(),
@@ -1083,6 +1132,45 @@ mod tests {
             input_summary: Some("{}".to_string()),
             output_preview: None,
         })
+    }
+
+    /// Never-frozen contract (stint 0467): tool-arg generation progress is
+    /// tracked while in flight, upgrades its name in place, hands off to the
+    /// running-tool row on dispatch, and never survives text or turn
+    /// boundaries.
+    #[test]
+    fn tool_progress_tracks_generation_and_clears_on_dispatch_and_text() {
+        let mut m = AssistantModel::fresh();
+        m.apply_tool_progress(Some("host.files.write".into()), 10);
+        assert!(
+            m.streaming.tool_progress.is_none(),
+            "progress outside an in-flight turn must be ignored"
+        );
+
+        submitted(&mut m, "build me an app");
+        m.apply_tool_progress(None, 12);
+        let p = m.streaming.tool_progress.as_ref().expect("progress set");
+        assert_eq!((p.name.as_deref(), p.arg_chars), (None, 12));
+
+        m.apply_tool_progress(Some("host.files.write".into()), 3400);
+        let p = m.streaming.tool_progress.as_ref().expect("progress kept");
+        assert_eq!(
+            (p.name.as_deref(), p.arg_chars),
+            (Some("host.files.write"), 3400)
+        );
+
+        tool_started(&mut m, "host.files.write");
+        assert!(
+            m.streaming.tool_progress.is_none(),
+            "dispatch hands the animated element to the running-tool row"
+        );
+
+        m.apply_tool_progress(Some("host.build.run".into()), 5);
+        m.apply_answer_delta("done!");
+        assert!(
+            m.streaming.tool_progress.is_none(),
+            "answer text arriving means generation is over"
+        );
     }
 
     #[test]

--- a/src/assistant/render.rs
+++ b/src/assistant/render.rs
@@ -29,6 +29,10 @@ use super::model::{
     AssistantModel, AssistantOverlay, CompactionState, PermissionChoice, ToolStatus, TurnRole,
 };
 
+/// Braille beat shared by every animated activity row (running tool,
+/// tool-call generation). Keyed to wall clock at 100ms per frame.
+const SPINNER_FRAMES: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+
 /// What the composer asked the pane shell to do this frame.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ComposerEvent {
@@ -567,9 +571,8 @@ impl AssistantRenderer {
         // repaints continuously while a turn is in flight, so this animates
         // without extra repaint requests. Elapsed seconds make a long tool
         // call (a 60s+ `app check`) read as progress, not a hang.
-        const FRAMES: [char; 10] = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
         let elapsed = active.started.elapsed();
-        let frame = FRAMES[(elapsed.as_millis() / 100) as usize % FRAMES.len()];
+        let frame = SPINNER_FRAMES[(elapsed.as_millis() / 100) as usize % SPINNER_FRAMES.len()];
         let elapsed_label = if elapsed.as_secs() >= 2 {
             format!(" · {}s", elapsed.as_secs())
         } else {
@@ -829,17 +832,60 @@ impl AssistantRenderer {
         // Same bubble as a committed reply, present from the first frame —
         // the thinking-dots beat and every streamed token sit on the
         // background, so it never appears only after streaming ends.
-        if model.streaming.partial_answer.is_empty() {
+        if !model.streaming.partial_answer.is_empty() {
+            let markdown = crate::ui::markdown::harden_soft_breaks(&model.streaming.partial_answer);
+            Self::assistant_bubble(ui, colors, md_cache, &markdown);
+        }
+        // Never-frozen rule (stint 0467): while a turn is in flight,
+        // something on screen always animates. Priority: the tool-generation
+        // row when the model is writing a call, the running-tool row (drawn
+        // by the caller) while one executes, the thinking dots otherwise —
+        // including after streamed text, which previously sat static for the
+        // whole argument stream.
+        if let Some(progress) = &model.streaming.tool_progress {
+            Self::draw_tool_progress_row(ui, colors, progress);
+        } else if model.active_tools.is_empty() {
             // The dots allocate an exact size, so the bubble self-sizes to
             // them — no width measurement needed.
             Self::chat_bubble(ui, colors, BubbleSide::Left, false, |ui| {
                 Self::draw_thinking_dots(ui, colors);
             });
-        } else {
-            let markdown = crate::ui::markdown::harden_soft_breaks(&model.streaming.partial_answer);
-            Self::assistant_bubble(ui, colors, md_cache, &markdown);
         }
         ui.add_space(style::SPACE_MD);
+    }
+
+    /// The model is writing a tool call — the longest otherwise-silent
+    /// stretch of an app-build turn. Spinner + tool name + cumulative
+    /// argument size + elapsed, so a 60s code generation reads as progress.
+    fn draw_tool_progress_row(
+        ui: &mut egui::Ui,
+        colors: &Colors,
+        progress: &super::model::ToolArgProgress,
+    ) {
+        let elapsed = progress.started.elapsed();
+        let frame = SPINNER_FRAMES[(elapsed.as_millis() / 100) as usize % SPINNER_FRAMES.len()];
+        let chars = if progress.arg_chars >= 1000 {
+            format!("{:.1}k chars", progress.arg_chars as f64 / 1000.0)
+        } else {
+            format!("{} chars", progress.arg_chars)
+        };
+        let elapsed_label = if elapsed.as_secs() >= 2 {
+            format!(" · {}s", elapsed.as_secs())
+        } else {
+            String::new()
+        };
+        let name = progress.name.as_deref().unwrap_or("tool call");
+        let line = format!("{frame} writing {name} · {chars}{elapsed_label}");
+        ui.scope(|ui| {
+            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
+            ui.label(
+                RichText::new(line)
+                    .size(style::TEXT_CAPTION)
+                    .monospace()
+                    .color(colors.accent),
+            );
+        });
+        ui.add_space(style::SPACE_SM);
     }
 
     /// Three dots pulsing in sequence — the "assistant is thinking" beat

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -1051,6 +1051,10 @@ impl WasmPane {
                                 done: false,
                             })
                         }
+                        // App-facing `ai.query` streams carry only text and
+                        // reasoning; tool-call generation progress drives the
+                        // assistant transcript, not app protocol events.
+                        crate::plexi_ai::turn_loop::TurnDelta::ToolCallProgress { .. } => return,
                     };
                     if let Err(e) = chunk_tx.send(event) {
                         log::warn!("wasm ai: stream receiver dropped: {e}");

--- a/src/plexi_ai/backend/mod.rs
+++ b/src/plexi_ai/backend/mod.rs
@@ -71,6 +71,15 @@ pub enum StreamEvent {
     /// Incremental reasoning ("thinking") chunk from a reasoning model.
     /// Displayed separately from the answer text; never part of `TurnResult::text`.
     Reasoning(String),
+    /// The model is generating a tool call (stint 0467). `name` is the
+    /// decoded tool name once the stream has delivered it; `arg_chars` is the
+    /// total argument chars accumulated so far across the in-flight calls.
+    /// Purely informational — the finished calls still arrive via
+    /// `ToolCalls`.
+    ToolCallProgress {
+        name: Option<String>,
+        arg_chars: usize,
+    },
     /// Turn complete. Token counts are `Some` only for metered backends.
     /// `generation_id` carries the `X-Generation-Id` response header value
     /// (OpenRouter-specific); the broker uses it to fetch the real cost after

--- a/src/plexi_ai/backend/openrouter.rs
+++ b/src/plexi_ai/backend/openrouter.rs
@@ -341,6 +341,20 @@ fn stream_openrouter(
                     entry.arguments.push_str(args);
                 }
             }
+            // Surface generation progress so the transcript can animate while
+            // the model writes a long tool call (stint 0467) — these argument
+            // streams are the longest silent stretch of an app-build turn.
+            let arg_chars: usize = partial_tool_calls
+                .values()
+                .map(|p| p.arguments.len())
+                .sum();
+            let name = partial_tool_calls
+                .iter()
+                .max_by_key(|(idx, _)| **idx)
+                .map(|(_, p)| &p.name)
+                .filter(|name| !name.is_empty())
+                .map(|name| tool_name_map.get(name).cloned().unwrap_or_else(|| name.clone()));
+            let _ = tx.send(StreamEvent::ToolCallProgress { name, arg_chars });
         }
 
         // When finish_reason == "tool_calls", finalize and emit.

--- a/src/plexi_ai/loop.rs
+++ b/src/plexi_ai/loop.rs
@@ -47,6 +47,13 @@ pub enum TurnDelta<'a> {
     /// Reasoning ("thinking") text from a reasoning model. Never part of
     /// `TurnResult::text`.
     Reasoning(&'a str),
+    /// The model is generating a tool call: name once known, cumulative
+    /// argument chars so far. Lets the UI animate the longest otherwise
+    /// silent stretch of a turn (stint 0467).
+    ToolCallProgress {
+        name: Option<&'a str>,
+        arg_chars: usize,
+    },
 }
 
 /// Error variants for a failed turn.
@@ -109,6 +116,12 @@ pub fn run_turn(
             }
             Ok(StreamEvent::ToolCalls(calls)) => {
                 tool_calls = calls;
+            }
+            Ok(StreamEvent::ToolCallProgress { name, arg_chars }) => {
+                on_delta(TurnDelta::ToolCallProgress {
+                    name: name.as_deref(),
+                    arg_chars,
+                });
             }
             Ok(StreamEvent::Done {
                 input_tokens: in_tok,

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1353,6 +1353,70 @@ mod tests {
         );
     }
 
+    /// Stint 0467, never-frozen rule: while a turn is in flight the
+    /// transcript always shows an animated element. Two screenshots: (1) the
+    /// model streamed a sentence and is now generating a tool call — the
+    /// generation row (`⠹ writing host.files.write · 3.4k chars`) renders
+    /// under the text; (2) same state with no generation info — the thinking
+    /// dots render under the text instead of the pre-0467 frozen bubble.
+    #[test]
+    fn screenshot_assistant_streaming_never_frozen() {
+        use crate::assistant::model::{Turn, TurnRole};
+
+        let ws = tempfile::tempdir().unwrap();
+        let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
+            std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
+        let mut assistant =
+            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path());
+        assistant.model.turns = vec![Turn {
+            role: TurnRole::User,
+            text: "build me a tictactoe app".to_string(),
+            created_at: "2026-07-19T00:00:00Z".to_string(),
+            status: None,
+            thoughts: None,
+            detail: None,
+            input_summary: None,
+            output_preview: None,
+        }];
+        assistant.model.streaming.in_flight = true;
+        assistant.model.streaming.partial_answer =
+            "The SDK uses state.get() from plexi_sdk. Let me fix all the issues.".to_string();
+        assistant
+            .model
+            .apply_tool_progress(Some("host.files.write".to_string()), 3400);
+
+        let mut h = PlexiUiHarness::new_sized(1000.0, 720.0);
+        h.step();
+        h.open_assistant_built(assistant, ws.path().to_path_buf());
+        h.run_steps(3);
+        h.save_screenshot("/tmp/plexi_assistant_streaming_tool_progress.png")
+            .expect("render failed");
+
+        // State 2: same turn with no generation info — a fresh pane, since
+        // the harness has no post-open mutable assistant accessor. The dots
+        // must take over under the text.
+        let broker2: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
+            std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
+        let mut assistant2 =
+            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker2, ws.path());
+        assistant2.model.streaming.in_flight = true;
+        assistant2.model.streaming.partial_answer =
+            "The SDK uses state.get() from plexi_sdk. Let me fix all the issues.".to_string();
+        let mut h2 = PlexiUiHarness::new_sized(1000.0, 720.0);
+        h2.step();
+        h2.open_assistant_built(assistant2, ws.path().to_path_buf());
+        h2.run_steps(2);
+        h2.save_screenshot("/tmp/plexi_assistant_streaming_dots_after_text.png")
+            .expect("render failed");
+        println!(
+            "Screenshots saved to /tmp/plexi_assistant_streaming_tool_progress.png \
+             (spinner + 'writing host.files.write · 3.4k chars' under the text \
+             bubble) and /tmp/plexi_assistant_streaming_dots_after_text.png \
+             (thinking dots under the text bubble) — neither state may render \
+             as static text alone."
+        );
+    }
+
     /// Stint 0455: an app-build turn's transcript renders chronologically —
     /// user message, first assistant segment, individual caret-dropdown tool
     /// rows (never a collapsed "N tool calls" trail), a failed row in the


### PR DESCRIPTION
Stint task: 0467 (no linked GitHub issue).

The 2026-07-19 mimo tictactoe run had 46s and 57s dead-air stretches while the model generated a full `main.py` as tool-call arguments: the streamed sentence sat static (dots only render when `partial_answer` is empty) and the stream layer discarded tool-argument fragments entirely, so the UI had no signal that code was being written. User directive: every waiting period animates; the transcript never looks frozen.

## Summary

- `StreamEvent::ToolCallProgress { name, arg_chars }`: the OpenRouter SSE parser emits cumulative argument progress (decoded tool name once known) as fragments accumulate; threaded through `TurnDelta::ToolCallProgress` → `StreamDelta::ToolProgress` → `AssistantModel::apply_tool_progress`.
- `StreamingState.tool_progress` tracks name/chars/started; cleared on dispatch (`tool_call_started`), on answer text arriving, and at every turn boundary (start/finish/interrupt reset paths). Info-logged when generation starts.
- Never-frozen render rule in `draw_streaming_row`: the generation row (`⠹ writing host.files.write · 3.4k chars · 12s`, shared braille `SPINNER_FRAMES`) renders while the model writes a call; the thinking dots now render under non-empty streamed text too whenever nothing else animates (previously only instead of it); running tools keep their own animated row. `ai.query` app streams intentionally skip progress deltas.

## Test evidence

- cargo test --bin plexi: 1532 passed, 6 failed — the same 6 pre-existing environment failures as clean alpha.
- New model test: progress ignored outside a turn, name upgrades in place, cleared on dispatch and on text delta.
- New screenshot test (`screenshot_assistant_streaming_never_frozen`): both waiting states rendered through the real pane path; PNGs reviewed (accent generation row under the text bubble; dots bubble in the no-info state) and deleted.
- Binary install required for live feel (animation cadence over a real OpenRouter stream): `just pr-install <N>` from this worktree, then run any app-build prompt and watch the write phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
