### PR TITLE
fix: guard delete_context router-emptying cascade; add File Explorer hidden-files toggle (stints 0454/0368)

### DIFF
--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -815,6 +815,138 @@ fn delete_context_cascades_and_cleans_depth_stack() {
     }
 }
 
+/// Stint 0454: deleting a root context whose descendant tree covers every
+/// other context must not empty the `WorkspaceRouter` — `remove_at` clamps
+/// `active` to 0 on an empty vec, and the next `router.active()` call panics.
+/// The delete must be refused, same as the pre-existing single-context guard.
+#[test]
+fn delete_context_refuses_cascade_that_would_empty_router() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let root_idx = app.router.active_idx();
+    app.router.get_mut(root_idx).name = "Root".to_string();
+    let root_id = app.router.active().context_id;
+
+    let child_id = 9101u64;
+    let grandchild_id = 9102u64;
+
+    app.router.push(crate::host::context::Context {
+        name: "Child".to_string(),
+        path: std::path::PathBuf::from("/tmp/child"),
+        root: None,
+        description: None,
+        context_id: child_id,
+        parent_id: Some(root_id),
+        depth: 1,
+        parked: false,
+    });
+    app.router.push(crate::host::context::Context {
+        name: "Grandchild".to_string(),
+        path: std::path::PathBuf::from("/tmp/grandchild"),
+        root: None,
+        description: None,
+        context_id: grandchild_id,
+        parent_id: Some(child_id),
+        depth: 2,
+        parked: false,
+    });
+
+    assert_eq!(app.router.len(), 3, "setup: root + child + grandchild");
+
+    let root_idx_now = app.router.position(|c| c.context_id == root_id).unwrap();
+    app.delete_context(root_idx_now);
+
+    // The cascade (root + child + grandchild) would have covered every
+    // context in the router — the delete must be refused entirely.
+    assert_eq!(
+        app.router.len(),
+        3,
+        "delete must be refused — router must be unchanged"
+    );
+    assert!(app.router.iter().any(|c| c.context_id == root_id));
+    assert!(app.router.iter().any(|c| c.context_id == child_id));
+    assert!(app.router.iter().any(|c| c.context_id == grandchild_id));
+
+    // Must not panic.
+    let _ = app.router.active();
+}
+
+/// Stint 0454 companion: a cascade that leaves an unrelated sibling context
+/// standing must still succeed exactly as before the guard was added.
+#[test]
+fn delete_context_cascade_allowed_when_unrelated_sibling_survives() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let root_idx = app.router.active_idx();
+    app.router.get_mut(root_idx).name = "Root".to_string();
+    let root_id = app.router.active().context_id;
+
+    let a_id = 9201u64;
+    let b_id = 9202u64;
+    let sibling_id = 9203u64;
+
+    app.router.push(crate::host::context::Context {
+        name: "A".to_string(),
+        path: std::path::PathBuf::from("/tmp/a"),
+        root: None,
+        description: None,
+        context_id: a_id,
+        parent_id: Some(root_id),
+        depth: 1,
+        parked: false,
+    });
+    app.router.push(crate::host::context::Context {
+        name: "B".to_string(),
+        path: std::path::PathBuf::from("/tmp/b"),
+        root: None,
+        description: None,
+        context_id: b_id,
+        parent_id: Some(a_id),
+        depth: 2,
+        parked: false,
+    });
+    app.router.push(crate::host::context::Context {
+        name: "Sibling".to_string(),
+        path: std::path::PathBuf::from("/tmp/sibling"),
+        root: None,
+        description: None,
+        context_id: sibling_id,
+        parent_id: Some(root_id),
+        depth: 1,
+        parked: false,
+    });
+
+    assert_eq!(app.router.len(), 4, "setup: root + A + B + sibling");
+
+    let a_idx_now = app.router.position(|c| c.context_id == a_id).unwrap();
+    app.delete_context(a_idx_now);
+
+    assert!(
+        app.router.iter().find(|c| c.context_id == a_id).is_none(),
+        "A should be deleted"
+    );
+    assert!(
+        app.router.iter().find(|c| c.context_id == b_id).is_none(),
+        "B should be cascade-deleted"
+    );
+    assert!(
+        app.router.iter().any(|c| c.context_id == root_id),
+        "root must survive"
+    );
+    assert!(
+        app.router.iter().any(|c| c.context_id == sibling_id),
+        "unrelated sibling must survive"
+    );
+    assert_eq!(app.router.len(), 2, "root + sibling remain");
+
+    // Must not panic.
+    let _ = app.router.active();
+}
+
 /// Issue #1801: context transition must rescan the registry and restart the watcher.
 ///
 /// Creates two temp roots each with a distinct workspace-local app, switches the

