### PR TITLE
ui: unify Assistant composer and notification copy (stint 0493)

### DIFF
--- a/src/assistant/render.rs
+++ b/src/assistant/render.rs
@@ -19,6 +19,7 @@ use crate::ui::button::{chrome_button, ButtonKind};
 use crate::ui::hints::{HintBar, HintGroup};
 use crate::ui::list::ListRow;
 use crate::ui::style;
+use crate::ui::text_field::TextArea;
 use crate::ui::theme::Colors;
 
 use crate::app_protocol::ModelTier;
@@ -1331,76 +1332,21 @@ impl AssistantRenderer {
             ))
             .show(ui, |ui| {
                 ui.set_width(ui.available_width());
-                // Glyph-height caret, unified with every other host text input
-                // (see `text_field::draw_text_caret`): hide egui's full-row
-                // caret (transparent + no blink) and paint a replacement that
-                // matches the glyph height on top.
-                ui.visuals_mut().text_cursor.blink = false;
-                ui.visuals_mut().text_cursor.stroke.color = egui::Color32::TRANSPARENT;
-                // The TextEdit reports its own height; the ScrollArea caps it at
-                // `max_text_h` and scrolls past that. No hand-rolled galley
-                // measurement — same shape as the quick-note composer. Measuring
-                // the height ourselves fought the TextEdit's real layout (it
-                // wraps against a width already reduced by the floating
-                // scrollbar's reserved gutter), which flashed a stray scrollbar
-                // mid-growth.
-                egui::ScrollArea::vertical()
-                    .id_salt("assistant_composer_scroll")
-                    .max_height(max_text_h)
-                    .show(ui, |ui| {
-                        let output = egui::TextEdit::multiline(&mut model.composer)
-                            .id(te_id)
-                            .desired_rows(1)
-                            .desired_width(f32::INFINITY)
-                            .frame(egui::Frame::NONE)
-                            // Left padding beyond egui's default `symmetric(4,
-                            // 2)` margin, so the caret and hint text never
-                            // sit flush against the composer's edge.
-                            .margin(egui::Margin {
-                                left: 6,
-                                right: 4,
-                                top: 2,
-                                bottom: 2,
-                            })
-                            // The hint galley (rendered at its own, smaller
-                            // size below) and the real-text/caret galley
-                            // otherwise both default to top-aligned, which
-                            // reads as off-center whenever their line
-                            // heights differ. Center both so the composer's
-                            // single row always looks vertically balanced.
-                            .vertical_align(egui::Align::Center)
-                            // Keep Tab in the composer: without the focus
-                            // lock, egui's frame-start focus traversal
-                            // moves focus away before the picker's Tab
-                            // handler ever sees the key.
-                            .lock_focus(true)
-                            // Plain Enter is consumed for submit before
-                            // the TextEdit runs; Shift+Enter is the
-                            // newline key (the default return_key is
-                            // unmodified Enter, so Shift+Enter would
-                            // otherwise insert nothing).
-                            .return_key(Some(egui::KeyboardShortcut::new(
-                                egui::Modifiers::SHIFT,
-                                egui::Key::Enter,
-                            )))
-                            .hint_text(
-                                RichText::new("Message the assistant — / for commands")
-                                    .size(style::TEXT_CAPTION)
-                                    .color(colors.text_dim),
-                            )
-                            .font(font_id.clone())
-                            .show(ui);
-                        crate::ui::text_field::draw_text_caret(
-                            ui,
-                            &output,
-                            style::TEXT_BODY,
-                            row_height,
-                            egui::Stroke::new(1.0_f32, colors.accent),
-                        );
-                        if output.response.changed() {
-                            model.reset_history_recall();
-                        }
-                    });
+                // TextArea owns multiline growth, overflow scrolling, focus
+                // lock, newline semantics, and the shared glyph-height caret.
+                let response = TextArea::composer(
+                    te_id,
+                    RichText::new("Message the assistant — / for commands")
+                        .size(style::TEXT_CAPTION)
+                        .color(colors.text_dim),
+                )
+                .max_height(max_text_h)
+                .font(font_id)
+                .hint_color(colors.text_dim)
+                .show(ui, &mut model.composer, colors);
+                if response.changed() {
+                    model.reset_history_recall();
+                }
             });
         frame_response.response.rect
     }

