### PR TITLE
Make cargo tests ignore ambient Plexi state (stint 0494)

### DIFF
--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ website-smoke:
 
 # Run the full test suite — HostHarness regression tests + unit tests.
 test:
-    cargo test
+    env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID cargo test
 
 # Rebuild the WASM POC components and refresh the committed test fixtures the
 # host runtime gate tests load (G3/G5 etc). Run after changing any
@@ -417,7 +417,7 @@ ship +issues:
 scene FILE out="/tmp/plexi-scenes" shots="1":
     PLEXI_SCENE={{FILE}} PLEXI_SCENE_OUT={{out}} \
     {{ if shots == "0" { "PLEXI_SCENE_NO_SHOTS=1" } else { "" } }} \
-    cargo test --bin plexi scene_single -- --ignored --exact scenes::tests::scene_single --nocapture
+    env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID cargo test --bin plexi scene_single -- --ignored --exact scenes::tests::scene_single --nocapture
 
 # Run the same TOML scene against an explicit installed host channel.
 # The runner owns and tears down the host unless PLEXI_SCENE_ATTACH=1 is set.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -958,6 +958,7 @@ pub fn workspace_channel_dir() -> String {
     if let Some(Some(profile)) = PROFILE_OVERRIDE.get() {
         return format!(".plexi-{profile}");
     }
+    #[cfg(not(test))]
     if let Some(channel) = std::env::var("PLEXI_CHANNEL")
         .ok()
         .filter(|c| !c.is_empty())
@@ -966,15 +967,32 @@ pub fn workspace_channel_dir() -> String {
         return format!(".plexi-{channel}");
     }
     static CHANNEL_DIR: OnceLock<String> = OnceLock::new();
-    CHANNEL_DIR
-        .get_or_init(|| {
-            let basename = std::env::current_exe()
-                .ok()
-                .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
-                .unwrap_or_else(|| "plexi".to_string());
-            channel_suffix_from_basename(&basename)
-        })
-        .clone()
+    #[cfg(not(test))]
+    {
+        return CHANNEL_DIR
+            .get_or_init(|| {
+                let basename = std::env::current_exe()
+                    .ok()
+                    .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+                    .unwrap_or_else(|| "plexi".to_string());
+                channel_suffix_from_basename(&basename)
+            })
+            .clone();
+    }
+    #[cfg(test)]
+    {
+        let channel_dir = CHANNEL_DIR
+            .get_or_init(|| {
+                let basename = std::env::current_exe()
+                    .ok()
+                    .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+                    .unwrap_or_else(|| "plexi".to_string());
+                channel_suffix_from_basename(&basename)
+            })
+            .clone();
+        assert_test_profile_is_isolated(&channel_dir);
+        channel_dir
+    }
 }
 
 /// Returns the config directory name based on the running binary basename.
