### PR TITLE
docs(skills): stop the ship-lifecycle duplicate-work chain (stint 0470)

### DIFF
--- a/.agents/skills/babysitter/SKILL.md
+++ b/.agents/skills/babysitter/SKILL.md
@@ -1,16 +1,18 @@
 ---
 name: babysitter
-description: "Land a queue of stint tasks as fast as possible by orchestrating Codex instances in Plexi panes. You give a ready Codex pane id + a list of stints; this loop batches them into as few PRs as possible, drives a WORKER Codex pane to implement each batch, spawns a separate TESTER Codex pane to validate the PR against the real install build, routes bugs between them until it passes, merges, then recycles panes for the next batch. You are the router, never the coder. Checks in every 15 min, manages Codex's 5-hour usage window. Triggered by /babysitter, \"babysit codex\", \"queue these stints in the other pane\"."
+description: "Land a queue of stint tasks as fast as possible by orchestrating agent instances in Plexi panes. You give a ready agent pane id + a list of stints; this loop batches them into as few PRs as possible, drives a WORKER pane to implement each batch, spawns a separate TESTER pane to validate the PR against the real install build, routes bugs between them until it passes, merges, then recycles panes for the next batch. You are the router, never the coder. Checks in every 15 min. Triggered by /babysitter, \"babysit the queue\", \"queue these stints in the other pane\"."
 source: local
 date_added: "2026-07-11"
 ---
 
-# Babysitter — Orchestrate Worker + Tester Codex Panes Through a Stint Queue
+# Babysitter — Orchestrate Worker + Tester Panes Through a Stint Queue
 
-You are a **router and coordinator, not a coder.** You never touch code, git, or the repo yourself. You drive Codex instances running in Plexi panes and pass messages between them. Two roles exist per batch:
+You are a **router and coordinator, not a coder.** You never touch code, git, or the repo yourself. You drive agent instances running in Plexi panes and pass messages between them. Two roles exist per batch:
 
-- **Worker** — a Codex pane that implements the batch and opens the PR.
-- **Tester** — a *separate, fresh* Codex pane that installs the PR build, drives the app to verify it, and reports bugs back to you.
+- **Worker** — a pane that implements the batch and opens the PR.
+- **Tester** — a *separate, fresh* pane that installs the PR build, drives the app to verify it, and reports bugs back to you.
+
+**Panes run Claude Code, launched with the `c` alias** (bypasses permissions). Set the model with `/model`. Everything below assumes that; there is no Codex in this loop.
 
 You are the wire between them: Worker → PR → Tester → (bugs) → you → Worker → (fix) → you → Tester → … → pass → merge → recycle.
 
@@ -20,7 +22,7 @@ You are the wire between them: Worker → PR → Tester → (bugs) → you → W
 /babysitter <PANE_ID> <STINT_ID> [<STINT_ID> ...]
 ```
 
-- `<PANE_ID>` — a pane running a **ready** Codex chat (user hands this to you, already at an idle prompt). This is your first Worker.
+- `<PANE_ID>` — a pane running a **ready** agent chat (user hands this to you, already at an idle prompt). This is your first Worker.
 - `<STINT_ID...>` — stints to land, in order.
 
 First action: confirm the worker pane is real and idle, and label it.
@@ -28,11 +30,11 @@ First action: confirm the worker pane is real and idle, and label it.
 plexi pane capture <PANE_ID> --from-cursor 0
 plexi pane name <PANE_ID> "worker-1"
 ```
-If it isn't a live Codex prompt, stop and tell the user. Never assume — capture first.
+If it isn't a live agent prompt, stop and tell the user. Never assume — capture first.
 
 ## Verified command cheatsheet
 
-Exact forms confirmed against the Codex TUI. Use them; don't invent variants.
+Exact forms confirmed in live runs. Use them; don't invent variants.
 
 | Need | Command |
 |---|---|
@@ -42,24 +44,27 @@ Exact forms confirmed against the Codex TUI. Use them; don't invent variants.
 | Read full pane buffer (verdict parsing only) | `plexi pane capture <id> --from-cursor 0` |
 | Read only *new* output (delta) | `plexi pane capture <id> --from-cursor <CURSOR>` |
 | Pane UI state as JSON | `plexi pane state <id>` |
-| Type a prompt (Codex TUI) | `plexi pane send <id> "<text>"` |
+| Type a prompt into the pane's TUI | `plexi pane send <id> "<text>"` |
 | **Submit** the prompt | `plexi pane key <id> enter` |
-| Interrupt Codex | `plexi pane key <id> ctrl+c` |
+| Interrupt the agent | `plexi pane key <id> ctrl+c` |
 | Open a new terminal pane | `plexi pane new -n "<label>"` |
-| Launch Codex in a shell pane | `plexi pane command <id> "co" --enter` |
+| Launch an agent in a shell pane | `plexi pane command <id> "c" --enter` |
+| Set the pane's model | `plexi pane send <id> "/model <name>"` then `key enter` |
 | Rename / label a pane | `plexi pane name <id> "<label>"` |
 | List panes (alive? find by name) | `plexi pane list` |
 | Close a pane | `plexi pane close <id>` |
 