--- a/src/overlays/notification_modal.rs
+++ b/src/overlays/notification_modal.rs
@@ -324,27 +324,11 @@ impl PlexiApp {
 
                 ui.add_space(style::SPACE_XL);
 
-                // Title — centered, large.
-                ui.vertical_centered(|ui| {
-                    ui.label(
-                        RichText::new(&notif.title)
-                            .size(style::TEXT_TITLE_XL)
-                            .color(self.colors.text_primary)
-                            .strong(),
-                    );
-                });
+                crate::ui::typography::modal_title_large(ui, &notif.title, &self.colors);
 
-                // Body — centered under the title.
                 if !notif.body.is_empty() {
                     ui.add_space(style::SPACE_MD);
-                    ui.vertical_centered(|ui| {
-                        ui.set_max_width(style::MODAL_WIDTH_NOTIFY - 120.0);
-                        ui.label(
-                            RichText::new(&notif.body)
-                                .size(style::TEXT_BODY)
-                                .color(self.colors.text_primary),
-                        );
-                    });
+                    crate::ui::typography::modal_body(ui, &notif.body, &self.colors);
                 }
 
                 // Image attachment (#74) — renders above the

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -160,6 +160,11 @@ pub enum Step {
     Close { close: String },
     /// Toggle the host sidebar.
     Sidebar { sidebar: bool },
+    /// Seed one message notification through the real host modal render path.
+    /// Headless-only: live scenes must create notifications through an app.
+    SeedNotification {
+        seed_notification: NotificationSeedSpec,
+    },
     /// Switch to the context at this router index.
     SwitchContext { switch_context: usize },
     /// Push the focused pane into a new subcontext with this name.
@@ -176,6 +181,14 @@ pub enum Step {
     AssertLabel { assert_label: AssertLabelSpec },
     /// Save a headless screenshot to `<out_dir>/<name>`.
     Shot { shot: String },
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct NotificationSeedSpec {
+    pub title: String,
+    #[serde(default)]
+    pub body: String,
 }
 
 /// One generic app-opening request. `kind` determines which production launch
@@ -1213,6 +1226,10 @@ impl LiveBackend {
                 "unsupported_live_verb",
                 "sidebar mutation has no sanctioned live CLI/IPC command",
             )),
+            Step::SeedNotification { .. } => Err(SceneError::new(
+                "unsupported_live_verb",
+                "seed_notification is headless-only; live scenes must notify through an app",
+            )),
         }
     }
 