@@ -986,6 +1004,7 @@ fn config_dir_name() -> String {
     if let Some(Some(profile)) = PROFILE_OVERRIDE.get() {
         return format!(".plexi-{profile}");
     }
+    #[cfg(not(test))]
     if let Some(channel) = std::env::var("PLEXI_CHANNEL")
         .ok()
         .filter(|c| !c.is_empty())
@@ -993,11 +1012,38 @@ fn config_dir_name() -> String {
         log::info!("config_dir_name: using PLEXI_CHANNEL={channel}");
         return format!(".plexi-{channel}");
     }
-    let basename = std::env::current_exe()
-        .ok()
-        .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
-        .unwrap_or_else(|| "plexi".to_string());
-    channel_suffix_from_basename(&basename)
+    #[cfg(not(test))]
+    {
+        let basename = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .unwrap_or_else(|| "plexi".to_string());
+        return channel_suffix_from_basename(&basename);
+    }
+    #[cfg(test)]
+    {
+        let basename = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .unwrap_or_else(|| "plexi".to_string());
+        let channel_dir = channel_suffix_from_basename(&basename);
+        assert_test_profile_is_isolated(&channel_dir);
+        channel_dir
+    }
+}
+
+#[cfg(test)]
+fn assert_test_profile_is_isolated(dir: &str) {
+    let is_real_profile = matches!(
+        dir,
+        ".plexi" | ".plexi-alpha" | ".plexi-beta" | ".plexi-stable"
+    ) || dir
+        .strip_prefix(".plexi-pr-")
+        .is_some_and(|suffix| !suffix.is_empty());
+    assert!(
+        !is_real_profile,
+        "test resolved config/workspace state to real channel profile dir {dir:?}; use set_test_profile_dir for isolated test state"
+    );
 }
 
 pub fn config_path() -> PathBuf {
@@ -1615,6 +1661,35 @@ mod tests {
     fn workspace_channel_dir_respects_test_channel_override() {
         let _guard = set_test_channel("pr-999");
         assert_eq!(workspace_channel_dir(), ".plexi-pr-999");
+    }
+
+    #[test]
+    fn ambient_channel_does_not_select_a_real_profile_in_tests_child() {
+        if std::env::var_os("TEST_AMBIENT_CHANNEL_CHILD").is_none() {
+            return;
+        }
+        assert_ne!(workspace_channel_dir(), ".plexi-beta");
+        assert_ne!(config_dir_name(), ".plexi-beta");
+    }
+
+    #[test]
+    fn ambient_channel_does_not_select_a_real_profile_in_tests() {
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "config::tests::ambient_channel_does_not_select_a_real_profile_in_tests_child",
+            ])
+            .env("PLEXI_CHANNEL", "beta")
+            .env("TEST_AMBIENT_CHANNEL_CHILD", "1")
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    #[test]
+    #[should_panic(expected = "real channel profile dir \".plexi-beta\"")]
+    fn isolated_profile_guard_names_real_profile_dir() {
+        assert_test_profile_is_isolated(".plexi-beta");
     }
 
     fn write(path: &Path, contents: &str) {

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -591,18 +591,30 @@ mod tests {
         h.open_file_browser(dir.path().to_path_buf());
         h.run_steps(2);
         h.harness()
-            .press_key_modifiers(egui::Modifiers::COMMAND, egui::Key::R);
+            .key_down_modifiers(egui::Modifiers::COMMAND, egui::Key::R);
+        h.step();
+        h.harness()
+            .key_up_modifiers(egui::Modifiers::COMMAND, egui::Key::R);
+        h.step();
         h.run_steps(3);
 
         h.harness()
-            .press_key_modifiers(egui::Modifiers::COMMAND, egui::Key::A);
+            .key_down_modifiers(egui::Modifiers::COMMAND, egui::Key::A);
+        h.step();
+        h.harness()
+            .key_up_modifiers(egui::Modifiers::COMMAND, egui::Key::A);
+        h.step();
         h.harness()
             .input_mut()
             .events
             .push(egui::Event::Text("renamed.txt".to_string()));
         h.step();
         h.harness()
-            .press_key_modifiers(egui::Modifiers::NONE, egui::Key::Enter);
+            .key_down_modifiers(egui::Modifiers::NONE, egui::Key::Enter);
+        h.step();
+        h.harness()
+            .key_up_modifiers(egui::Modifiers::NONE, egui::Key::Enter);
+        h.step();
         h.run_steps(2);
 
         assert!(!original.exists(), "Enter must rename the original path");


### PR DESCRIPTION
## Summary

Implements stint 0494. No linked GitHub issue; stint is authoritative.

- Ignore ambient `PLEXI_CHANNEL` during test-only config and workspace resolution.
- Panic when fallback test resolution selects a real channel profile, with guidance to use `set_test_profile_dir`.
- Strip inherited Plexi pane and context variables from Just test recipes.
- Update the stale egui test helper calls required for the alpha test suite to compile.

## Done When

- Test builds resolve through the thread-local override, `PROFILE_OVERRIDE`, then the hash-suffixed throwaway profile.
- A child-process regression proves `PLEXI_CHANNEL=beta` cannot select `.plexi-beta`.
- Real profile fallback names fail fast in tests.
- Production channel resolution remains unchanged.

## Test evidence

- `env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID cargo test --bin plexi`: 1552 passed, 0 failed, 2 ignored.
- `cargo fmt --all --check`: passed.
- `cargo build`: passed.
- Codex review: no actionable regression found.
- Conclusion: install skippable; this is test-only resolution and test-runner coverage with no production behavior change.