### PR TITLE
cli/host: pointer-click passthrough for AppRuntime::Builtin panes (stint 0469)

### DIFF
--- a/src/app/app_trait.rs
+++ b/src/app/app_trait.rs
@@ -231,8 +231,18 @@ pub trait App: Send {
     /// Human-readable display name shown in the pane title.
     fn display_name(&self) -> String;
 
-    /// Render the app into the given Ui region.
-    fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>);
+    /// Render the app into the given Ui region. `pending_click` (stint 0469) is
+    /// a synthetic pointer click queued by `plexi pane click --node` /
+    /// `HostHarness::inject_node_click`, delivered the same frame a real click's
+    /// hit-test result would reach. Apps that expose activatable widgets to
+    /// node-targeted clicks match it against their own `egui::Id`s (see File
+    /// Explorer in `src/file_browser/mod.rs`); apps that don't ignore it.
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        ctx: &AppRenderContext<'_>,
+        pending_click: Option<crate::host::pane::PendingPaneClick>,
+    );
 
     /// Handle raw key input before the app's own render pass.
     /// Return `Consumed` to prevent downstream handlers from seeing the event.

--- a/src/app/audio_player_app.rs
+++ b/src/app/audio_player_app.rs
@@ -109,7 +109,12 @@ impl App for AudioPlayerApp {
         format!("Audio - {}", self.filename())
     }
 
