### PR TITLE
chore: log hygiene sweep; fix all float_literal_f32_fallback warnings (stints 0417/0418)

### DIFF
--- a/deps/egui_commonmark_backend-0.20.0/src/elements.rs
+++ b/deps/egui_commonmark_backend-0.20.0/src/elements.rs
@@ -40,7 +40,7 @@ pub fn bullet_point_hollow(ui: &mut Ui) {
         rect.center(),
         rect.height() / 6.0,
         egui::Color32::TRANSPARENT,
-        egui::Stroke::new(0.6, ui.visuals().strong_text_color()),
+        egui::Stroke::new(0.6_f32, ui.visuals().strong_text_color()),
     );
 }
 
@@ -287,7 +287,7 @@ pub fn blockquote(ui: &mut Ui, accent: egui::Color32, add_contents: impl FnOnce(
                     response.rect.left_bottom().y - 5.0,
                 ),
             ],
-            egui::Stroke::new(3.0, accent),
+            egui::Stroke::new(3.0_f32, accent),
         ),
     );
 }

--- a/deps/egui_term/src/graphics.rs
+++ b/deps/egui_term/src/graphics.rs
@@ -104,7 +104,7 @@ fn corner_shapes(c: char, cell_rect: Rect, fg: Color32) -> Option<Vec<Shape>> {
     let bottom = cell_rect.max.y;
     let left = cell_rect.min.x;
     let right = cell_rect.max.x;
-    let stroke = Stroke::new(1.0, fg);
+    let stroke = Stroke::new(1.0_f32, fg);
 
     // Each arm goes from the cell center to the midpoint of an edge.
     // Names: U=up (center→top), D=down (center→bottom), L=left, R=right.
@@ -149,13 +149,13 @@ fn circle_shape(c: char, cell_rect: Rect, fg: Color32) -> Option<Shape> {
         // ○ WHITE CIRCLE — outline variant
         '\u{25CB}' => {
             let radius = half_w * 0.72;
-            let stroke = Stroke::new(1.0, fg);
+            let stroke = Stroke::new(1.0_f32, fg);
             Some(Shape::Circle(CircleShape::stroke(center, radius, stroke)))
         },
         // ◉ FISHEYE — filled circle with smaller inner circle
         '\u{25C9}' => {
             let radius = half_w * 0.72;
-            let stroke = Stroke::new(1.0, fg);
+            let stroke = Stroke::new(1.0_f32, fg);
             Some(Shape::Circle(CircleShape::stroke(center, radius, stroke)))
         },
         // ⏺ BLACK CIRCLE FOR RECORD
@@ -171,7 +171,7 @@ fn circle_shape(c: char, cell_rect: Rect, fg: Color32) -> Option<Shape> {
         // ◦ WHITE BULLET (smaller outline dot)
         '\u{25E6}' => {
             let radius = half_w * 0.38;
-            let stroke = Stroke::new(1.0, fg);
+            let stroke = Stroke::new(1.0_f32, fg);
             Some(Shape::Circle(CircleShape::stroke(center, radius, stroke)))
         },
         _ => None,

--- a/deps/egui_term/src/view.rs
+++ b/deps/egui_term/src/view.rs
@@ -791,7 +791,7 @@ impl<'a> TerminalView<'a> {
                     shapes.push(Shape::Rect(RectShape::stroke(
                         cell_rect,
                         CornerRadius::default(),
-                        Stroke::new(1.0, cursor_color),
+                        Stroke::new(1.0_f32, cursor_color),
                         egui::StrokeKind::Inside,
                     )));
                 }
@@ -1012,7 +1012,7 @@ impl<'a> TerminalView<'a> {
                 pill_rect,
                 CornerRadius::same(6),
                 Stroke::new(
-                    1.0,
+                    1.0_f32,
                     Color32::from_rgba_unmultiplied(100, 100, 100, 120),
                 ),
                 egui::StrokeKind::Inside,
@@ -1062,7 +1062,7 @@ impl<'a> TerminalView<'a> {
                         Pos2::new(cursor_x + 1.0, pill_rect.max.y - pill_pad_v),
                     ],
                     Stroke::new(
-                        1.5,
+                        1.5_f32,
                         Color32::from_rgba_unmultiplied(200, 200, 200, 200),
                     ),
                 );

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -1452,7 +1452,7 @@ impl PlexiApp {
                     while y < screen.bottom() {
                         painter.line_segment(
                             [egui::pos2(screen.left(), y), egui::pos2(screen.right(), y)],
-                            Stroke::new(0.5, Color32::from_black_alpha(38)),
+                            Stroke::new(0.5_f32, Color32::from_black_alpha(38)),
                         );
                         y += 3.0;
                     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2354,7 +2354,7 @@ impl eframe::App for PlexiApp {
             crate::platform::frame_diag::note_egui_causes(&ctx.repaint_causes());
             if elapsed >= std::time::Duration::from_secs(10) {
                 let counts = crate::platform::frame_diag::snapshot_and_reset();
-                log::info!(
+                log::debug!(
                     target: "plexi::frame_diag",
                     "{}",
                     crate::platform::frame_diag::summary_line(
@@ -2364,7 +2364,7 @@ impl eframe::App for PlexiApp {
                     )
                 );
                 let egui_counts = crate::platform::frame_diag::egui_snapshot_and_reset();
-                log::info!(
+                log::debug!(
                     target: "plexi::frame_diag",
                     "{}",
                     crate::platform::frame_diag::egui_summary_line(&egui_counts, 8)

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -523,6 +523,11 @@ impl AppRegistry {
             }
         };
 
+        // Collected rather than logged per-entry (stint 0417): a channel with
+        // several unbundled example/dev apps produced a dozen WARN lines per
+        // rescan, drowning real signal. One summary line names them all.
+        let mut skipped: Vec<String> = Vec::new();
+
         for entry in read_dir.flatten() {
             let entry_dir = entry.path();
             if !entry_dir.is_dir() {
@@ -614,10 +619,20 @@ impl AppRegistry {
                             entry_dir.file_name()
                         );
                     } else {
-                        log::warn!("AppRegistry: skipping {:?}: {e}", entry_dir.file_name());
+                        skipped.push(format!("{:?}: {e}", entry_dir.file_name()));
                     }
                 }
             }
+        }
+
+        if !skipped.is_empty() {
+            log::warn!(
+                "AppRegistry: skipped {} entr{} in {:?}: {}",
+                skipped.len(),
+                if skipped.len() == 1 { "y" } else { "ies" },
+                dir,
+                skipped.join("; ")
+            );
         }
     }
 
@@ -1015,6 +1030,32 @@ mod tests {
             .get("global-only")
             .expect("global app should appear");
         assert_eq!(entry.source, RegistrySource::Global);
+    }
+
+    /// Stint 0417: broken app dirs (missing manifest.toml) must be collected
+    /// into one summary WARN per scan, not one WARN per broken dir — and
+    /// valid apps in the same directory must still be discovered normally.
+    #[test]
+    fn broken_app_dirs_are_summarized_not_logged_per_entry() {
+        let global = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let channel_dir = crate::config::workspace_channel_dir();
+        fs::create_dir_all(workspace.path().join(&channel_dir)).unwrap();
+
+        write_app(global.path(), "valid-app", "Valid App");
+        // No manifest.toml in these — load_app fails for each.
+        fs::create_dir_all(global.path().join("broken-one")).unwrap();
+        fs::create_dir_all(global.path().join("broken-two")).unwrap();
+        fs::create_dir_all(global.path().join("broken-three")).unwrap();
+
+        let registry = AppRegistry::load_with_global(workspace.path(), global.path());
+        assert!(
+            registry.get("valid-app").is_some(),
+            "valid app must still be discovered alongside broken dirs"
+        );
+        assert!(registry.get("broken-one").is_none());
+        assert!(registry.get("broken-two").is_none());
+        assert!(registry.get("broken-three").is_none());
     }
 
     #[test]

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -698,7 +698,7 @@ impl PlexiApp {
                         ui.painter().rect_stroke(
                             zoom_rect,
                             CornerRadius::same(4),
-                            Stroke::new(2.0, self.colors.accent),
+                            Stroke::new(2.0_f32, self.colors.accent),
                             StrokeKind::Inside,
                         );
 
@@ -962,7 +962,7 @@ impl PlexiApp {
                                     egui::pos2(pane_rect.right(), pane_rect.bottom()),
                                 ),
                             };
-                            ui.painter().line_segment([p1, p2], egui::Stroke::new(3.0, edge_color));
+                            ui.painter().line_segment([p1, p2], egui::Stroke::new(3.0_f32, edge_color));
                             crate::platform::frame_diag::note(
                                 crate::platform::frame_diag::RepaintCause::EdgePulse,
                             );

--- a/src/app/secrets_app.rs
+++ b/src/app/secrets_app.rs
@@ -428,7 +428,7 @@ impl App for SecretsApp {
                 egui::pos2(header_rect.left(), header_rect.bottom()),
                 egui::pos2(header_rect.right(), header_rect.bottom()),
             ],
-            egui::Stroke::new(1.0, colors.border),
+            egui::Stroke::new(1.0_f32, colors.border),
         );
 
         let mut header_ui = ui.new_child(
@@ -490,7 +490,7 @@ impl App for SecretsApp {
                     egui::pos2(form_rect.left(), form_rect.top()),
                     egui::pos2(form_rect.right(), form_rect.top()),
                 ],
-                egui::Stroke::new(1.0, colors.border),
+                egui::Stroke::new(1.0_f32, colors.border),
             );
 
             let mut form_ui = ui.new_child(

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -1054,7 +1054,7 @@ impl App for TextEditorApp {
                     &output,
                     self.font_size,
                     row_height,
-                    egui::Stroke::new(1.0, colors.accent),
+                    egui::Stroke::new(1.0_f32, colors.accent),
                 );
 
                 // Tab/Enter/smart-backspace are consumed above before TextEdit

--- a/src/assistant/render.rs
+++ b/src/assistant/render.rs
@@ -615,7 +615,7 @@ impl AssistantRenderer {
         let mut choice = None;
         egui::Frame::new()
             .fill(colors.bg_active)
-            .stroke(egui::Stroke::new(1.0, colors.accent))
+            .stroke(egui::Stroke::new(1.0_f32, colors.accent))
             .corner_radius(style::RADIUS_MD)
             .inner_margin(egui::Margin::same(style::SPACE_SM as i8))
             .show(ui, |ui| {
@@ -668,7 +668,7 @@ impl AssistantRenderer {
                             ui.painter().rect_stroke(
                                 resp.rect.expand(2.0),
                                 style::RADIUS_MD,
-                                egui::Stroke::new(2.0, colors.accent),
+                                egui::Stroke::new(2.0_f32, colors.accent),
                                 egui::StrokeKind::Outside,
                             );
                         }
@@ -777,7 +777,7 @@ impl AssistantRenderer {
         add_contents: impl FnOnce(&mut egui::Ui),
     ) {
         let outline = if stroke {
-            egui::Stroke::new(1.0, colors.border)
+            egui::Stroke::new(1.0_f32, colors.border)
         } else {
             egui::Stroke::NONE
         };
@@ -1075,7 +1075,7 @@ impl AssistantRenderer {
                 ui.set_width(composer_rect.width());
                 egui::Frame::new()
                     .fill(colors.bg_active)
-                    .stroke(egui::Stroke::new(1.0, colors.border))
+                    .stroke(egui::Stroke::new(1.0_f32, colors.border))
                     .corner_radius(style::RADIUS_MD)
                     .inner_margin(egui::Margin::same(margin as i8))
                     .show(ui, |ui| {
@@ -1181,7 +1181,7 @@ impl AssistantRenderer {
                 ui.set_width(composer_rect.width());
                 egui::Frame::new()
                     .fill(colors.bg_active)
-                    .stroke(egui::Stroke::new(1.0, colors.border))
+                    .stroke(egui::Stroke::new(1.0_f32, colors.border))
                     .corner_radius(style::RADIUS_MD)
                     .inner_margin(egui::Margin::same(margin as i8))
                     .show(ui, |ui| {
@@ -1313,7 +1313,7 @@ impl AssistantRenderer {
 
         let frame_response = egui::Frame::new()
             .fill(colors.bg_active)
-            .stroke(egui::Stroke::new(1.0, stroke_color))
+            .stroke(egui::Stroke::new(1.0_f32, stroke_color))
             .corner_radius(style::RADIUS_MD)
             .inner_margin(egui::Margin::symmetric(
                 style::SPACE_SM as i8,
@@ -1385,7 +1385,7 @@ impl AssistantRenderer {
                             &output,
                             style::TEXT_BODY,
                             row_height,
-                            egui::Stroke::new(1.0, colors.accent),
+                            egui::Stroke::new(1.0_f32, colors.accent),
                         );
                         if output.response.changed() {
                             model.reset_history_recall();

--- a/src/file_browser/icons.rs
+++ b/src/file_browser/icons.rs
@@ -80,7 +80,7 @@ pub(crate) fn paint_entry_icon(
     painter.rect_stroke(
         sheet,
         CornerRadius::same(2),
-        Stroke::new(1.0, colors.border),
+        Stroke::new(1.0_f32, colors.border),
         StrokeKind::Inside,
     );
     let fold_poly = vec![
@@ -91,7 +91,7 @@ pub(crate) fn paint_entry_icon(
     painter.add(egui::Shape::convex_polygon(
         fold_poly,
         colors.bg_active.gamma_multiply(0.75),
-        Stroke::new(1.0, colors.border),
+        Stroke::new(1.0_f32, colors.border),
     ));
 
     let x = |t: f32| sheet.left() + sheet.width() * t;
@@ -129,7 +129,7 @@ pub(crate) fn paint_entry_icon(
                     egui::pos2(x(0.26), y(0.58)),
                 ],
                 c,
-                Stroke::new(0.0, Color32::TRANSPARENT),
+                Stroke::new(0.0_f32, Color32::TRANSPARENT),
             ));
             painter.line_segment(
                 [egui::pos2(x(0.56), y(0.44)), egui::pos2(x(0.66), y(0.54))],
@@ -161,7 +161,7 @@ pub(crate) fn paint_entry_icon(
                     egui::pos2(x(0.74), y(0.30)),
                 ],
                 c,
-                Stroke::new(0.0, Color32::TRANSPARENT),
+                Stroke::new(0.0_f32, Color32::TRANSPARENT),
             ));
             if matches!(kind, FileIconKind::Markdown) {
                 painter.line_segment(

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -1268,7 +1268,7 @@ impl FileBrowserApp {
                     egui::pos2(cell.right(), cell.top() + 5.0),
                     egui::pos2(cell.right(), cell.bottom() - 5.0),
                 ],
-                Stroke::new(1.0, colors.border),
+                Stroke::new(1.0_f32, colors.border),
             );
         }
     }
@@ -1365,7 +1365,7 @@ impl FileBrowserApp {
 
         egui::Frame::new()
             .fill(colors.bg_sidebar)
-            .stroke(Stroke::new(1.0, colors.border))
+            .stroke(Stroke::new(1.0_f32, colors.border))
             .corner_radius(CornerRadius::same(6))
             .inner_margin(egui::Margin::same(8))
             .show(ui, |ui| {
@@ -1393,7 +1393,7 @@ impl FileBrowserApp {
                 ui.painter().rect_stroke(
                     slot_rect,
                     CornerRadius::same(4),
-                    Stroke::new(1.0, colors.border),
+                    Stroke::new(1.0_f32, colors.border),
                     StrokeKind::Inside,
                 );
                 if let Some(texture) = &self.preview_texture {
@@ -1444,7 +1444,7 @@ impl FileBrowserApp {
 
         egui::Frame::new()
             .fill(colors.bg_sidebar)
-            .stroke(Stroke::new(1.0, colors.border))
+            .stroke(Stroke::new(1.0_f32, colors.border))
             .corner_radius(CornerRadius::same(6))
             .inner_margin(egui::Margin::same(8))
             .show(ui, |ui| {
@@ -1488,7 +1488,7 @@ impl FileBrowserApp {
 
         egui::Frame::new()
             .fill(colors.bg_sidebar)
-            .stroke(Stroke::new(1.0, colors.border))
+            .stroke(Stroke::new(1.0_f32, colors.border))
             .corner_radius(CornerRadius::same(6))
             .inner_margin(egui::Margin::same(8))
             .show(ui, |ui| {
@@ -1513,7 +1513,7 @@ impl FileBrowserApp {
     fn draw_generic_sidebar(&mut self, ui: &mut egui::Ui, colors: &Colors, entry: &Entry) {
         egui::Frame::new()
             .fill(colors.bg_sidebar)
-            .stroke(Stroke::new(1.0, colors.border))
+            .stroke(Stroke::new(1.0_f32, colors.border))
             .corner_radius(CornerRadius::same(6))
             .inner_margin(egui::Margin::same(8))
             .show(ui, |ui| {
@@ -1698,7 +1698,7 @@ impl FileBrowserApp {
                             &output,
                             font_id.size,
                             row_height,
-                            egui::Stroke::new(1.0, colors.accent),
+                            egui::Stroke::new(1.0_f32, colors.accent),
                         );
                         output.response
                     })
@@ -1749,7 +1749,7 @@ impl FileBrowserApp {
         ui.painter().rect_stroke(
             slot_rect,
             style::RADIUS_MD,
-            Stroke::new(1.0, colors.border),
+            Stroke::new(1.0_f32, colors.border),
             StrokeKind::Inside,
         );
         if let Some(texture) = &self.preview_texture {
@@ -2126,7 +2126,7 @@ impl App for FileBrowserApp {
                                 egui::pos2(splitter_rect.center().x, splitter_rect.top()),
                                 egui::pos2(splitter_rect.center().x, splitter_rect.bottom()),
                             ],
-                            Stroke::new(1.0, colors.border),
+                            Stroke::new(1.0_f32, colors.border),
                         );
                         ui.allocate_ui_with_layout(
                             egui::vec2(self.inspector_width, body_height),

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -1476,11 +1476,19 @@ impl LivePythonPane {
         }
         let stderr = self.runtime.drain_stderr();
         if !stderr.trim().is_empty() {
-            log::error!(
-                "app::{} CPython WASM stderr: {}",
-                self.app_id,
-                stderr.trim()
-            );
+            if is_benign_cpython_wasi_stderr(&stderr) {
+                log::debug!(
+                    "app::{} CPython WASM stderr (benign WASI startup noise): {}",
+                    self.app_id,
+                    stderr.trim()
+                );
+            } else {
+                log::error!(
+                    "app::{} CPython WASM stderr: {}",
+                    self.app_id,
+                    stderr.trim()
+                );
+            }
         }
     }
 
@@ -1981,6 +1989,22 @@ fn python_semantic_state(tree: Option<&PythonUiTree>) -> crate::host::pane::Sema
         }
     }
     state
+}
+
+/// Stint 0417: CPython-in-WASI prints `Could not find platform dependent
+/// libraries <exec_prefix>` to stderr on every guest boot even when the
+/// runtime starts and runs fine — WASI has no real filesystem layout for
+/// CPython's `sysconfig` probe to find. Logging that line at ERROR trains
+/// agents and humans to ignore real guest tracebacks in the same stream.
+/// Returns true only when *every* non-empty line matches a known-benign
+/// pattern; any unrecognized line (a real traceback) keeps the ERROR level.
+fn is_benign_cpython_wasi_stderr(stderr: &str) -> bool {
+    const BENIGN_SUBSTRINGS: &[&str] = &["Could not find platform dependent libraries"];
+    stderr
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .all(|line| BENIGN_SUBSTRINGS.iter().any(|needle| line.contains(needle)))
 }
 
 fn python_key_name(key: egui::Key) -> String {
@@ -3477,6 +3501,35 @@ mod tests {
     struct NoopWake;
     impl Wake for NoopWake {
         fn wake(self: Arc<Self>) {}
+    }
+
+    /// Stint 0417: the benign CPython WASI startup line must classify as
+    /// non-error so it doesn't drown real guest tracebacks in the log.
+    #[test]
+    fn is_benign_cpython_wasi_stderr_recognizes_known_benign_line() {
+        assert!(is_benign_cpython_wasi_stderr(
+            "Could not find platform dependent libraries <exec_prefix>\n"
+        ));
+        // Repeated/whitespace-padded — still benign.
+        assert!(is_benign_cpython_wasi_stderr(
+            "  Could not find platform dependent libraries <exec_prefix>  \n\
+             Could not find platform dependent libraries <exec_prefix>\n"
+        ));
+        // Empty stderr trivially has no non-benign lines.
+        assert!(is_benign_cpython_wasi_stderr(""));
+        assert!(is_benign_cpython_wasi_stderr("\n\n"));
+    }
+
+    #[test]
+    fn is_benign_cpython_wasi_stderr_keeps_real_tracebacks_at_error() {
+        assert!(!is_benign_cpython_wasi_stderr(
+            "Traceback (most recent call last):\n  File \"logs.py\", line 10\nNameError: x"
+        ));
+        // A benign line mixed with a real traceback must not be swallowed.
+        assert!(!is_benign_cpython_wasi_stderr(
+            "Could not find platform dependent libraries <exec_prefix>\n\
+             Traceback (most recent call last):\n  ZeroDivisionError"
+        ));
     }
 
     #[test]

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -286,7 +286,7 @@ impl PlexiApp {
                 if let Some(ref latest) = self.update_available.clone() {
                     egui::Frame::new()
                         .fill(self.colors.accent.gamma_multiply(0.15))
-                        .stroke(Stroke::new(1.0, self.colors.accent.gamma_multiply(0.4)))
+                        .stroke(Stroke::new(1.0_f32, self.colors.accent.gamma_multiply(0.4)))
                         .corner_radius(R6)
                         .inner_margin(egui::Margin::symmetric(12, 8))
                         .show(ui, |ui| {
@@ -316,7 +316,7 @@ impl PlexiApp {
                                                 .color(self.colors.text_dim),
                                         )
                                         .fill(egui::Color32::TRANSPARENT)
-                                        .stroke(Stroke::new(1.0, self.colors.border))
+                                        .stroke(Stroke::new(1.0_f32, self.colors.border))
                                         .corner_radius(egui::CornerRadius::same(4));
                                         if ui.add(cancel_btn).clicked() {
                                             self.update_confirm_prompt = false;

--- a/src/overlays/setup.rs
+++ b/src/overlays/setup.rs
@@ -62,7 +62,7 @@ impl PlexiApp {
         ui.allocate_new_ui(egui::UiBuilder::new().max_rect(box_rect), |ui| {
             egui::Frame::new()
                 .fill(colors.bg_sidebar)
-                .stroke(Stroke::new(1.0, colors.border))
+                .stroke(Stroke::new(1.0_f32, colors.border))
                 .corner_radius(style::RADIUS_MD)
                 .inner_margin(egui::Margin::symmetric(
                     style::MODAL_PADDING_H,

--- a/src/render/headless_renderer.rs
+++ b/src/render/headless_renderer.rs
@@ -326,13 +326,13 @@ impl HeadlessRenderer {
                         .unwrap_or_default();
                     let gap_size = if dir == "column" {
                         taffy::geometry::Size {
-                            width: length(0.0),
+                            width: length(0.0_f32),
                             height: length(g),
                         }
                     } else {
                         taffy::geometry::Size {
                             width: length(g),
-                            height: length(0.0),
+                            height: length(0.0_f32),
                         }
                     };
                     let style = taffy::style::Style {
@@ -354,13 +354,13 @@ impl HeadlessRenderer {
         };
         let gap_size = if direction == "column" {
             taffy::geometry::Size {
-                width: length(0.0),
+                width: length(0.0_f32),
                 height: length(gap),
             }
         } else {
             taffy::geometry::Size {
                 width: length(gap),
-                height: length(0.0),
+                height: length(0.0_f32),
             }
         };
 

--- a/src/render/minimap.rs
+++ b/src/render/minimap.rs
@@ -172,7 +172,7 @@ pub fn render_minimap(
     ui.painter().rect_stroke(
         panel_rect,
         egui::CornerRadius::same(CORNER_RADIUS as u8),
-        egui::Stroke::new(1.0, colors.border),
+        egui::Stroke::new(1.0_f32, colors.border),
         egui::StrokeKind::Inside,
     );
 
@@ -237,7 +237,7 @@ pub fn render_minimap(
             cell_rect,
             egui::CornerRadius::same(3),
             fill,
-            egui::Stroke::new(1.0, border_color),
+            egui::Stroke::new(1.0_f32, border_color),
             egui::StrokeKind::Inside,
         );
 

--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -180,7 +180,7 @@ pub(crate) fn paint_tab_bar(
                     egui::pos2(divider_x, bar_rect.top() + inset),
                     egui::pos2(divider_x, bar_rect.bottom() - inset),
                 ],
-                egui::Stroke::new(1.5, colors.border),
+                egui::Stroke::new(1.5_f32, colors.border),
             );
         }
 
@@ -279,7 +279,7 @@ pub(crate) fn paint_tab_bar(
         painter.rect_stroke(
             chip_rect,
             egui::CornerRadius::same(3),
-            egui::Stroke::new(1.0, colors.border),
+            egui::Stroke::new(1.0_f32, colors.border),
             egui::StrokeKind::Inside,
         );
         painter.text(
@@ -719,7 +719,7 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
         match resize_state {
             ResizeState::Idle => egui::Stroke::NONE,
             ResizeState::Hovering | ResizeState::Dragging => {
-                egui::Stroke::new(2.0, self.colors.text_primary)
+                egui::Stroke::new(2.0_f32, self.colors.text_primary)
             }
         }
     }
@@ -933,7 +933,7 @@ pub(crate) fn paint_portal_minimap(
         painter.rect_stroke(
             win_rect,
             WIN_RADIUS,
-            egui::Stroke::new(1.0, frame_border),
+            egui::Stroke::new(1.0_f32, frame_border),
             egui::StrokeKind::Outside,
         );
 
@@ -988,7 +988,7 @@ pub(crate) fn paint_portal_minimap(
                         egui::pos2(cell.min.x, glow_y),
                         egui::pos2(cell.max.x, glow_y),
                     ],
-                    egui::Stroke::new(1.5, glow_color),
+                    egui::Stroke::new(1.5_f32, glow_color),
                 );
 
                 // Focused border
@@ -1001,7 +1001,7 @@ pub(crate) fn paint_portal_minimap(
                 painter.rect_stroke(
                     cell,
                     2.0,
-                    egui::Stroke::new(1.0, accent_border),
+                    egui::Stroke::new(1.0_f32, accent_border),
                     egui::StrokeKind::Middle,
                 );
             } else {
@@ -1014,7 +1014,7 @@ pub(crate) fn paint_portal_minimap(
                 painter.rect_stroke(
                     cell,
                     2.0,
-                    egui::Stroke::new(1.0, dim_border),
+                    egui::Stroke::new(1.0_f32, dim_border),
                     egui::StrokeKind::Middle,
                 );
             }
@@ -1178,7 +1178,7 @@ pub(crate) fn paint_portal_minimap(
                     painter.add(egui::Shape::convex_polygon(
                         body,
                         fill,
-                        egui::Stroke::new(1.0, outline),
+                        egui::Stroke::new(1.0_f32, outline),
                     ));
                     // Folded corner triangle, a touch lighter than the body.
                     painter.add(egui::Shape::convex_polygon(
@@ -1193,7 +1193,7 @@ pub(crate) fn paint_portal_minimap(
                             colors.text_dim.b(),
                             icon_alpha / 2,
                         ),
-                        egui::Stroke::new(1.0, outline),
+                        egui::Stroke::new(1.0_f32, outline),
                     ));
 
                     // Text rules — drop the last when the glyph is tiny.
@@ -1252,7 +1252,7 @@ pub(crate) fn paint_portal_minimap(
                                 painter.rect_stroke(
                                     rect,
                                     2.0,
-                                    egui::Stroke::new(1.0, outline_color),
+                                    egui::Stroke::new(1.0_f32, outline_color),
                                     egui::StrokeKind::Inside,
                                 );
                             }

--- a/src/ui/code_viewer.rs
+++ b/src/ui/code_viewer.rs
@@ -41,7 +41,7 @@ impl<'a> ReadOnlyCodeViewer<'a> {
 
         egui::Frame::new()
             .fill(colors.bg_active)
-            .stroke(egui::Stroke::new(1.0, colors.border))
+            .stroke(egui::Stroke::new(1.0_f32, colors.border))
             .corner_radius(style::RADIUS_MD)
             .inner_margin(egui::Margin::symmetric(10, 8))
             .show(ui, |ui| {

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -122,7 +122,7 @@ pub(crate) fn paint_table_header_background(ui: &egui::Ui, rect: egui::Rect, col
     ui.painter().rect_stroke(
         rect,
         style::RADIUS_MD,
-        Stroke::new(1.0, colors.border),
+        Stroke::new(1.0_f32, colors.border),
         StrokeKind::Inside,
     );
 }
@@ -293,7 +293,7 @@ impl<'a> ListRow<'a> {
             ui.painter().rect_stroke(
                 inset,
                 style::RADIUS_SM,
-                Stroke::new(1.0, colors.danger.gamma_multiply(0.35)),
+                Stroke::new(1.0_f32, colors.danger.gamma_multiply(0.35)),
                 StrokeKind::Inside,
             );
         } else if response.hovered() {
@@ -598,7 +598,7 @@ pub fn selection_shapes(row_rect: egui::Rect, colors: &Colors) -> [egui::Shape; 
         egui::Shape::rect_stroke(
             inset,
             style::RADIUS_SM,
-            Stroke::new(1.0, colors.accent.gamma_multiply(0.45)),
+            Stroke::new(1.0_f32, colors.accent.gamma_multiply(0.45)),
             StrokeKind::Inside,
         ),
     ]
@@ -768,7 +768,7 @@ fn draw_pips(
         );
         if hidden {
             ui.painter()
-                .circle_stroke(center, PANE_PIP_RADIUS, Stroke::new(1.0, color));
+                .circle_stroke(center, PANE_PIP_RADIUS, Stroke::new(1.0_f32, color));
         } else {
             ui.painter().circle_filled(center, PANE_PIP_RADIUS, color);
         }

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -38,7 +38,7 @@ pub fn show(
         s.visuals.hyperlink_color = colors.accent;
         s.visuals.faint_bg_color = colors.bg_hover;
         s.visuals.widgets.noninteractive.corner_radius = style::RADIUS_MD;
-        s.visuals.widgets.noninteractive.bg_stroke = egui::Stroke::new(1.0, colors.border);
+        s.visuals.widgets.noninteractive.bg_stroke = egui::Stroke::new(1.0_f32, colors.border);
         s.spacing.item_spacing.y = style::SPACE_SM;
         s.text_styles
             .insert(egui::TextStyle::Body, egui::FontId::proportional(base_size));

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -158,7 +158,7 @@ impl<'a> ModalShell<'a> {
                 }
                 egui::Frame::new()
                     .fill(colors.bg_sidebar)
-                    .stroke(egui::Stroke::new(1.0, colors.border))
+                    .stroke(egui::Stroke::new(1.0_f32, colors.border))
                     .corner_radius(style::RADIUS_LG)
                     .shadow(egui::Shadow {
                         offset: [0, 12],

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -573,7 +573,7 @@ impl PlexiApp {
                     ui.painter().rect_stroke(
                         rect.shrink(2.0),
                         crate::ui::style::RADIUS_SM,
-                        Stroke::new(1.5, self.colors.accent),
+                        Stroke::new(1.5_f32, self.colors.accent),
                         egui::StrokeKind::Inside,
                     );
                 }
@@ -585,7 +585,7 @@ impl PlexiApp {
                         egui::pos2(x0, line_y),
                         egui::pos2(x0 + sidebar_width, line_y),
                     ],
-                    Stroke::new(2.0, self.colors.accent),
+                    Stroke::new(2.0_f32, self.colors.accent),
                 );
             }
         }

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -131,7 +131,7 @@ fn draw_pips(
         }
         let center = egui::pos2(cx, cy);
         if is_hidden {
-            painter.circle_stroke(center, PANE_DOT_RADIUS, egui::Stroke::new(1.0, color));
+            painter.circle_stroke(center, PANE_DOT_RADIUS, egui::Stroke::new(1.0_f32, color));
         } else {
             painter.circle_filled(center, PANE_DOT_RADIUS, color);
         }

--- a/src/ui/surface.rs
+++ b/src/ui/surface.rs
@@ -81,7 +81,7 @@ pub(crate) fn color_swatch(
     ui.painter().rect_stroke(
         rect,
         style::RADIUS_MD,
-        egui::Stroke::new(1.0, colors.border),
+        egui::Stroke::new(1.0_f32, colors.border),
         egui::StrokeKind::Inside,
     );
     crate::ui::list::paint_text_centered(
@@ -111,7 +111,7 @@ pub(crate) fn status_chip_with_color(
 ) -> egui::Response {
     egui::Frame::new()
         .fill(colors.bg_active)
-        .stroke(egui::Stroke::new(1.0, color))
+        .stroke(egui::Stroke::new(1.0_f32, color))
         .corner_radius(style::RADIUS_BADGE)
         .inner_margin(egui::Margin::symmetric(
             style::BADGE_PAD_H as i8,
@@ -131,7 +131,7 @@ pub(crate) fn empty_state_panel(
 ) -> egui::Response {
     egui::Frame::new()
         .fill(colors.bg_toolbar)
-        .stroke(egui::Stroke::new(1.0, colors.border))
+        .stroke(egui::Stroke::new(1.0_f32, colors.border))
         .corner_radius(style::RADIUS_MD)
         .inner_margin(egui::Margin::symmetric(12, 10))
         .show(ui, |ui| {
@@ -174,7 +174,7 @@ pub(crate) fn trust_decision_panel(
     };
     egui::Frame::new()
         .fill(colors.bg_toolbar)
-        .stroke(egui::Stroke::new(1.0, accent.gamma_multiply(0.45)))
+        .stroke(egui::Stroke::new(1.0_f32, accent.gamma_multiply(0.45)))
         .corner_radius(style::RADIUS_MD)
         .inner_margin(egui::Margin::symmetric(12, 10))
         .show(ui, |ui| {

--- a/src/ui/text_field.rs
+++ b/src/ui/text_field.rs
@@ -26,8 +26,8 @@ fn styled_text_input_inner(
         ui.visuals_mut().text_cursor.blink = false;
         ui.visuals_mut().text_cursor.stroke.color = egui::Color32::TRANSPARENT;
         ui.visuals_mut().extreme_bg_color = colors.bg_active;
-        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
-        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
+        ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0_f32, colors.accent);
+        ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0_f32, colors.border);
         let font_id = egui::TextStyle::Body.resolve(ui.style());
         let row_height = ui.fonts(|f| f.row_height(&font_id));
         let edit = egui::TextEdit::singleline(buf)
@@ -43,7 +43,7 @@ fn styled_text_input_inner(
             &output,
             font_id.size,
             row_height,
-            egui::Stroke::new(1.0, colors.accent),
+            egui::Stroke::new(1.0_f32, colors.accent),
         );
         output.response
     })
@@ -342,8 +342,8 @@ impl<'a> TextArea<'a> {
             ui.visuals_mut().text_cursor.blink = false;
             ui.visuals_mut().text_cursor.stroke.color = egui::Color32::TRANSPARENT;
             ui.visuals_mut().extreme_bg_color = colors.bg_active;
-            ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
-            ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0, colors.border);
+            ui.visuals_mut().widgets.active.bg_stroke = egui::Stroke::new(1.0_f32, colors.accent);
+            ui.visuals_mut().widgets.inactive.bg_stroke = egui::Stroke::new(1.0_f32, colors.border);
 
             let row_height = ui.fonts(|f| f.row_height(&self.font_id));
             let output = egui::TextEdit::multiline(buf)
@@ -361,7 +361,7 @@ impl<'a> TextArea<'a> {
                 &output,
                 self.font_id.size,
                 row_height,
-                egui::Stroke::new(1.0, colors.accent),
+                egui::Stroke::new(1.0_f32, colors.accent),
             );
             output.response
         })

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -852,7 +852,7 @@ pub fn setup_style(ctx: &egui::Context, colors: &Colors, dark_mode: bool) {
     } else {
         egui::Visuals::light()
     };
-    let hairline = egui::Stroke::new(1.0, colors.border);
+    let hairline = egui::Stroke::new(1.0_f32, colors.border);
     let v = &mut style.visuals;
 
     // Surfaces — layered from the workspace floor up through raised chrome.
@@ -881,8 +881,8 @@ pub fn setup_style(ctx: &egui::Context, colors: &Colors, dark_mode: bool) {
     // green cursor that ignore the theme entirely.
     v.hyperlink_color = colors.accent;
     v.selection.bg_fill = colors.accent.gamma_multiply(0.35);
-    v.selection.stroke = egui::Stroke::new(1.0, colors.accent);
-    v.text_cursor.stroke = egui::Stroke::new(1.0, colors.accent);
+    v.selection.stroke = egui::Stroke::new(1.0_f32, colors.accent);
+    v.text_cursor.stroke = egui::Stroke::new(1.0_f32, colors.accent);
     v.warn_fg_color = colors.warning;
     v.error_fg_color = colors.danger;
     v.slider_trailing_fill = true;
@@ -895,18 +895,18 @@ pub fn setup_style(ctx: &egui::Context, colors: &Colors, dark_mode: bool) {
     w.noninteractive.bg_fill = colors.bg_sidebar;
     w.noninteractive.weak_bg_fill = colors.bg_sidebar;
     w.noninteractive.bg_stroke = hairline; // Separators.
-    w.noninteractive.fg_stroke = egui::Stroke::new(1.0, colors.text_dim);
+    w.noninteractive.fg_stroke = egui::Stroke::new(1.0_f32, colors.text_dim);
     w.inactive.bg_fill = colors.bg_hover;
     w.inactive.weak_bg_fill = colors.bg_hover;
     w.inactive.bg_stroke = hairline;
     w.inactive.fg_stroke = text(1.0);
     w.hovered.bg_fill = colors.bg_sidebar_hover;
     w.hovered.weak_bg_fill = colors.bg_sidebar_hover;
-    w.hovered.bg_stroke = egui::Stroke::new(1.0, colors.text_section);
+    w.hovered.bg_stroke = egui::Stroke::new(1.0_f32, colors.text_section);
     w.hovered.fg_stroke = text(1.5);
     w.active.bg_fill = colors.bg_active;
     w.active.weak_bg_fill = colors.bg_active;
-    w.active.bg_stroke = egui::Stroke::new(1.0, colors.accent);
+    w.active.bg_stroke = egui::Stroke::new(1.0_f32, colors.accent);
     w.active.fg_stroke = text(2.0);
     w.open.bg_fill = colors.bg_active;
     w.open.weak_bg_fill = colors.bg_active;

--- a/src/ui/toast.rs
+++ b/src/ui/toast.rs
@@ -37,7 +37,7 @@ impl<'a> ToastShell<'a> {
             .show(ctx, |ui| {
                 egui::Frame::new()
                     .fill(colors.bg_sidebar)
-                    .stroke(egui::Stroke::new(1.0, colors.border))
+                    .stroke(egui::Stroke::new(1.0_f32, colors.border))
                     .corner_radius(style::RADIUS_SM)
                     .inner_margin(egui::Margin::symmetric(16, 10))
                     .show(ui, |ui| {


### PR DESCRIPTION
## Summary

Bundles two P2 stint tasks — no linked GitHub issues, stint is authoritative.

**Stint 0417 — log hygiene: frame_diag to debug, dedup registry WARN-spam, benign CPython WASI stderr off ERROR**
- `frame_diag`'s per-window FPS/cause summary lines (`src/app/mod.rs`) moved from `info` to `debug` — previously fired every 10s regardless of activity, drowning real signal.
- `AppRegistry::scan_dir` (`src/app/registry.rs`) now collects per-app load failures into one summary WARN per rescan (`skipped N entries in <dir>: ...`) instead of a `log::warn!` per broken app dir — a channel with several unbundled example/dev apps produced a dozen lines every rescan.
- CPython-in-WASI's known-benign startup stderr (`Could not find platform dependent libraries <exec_prefix>` — WASI has no real filesystem for `sysconfig`'s probe, runtime starts fine regardless) now classifies at `debug` via a new `is_benign_cpython_wasi_stderr()` helper in `src/host/wasm_python.rs`. Any other stderr content — including a benign line mixed with a real traceback — still logs at `error`.

**Stint 0418 — fix `float_literal_f32_fallback` warnings (future rustc hard error)**
- Every flagged float literal (81 sites across 25 files, extracted precisely from a full `cargo build` warning sweep) now carries an explicit `_f32` suffix — including the vendored `egui_term` and `egui_commonmark_backend` forks under `deps/`, which are tracked in this repo and part of the build graph.
- `cargo build` now emits zero `float_literal_f32_fallback` warnings.
- Purely mechanical: no literal value changed, only annotated with its already-inferred type.

## Test evidence

- `cargo test --bin plexi`: **1539 passed, 0 failed, 2 ignored** (6 pre-existing environment-dependent failures excluded via `--skip` — confirmed unrelated to this diff across the prior two PRs in this series).
- New Rust unit tests:
  - `is_benign_cpython_wasi_stderr_recognizes_known_benign_line` / `..._keeps_real_tracebacks_at_error` (`src/host/wasm_python.rs`) — lock in the stderr classification, including the mixed-benign-and-traceback case.
  - `broken_app_dirs_are_summarized_not_logged_per_entry` (`src/app/registry.rs`) — confirms the loop restructuring still discovers valid apps alongside broken ones.
- `sdk/python` pytest (`uv run pytest tests/`): **236 passed, 1 skipped** (no SDK/Python files touched; run for completeness).
- `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py`: **Success: no issues found in 27 source files**.
- `just check-cli-docs`, `just check-config-docs`, `just check-sdk-docs`, `just check-capability-docs`: all up to date, no regen needed.
- `cargo build --bin plexi`: clean, **zero** `float_literal_f32_fallback` warnings (confirmed via full `cargo clean -p plexi && cargo build` sweep before and after).

Both stints are pure logging/annotation changes with direct test coverage or a build-warning-count proof — no visible UI, keyboard, or app-launch behavior changes. Install is skippable; the diff has no user-facing surface to click-drive.

## Test plan
- [ ] `just pr-install <PR>` optional — no behavior change to verify interactively
- [ ] Confirm `cargo build` on the PR build shows zero `float_literal_f32_fallback` warnings
- [ ] Tail `plexi.log` for a few minutes on a live PR-build host: no `plexi::frame_diag` INFO spam, no per-app `AppRegistry: skipping` WARN spam, no ERROR-level CPython WASI `<exec_prefix>` lines