--- a/src/file_browser/helpers.rs
+++ b/src/file_browser/helpers.rs
@@ -226,6 +226,7 @@ pub(crate) struct ColumnModel {
     pub columns: Vec<ColumnConfig>,
     pub sort: SortDescriptor,
     pub folders_on_top: bool,
+    pub show_hidden: bool,
 }
 
 impl Default for ColumnModel {
@@ -243,6 +244,7 @@ impl Default for ColumnModel {
             ],
             sort: SortDescriptor::default(),
             folders_on_top: true,
+            show_hidden: false,
         }
     }
 }
@@ -322,6 +324,7 @@ impl ColumnModel {
                 "direction": self.sort.direction.key(),
             },
             "folders_on_top": self.folders_on_top,
+            "show_hidden": self.show_hidden,
             "columns": self.columns.iter().map(|column| {
                 serde_json::json!({
                     "id": column.id.key(),
@@ -348,6 +351,9 @@ impl ColumnModel {
         }
         if let Some(folders_on_top) = value["folders_on_top"].as_bool() {
             model.folders_on_top = folders_on_top;
+        }
+        if let Some(show_hidden) = value["show_hidden"].as_bool() {
+            model.show_hidden = show_hidden;
         }
         if let Some(columns) = value["columns"].as_array() {
             let mut restored = Vec::new();

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -345,7 +345,7 @@ impl FileBrowserApp {
                     .filter_map(|e| {
                         let e = e.ok()?;
                         let name = e.file_name().to_string_lossy().to_string();
-                        if name.starts_with('.') {
+                        if name.starts_with('.') && !self.columns.show_hidden {
                             return None;
                         }
                         let path = e.path();
@@ -1903,6 +1903,15 @@ impl FileBrowserApp {
                                 self.columns.folders_on_top
                             );
                         }
+                        let mut show_hidden = self.columns.show_hidden;
+                        if ui.checkbox(&mut show_hidden, "Show hidden files").changed() {
+                            self.columns.show_hidden = show_hidden;
+                            self.refresh_preserving_filter();
+                            log::info!(
+                                "file_browser: show_hidden changed to {}",
+                                self.columns.show_hidden
+                            );
+                        }
                         let mut inspector = self.inspector_open;
                         if ui.checkbox(&mut inspector, "Inspector").changed() {
                             self.toggle_inspector();
@@ -3199,6 +3208,7 @@ mod tests {
         app.columns.set_column_visible(ColumnId::Created, true);
         app.columns.move_column(ColumnId::Created, -1);
         app.columns.folders_on_top = false;
+        app.columns.show_hidden = true;
 
         let state = app.serialize_state().expect("state");
         let mut restored = FileBrowserApp::new(app.cwd.clone());
@@ -3207,6 +3217,7 @@ mod tests {
         assert_eq!(restored.columns.sort.column, ColumnId::Size);
         assert_eq!(restored.columns.sort.direction, SortDirection::Desc);
         assert!(!restored.columns.folders_on_top);
+        assert!(restored.columns.show_hidden);
         assert_eq!(
             restored
                 .columns
@@ -3238,6 +3249,40 @@ mod tests {
             .position(|column| column.id == ColumnId::Modified)
             .expect("modified column");
         assert!(created_index < modified_index);
+    }
+
+    /// Stint 0368: dotfile entries are filtered out of the listing by default,
+    /// and reappear once `show_hidden` is toggled on.
+    #[test]
+    fn show_hidden_toggle_filters_dotfile_entries() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("visible.txt"), b"v").expect("write visible");
+        std::fs::write(dir.path().join(".hidden"), b"h").expect("write hidden");
+        let mut app = FileBrowserApp::new(dir.path().to_path_buf());
+
+        assert!(!app.columns.show_hidden, "hidden files are off by default");
+        assert!(app.entries.iter().any(|e| e.name == "visible.txt"));
+        assert!(
+            !app.entries.iter().any(|e| e.name == ".hidden"),
+            "dotfile must be filtered out while show_hidden is off"
+        );
+
+        app.columns.show_hidden = true;
+        app.refresh_preserving_filter();
+
+        assert!(app.entries.iter().any(|e| e.name == "visible.txt"));
+        assert!(
+            app.entries.iter().any(|e| e.name == ".hidden"),
+            "dotfile must appear once show_hidden is on"
+        );
+
+        app.columns.show_hidden = false;
+        app.refresh_preserving_filter();
+
+        assert!(
+            !app.entries.iter().any(|e| e.name == ".hidden"),
+            "dotfile must be filtered again once show_hidden is toggled back off"
+        );
     }
 
     #[test]

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -857,6 +857,20 @@ impl PlexiApp {
                 }
             }
         }
+        // Refuse a cascade that would empty the router entirely — `remove_at`
+        // clamps `active` to 0 on an empty vec, and the next `router.active()`
+        // call panics with an out-of-bounds index. Same semantics as the
+        // single-context guard above, just discovered after the BFS instead
+        // of before it.
+        if deleted.len() >= self.router.len() {
+            log::warn!(
+                "delete_context: refusing cascade of ctx_id={target_ctx_id} + {} descendants — \
+                 would empty the router (no surviving contexts)",
+                deleted.len() - 1
+            );
+            return;
+        }
+
         log::info!(
             "delete_context: cascading delete of ctx_id={target_ctx_id} + {} descendants ({:?})",
             deleted.len() - 1,


### PR DESCRIPTION
## Summary

Bundles two P2 stint tasks — no linked GitHub issues, stint is authoritative.

**Stint 0454 — `delete_context` cascade can empty the router → `active()` panics**
- `delete_context` (`src/pane_ops/workspace.rs`) computes the target + all descendants via BFS, then refuses the delete if that set covers every context in the router — same semantics as the pre-existing single-context guard (`router.len() <= 1`), just checked after the cascade is computed instead of before it.
- Observed live in beta (2026-07-18): deleting a root context whose descendant tree included every other context emptied the `WorkspaceRouter`; `remove_at` clamps `active` to `len().saturating_sub(1)` = 0 on an empty vec, and the next `router.active()` panicked, triggering a crash-recovery restart.
- Two new `HostHarness` tests in `src/app/tests/context_tests.rs`: `delete_context_refuses_cascade_that_would_empty_router` (root parents all descendants → refused, router unchanged, no panic) and `delete_context_cascade_allowed_when_unrelated_sibling_survives` (companion — cascade still succeeds when an unrelated sibling context survives).

**Stint 0368 — File Explorer: show/hide hidden files toggle**
- Added a "Show hidden files" checkbox to File Explorer's `View ⌄` menu, next to the existing "Folders first" toggle.
- `ColumnModel` (`src/file_browser/helpers.rs`) gains a `show_hidden: bool` field (default `false`), serialized/restored in pane state alongside sort, folders-on-top, and column visibility — the same persistence path, no new mechanism.
- `refresh()` (`src/file_browser/mod.rs`) now only filters `.`-prefixed entries when `show_hidden` is off.
- New test `show_hidden_toggle_filters_dotfile_entries` covers the listing filter end-to-end (off → filtered, on → visible, back off → filtered again); existing `serialized_state_persists_column_preferences` extended to cover `show_hidden` round-tripping through serialize/restore.

## Test evidence

- `cargo test --bin plexi`: **1536 passed, 0 failed, 2 ignored** (6 pre-existing environment-dependent failures — workspace-root resolution tests sensitive to `$HOME` ancestry, and a Catppuccin-Latte screenshot color test — excluded via `--skip`; these reproduce identically on unmodified `alpha` HEAD, confirmed in the prior PR #2444, unrelated to this diff).
- `sdk/python` pytest (`uv run pytest tests/`): **236 passed, 1 skipped** (no SDK/Python files touched by this diff; run for completeness).
- `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py`: **Success: no issues found in 27 source files**.
- `just check-cli-docs`, `just check-config-docs`, `just check-sdk-docs`, `just check-capability-docs`: all up to date, no regen needed (this diff touches no CLI flags, config schema, SDK surface, or PGAP capabilities).
- `cargo build --bin plexi`: clean.

Both changes are pure host logic with direct `HostHarness` coverage exercising the full user-visible behavior (panic-guard invariant for 0454; listing-filter + persistence round-trip for 0368). The 0368 toggle itself lives inside an already-existing collapsed menu popup (no layout change to the always-visible toolbar), so it doesn't need new scene/screenshot fixtures — the existing `tests/scenes/file-browser*.toml` scenes are unaffected.

## Test plan
- [ ] `just pr-install <PR>`, launch `plexi-pr-<PR>`
- [ ] Create a context tree where a root context parents every other context; delete the root — it should be refused (with a log warning), not crash the host
- [ ] Delete a context that has descendants but an unrelated sibling survives — cascade should succeed as before
- [ ] Open File Explorer in a directory with dotfiles, toggle "Show hidden files" in the `View ⌄` menu — dotfiles should appear/disappear accordingly, and the preference should persist across a pane reload