-    fn ui(&mut self, ui: &mut egui::Ui, _ctx: &AppRenderContext<'_>) {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _ctx: &AppRenderContext<'_>,
+        _pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
         self.sync_position();
         if self.playing {
             ui.ctx().request_repaint();

--- a/src/app/image_viewer_app.rs
+++ b/src/app/image_viewer_app.rs
@@ -80,7 +80,12 @@ impl App for ImageViewerApp {
         format!("Image - {}", self.filename())
     }
 
-    fn ui(&mut self, ui: &mut egui::Ui, _ctx: &AppRenderContext<'_>) {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _ctx: &AppRenderContext<'_>,
+        _pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
         self.load_texture(ui.ctx());
 
         ui.horizontal(|ui| {

--- a/src/app/secrets_app.rs
+++ b/src/app/secrets_app.rs
@@ -383,7 +383,12 @@ impl App for SecretsApp {
         }
     }
 
-    fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        ctx: &AppRenderContext<'_>,
+        _pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
         let colors = ctx.colors;
         let pane_key = ctx.pane_id;
         let rect = ui.max_rect();

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -749,7 +749,12 @@ impl App for TextEditorApp {
         log::info!("TextEditorApp: font_size -> {}", self.font_size);
     }
 
-    fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        ctx: &AppRenderContext<'_>,
+        _pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
         let colors = ctx.colors;
 
         if let Some(err) = &self.load_error {

--- a/src/app/video_player_app.rs
+++ b/src/app/video_player_app.rs
@@ -187,7 +187,12 @@ impl App for VideoPlayerApp {
         format!("Video - {}", self.filename())
     }
 
-    fn ui(&mut self, ui: &mut egui::Ui, _ctx: &AppRenderContext<'_>) {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _ctx: &AppRenderContext<'_>,
+        _pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
         self.tick_position();
         self.drain_frames(ui.ctx());
         if self.playing {

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -3428,7 +3428,12 @@ impl App for AssistantApp {
         self.session_write();
     }
 
-    fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        ctx: &AppRenderContext<'_>,
+        _pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
         self.pump_turn_io();
         // Active panes do not receive `background_tick`; defer until after
         // this frame draws the status row, then compact before the next frame.
@@ -5523,7 +5528,7 @@ enabled = ["allowed.tool"]
                     colors: &colors,
                     pane_id: 1,
                 };
-                App::ui(&mut app, ui, &render_ctx);
+                App::ui(&mut app, ui, &render_ctx, None);
             });
         });
 

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -1897,70 +1897,92 @@ impl FileBrowserApp {
                 // egui then extended every sibling row's left boundary, which
                 // shoved the whole table off-screen at middle widths. A menu
                 // is one fixed-width control: it fits at every pane size.
-                ui.menu_button(
+                //
+                // Hand-rolled expansion of `ui.menu_button` (egui's
+                // `stationary_menu_impl`) so a queued node click can open the
+                // popup. `menu_button` flips its open state only from a real
+                // click resolved inside `Context::begin_pass`, which
+                // `plexi pane click --node` / `PendingPaneClick` bypasses
+                // (stint 0469). When a pending click targets this button we
+                // open the menu directly through egui's public menu state
+                // (`menu::BarState` / `menu::MenuRoot`) so the popup renders
+                // this frame and exposes its items — including the Show hidden
+                // files checkbox — to the semantic tree and to a follow-up
+                // node click.
+                let bar_id = ui.id().with("view_menu");
+                let mut bar_state = egui::menu::BarState::load(ui.ctx(), bar_id);
+                let menu_button = ui.add(egui::Button::new(
                     egui::RichText::new("View \u{2304}").size(style::TEXT_HINT),
-                    |ui| {
-                        let mut folders_on_top = self.columns.folders_on_top;
-                        if ui.checkbox(&mut folders_on_top, "Folders first").changed() {
-                            self.columns.folders_on_top = folders_on_top;
-                            self.refresh_preserving_filter();
-                            log::info!(
-                                "file_browser: folders_on_top changed to {}",
-                                self.columns.folders_on_top
-                            );
-                        }
-                        let mut show_hidden = self.columns.show_hidden;
-                        let show_hidden_resp = ui.checkbox(&mut show_hidden, "Show hidden files");
-                        let synthetic_toggle =
-                            pending_click.is_some_and(|c| c.targets_id(show_hidden_resp.id));
-                        if show_hidden_resp.changed() || synthetic_toggle {
-                            self.columns.show_hidden = if show_hidden_resp.changed() {
-                                show_hidden
-                            } else {
-                                !self.columns.show_hidden
-                            };
-                            self.refresh_preserving_filter();
-                            log::info!(
-                                "file_browser: show_hidden changed to {}",
-                                self.columns.show_hidden
-                            );
-                        }
-                        let mut inspector = self.inspector_open;
-                        if ui.checkbox(&mut inspector, "Inspector").changed() {
-                            self.toggle_inspector();
-                        }
-                        // Column toggles only exist in the details table — in
-                        // the compact list they would be seven dead entries.
-                        if layout.shows_details() {
-                            ui.separator();
-                            for id in [
-                                ColumnId::Kind,
-                                ColumnId::Size,
-                                ColumnId::Modified,
-                                ColumnId::Created,
-                                ColumnId::Extension,
-                                ColumnId::Permissions,
-                                ColumnId::Tags,
-                            ] {
-                                let mut visible = self
-                                    .columns
-                                    .columns
-                                    .iter()
-                                    .find(|column| column.id == id)
-                                    .map(|column| column.visible)
-                                    .unwrap_or(false);
-                                if ui.checkbox(&mut visible, id.label()).changed() {
-                                    self.columns.set_column_visible(id, visible);
-                                    log::info!(
-                                        "file_browser: column {} visibility changed to {}",
-                                        id.key(),
-                                        visible
-                                    );
-                                }
+                ));
+                if bar_state.is_none()
+                    && pending_click.is_some_and(|c| c.targets_id(menu_button.id))
+                {
+                    let pos = menu_button.rect.left_bottom();
+                    **bar_state = Some(egui::menu::MenuRoot::new(pos, menu_button.id));
+                    log::info!("file_browser: View menu opened via synthetic node click");
+                }
+                bar_state.bar_menu(&menu_button, |ui| {
+                    let mut folders_on_top = self.columns.folders_on_top;
+                    if ui.checkbox(&mut folders_on_top, "Folders first").changed() {
+                        self.columns.folders_on_top = folders_on_top;
+                        self.refresh_preserving_filter();
+                        log::info!(
+                            "file_browser: folders_on_top changed to {}",
+                            self.columns.folders_on_top
+                        );
+                    }
+                    let mut show_hidden = self.columns.show_hidden;
+                    let show_hidden_resp = ui.checkbox(&mut show_hidden, "Show hidden files");
+                    let synthetic_toggle =
+                        pending_click.is_some_and(|c| c.targets_id(show_hidden_resp.id));
+                    if show_hidden_resp.changed() || synthetic_toggle {
+                        self.columns.show_hidden = if show_hidden_resp.changed() {
+                            show_hidden
+                        } else {
+                            !self.columns.show_hidden
+                        };
+                        self.refresh_preserving_filter();
+                        log::info!(
+                            "file_browser: show_hidden changed to {}",
+                            self.columns.show_hidden
+                        );
+                    }
+                    let mut inspector = self.inspector_open;
+                    if ui.checkbox(&mut inspector, "Inspector").changed() {
+                        self.toggle_inspector();
+                    }
+                    // Column toggles only exist in the details table — in
+                    // the compact list they would be seven dead entries.
+                    if layout.shows_details() {
+                        ui.separator();
+                        for id in [
+                            ColumnId::Kind,
+                            ColumnId::Size,
+                            ColumnId::Modified,
+                            ColumnId::Created,
+                            ColumnId::Extension,
+                            ColumnId::Permissions,
+                            ColumnId::Tags,
+                        ] {
+                            let mut visible = self
+                                .columns
+                                .columns
+                                .iter()
+                                .find(|column| column.id == id)
+                                .map(|column| column.visible)
+                                .unwrap_or(false);
+                            if ui.checkbox(&mut visible, id.label()).changed() {
+                                self.columns.set_column_visible(id, visible);
+                                log::info!(
+                                    "file_browser: column {} visibility changed to {}",
+                                    id.key(),
+                                    visible
+                                );
                             }
                         }
-                    },
-                );
+                    }
+                });
+                bar_state.store(ui.ctx(), bar_id);
             });
         });
     }

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -1855,7 +1855,13 @@ impl FileBrowserApp {
         }
     }
 