-`co` is the alias for `codex -s danger-full-access`. **Label every pane** (`worker-N`, `tester-N`) so you can find them in `plexi pane list` by name instead of tracking bare ids.
+**Label every pane** (`worker-N`, `tester-N`) so you can find them in `plexi pane list` by name instead of tracking bare ids.
+
+**Backtick trap:** never put backticks in the text you pass to `plexi pane send` from a double-quoted shell string — they trigger command substitution and the send fails or mangles. Write commands and paths bare in briefs.
 
 ### Capture forms — `--lines 20` is the default; full-buffer reads are the exception
 
 Since stint 0383 (PR #2390), `capture --lines N` returns the last N real content lines on full-screen TUIs. Cost order, cheapest first:
 
-- `plexi pane capture <id> --lines 20` → bounded tail. **Default for every status check** — it answers "what is Codex's last message" in ~20 lines.
+- `plexi pane capture <id> --lines 20` → bounded tail. **Default for every status check** — it answers "what is the agent's last message" in ~20 lines.
 - `plexi pane capture <id> --from-cursor <CURSOR>` → delta since a known cursor.
-- `plexi pane capture <id> --from-cursor 0` → full buffer. Only when parsing a long verdict/report whose start you'd otherwise miss — and delegate that read to a sub-agent.
+- `plexi pane capture <id> --from-cursor 0` → full buffer. Only when parsing a long verdict/report whose start you'd otherwise miss. Prefer narrowing it with `grep`/`sed` over dumping the whole thing; delegate to a sub-agent only when the report is genuinely too long to narrow.
 
 Known pre-existing bug (stint 0385): `--from-cursor <N>` deltas can return empty on a live pane. If a delta comes back empty, fall back to `--lines`, not to a full-buffer dump.
 
@@ -110,7 +115,7 @@ The failure mode this skill exists to prevent: send a key → capture comes back
 
 ### CRITICAL gotcha — send does not submit
 
-`plexi pane send`'s `\n` does **not** reliably auto-submit inside the Codex TUI. Standing two-step, used dozens of times:
+`plexi pane send`'s `\n` does **not** reliably auto-submit inside the agent TUI. Standing two-step, used dozens of times:
 
 ```
 plexi pane send <id> "<prompt text>"
@@ -120,15 +125,15 @@ sleep 3
 plexi pane capture <id> --from-cursor 0   # confirm it took; re-send enter ONCE if not
 ```
 
-(This is for the Codex *TUI*. To launch `co` at the *shell* level in a fresh pane, `plexi pane command <id> "co" --enter` is fine.)
+(This is for typing into a pane's *TUI*. Launching the agent at the *shell* level in a fresh pane uses `plexi pane command <id> "c" --enter`.)
 
 ## Batch into as few PRs as possible (hard rule)
 
 Before feeding anything, group the queue. **Fewer PRs is always better.** Small or related stints ship together in **one** PR — never one-PR-per-stint when they can combine. Parallelize implementation where stints don't share files, but collapse the result into the smallest number of PRs that makes sense. A **batch** is the unit of work below, not a single stint. Group by shared subsystem/files, small size, logical cohesion. When in doubt, combine.
 
-## Spawning a Codex pane
+## Spawning an agent pane
 
-**This deployment launches workers/testers as Claude Code panes via the `c` alias (bypasses permissions), not Codex/`co`.** The `/model` slash command sets their model. The Codex-TUI command forms in the cheatsheet still apply to the pane's TUI, but the agent inside is Claude Code launched with `c`.
+Workers and testers are Claude Code panes launched with the `c` alias (bypasses permissions); `/model` sets the model.
 
 ```
 plexi pane new -n "worker-<N>"          # or tester-<N>
@@ -162,14 +167,16 @@ Set the model at each batch boundary, based on the batch's size, **before** send
 
 For each **batch**, in order:
 
-1. **Worker: implement + open PR.** Send the worker Codex a directive:
-   > "Land stints `<ID>[, <ID>...]` **together in a single PR**. Run `stint show <ID>` for each, then claim them, implement in one worktree branched from alpha, and open ONE PR to alpha covering all of them per the repo AGENTS.md ship pipeline. Do NOT merge — a separate tester will validate first. **Before pushing, run the full CI-equivalent local gate, not just `cargo test --bin plexi`**: `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py`, and every `just gen-*-docs` / `just check-*-docs` generator touched by the diff (SDK, capability, config, authoring, CLI docs) — regenerate and commit any that are stale. `cargo test --bin plexi` passing is not sufficient evidence the PR is green; confirm with `gh pr checks <PR#>` after push and fix any red check before reporting done. **HARD GATE: paste the final green summary line of every suite you ran (`just test`, sdk pytest, mypy) in your reply — an unverified push gets bounced back without a tester round.** **Never end your turn while a build or test is still running — wait on it in the foreground and report its result.** Reply with the PR number when it's open and checks are green."
+1. **Worker: implement + open PR.** Send the worker a directive:
+   > "Land stints `<ID>[, <ID>...]` **together in a single PR**. Run `stint show <ID>` for each, then claim them, implement in one worktree branched from alpha, and open ONE PR to alpha covering all of them per the repo AGENTS.md ship pipeline. **Stop once the PR is open and checks are green — do NOT invoke `/validate-pr`, and do NOT merge.** A separate tester pane owns validation. **Before pushing, run the full CI-equivalent local gate, not just `cargo test --bin plexi`**: `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py`, and every `just gen-*-docs` / `just check-*-docs` generator touched by the diff (SDK, capability, config, authoring, CLI docs) — regenerate and commit any that are stale. `cargo test --bin plexi` passing is not sufficient evidence the PR is green; confirm with `gh pr checks <PR#>` after push and fix any red check before reporting done. **HARD GATE: paste the final green summary line of every suite you ran (`just test`, sdk pytest, mypy) in your reply — an unverified push gets bounced back without a tester round.** **Never end your turn while a build or test is still running — wait on it in the foreground and report its result.** Reply with the PR number when it's open and checks are green."
 
-   These two brief clauses exist because they were the top two token sinks in practice: workers pushing red (each unverified push burns a full tester round — install + validation) and workers yielding their turn mid-compile (each yield burns a nudge round-trip). State them up front in every worker brief, including fix-round briefs.
+   These three brief clauses exist because they were the top token sinks in practice: workers running `/validate-pr` (the pipeline auto-chains `implement-stint` → `open-pr` → `validate-pr`, so a worker that follows the skills literally installs the build itself — a ~5 min compile the tester then repeats — and parks on a `[TESTING]` block waiting for a reply that never comes, which you then read as "idle with unfinished work" and burn a nudge on), workers pushing red (each unverified push burns a full tester round), and workers yielding their turn mid-compile (each yield burns a nudge round-trip). State all three up front in every worker brief, including fix-round briefs.
 
    **Verify, don't trust the worker's self-report.** After the worker replies with a PR number, you run `gh pr checks <PR#>` yourself before spawning the tester. If anything is red, send it straight back to the worker as a bug (same routing as a tester-found bug) — do not spawn the tester against a build with known-red CI.
 
-   **RUST-ONLY PRs SHOW ONLY `claude` + CodeRabbit IN CI; that is GREEN, not incomplete.** The `typecheck` and `check-*-docs` GitHub jobs are conditional on Python (`sdk/python`) or docs changes. A pure-Rust-host PR (e.g. `src/*.rs` only) will NEVER spawn a `typecheck` job, so `gh pr checks` returning just `claude: skipping` + `CodeRabbit: pass` is a full green, not a half-reported run. Do NOT wait or poll for a typecheck that will never appear; that is a silent stall. The real gate for a Rust PR is the worker's local `cargo test --bin plexi` summary (make the worker paste it) plus the tester round, NOT CI.
+   **RUST-ONLY PRs SHOW ONLY `claude` + CodeRabbit IN CI; that is GREEN, not incomplete.** The `typecheck` and `check-*-docs` GitHub jobs are conditional on Python (`sdk/python`) or docs changes. A pure-Rust-host PR (e.g. `src/*.rs` only) will NEVER spawn a `typecheck` job, so `gh pr checks` returning just `claude: skipping` + `CodeRabbit: pass` is a full green, not a half-reported run. Do NOT wait or poll for a typecheck that will never appear; that is a silent stall.
+
+   **But green ≠ reviewed.** `CodeRabbit` currently reports "Review skipped: automatic reviews are disabled" on every PR, and `claude` skips on Rust-only diffs — neither is actually reading the code. The real gate for a Rust PR is the worker's local `cargo test --bin plexi` summary (make the worker paste it), the pre-push Codex review in `/implement-stint` Phase 4, and the tester round. Never tell a user a diff was "reviewed by CI."
 
    Send → `key enter` **once**. Confirm it registered by polling the **status bar** (`plexi pane capture <id> --lines 3`) until `esc to interrupt` appears — not by re-sending. A long brief often pastes as a collapsed block (`paste again to expand`) and needs exactly one more `enter` to submit; that is the only sanctioned re-send.
 
@@ -177,7 +184,7 @@ For each **batch**, in order:
 
    ```
    plexi pane list 2>&1 | grep -v "sudo:"           # agent.state: working or idle
-   plexi pane capture <id> --lines 20 2>&1 | grep -v "sudo:"   # Codex's last message
+   plexi pane capture <id> --lines 20 2>&1 | grep -v "sudo:"   # agent's last message
    ```
 
    `working` → reschedule, done. `idle` → the 20-line tail almost always contains the verdict/reply/blocker; act on it directly. This replaced ~40k-token sub-agent reads with ~1k-token direct reads in practice.
@@ -192,8 +199,14 @@ For each **batch**, in order:
    Bash (run_in_background): until [ "$(gh pr view <PR#> --json state --jq .state)" != "OPEN" ]; do sleep 15; done; gh pr view <PR#> --json state,mergedAt
    ```
 
-3. **Spawn the Tester (fresh Codex pane) once the PR is open.** New pane, `co`, labeled `tester-<N>`. First gate on the diff: **if the PR is docs/scripts/manifests-only with no runtime behavior change, the tester does a diff review + `just test` and skips the 5-minute install** — say so in the brief and let the tester judge from `gh pr diff <PR#> --name-only`. Otherwise brief it:
-   > "Validate PR #`<PR#>` for Plexi. Install it with `just pr-install <PR#>` (from that PR's worktree), then **actually drive the installed `plexi-pr-<PR#>` build** — open the app, use the specific feature these stints added, and confirm end-to-end that it really works (not just that it compiles). Where the PR adds an assertion/validation/guard, prove it is **falsifiable**: deliberately violate it locally, watch it fail with a clear message, revert. Use the host's own primitives to observe it, never macOS `screencapture`/screen-recording (see below). Do NOT re-run test suites (`cargo test`, `just test`, pytest) — CI already proved them green; your job is exclusively behavior the suites can't see. Report a clear PASS, or a numbered list of concrete bugs/repro steps. Do not touch the code."
+3. **Spawn the Tester (fresh pane) once the PR is open.** New pane launched with `c`, labeled `tester-<N>`; set its model with `/model` before briefing. First gate on the diff — judge from `gh pr diff <PR#> --name-only`:
+
+   - **Docs/scripts/manifests-only, no runtime behavior change** → the tester does a diff review only and skips both the install and the suites. There is nothing to live-drive and the worker already ran the suites pre-push; re-running them here duplicates that.
+   - **Anything else** → the install-and-drive brief below.
+
+   > "Validate PR #`<PR#>` for Plexi. Install it with `just pr-install <PR#>` (from that PR's worktree), then **actually drive the installed `plexi-pr-<PR#>` build** — open the app, use the specific feature these stints added, and confirm end-to-end that it really works (not just that it compiles). Where the PR adds an assertion/validation/guard, prove it is **falsifiable**: deliberately violate it locally, watch it fail with a clear message, revert. Use the host's own primitives to observe it, never macOS `screencapture`/screen-recording (see below). Do NOT re-run test suites (`cargo test`, `just test`, pytest) — the worker already ran them green pre-push and pasted the summary; your job is exclusively behavior the suites can't see. Report a clear PASS, or a numbered list of concrete bugs/repro steps. Do not touch the code."
+
+   **The tester validates behavior, not the diff.** It does not re-review code — AI diff review already happened once, pre-push, in `/implement-stint` Phase 4. Live-driving the real build is the thing only this pane can do; that is its entire job.
 
    **Never let the tester reach for macOS `screencapture`, screen recording, or any OS permission prompt to observe the host.** Plexi ships its own capture primitives that need zero OS permission — use them instead:
    - `plexi-pr-<N> pane state <id>` — normalized semantic tree (assert on `semantic.nodes`, not pixels).
@@ -212,7 +225,13 @@ For each **batch**, in order:
      Loop worker ↔ tester until the tester returns a clean PASS. You are the only channel between them.
    - **PASS** → proceed to merge.
 
-5. **Merge (only after tester PASS).** You confirm the state yourself, then have the worker squash-merge to alpha (it owns git):
+5. **Merge — after tester PASS *and* the human gate.** A PASS is not permission to merge.
+
+   **Default (always, unless the user opted out): surface the passing PR and wait.** Report the verdict and ask for explicit merge approval. Do not proceed on your own judgment that the evidence looks strong — that is exactly the reasoning that merges something the user wanted to see first.
+
+   **Only skip the wait when the user has explicitly opted into auto-merge for this queue** (see Rules). If they have, merge on PASS and roll straight to the next batch.
+
+   Once approved, you confirm the state yourself, then have the worker squash-merge to alpha (it owns git):
    ```
    gh pr view <PR#> --json state,mergedAt
    ```
@@ -263,20 +282,12 @@ For each **batch**, in order:
 
    Recycle at clean boundaries only — batch merged, or pane about to take an unrelated task. Never mid-fix.
 
-## Usage-window management (Codex's 5-hour limit)
+## Usage-limit handling
 
-When a pane prints `■ You've hit your usage limit. ... try again at 8:39 PM.`, parse the reset time and branch:
+When a pane reports it has hit a usage limit, parse the reset time and branch:
 
 - **Reset < 1 hour away** → wait. `ScheduleWakeup` for just past the reset, then resume that pane's task (send `enter` or re-send the prompt) and capture to confirm it picked back up.
-- **Reset ≥ 1 hour away** (window burned, too long to idle) → switch usage buckets instead of waiting; we have resets to spend. **In that pane:**
-  ```
-  plexi pane send <id> "/usage"
-  sleep 1
-  plexi pane key <id> enter
-  sleep 2
-  plexi pane capture <id> --from-cursor 0      # read the menu
-  ```
-  Drive the menu with `plexi pane key <id> <up|down|enter>` to re-enable / select the next allotment (options are TUI-version-dependent — read them each time). Capture after every keypress. Then resume the in-flight task.
+- **Reset ≥ 1 hour away** → don't idle the queue. Report the wall to the user with the reset time and ask how to proceed; they may want to switch accounts, drop to a cheaper model via `/model`, or pause the run.
 
 Applies to whichever pane hit the wall — worker or tester.
 
@@ -292,12 +303,12 @@ When the user asks for a report, status, or "is the loop running", the deliverab
 
 ## Rules
 
-- You never write code, run git, or merge yourself. You spawn, label, route messages, and observe. All work is the Codex panes'.
+- You never write code, run git, or merge yourself. You spawn, label, route messages, and observe. All work is the agent panes'.
 - **Two panes per batch**: worker implements, a *separate fresh* tester validates. The tester must drive the real `plexi-pr-<N>` install build and use the feature — no pass on a compile alone.
 - **Fewest PRs possible** — batch small/related stints into one PR.
 - **No merge without a tester PASS.** Bugs route worker ↔ tester through you until clean.
 - **Opt-in auto-merge (user triggers it, never the default).** Default holds: surface each passing PR to the user and wait. But when the user explicitly says the queue is good to merge and they will test holistically at the end (e.g. a final e2e gate), drop the human-hold gate: on tester PASS, have the worker squash-merge to alpha immediately and roll to the next batch with no surfacing-and-waiting. Keep the tester round; it protects alpha's trunk for downstream stints. Only the human-hold is removed.
-- **Protect your context.** Never dump full pane captures into your own window — delegate reading to a sub-agent that returns a minified report, and use `--from-cursor` for deltas. You hold summaries, not scrollback.
+- **Protect your context.** Default to `--lines 20` reads and narrow full-buffer reads with `grep`/`sed`. Sub-agent delegation is the exception for genuinely long reports, not the default — see the capture-forms section. You hold summaries, not scrollback.
 - **Label every pane** and recycle (close both, spawn fresh worker) between batches.
 - Verify state with `gh`/`stint`, not any pane's self-report.
 - Keep the 15-min cadence via `ScheduleWakeup`; nudge rather than wait passively.

--- a/.agents/skills/create-stint/SKILL.md
+++ b/.agents/skills/create-stint/SKILL.md
@@ -59,7 +59,9 @@ For bug tasks, verify the root cause by reading code. Never state an unverified 
 
 Grep `GOTCHAS.md` for related pitfalls if it exists.
 
-**Before writing the task file, present the decided implementation plan to the user and confirm.** One approach only — no options, no A/B. If multiple approaches exist, pick the best one yourself and state it. Only ask the user if there is a genuine trade-off they must own (e.g., breaking API change, scope that affects other teams). Wait for confirmation before proceeding to Step 3.
+**When a human is in the loop, present the decided implementation plan and confirm before writing the task file.** One approach only — no options, no A/B. If multiple approaches exist, pick the best one yourself and state it. Only ask the user if there is a genuine trade-off they must own (e.g., breaking API change, scope that affects other teams). Wait for confirmation before proceeding to Step 3.
+
+**Autonomous mode — no human to confirm with.** When this skill is invoked by an agent mid-run (a babysitter worker filing a follow-up, a tester recording a discovered gap, any unattended flow), there is nobody to answer and waiting deadlocks the caller. In that case: skip the confirmation gate, pick the approach yourself, and write the chosen approach into the task body's `## Scope` as the decision of record. If a genuine trade-off exists that a human should own, still write the task — put the open decision under `## Open Questions` and set priority so it surfaces, rather than blocking on an answer that will never come. Never stall an unattended run waiting for confirmation.
 
 ---
 

--- a/.agents/skills/implement-stint/SKILL.md
+++ b/.agents/skills/implement-stint/SKILL.md
@@ -277,12 +277,24 @@ Receive the summary from Sub-agent I.
 
 **Orchestrator diff review:** Run `git -C <worktree-path> diff --staged --stat` and spot-check the diff before committing. If Sub-agent I reported unresolved Codex findings, surface them to the user and ask whether to proceed or iterate.
 
+### Who reviews what
+
+This phase is the **single owner of AI diff review** for the whole pipeline. Sub-agent I's Codex pass above is the one AI review the diff gets, and it runs pre-push where findings are cheapest to fix — the worktree is live and no PR churn is needed.
+
+The other phases deliberately do not review:
+
+| Layer | Reviews? |
+|---|---|
+| `/implement-stint` Phase 4 (here) | **Yes** — Codex, max 2 runs, pre-push |
+| `/open-pr` | No — its own Rules already say so |
+| `/validate-pr` | No — owns install + user acceptance; carries this phase's verdict into the testing block |
+| Babysitter tester pane | Behavior only — live-drives the build, does not re-review the diff |
+
+**CI is not a review layer today.** The `CodeRabbit` check reports "automatic reviews are disabled" on every PR, and the `claude` check is conditional and skips on Rust-only diffs. Treat a green `gh pr checks` as "nothing red," not as "the diff was reviewed." If this phase's review is skipped, the diff ships unreviewed — say so in the handoff rather than assuming CI caught it.
+
 Then run the `/testing` skill (`.agents/skills/testing/SKILL.md`) to produce the `**Test evidence:**` block — diff classification, harness tests, headless render screenshots for visual changes. Include the block in the Ship Log entry (or PR body when no issue is linked) during handoff.
 
-Validation bias:
-
-- Use `binary install required` as the default conclusion for visible UI, keyboard, app-launch, channel, filesystem, host/runtime, or interaction changes.
-- Use `install skippable — full coverage` only for pure logic, docs-only, or changes with direct HostHarness/PlexiUiHarness/scene coverage that exercises the full user-visible behavior.
+**Install-skip conclusion:** the `/testing` skill's Step 5 conclusion rules are the single source of truth. Apply them as written — do not re-derive skip criteria here.
 - If binary install is required, explicitly state that validation should install the PR build with `just pr-install <PR>` after `/open-pr` creates the PR. The validator should run `plexi-pr-<PR>` from the relevant workspace, not `plexi` or `plexi-alpha`.
 - Never cite `cargo build` or a feature-worktree app install as install evidence.
 
@@ -330,6 +342,8 @@ pipeline_slots_set implement <issue-or-task> "" pushed "" ""
 Then invoke `/open-pr` inline for the branch. Do not run `stint done` here; `/merge-pr` closes the task after the PR merges and alpha is verified.
 
 If no linked GitHub issue exists, still invoke `/open-pr` for the branch. The PR body should name the stint task and state that there is no linked GitHub issue.
+
+**Stop-at-PR-open mode.** When the invoker says to stop once the PR is open — babysitter workers always do — hand off to `/open-pr` but tell it not to chain into `/validate-pr`. Report the PR number and green checks, then end the turn. A separate tester owns validation in that mode; running `/validate-pr` anyway costs a duplicate `just pr-install` (~5 min) and leaves the turn parked on a `[TESTING]` block waiting for a reply that is not coming.
 
 ## Blocked Or Abandoned Work
 

--- a/.agents/skills/open-pr/SKILL.md
+++ b/.agents/skills/open-pr/SKILL.md
@@ -139,7 +139,7 @@ gh issue edit <N> \
   --remove-label "in progress"
 ```
 
-Invoke `/validate-pr <pr-number>` inline in the same pane.
+Invoke `/validate-pr <pr-number>` inline in the same pane — **unless the caller asked to stop at PR-open** (babysitter workers always do). In that mode, report the PR number and check status and end the turn; a separate tester owns validation.
 
 ---
 
@@ -148,6 +148,6 @@ Invoke `/validate-pr <pr-number>` inline in the same pane.
 - PR always targets `alpha` — never `beta` or `main`
 - Never push to `alpha`, `beta`, or `main` directly
 - Idempotency: re-running on an already-open PR advances labels, never errors
-- All quality review happens in `/validate-pr` — open-pr does not run any review
+- open-pr runs no review. AI diff review is owned solely by `/implement-stint` Phase 4 (pre-push) — see "Who reviews what" there. `/validate-pr` does not review either.
 
 

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -138,12 +138,16 @@ Append to the Ship Log entry for this attempt (issue body), or the PR descriptio
 - Conclusion: install skippable — full coverage | binary install required — <why>
 ```
 
+**These conclusion rules are the single source of truth for install-skip.** `/implement-stint` and `/validate-pr` consume the conclusion this block produces — they never re-derive it against their own criteria. If you are editing skip criteria anywhere else, you are editing the wrong file.
+
 Conclusion rules:
-- `install skippable — full coverage`: every touched layer has green tests AND any visual change has an inspected screenshot.
-- `binary install required`: PTY/terminal interaction, keyboard-capture flows, anything `#[ignore = "requires-pty"]`, or behavior only observable in the installed bundle (menus, dock, file associations).
+- `install skippable — full coverage`: every touched layer has green tests AND any visual change has an inspected screenshot. This includes pure-logic and docs-only changes with direct `HostHarness`/`PlexiUiHarness`/scene coverage of the full user-visible behavior — coverage is the test, not cosmetic-ness.
+- `binary install required`: PTY/terminal interaction, keyboard-capture flows, anything `#[ignore = "requires-pty"]`, or behavior only observable in the installed bundle (menus, dock, file associations). This is the default for visible UI, keyboard, app-launch, channel, filesystem, host/runtime, or interaction changes.
+- `docs-only — no test evidence required`: markdown, comments, or skill/doc text with no code path touched.
 - A `LiveBackend` change always requires `just scene-live` against the installed
   PR channel. Headless parity proves schema semantics, not CLI execution or
   eventual polling against a real host.
+- `apps/` changes always require binary install regardless of conclusion — the app registry and bundle layout are only exercised by a real install.
 
 ## Guards
 

--- a/.agents/skills/validate-pr/SKILL.md
+++ b/.agents/skills/validate-pr/SKILL.md
@@ -123,15 +123,15 @@ Evaluate the conclusion, **then apply overrides**:
 
 **Do not re-run `cargo test` in validation.** The suite ran during implementation; the Test Evidence block is the authoritative record. Validation owns diff review and user acceptance, not test execution. Never re-run a suite that the Ship Log already reports as green.
 
-**Default mode: install the binary.** Always run `just pr-install $PR_NUMBER` unless one of the explicit skip conditions below applies. The install cost is low and gives the user the option to manually exercise the change.
+**Default mode: install the binary.** Always run `just pr-install $PR_NUMBER` unless the skip gate below applies. The install cost is low and gives the user the option to manually exercise the change.
 
-**Skip install only if ALL of the following hold:**
-- Test evidence explicitly says `install skippable — full coverage`
-- No `apps/` files changed
-- Done When does not require binary exercise
-- Changes are exclusively: cosmetic constants, help strings, markdown, or config TOML values
+**Skip install when the Test Evidence conclusion says to.** The `/testing` skill's Step 5 conclusion rules are the single source of truth for this decision — consume the conclusion verbatim, do not re-derive it here:
+- `install skippable — full coverage` or `docs-only` → diff-review mode
+- `binary install required` → install
+- Block absent → fall through to the install-trigger list below
+- Override regardless of conclusion: `apps/` files changed, or Done When requires binary exercise
 
-If skipping → mark Install row as `skipped — <reason>`, proceed to Step 2b (automated quality checks).
+If skipping → mark Install row as `skipped — <reason>`, proceed to Step 3 (write and surface the testing block).
 
 ---
 
@@ -175,50 +175,19 @@ fi
 PR_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*= "//' | tr -d '"')
 ```
 
-Wait for completion. The binary is now installed (`$PR_VERSION`). Move immediately to Step 2b.
+Wait for completion. The binary is now installed (`$PR_VERSION`). Move immediately to Step 3.
 
-> **HARD STOP — do not launch the PR binary.** Do not tail logs waiting for app output. Do not poll, watch, or sleep. The full sequence after install is: Codex review → write testing block → notify → stop. The user launches and exercises the app; that is not the agent's job.
+> **HARD STOP — do not launch the PR binary.** Do not tail logs waiting for app output. Do not poll, watch, or sleep. The full sequence after install is: write testing block → notify → stop. The user launches and exercises the app; that is not the agent's job.
 
 ---
 
-## Step 2b — Automated Quality Checks
+## No AI review in this phase
 
-**Skip gate — assess before running.** Read the diff and changed file list, then classify the PR:
+AI diff review happens **once**, pre-push, in `/implement-stint` Phase 4. This skill does not run it again — a second pass over the same diff costs a full Codex run and, in babysitter mode, duplicates what the tester pane is already doing with fresh eyes.
 
-- **Run checks** if any changed file contains: new logic, new branches, new error paths, behavioral changes, new API surface, bug fixes, or anything systemic that could break silently. Always run for `sdk/` changes.
-- **Skip checks** if ANY of these conditions holds:
-  - ALL changes are exclusively: color/spacing/font-size constants, help/doc strings, markdown files, config TOML values, label/copy text, or UI layout values that require human eyes to verify anyway. Set `AI_FINDINGS="skipped — cosmetic/style change, user verifies visually"`.
-  - The diff is **fewer than 5 lines changed** (additions + deletions combined, excluding blank lines and comments). Set `AI_FINDINGS="skipped — diff under 5 lines, low infrastructural risk"`.
-  - ALL changed files are under `apps/` (app code, not SDK). Set `AI_FINDINGS="skipped — apps-only change, no host/SDK risk"`.
+Carry the implementation phase's verdict into the testing block as `AI_FINDINGS` (the Ship Log's `Codex verdict:` line). If that line is missing, set `AI_FINDINGS="no pre-push review recorded"` and say so plainly rather than running a review here to fill the gap.
 
-When in doubt, run Codex review. Do not expand to broad cargo tests or binary install from doubt alone.
-
-**Review-run cap:** Run Codex review at most twice for one validation attempt without checking with Ian. The first run is the normal review. If it finds issues and you push fixes, one rerun is allowed to verify those fixes. If the second run finds more issues, stop, report the remaining findings, and ask Ian before running review again.
-
-**If running — Codex review (low reasoning):**
-
-```bash
-# Use git worktree list to find the alpha root — git rev-parse --show-toplevel returns the
-# CWD's worktree path (not the main repo root) when run from inside a worktree.
-ALPHA_ROOT=$(git worktree list --porcelain | grep -B2 "branch refs/heads/alpha" | grep "^worktree " | head -1 | cut -d' ' -f2)
-REVIEW_OUT="/tmp/plexi-pr-$PR_NUMBER-codex-review.txt"
-(cd "$ALPHA_ROOT/worktrees/$BRANCH" && \
-  codex review \
-    -c model_reasoning_effort=low \
-    --base alpha \
-    "Review this git diff for a Rust/Python codebase. Focus on: correctness bugs, unsafe patterns, missed error handling, and clear simplification opportunities. Do not flag style, formatting, or cosmetic issues. Reply with a concise bulleted findings list referencing file and line where possible, or 'No issues found.' if the diff is clean." \
-  > "$REVIEW_OUT" 2>&1) || true
-
-AI_FINDINGS=$(tail -120 "$REVIEW_OUT")
-
-if [ -z "$AI_FINDINGS" ]; then
-  AI_FINDINGS="Codex review completed; no output detected. Full raw output: $REVIEW_OUT"
-fi
-```
-
-Only surface `AI_FINDINGS` in the testing block. Do not paste the raw Codex transcript into chat. If you need to inspect raw output, read the temp file narrowly with `tail`, `rg`, or `sed`.
-
-After the optional PR install, mergeable check, and review summary are available, surface the testing block immediately. Do not launch the PR app, browse logs, run broad full-suite tests, or keep investigating unless the install, build, targeted tests, or Codex findings show a real blocker.
+Surface the testing block as soon as the install and mergeable check are done. Do not launch the PR app, browse logs, or run broad full-suite tests unless the install or build shows a real blocker.
 
 ---
 
@@ -279,7 +248,7 @@ Reply: "pass" | "fail: <desc>" | "modify: <change>"
 
 On the diff-review path, omit the `Pass:` / `Fail:` criteria entirely. The user is reviewing the Codex findings, not exercising a binary. Only the install path asks the user to verify observable stop-check criteria.
 
-AI_FINDINGS always shown verbatim when review ran; if skipped, one-line reason in the table is sufficient.
+AI_FINDINGS always shown verbatim when a pre-push review verdict exists; if none was recorded, say so in one line rather than leaving the row blank.
 
 **Your final response for this turn must be the testing block above.** Do not replace it with a status recap. Do not keep working after it is surfaced.
 
@@ -483,10 +452,10 @@ Issue re-labeled ready for next attempt
 
 ## Diff-Review Testing Block (default)
 
-Still run Step 2b unless the diff is exclusively cosmetic/style. Then surface the diff-review testing block format from Step 3. Key differences from the install path:
+Surface the diff-review testing block format from Step 3. Key differences from the install path:
 - No attempt count in header (no retry loop for diff-only)
 - No `Pass:` / `Fail:` stop-check criteria — those are only for binary install validation
-- Show AI_FINDINGS verbatim; the user is reviewing the automated findings, not exercising a binary
+- Show AI_FINDINGS verbatim (the pre-push verdict carried from `/implement-stint`); the user is reviewing those findings plus the diff, not exercising a binary
 
 Flip pane status the same as the install path before notifying:
 ```bash
@@ -498,10 +467,8 @@ pipeline_slots_set validate "$ISSUE_NUMBER" "$PR_NUMBER" needs-you "Review the d
 
 ## Rules
 
-- Binary install is the default. Skip only when test evidence says skippable AND no apps/ changes AND changes are purely cosmetic.
-- Step 2b quality checks (Codex diff review) run unless skipped by the skip gate — assess the diff, then decide
-- Skip conditions: cosmetic/style-only changes; diff under 5 lines; apps/-only changes. Always run for sdk/ changes.
-- Do not run Codex review more than twice in one validation attempt without checking with Ian
+- Binary install is the default. Skip only per the Test Evidence conclusion (single source: `/testing` Step 5), with the `apps/`-changed and Done-When overrides.
+- **This skill runs no AI diff review.** Pre-push Codex review is owned by `/implement-stint` Phase 4 — see "Who reviews what" there. Validation owns install and user acceptance, not review.
 - Cosmetic = colors, spacing, font sizes, help strings, markdown, config values, UI copy — anything where human visual verification is the only meaningful check
 - Do not run cargo tests during validation unless Codex review names a specific risk that needs a specific test command
 - AI_FINDINGS is always shown verbatim — never summarized or filtered


### PR DESCRIPTION
## Summary

Implements stint 0470. No linked GitHub issue — stint is authoritative.

An audit found the ship-lifecycle skills doing the same work up to four times per PR, plus several self-contradictions where an edit landed on one half of a doc and not the other. Every claim was verified against the actual files before changing anything.

## What changed

**Worker briefs stop at PR-open.** The pipeline auto-chains `implement-stint` → `open-pr` → `validate-pr`, so a babysitter worker following the skills literally installs the build itself (~5 min compile the tester then repeats), re-reviews the diff, and parks on a `[TESTING]` block waiting for a reply that never comes. `open-pr` and `implement-stint` now honor an explicit stop-at-PR-open mode.

**One AI review, not four.** Review is owned solely by `implement-stint` Phase 4 (pre-push, cheapest place to fix). Removed `validate-pr`'s duplicate Codex pass — it now carries the pre-push verdict into the testing block.

**Documented that CI is not a review layer.** `CodeRabbit` reports "Review skipped: automatic reviews are disabled" on every PR and the `claude` check skips on Rust-only diffs. A green `gh pr checks` means "nothing red", not "reviewed" — the skills now say so rather than implying CI has the diff covered.

**Install-skip has one definition.** It was defined three times and they disagreed; `validate-pr` also contradicted itself (its table honored `install skippable — full coverage` while its Rules demanded cosmetic-only, making a pure-logic change with full harness coverage simultaneously skippable and forbidden). `/testing` Step 5 is now the single source; the others consume its conclusion verbatim.

**Babysitter's stale halves resolved** — each was a live contradiction:
- sub-agent reads: Rules said always delegate, loop step 2 said direct reads are the default and cheaper. Kept the cheap default.
- auto-merge: Rules said surface-and-wait by default, step 5 read as merge-on-PASS. **This one actually bit** — a run auto-merged its first batch without asking.
- tester suites: brief said "don't re-run suites", docs-only path said run `just test`.
- Codex: the cheatsheet, tester spawn, and the entire 5-hour usage-window section drove a TUI that isn't running — panes are Claude Code via `c`.

**`create-stint` works unattended.** Its confirmation gate deadlocked any agent filing a follow-up stint mid-run. Added an autonomous path that records the decision in the task body instead of blocking.

Also documented the backtick trap in `plexi pane send` briefs, which broke two sends during the run that surfaced this work.

## Test evidence

- `just check-docs`: CLI, config, SDK, PGAP capability, docs-coverage, and authoring checks all green
- Conclusion: `docs-only — no test evidence required` — skills markdown only, no code path touched

Net −2 lines: more contradiction deleted than guidance added.

## Follow-up

Stint 0471 (blocked on this) converges the two merge procedures and adds the stint-first/no-issue path through `open-pr`/`validate-pr`.