@@ -1645,6 +1662,9 @@ fn step_label(step: &Step) -> String {
         Step::Focus { focus } => format!("focus {focus}"),
         Step::Close { close } => format!("close {close}"),
         Step::Sidebar { sidebar } => format!("sidebar {sidebar}"),
+        Step::SeedNotification { seed_notification } => {
+            format!("seed_notification {:?}", seed_notification.title)
+        }
         Step::SwitchContext { switch_context } => format!("switch_context {switch_context}"),
         Step::PushToSubcontext { push_to_subcontext } => {
             format!("push_to_subcontext {push_to_subcontext}")
@@ -1860,6 +1880,46 @@ impl HeadlessBackend {
                 self.h.with_app_mut(|app| app.sidebar_visible = v);
                 self.h.step();
                 Ok(None)
+            }
+            Step::SeedNotification { seed_notification } => {
+                let title = seed_notification.title.clone();
+                let body = seed_notification.body.clone();
+                let id = self.h.with_app_mut(|app| {
+                    let id = format!("__scene_notification_{}", app.pending_notifications.len());
+                    app.pending_notifications
+                        .push(crate::app::PendingNotification {
+                            notify_id: id.clone(),
+                            sender_pane_id: 0,
+                            source_context_id: 0,
+                            source_window_id: 0,
+                            level: "info".to_string(),
+                            title,
+                            body,
+                            kind: crate::app_protocol::NotifyKind::Message,
+                            options: Vec::new(),
+                            input_prompt: None,
+                            required: false,
+                            priority: 0,
+                            scope: crate::app_protocol::NotifyScope::Global,
+                            image_inline: None,
+                            image_pipe_id: None,
+                            response_file: None,
+                            timeout_secs: None,
+                            on_dismiss: None,
+                            enqueued_at: std::time::Instant::now(),
+                            tombstoned: false,
+                            deliver_after: None,
+                        });
+                    app.show_notification_modal = true;
+                    if app.current_notify_id.is_none() {
+                        app.current_notify_id = Some(id.clone());
+                    }
+                    id
+                });
+                self.h.run_steps(2);
+                Ok(Some(StepDetail::Message {
+                    message: format!("seeded notification {id}"),
+                }))
             }
             Step::SwitchContext { switch_context } => {
                 let idx = *switch_context;

--- a/src/ui/overlay.rs
+++ b/src/ui/overlay.rs
@@ -119,6 +119,12 @@ impl<'a> ModalShell<'a> {
             && ctx.input_mut(|i| i.consume_key(egui::Modifiers::NONE, egui::Key::Escape));
 
         let screen = ctx.content_rect();
+        // Modal widths are preferred content widths, not permission to draw
+        // outside a narrow viewport. Preserve one spacing token of edge
+        // clearance in addition to the frame's horizontal padding.
+        let available_content_width =
+            (screen.width() - 2.0 * (style::SPACE_MD + f32::from(style::MODAL_PADDING_H))).max(0.0);
+        let content_width = self.width.min(available_content_width);
         if self.scrim_strength > 0.0 {
             let alpha = (self.scrim_strength * 255.0).round() as u8;
             // Scrim sits one layer below the modal so an elevated modal
@@ -173,7 +179,7 @@ impl<'a> ModalShell<'a> {
                     .show(ui, |ui| {
                         // width(0.0) = auto-size to content (toasts, pills).
                         if self.width > 0.0 {
-                            ui.set_width(self.width);
+                            ui.set_width(content_width);
                         }
                         if let Some(title) = self.title {
                             crate::ui::typography::modal_title(ui, title, colors);

--- a/src/ui/text_field.rs
+++ b/src/ui/text_field.rs
@@ -211,6 +211,9 @@ pub(crate) struct TextArea<'a> {
     hint_color: Option<egui::Color32>,
     margin: egui::Margin,
     frame: bool,
+    vertical_align: egui::Align,
+    lock_focus: bool,
+    return_key: Option<egui::KeyboardShortcut>,
     log_name: &'a str,
 }
 
@@ -229,8 +232,38 @@ impl<'a> TextArea<'a> {
             hint_color: None,
             margin: egui::Margin::symmetric(8, 5),
             frame: true,
+            vertical_align: egui::Align::Min,
+            lock_focus: false,
+            // Preserve egui TextEdit's multiline default unless a semantic
+            // variant reserves Enter for its owner (for example, composer).
+            return_key: Some(egui::KeyboardShortcut::new(
+                egui::Modifiers::NONE,
+                egui::Key::Enter,
+            )),
             log_name: "text_area",
         }
+    }
+
+    /// A one-row composer that grows with wrapped content and keeps Tab in
+    /// the editor. Plain Enter is reserved for the owning surface's submit
+    /// handler; Shift+Enter is the editor's newline shortcut.
+    pub(crate) fn composer(id: egui::Id, hint: impl Into<egui::WidgetText>) -> Self {
+        Self::multiline(id, hint)
+            .rows(1)
+            .frame(false)
+            .margin(egui::Margin {
+                left: 6,
+                right: 4,
+                top: 2,
+                bottom: 2,
+            })
+            .vertical_align(egui::Align::Center)
+            .lock_focus(true)
+            .return_key(egui::KeyboardShortcut::new(
+                egui::Modifiers::SHIFT,
+                egui::Key::Enter,
+            ))
+            .log_name("composer")
     }
 
     /// See [`TextField::surface`].
@@ -289,6 +322,21 @@ impl<'a> TextArea<'a> {
         self
     }
 
+    fn vertical_align(mut self, vertical_align: egui::Align) -> Self {
+        self.vertical_align = vertical_align;
+        self
+    }
+
+    fn lock_focus(mut self, lock_focus: bool) -> Self {
+        self.lock_focus = lock_focus;
+        self
+    }
+
+    fn return_key(mut self, return_key: egui::KeyboardShortcut) -> Self {
+        self.return_key = Some(return_key);
+        self
+    }
+
     pub(crate) fn log_name(mut self, log_name: &'a str) -> Self {
         self.log_name = log_name;
         self
@@ -306,6 +354,7 @@ impl<'a> TextArea<'a> {
         let log_name = self.log_name;
         let response = if let Some(max_height) = self.max_height {
             egui::ScrollArea::vertical()
+                .id_salt(id.with("scroll"))
                 .max_height(max_height)
                 .show(ui, |ui| self.show_editor(ui, buf, colors))
                 .inner
@@ -353,6 +402,9 @@ impl<'a> TextArea<'a> {
                 .desired_width(self.desired_width)
                 .desired_rows(self.rows)
                 .margin(self.margin)
+                .vertical_align(self.vertical_align)
+                .lock_focus(self.lock_focus)
+                .return_key(self.return_key)
                 .hint_text(hint);
             let edit = if self.frame {
                 edit
@@ -370,5 +422,38 @@ impl<'a> TextArea<'a> {
             output.response.response
         })
         .inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn composer_reserves_plain_enter_and_uses_shift_enter_for_newlines() {
+        let area = TextArea::composer(egui::Id::new("composer"), "hint");
+
+        assert_eq!(area.rows, 1);
+        assert!(area.lock_focus);
+        assert_eq!(
+            area.return_key,
+            Some(egui::KeyboardShortcut::new(
+                egui::Modifiers::SHIFT,
+                egui::Key::Enter,
+            ))
+        );
+    }
+
+    #[test]
+    fn ordinary_text_area_keeps_plain_enter_newlines() {
+        let area = TextArea::multiline(egui::Id::new("ordinary"), "hint");
+
+        assert_eq!(
+            area.return_key,
+            Some(egui::KeyboardShortcut::new(
+                egui::Modifiers::NONE,
+                egui::Key::Enter,
+            ))
+        );
     }
 }

--- a/src/ui/typography.rs
+++ b/src/ui/typography.rs
@@ -15,6 +15,24 @@ pub(crate) fn modal_title(ui: &mut Ui, text: &str, colors: &Colors) -> Response 
     ))
 }
 
+/// Large modal heading with the modal shell's default start alignment.
+pub(crate) fn modal_title_large(ui: &mut Ui, text: &str, colors: &Colors) -> Response {
+    ui.add(wrapped_label(
+        RichText::new(text)
+            .font(theme::font_medium(style::TEXT_TITLE_XL))
+            .color(colors.text_primary),
+    ))
+}
+
+/// Primary modal copy with the modal shell's default start alignment.
+pub(crate) fn modal_body(ui: &mut Ui, text: &str, colors: &Colors) -> Response {
+    ui.add(wrapped_label(
+        RichText::new(text)
+            .size(style::TEXT_BODY)
+            .color(colors.text_primary),
+    ))
+}
+
 pub(crate) fn body(ui: &mut Ui, text: impl Into<String>, colors: &Colors) -> Response {
     ui.add(wrapped_label(
         RichText::new(text.into())

--- a/tests/scenes/assistant-composer.toml
+++ b/tests/scenes/assistant-composer.toml
@@ -8,15 +8,47 @@ open = { kind = "builtin", id = "assistant", as = "assistant" }
 [[steps]]
 run_steps = 2
 
-# Stint 0423: pristine empty composer — hint text and caret must read as
-# vertically centered with left breathing room, not flush against the edge.
-# The hint is painted directly (not a `ui.label`), so it isn't visible to
-# `assert_label`; the screenshot is the evidence.
 [[steps]]
 assert = { target = "assistant", exists = true, focused = true, pane_count = 1 }
 
 [[steps]]
 shot = "assistant-composer-empty.png"
+
+[[steps]]
+text = { target = "assistant", value = "A single-line composer message." }
+
+[[steps]]
+run_steps = 2
+
+[[steps]]
+shot = "assistant-composer-one-line.png"
+
+[[steps]]
+key = { target = "assistant", value = "cmd+a" }
+
+[[steps]]
+text = { target = "assistant", value = "This wrapped composer message is deliberately long enough to cross several visual lines while the editor grows naturally with its content and remains anchored above the hint bar." }
+
+[[steps]]
+run_steps = 2
+
+[[steps]]
+shot = "assistant-composer-wrapped.png"
+
+[[steps]]
+key = { target = "assistant", value = "cmd+a" }
+
+[[steps]]
+text = { target = "assistant", value = "Maximum-height composer line one.\nLine two keeps growing.\nLine three keeps growing.\nLine four keeps growing.\nLine five keeps growing.\nLine six keeps growing.\nLine seven keeps growing.\nLine eight keeps growing.\nLine nine keeps growing.\nLine ten proves overflow scrolling." }
+
+[[steps]]
+run_steps = 2
+
+[[steps]]
+shot = "assistant-composer-max-height.png"
+
+[[steps]]
+key = { target = "assistant", value = "cmd+a" }
 
 [[steps]]
 text = { target = "assistant", value = "/help" }

--- a/tests/scenes/notification-modal-short-narrow.toml
+++ b/tests/scenes/notification-modal-short-narrow.toml
@@ -1,0 +1,10 @@
+size = [520.0, 640.0]
+
+[[steps]]
+seed_notification = { title = "Build complete", body = "The release candidate is ready." }
+
+[[steps]]
+assert_label = { target = "host", label = "Build complete" }
+
+[[steps]]
+shot = "notification-modal-short-narrow.png"

--- a/tests/scenes/notification-modal-short-wide.toml
+++ b/tests/scenes/notification-modal-short-wide.toml
@@ -1,0 +1,10 @@
+size = [1280.0, 800.0]
+
+[[steps]]
+seed_notification = { title = "Build complete", body = "The release candidate is ready." }
+
+[[steps]]
+assert_label = { target = "host", label = "Build complete" }
+
+[[steps]]
+shot = "notification-modal-short-wide.png"

--- a/tests/scenes/notification-modal-wrapped-narrow.toml
+++ b/tests/scenes/notification-modal-wrapped-narrow.toml
@@ -1,0 +1,10 @@
+size = [520.0, 640.0]
+
+[[steps]]
+seed_notification = { title = "The workspace synchronization needs your attention before publishing can continue", body = "A remote update changed files used by this release. Review the affected paths, resolve the differences, and run validation again before publishing the workspace." }
+
+[[steps]]
+assert_label = { target = "host", label = "The workspace synchronization needs your attention before publishing can continue" }
+
+[[steps]]
+shot = "notification-modal-wrapped-narrow.png"

--- a/tests/scenes/notification-modal-wrapped-wide.toml
+++ b/tests/scenes/notification-modal-wrapped-wide.toml
@@ -1,0 +1,10 @@
+size = [1280.0, 800.0]
+
+[[steps]]
+seed_notification = { title = "The workspace synchronization needs your attention before publishing can continue", body = "A remote update changed files used by this release. Review the affected paths, resolve the differences, and run validation again before publishing the workspace." }
+
+[[steps]]
+assert_label = { target = "host", label = "The workspace synchronization needs your attention before publishing can continue" }
+
+[[steps]]
+shot = "notification-modal-wrapped-wide.png"


### PR DESCRIPTION
## Summary

Implements stint 0493. No linked GitHub issue — stint is authoritative.

- Moves the Assistant composer onto a semantic shared `TextArea` variant that owns growth, overflow scrolling, focus locking, Shift+Enter newlines, and the shared caret.
- Moves notification title/body rendering onto start-aligned modal typography and constrains preferred modal width on narrow viewports.
- Adds headless scene coverage for one-line, wrapped, and max-height composer states plus short/wrapped notification copy at narrow and wide sizes.

## Done When

- Assistant composer uses shared TextArea while preserving growth-to-content, internal scrolling, Shift+Enter newline, and Enter submit.
- Notification title and body align to start through shared modal/typography primitives; intended status/image fallbacks remain centered.
- Required headless visual matrix is rendered and inspected.

## Test Plan

- `RUST_TEST_THREADS=1 cargo test --bin plexi`
  - `test result: ok. 1549 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out`
- `cargo build`
  - `Finished dev profile`
- `just scene tests/scenes/assistant-composer.toml`
- `just scene tests/scenes/notification-modal-short-narrow.toml`
- `just scene tests/scenes/notification-modal-short-wide.toml`
- `just scene tests/scenes/notification-modal-wrapped-narrow.toml`
- `just scene tests/scenes/notification-modal-wrapped-wide.toml`
- `git diff --check`

## Formatting

`cargo fmt --all --check` reports the existing alpha-wide rustfmt backlog (4,257 diff lines, including vendored `deps/egui_term` and unrelated source files). This PR does not broaden scope into a repository-wide mechanical format rewrite; its changed blocks and staged diff were checked directly.