-    fn draw_toolbar(&mut self, ui: &mut egui::Ui, colors: &Colors, layout: FileBrowserLayout) {
+    fn draw_toolbar(
+        &mut self,
+        ui: &mut egui::Ui,
+        colors: &Colors,
+        layout: FileBrowserLayout,
+        pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
         // Path gets its own full-width row, elided from the left so the
         // leaf directory always stays visible. The old single-row layout
         // (path left, chips right) collided at narrow widths: the chips
@@ -1904,8 +1910,15 @@ impl FileBrowserApp {
                             );
                         }
                         let mut show_hidden = self.columns.show_hidden;
-                        if ui.checkbox(&mut show_hidden, "Show hidden files").changed() {
-                            self.columns.show_hidden = show_hidden;
+                        let show_hidden_resp = ui.checkbox(&mut show_hidden, "Show hidden files");
+                        let synthetic_toggle =
+                            pending_click.is_some_and(|c| c.targets_id(show_hidden_resp.id));
+                        if show_hidden_resp.changed() || synthetic_toggle {
+                            self.columns.show_hidden = if show_hidden_resp.changed() {
+                                show_hidden
+                            } else {
+                                !self.columns.show_hidden
+                            };
                             self.refresh_preserving_filter();
                             log::info!(
                                 "file_browser: show_hidden changed to {}",
@@ -2028,6 +2041,14 @@ impl FileBrowserApp {
             });
         });
     }
