### PR TITLE
ui: migrate rename and Secrets hints to shared primitives

### DIFF
--- a/src/app/secrets_app.rs
+++ b/src/app/secrets_app.rs
@@ -397,6 +397,7 @@ impl App for SecretsApp {
 
         const HEADER_H: f32 = 44.0;
         const FORM_H: f32 = 212.0;
+        const FORM_PAD_H: f32 = 20.0;
 
         // Process clipboard copy request (needs ui.ctx() — not available in handle_key).
         if self.copy_pending {
@@ -488,8 +489,20 @@ impl App for SecretsApp {
 
         // ── Add form (when active) ───────────────────────────────────────────
         if self.mode == Mode::Adding {
+            let hints = [
+                HintGroup::new(&["Tab"], "advance"),
+                HintGroup::new(&["Enter"], "save"),
+                HintGroup::new(&["Esc"], "cancel"),
+            ];
+            let form_content_width = (rect.width() - FORM_PAD_H * 2.0).max(0.0);
+            let hint_width = hints.iter().map(|group| group.width(ui)).sum::<f32>()
+                + style::SPACE_MD * hints.len().saturating_sub(1) as f32;
+            let wrap_hints = hint_width > form_content_width;
+            let wrapped_hint_row_h =
+                style::SPACE_MD + style::TEXT_HINT + style::KEYCHIP_PAD_V * 2.0;
             let available_form_h = (rect.bottom() - list_top).max(0.0);
-            let form_h = FORM_H.min(available_form_h);
+            let desired_form_h = FORM_H + if wrap_hints { wrapped_hint_row_h } else { 0.0 };
+            let form_h = desired_form_h.min(available_form_h);
             let form_rect =
                 egui::Rect::from_min_max(egui::pos2(rect.left(), rect.bottom() - form_h), rect.max);
             ui.painter().rect_filled(form_rect, 0.0, colors.bg_sidebar);
@@ -501,14 +514,14 @@ impl App for SecretsApp {
                 egui::Stroke::new(1.0_f32, colors.border),
             );
 
-            let vertical_padding = if form_h < FORM_H {
+            let vertical_padding = if form_h < desired_form_h {
                 0.0
             } else {
                 style::SPACE_SM * 2.0
             };
             let mut form_ui = ui.new_child(
                 egui::UiBuilder::new()
-                    .max_rect(form_rect.shrink2(egui::vec2(20.0, vertical_padding))),
+                    .max_rect(form_rect.shrink2(egui::vec2(FORM_PAD_H, vertical_padding))),
             );
 
             form_ui.vertical(|ui| {
@@ -619,12 +632,12 @@ impl App for SecretsApp {
                     }
                 });
 
-                let hints = [
-                    HintGroup::new(&["Tab"], "advance"),
-                    HintGroup::new(&["Enter"], "save"),
-                    HintGroup::new(&["Esc"], "cancel"),
-                ];
-                HintBar::new(&hints).show(ui, colors);
+                if wrap_hints {
+                    HintBar::new(&hints[..2]).show(ui, colors);
+                    HintBar::new(&hints[2..]).show(ui, colors);
+                } else {
+                    HintBar::new(&hints).show(ui, colors);
+                }
             });
 
             if form_rect.top() > list_top + 1.0 {

--- a/src/app/secrets_app.rs
+++ b/src/app/secrets_app.rs
@@ -1,4 +1,5 @@
 use crate::app::app_trait::{App, AppCommand, AppRenderContext};
+use crate::ui::hints::{HintBar, HintGroup};
 use crate::ui::{labels, row, shortcuts, style};
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -395,7 +396,7 @@ impl App for SecretsApp {
         ui.painter().rect_filled(rect, 0.0, colors.terminal_bg);
 
         const HEADER_H: f32 = 44.0;
-        const FORM_H: f32 = 140.0;
+        const FORM_H: f32 = 212.0;
 
         // Process clipboard copy request (needs ui.ctx() — not available in handle_key).
         if self.copy_pending {
@@ -487,8 +488,10 @@ impl App for SecretsApp {
 
         // ── Add form (when active) ───────────────────────────────────────────
         if self.mode == Mode::Adding {
+            let available_form_h = (rect.bottom() - list_top).max(0.0);
+            let form_h = FORM_H.min(available_form_h);
             let form_rect =
-                egui::Rect::from_min_max(egui::pos2(rect.left(), rect.bottom() - FORM_H), rect.max);
+                egui::Rect::from_min_max(egui::pos2(rect.left(), rect.bottom() - form_h), rect.max);
             ui.painter().rect_filled(form_rect, 0.0, colors.bg_sidebar);
             ui.painter().line_segment(
                 [
@@ -498,9 +501,14 @@ impl App for SecretsApp {
                 egui::Stroke::new(1.0_f32, colors.border),
             );
 
+            let vertical_padding = if form_h < FORM_H {
+                0.0
+            } else {
+                style::SPACE_SM * 2.0
+            };
             let mut form_ui = ui.new_child(
                 egui::UiBuilder::new()
-                    .max_rect(form_rect.shrink2(egui::vec2(20.0, style::SPACE_SM * 2.0))),
+                    .max_rect(form_rect.shrink2(egui::vec2(20.0, vertical_padding))),
             );
 
             form_ui.vertical(|ui| {
@@ -609,22 +617,23 @@ impl App for SecretsApp {
                     {
                         self.cancel_add();
                     }
-                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        ui.label(
-                            egui::RichText::new("Tab to advance · Enter to save · Esc to cancel")
-                                .color(colors.text_dim.linear_multiply(0.6))
-                                .size(style::TEXT_HINT)
-                                .family(egui::FontFamily::Monospace),
-                        );
-                    });
                 });
+
+                let hints = [
+                    HintGroup::new(&["Tab"], "advance"),
+                    HintGroup::new(&["Enter"], "save"),
+                    HintGroup::new(&["Esc"], "cancel"),
+                ];
+                HintBar::new(&hints).show(ui, colors);
             });
 
-            let list_rect = egui::Rect::from_min_max(
-                egui::pos2(rect.left(), list_top),
-                egui::pos2(rect.right(), form_rect.top() - 1.0),
-            );
-            self.draw_list(ui, colors, list_rect);
+            if form_rect.top() > list_top + 1.0 {
+                let list_rect = egui::Rect::from_min_max(
+                    egui::pos2(rect.left(), list_top),
+                    egui::pos2(rect.right(), form_rect.top() - 1.0),
+                );
+                self.draw_list(ui, colors, list_rect);
+            }
         } else {
             let list_rect = egui::Rect::from_min_max(egui::pos2(rect.left(), list_top), rect.max);
             self.draw_list(ui, colors, list_rect);

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -10,6 +10,7 @@ use crate::ui::hints::{HintBar, HintGroup};
 use crate::ui::list::{self, ListRow};
 use crate::ui::overlay::ModalShell;
 use crate::ui::style;
+use crate::ui::text_field::TextField;
 use crate::ui::theme::Colors;
 use egui::{Color32, CornerRadius, Stroke, StrokeKind};
 use image::imageops::FilterType;
@@ -1682,27 +1683,11 @@ impl FileBrowserApp {
             .title("Rename")
             .escape(true)
             .show(ctx, colors, |ui| {
-                let text_response = ui
-                    .scope(|ui| {
-                        // egui's caret is hidden (transparent, non-blinking);
-                        // draw_text_caret paints a glyph-height replacement on top.
-                        ui.visuals_mut().text_cursor.blink = false;
-                        ui.visuals_mut().text_cursor.stroke.color = egui::Color32::TRANSPARENT;
-                        let font_id = egui::TextStyle::Body.resolve(ui.style());
-                        let row_height = ui.fonts(|f| f.row_height(&font_id));
-                        let output = egui::TextEdit::singleline(&mut self.rename_buffer)
-                            .desired_width(f32::INFINITY)
-                            .show(ui);
-                        crate::ui::text_field::draw_text_caret(
-                            ui,
-                            &output,
-                            font_id.size,
-                            row_height,
-                            egui::Stroke::new(1.0_f32, colors.accent),
-                        );
-                        output.response
-                    })
-                    .inner;
+                let text_response = TextField::singleline(
+                    egui::Id::new(("file_browser_rename_input", pane_key)),
+                    "",
+                )
+                .show(ui, &mut self.rename_buffer, colors);
                 // Claim the rename field while the modal is open (stint 0429):
                 // the reconciler grants it while this pane owns input and
                 // surrenders it if ownership moves elsewhere.

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -1688,6 +1688,8 @@ impl FileBrowserApp {
                     "",
                 )
                 .show(ui, &mut self.rename_buffer, colors);
+                let submitted = text_response.lost_focus()
+                    && ui.input(|input| input.key_pressed(egui::Key::Enter));
                 // Claim the rename field while the modal is open (stint 0429):
                 // the reconciler grants it while this pane owns input and
                 // surrenders it if ownership moves elsewhere.
@@ -1696,6 +1698,9 @@ impl FileBrowserApp {
                     crate::ui::focus::SurfaceKey::Pane(pane_key),
                     text_response.id,
                 );
+                if submitted {
+                    self.confirm_rename_modal();
+                }
                 ui.add_space(style::SPACE_MD);
                 ui.horizontal(|ui| {
                     if ui.button("Cancel").clicked() {

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -587,6 +587,39 @@ mod tests {
         );
     }
 
+    #[test]
+    fn file_browser_rename_text_field_commits_on_enter() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let original = dir.path().join("original.txt");
+        let renamed = dir.path().join("renamed.txt");
+        std::fs::write(&original, b"contents").expect("write fixture");
+
+        let mut h = PlexiUiHarness::new_sized(720.0, 520.0);
+        h.open_file_browser(dir.path().to_path_buf());
+        h.run_steps(2);
+        h.harness()
+            .press_key_modifiers(egui::Modifiers::COMMAND, egui::Key::R);
+        h.run_steps(3);
+
+        h.harness()
+            .press_key_modifiers(egui::Modifiers::COMMAND, egui::Key::A);
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::Text("renamed.txt".to_string()));
+        h.step();
+        h.harness()
+            .press_key_modifiers(egui::Modifiers::NONE, egui::Key::Enter);
+        h.run_steps(2);
+
+        assert!(!original.exists(), "Enter must rename the original path");
+        assert!(renamed.exists(), "Enter must create the renamed path");
+        assert_eq!(
+            std::fs::read(&renamed).expect("read renamed file"),
+            b"contents"
+        );
+    }
+
     /// Render the initial empty state and save a screenshot for visual inspection.
     /// File written to /tmp/plexi_init.png.
     #[test]
@@ -1819,11 +1852,14 @@ mod tests {
         let img = h.render().expect("render failed");
         img.save("/tmp/plexi_catppuccin_latte_palette.png")
             .expect("save screenshot");
-        let center = img.get_pixel(img.width() / 2, img.height() / 2).0;
-        let center_luma = (u16::from(center[0]) + u16::from(center[1]) + u16::from(center[2])) / 3;
+        // Probe the blank right gutter inside the modal. The image center can
+        // land on a command description as the registered app list changes.
+        let surface = img.get_pixel(img.width() * 3 / 4, img.height() / 2).0;
+        let center_luma =
+            (u16::from(surface[0]) + u16::from(surface[1]) + u16::from(surface[2])) / 3;
         assert!(
             center_luma > 180,
-            "Catppuccin Latte palette center should be light, got rgba={center:?}"
+            "Catppuccin Latte palette surface should be light, got rgba={surface:?}"
         );
         println!("Screenshot saved to /tmp/plexi_catppuccin_latte_palette.png");
     }

--- a/tests/scenes/file-browser-rename.toml
+++ b/tests/scenes/file-browser-rename.toml
@@ -1,0 +1,17 @@
+# File Browser rename modal uses the shared text-field chrome.
+size = [720.0, 520.0]
+
+[[steps]]
+open = { kind = "builtin", id = "file_browser", cwd = ".", as = "files" }
+
+[[steps]]
+key = { target = "files", value = "cmd+r" }
+
+[[steps]]
+run_steps = 3
+
+[[steps]]
+assert_label = { target = "host", label = "Rename" }
+
+[[steps]]
+shot = "file-browser-rename.png"

--- a/tests/scenes/secrets-add-form.toml
+++ b/tests/scenes/secrets-add-form.toml
@@ -1,5 +1,5 @@
 # Secrets add form keeps actions separate from the shared shortcut hint bar.
-size = [520.0, 280.0]
+size = [290.0, 360.0]
 
 [[steps]]
 open = { kind = "builtin", id = "secrets_manager", as = "secrets" }

--- a/tests/scenes/secrets-add-form.toml
+++ b/tests/scenes/secrets-add-form.toml
@@ -1,0 +1,18 @@
+# Secrets add form keeps actions separate from the shared shortcut hint bar.
+size = [520.0, 280.0]
+
+[[steps]]
+open = { kind = "builtin", id = "secrets_manager", as = "secrets" }
+
+[[steps]]
+# Bare printable scene keys become text events; Shift+N reaches the native key handler.
+key = { target = "secrets", value = "shift+n" }
+
+[[steps]]
+run_steps = 3
+
+[[steps]]
+assert_label = { target = "secrets", label = "New Secret" }
+
+[[steps]]
+shot = "secrets-add-form.png"


### PR DESCRIPTION
## Summary

- move File Browser rename input onto the shared `TextField` while retaining its pane-scoped focus claim
- commit rename on the shared single-line field's Enter focus-loss, with a filesystem regression test
- render Secrets add-form shortcuts through `HintBar` and wrap complete hint groups at constrained widths
- reserve the wrapped footer row from measured content width and keep the visual scene at 290 px
- stabilize the existing Catppuccin light screenshot probe so registered-app text cannot cause a false failure

## Rejection fixes

- File Browser: installed PR build renamed the selected fixture on Enter, closed the modal, changed the on-disk path, and logged `file_browser: renamed ...`.
- Secrets: pane-cropped installed-host capture at 291 x 863 shows `Tab advance` and `Enter save` on the first row and centered `Esc cancel` on the second, with no clipping.
- Alpha baseline: the unchanged Host UI Gallery three-group `HintBar` clips `dismiss` at 290 px. General primitive overflow is tracked in stint 0492; this PR keeps the Secrets correction scoped to its callsite.

## Test evidence

- `cargo build`: passed
- `RUST_TEST_THREADS=1 cargo test --bin plexi`: `test result: ok. 1547 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 231.83s`
- `just scene tests/scenes/secrets-add-form.toml /tmp/plexi-scenes-0491 1`: passed; inspected the 290 x 360 PNG
- installed `pr-2453`: verified File Browser Enter rename against disk and log output
- installed `pr-2453`: inspected `/tmp/plexi-0491-secrets-live-290.png` from sanctioned `host screenshot --pane` capture
- `cargo fmt --all --check`: repository-wide failure on unchanged alpha formatting (4,257 output lines under Rust 1.97); no formatter diff points at the changed regions
- docs generation/checks: not applicable; no doc or schema source changed
- Conclusion: binary install required - visible native UI and keyboard focus paths changed

## Stint

0491