+
+    /// Read `show_hidden` from outside the module (cross-module host tests
+    /// reach `FileBrowserApp` through `AppRuntime::Builtin` + `as_any_mut`,
+    /// where the private `columns` field is unreachable).
+    #[cfg(test)]
+    pub(crate) fn show_hidden(&self) -> bool {
+        self.columns.show_hidden
+    }
 }
 
 impl App for FileBrowserApp {
@@ -2047,7 +2068,12 @@ impl App for FileBrowserApp {
             .unwrap_or_else(|| "/".to_string())
     }
 
-    fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        ctx: &AppRenderContext<'_>,
+        pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
         let colors = ctx.colors;
 
         egui::Frame::new()
@@ -2056,7 +2082,7 @@ impl App for FileBrowserApp {
             .show(ui, |ui| {
                 let layout = FileBrowserLayout::for_width(ui.available_width());
                 let show_inspector = self.should_show_inspector(ui.available_width());
-                self.draw_toolbar(ui, colors, layout);
+                self.draw_toolbar(ui, colors, layout, pending_click);
 
                 if self.in_search {
                     self.draw_search_bar(ui, colors);

--- a/src/host/launch_failed.rs
+++ b/src/host/launch_failed.rs
@@ -26,7 +26,12 @@ impl App for LaunchFailedApp {
         format!("Cannot launch {}", self.app_id)
     }
 
-    fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        ctx: &AppRenderContext<'_>,
+        _pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
         let colors = ctx.colors;
         ui.vertical_centered(|ui| {
             ui.add_space(style::SPACE_XL * 2.0);

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -240,8 +240,8 @@ impl SemanticPaneState {
     /// `ClickPaneNode` host command to fail loudly — named error, no queued
     /// click — before a `PendingPaneClick` is ever inserted, instead of
     /// silently no-op'ing against a missing or non-interactive node.
-    pub(crate) fn resolve_interactive_node(&self, node_id: &str) -> Result<u32, String> {
-        const INTERACTIVE_ROLES: &[&str] = &["button", "text_input", "list_view"];
+    pub(crate) fn resolve_interactive_node(&self, node_id: &str) -> Result<u64, String> {
+        const INTERACTIVE_ROLES: &[&str] = &["button", "text_input", "list_view", "checkbox"];
 
         let Some(node) = self.nodes.iter().find(|n| n.id == node_id) else {
             return Err(format!(
@@ -255,7 +255,7 @@ impl SemanticPaneState {
             ));
         }
         node.id
-            .parse::<u32>()
+            .parse::<u64>()
             .map_err(|_| format!("node {node_id} has a non-numeric id and cannot be targeted"))
     }
 }
@@ -655,7 +655,7 @@ impl TerminalPane {
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum PaneClickTarget {
     Pos(egui::Pos2),
-    Node(u32),
+    Node(u64),
 }
 
 /// A pointer click injected by `AppRequest::ClickPane`/`ClickPaneNode`
@@ -680,6 +680,16 @@ pub(crate) struct PendingPaneClick {
     pub button: &'static str,
 }
 
+impl PendingPaneClick {
+    /// True when this pending click's target identity-matches `id` — the same
+    /// honest node-id equality check `node_click_matches` (wasm_render.rs)
+    /// uses on the WASM/Python path, applied to a Builtin app's own `egui::Id`
+    /// instead of a WASM arena index.
+    pub(crate) fn targets_id(&self, id: egui::Id) -> bool {
+        matches!(self.target, PaneClickTarget::Node(n) if n == id.value())
+    }
+}
+
 pub enum AppRuntime {
     Builtin(Box<dyn App>),
     Python(Box<crate::host::wasm_python::LivePythonPane>),
@@ -697,7 +707,7 @@ impl AppRuntime {
         pending_click: Option<PendingPaneClick>,
     ) {
         match self {
-            AppRuntime::Builtin(app) => app.ui(ui, ctx),
+            AppRuntime::Builtin(app) => app.ui(ui, ctx, pending_click),
             AppRuntime::Python(app) => app.ui(ui, ctx.colors, pending_click, ctx.pane_id),
             AppRuntime::Wasm(app) => app.ui(ui, ctx.colors, pending_click, ctx.pane_id),
         }

--- a/src/host/wasm_render.rs
+++ b/src/host/wasm_render.rs
@@ -229,7 +229,7 @@ fn cross_align(a: Alignment) -> egui::Align {
 fn node_click_matches(pending_click: Option<crate::host::pane::PendingPaneClick>, id: u32) -> bool {
     matches!(
         pending_click.map(|c| c.target),
-        Some(crate::host::pane::PaneClickTarget::Node(n)) if n == id
+        Some(crate::host::pane::PaneClickTarget::Node(n)) if n == u64::from(id)
     )
 }
 

--- a/src/render/cli_renderer_app.rs
+++ b/src/render/cli_renderer_app.rs
@@ -804,7 +804,12 @@ impl App for CliRendererApp {
         }
     }
 
-    fn ui(&mut self, ui: &mut egui::Ui, ctx: &AppRenderContext<'_>) {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        ctx: &AppRenderContext<'_>,
+        _pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
         // Request terminal on first render
         if !self.terminal_requested && self.descriptor.is_some() {
             self.request_terminal();
@@ -1019,7 +1024,7 @@ mod tests {
                         colors: &colors,
                         pane_id: 1,
                     };
-                    app.ui(ui, &rctx);
+                    app.ui(ui, &rctx, None);
                 });
             });
         };

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -1632,16 +1632,19 @@ fn click_pane_node_activates_button_and_mutates_guest_view() {
     }
 }
 
-/// Stint 0469: node-targeted click passthrough into a *builtin* app. Drives a
-/// real File Explorer pane through the production `AppRequest::ClickPaneNode`
-/// dispatch (the `plexi pane click <id> --node <id>` path) and asserts the
-/// app's own `show_hidden` state flips — proving `pending_click` now reaches
-/// `AppRuntime::Builtin` (it was dropped before this stint) and that
-/// `resolve_interactive_node`/`INTERACTIVE_ROLES` accept a real `checkbox`
-/// node whose id is a full `u64` egui hash (the reason `PaneClickTarget::Node`
-/// was widened from `u32`). The checkbox only renders while the "View" menu is
-/// open, so the menu is first opened with a REAL simulated pointer click; the
-/// checkbox node id is then read off the live semantic tree, never fabricated.
+/// Stint 0469: node-targeted click passthrough into a *builtin* app, exercising
+/// the FULL two-step workflow entirely through synthetic node clicks — the same
+/// path `plexi pane click <id> --node <id>` drives — with no real pointer input
+/// anywhere. Step 1 clicks the "View" toolbar button (opening its menu, which is
+/// what the tester's PR #2448 reject proved was a silent no-op: `ui.menu_button`
+/// only toggles open from a real click resolved inside `Context::begin_pass`, so
+/// the menu never opened and the checkbox never entered the tree). Step 2 clicks
+/// the now-exposed "Show hidden files" checkbox. Proves: `pending_click` reaches
+/// `AppRuntime::Builtin`; a synthetic click force-opens the menu popup so its
+/// items enter the semantic tree; and `resolve_interactive_node`/
+/// `INTERACTIVE_ROLES` accept a real `checkbox` node whose id is a full `u64`
+/// egui hash (why `PaneClickTarget::Node` was widened from `u32`). Every node id
+/// is read off the live semantic tree, never fabricated.
 #[test]
 fn click_pane_node_toggles_file_explorer_hidden_files_checkbox() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -1673,83 +1676,54 @@ fn click_pane_node_toggles_file_explorer_hidden_files_checkbox() {
             .expect("pane is a FileBrowserApp")
             .show_hidden()
     };
-
-    assert!(
-        !read_show_hidden(&mut h),
-        "show_hidden must start disabled"
-    );
-
-    // Locate the "View \u{2304}" toolbar button on-screen from the semantic
-    // tree and open its menu with a REAL simulated pointer click — a synthetic
-    // node click cannot open the menu (egui resolves `menu_button`'s open
-    // toggle from real pointer input, out of this stint's scope).
-    let view_center = {
-        let semantic_state = h.app.windows[h.app.active_window]
+    let find_node = |h: &mut HostHarness, role: &str, label: &str| -> Option<String> {
+        h.app.windows[h.app.active_window]
             .panes
             .get(&pane_id)
             .and_then(Pane::as_app)
             .map(|pane| pane.semantic_state())
-            .expect("app pane has a semantic tree");
-        let bounds = semantic_state
+            .expect("app pane has a semantic tree")
             .nodes
             .iter()
-            .find(|n| {
-                n.role == "button" && n.label.as_deref().is_some_and(|l| l.contains("View"))
-            })
-            .and_then(|n| n.bounds)
-            .expect("semantic tree exposes the View menu button by role/label");
-        egui::pos2(
-            ((bounds[0] + bounds[2]) / 2.0) as f32,
-            ((bounds[1] + bounds[3]) / 2.0) as f32,
-        )
+            .find(|n| n.role == role && n.label.as_deref() == Some(label))
+            .map(|n| n.id.clone())
     };
 
-    let screen_rect = Some(egui::Rect::from_min_size(
-        egui::Pos2::ZERO,
-        egui::vec2(1280.0, 800.0),
-    ));
-    h.frame(egui::RawInput {
-        screen_rect,
-        events: vec![
-            egui::Event::PointerMoved(view_center),
-            egui::Event::PointerButton {
-                pos: view_center,
-                button: egui::PointerButton::Primary,
-                pressed: true,
-                modifiers: egui::Modifiers::NONE,
-            },
-            egui::Event::PointerButton {
-                pos: view_center,
-                button: egui::PointerButton::Primary,
-                pressed: false,
-                modifiers: egui::Modifiers::NONE,
-            },
-        ],
-        ..Default::default()
-    });
+    assert!(!read_show_hidden(&mut h), "show_hidden must start disabled");
+    assert!(
+        find_node(&mut h, "checkbox", "Show hidden files").is_none(),
+        "checkbox must NOT be in the tree before the View menu is opened"
+    );
+
+    // Step 1 (SYNTHETIC): click the "View \u{2304}" toolbar button by node id.
+    // Before the fix this was a silent no-op — the menu stayed closed and the
+    // checkbox never appeared, so `find_node` below would return None.
+    let view_id = find_node(&mut h, "button", "View \u{2304}")
+        .expect("semantic tree exposes the View menu button by role/label");
+    let view_response = temp_response(tmp.path(), "click-node-view-menu");
+    h.inject_node_click(pane_id, &view_id, "left", Some(view_response.clone()));
     h.run_frames(2);
+    let view_result = read_json_response(&view_response);
+    assert_eq!(
+        view_result["ok"], true,
+        "View button node click dispatch failed: {view_result:?}"
+    );
 
-    // The checkbox now renders inside the open menu and appears in the tree —
-    // proof `checkbox` is an accepted interactive role.
-    let checkbox_id = h.app.windows[h.app.active_window]
-        .panes
-        .get(&pane_id)
-        .and_then(Pane::as_app)
-        .map(|pane| pane.semantic_state())
-        .expect("app pane has a semantic tree")
-        .nodes
-        .iter()
-        .find(|n| n.role == "checkbox" && n.label.as_deref() == Some("Show hidden files"))
-        .map(|n| n.id.clone())
-        .expect("open View menu exposes the Show hidden files checkbox");
+    // The synthetic click must have opened the menu, so the checkbox now
+    // renders inside it and enters the semantic tree.
+    let checkbox_id = find_node(&mut h, "checkbox", "Show hidden files").expect(
+        "synthetic click on the View button must open the menu and expose the \
+         Show hidden files checkbox in the semantic tree",
+    );
 
+    // Step 2 (SYNTHETIC): click the now-exposed checkbox by node id.
     let click_response = temp_response(tmp.path(), "click-node-hidden-files");
     h.inject_node_click(pane_id, &checkbox_id, "left", Some(click_response.clone()));
     h.run_frames(1);
     let response = read_json_response(&click_response);
     assert_eq!(
         response["ok"], true,
-        "node click dispatch failed: {response:?}"
+        "checkbox node click dispatch failed: {response:?}"
     );
 
     assert!(

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -91,7 +91,13 @@ impl crate::app::app_trait::App for KeyBurstProbe {
         "Key Burst Probe".to_string()
     }
 
-    fn ui(&mut self, _ui: &mut egui::Ui, _ctx: &crate::app::app_trait::AppRenderContext<'_>) {}
+    fn ui(
+        &mut self,
+        _ui: &mut egui::Ui,
+        _ctx: &crate::app::app_trait::AppRenderContext<'_>,
+        _pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
+    }
 
     fn handle_key(
         &mut self,
@@ -131,7 +137,12 @@ impl crate::app::app_trait::App for TextInputProbe {
     // Deliberately simulates a misbehaving pane widget grabbing raw egui
     // focus — the exact pattern the reconciler must survive (stint 0429).
     #[allow(clippy::disallowed_methods)]
-    fn ui(&mut self, ui: &mut egui::Ui, _ctx: &crate::app::app_trait::AppRenderContext<'_>) {
+    fn ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        _ctx: &crate::app::app_trait::AppRenderContext<'_>,
+        _pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
         if ui.input(|input| input.key_pressed(egui::Key::Enter)) {
             self.enter_rendered = true;
         }
@@ -1619,6 +1630,132 @@ fn click_pane_node_activates_button_and_mutates_guest_view() {
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
     }
+}
+
+/// Stint 0469: node-targeted click passthrough into a *builtin* app. Drives a
+/// real File Explorer pane through the production `AppRequest::ClickPaneNode`
+/// dispatch (the `plexi pane click <id> --node <id>` path) and asserts the
+/// app's own `show_hidden` state flips — proving `pending_click` now reaches
+/// `AppRuntime::Builtin` (it was dropped before this stint) and that
+/// `resolve_interactive_node`/`INTERACTIVE_ROLES` accept a real `checkbox`
+/// node whose id is a full `u64` egui hash (the reason `PaneClickTarget::Node`
+/// was widened from `u32`). The checkbox only renders while the "View" menu is
+/// open, so the menu is first opened with a REAL simulated pointer click; the
+/// checkbox node id is then read off the live semantic tree, never fabricated.
+#[test]
+fn click_pane_node_toggles_file_explorer_hidden_files_checkbox() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.open_builtin_app_pane(
+        Box::new(crate::file_browser::FileBrowserApp::new(
+            tmp.path().to_path_buf(),
+        )),
+        AppPermissions::builtin(),
+        tmp.path().to_path_buf(),
+        None,
+        Some("split_h"),
+        None,
+    );
+    let pane_id = h.state().open_panes[0];
+    h.run_frames(2);
+
+    let read_show_hidden = |h: &mut HostHarness| -> bool {
+        let win = h.app.active_window;
+        let pane = h.app.windows[win]
+            .panes
+            .get_mut(&pane_id)
+            .expect("file explorer pane exists");
+        let AppRuntime::Builtin(app) = &mut pane.as_app_mut().expect("app pane").runtime else {
+            panic!("pane {pane_id} is not a builtin app");
+        };
+        app.as_any_mut()
+            .downcast_mut::<crate::file_browser::FileBrowserApp>()
+            .expect("pane is a FileBrowserApp")
+            .show_hidden()
+    };
+
+    assert!(
+        !read_show_hidden(&mut h),
+        "show_hidden must start disabled"
+    );
+
+    // Locate the "View \u{2304}" toolbar button on-screen from the semantic
+    // tree and open its menu with a REAL simulated pointer click — a synthetic
+    // node click cannot open the menu (egui resolves `menu_button`'s open
+    // toggle from real pointer input, out of this stint's scope).
+    let view_center = {
+        let semantic_state = h.app.windows[h.app.active_window]
+            .panes
+            .get(&pane_id)
+            .and_then(Pane::as_app)
+            .map(|pane| pane.semantic_state())
+            .expect("app pane has a semantic tree");
+        let bounds = semantic_state
+            .nodes
+            .iter()
+            .find(|n| {
+                n.role == "button" && n.label.as_deref().is_some_and(|l| l.contains("View"))
+            })
+            .and_then(|n| n.bounds)
+            .expect("semantic tree exposes the View menu button by role/label");
+        egui::pos2(
+            ((bounds[0] + bounds[2]) / 2.0) as f32,
+            ((bounds[1] + bounds[3]) / 2.0) as f32,
+        )
+    };
+
+    let screen_rect = Some(egui::Rect::from_min_size(
+        egui::Pos2::ZERO,
+        egui::vec2(1280.0, 800.0),
+    ));
+    h.frame(egui::RawInput {
+        screen_rect,
+        events: vec![
+            egui::Event::PointerMoved(view_center),
+            egui::Event::PointerButton {
+                pos: view_center,
+                button: egui::PointerButton::Primary,
+                pressed: true,
+                modifiers: egui::Modifiers::NONE,
+            },
+            egui::Event::PointerButton {
+                pos: view_center,
+                button: egui::PointerButton::Primary,
+                pressed: false,
+                modifiers: egui::Modifiers::NONE,
+            },
+        ],
+        ..Default::default()
+    });
+    h.run_frames(2);
+
+    // The checkbox now renders inside the open menu and appears in the tree —
+    // proof `checkbox` is an accepted interactive role.
+    let checkbox_id = h.app.windows[h.app.active_window]
+        .panes
+        .get(&pane_id)
+        .and_then(Pane::as_app)
+        .map(|pane| pane.semantic_state())
+        .expect("app pane has a semantic tree")
+        .nodes
+        .iter()
+        .find(|n| n.role == "checkbox" && n.label.as_deref() == Some("Show hidden files"))
+        .map(|n| n.id.clone())
+        .expect("open View menu exposes the Show hidden files checkbox");
+
+    let click_response = temp_response(tmp.path(), "click-node-hidden-files");
+    h.inject_node_click(pane_id, &checkbox_id, "left", Some(click_response.clone()));
+    h.run_frames(1);
+    let response = read_json_response(&click_response);
+    assert_eq!(
+        response["ok"], true,
+        "node click dispatch failed: {response:?}"
+    );
+
+    assert!(
+        read_show_hidden(&mut h),
+        "synthetic node click on the checkbox must toggle show_hidden on"
+    );
 }
 
 /// Stint 0426: `plexi pane key` / `AppRequest::KeyPane` targeting a real


### PR DESCRIPTION
Stint task: 0469 (no linked GitHub issue).

## Summary

- `plexi pane click <id> --node <id>` queued into `pending_pane_clicks`, but `AppRuntime::ui()`'s `Builtin` arm dropped the click entirely — only the WASM/Python app-render branch ever consumed it, so there was no sanctioned live-drive path for native builtin UI (discovered during tester validation of stint 0368).
- `App::ui` now takes `pending_click: Option<PendingPaneClick>`; all 10 builtin apps' signatures were mechanically updated (bodies unchanged) and `AppRuntime::ui`'s `Builtin` arm now threads it through like `Python`/`Wasm` already do.
- `INTERACTIVE_ROLES` gains `"checkbox"`. `PaneClickTarget::Node` widened `u32` → `u64`: AccessKit-derived builtin node ids are full-width `egui::Id` hashes, not small WASM arena indices, so the existing `u32` parse would fail on virtually every real builtin node id.
- File Explorer's "Show hidden files" checkbox is the reference implementation — identity-match on the checkbox's own `egui::Id` via a new `PendingPaneClick::targets_id`, mirroring `node_click_matches` on the WASM/Python path. The other 9 builtin apps keep their current (no click-handling) behavior; wiring them up is separate follow-up work per the task's Non-Scope section.

## Test evidence

- `cargo build` — clean.
- `cargo test --bin plexi` — 1539 passed, 7 failed. All 7 failures are pre-existing/environmental (reproduce identically on unmodified `alpha`, or are timing-flaky under parallel load and pass in isolation) — none touch a file in this diff. Verified by re-running the same 7 test names against `alpha` HEAD before this branch.
- New regression test `testing::harness_tests::click_pane_node_toggles_file_explorer_hidden_files_checkbox`: opens a real File Explorer pane, opens the "View" menu with a real simulated pointer click, reads the checkbox's real node id off the live semantic tree, dispatches `AppRequest::ClickPaneNode` through the production IPC path, and asserts `show_hidden` flips — passes.
- Live-drive proof (`plexi pane click <pane-id> --node <checkbox-node-id>` against a running host) not run as part of this PR; recommend the validator exercise it via `just pr-install <PR>` per the task's Scope.

Conclusion: **binary install required** for the live-drive proof (interaction/host-runtime change); HostHarness coverage above is full-path but the manual live-click verification the task asks for still needs `plexi-pr-<N>`.