### PR TITLE
fix(ui): wrap HintBar groups at constrained widths (stint 0492)

### DIFF
--- a/src/app/secrets_app.rs
+++ b/src/app/secrets_app.rs
@@ -495,13 +495,9 @@ impl App for SecretsApp {
                 HintGroup::new(&["Esc"], "cancel"),
             ];
             let form_content_width = (rect.width() - FORM_PAD_H * 2.0).max(0.0);
-            let hint_width = hints.iter().map(|group| group.width(ui)).sum::<f32>()
-                + style::SPACE_MD * hints.len().saturating_sub(1) as f32;
-            let wrap_hints = hint_width > form_content_width;
-            let wrapped_hint_row_h =
-                style::SPACE_MD + style::TEXT_HINT + style::KEYCHIP_PAD_V * 2.0;
             let available_form_h = (rect.bottom() - list_top).max(0.0);
-            let desired_form_h = FORM_H + if wrap_hints { wrapped_hint_row_h } else { 0.0 };
+            let desired_form_h =
+                FORM_H + HintBar::new(&hints).additional_height(ui, form_content_width);
             let form_h = desired_form_h.min(available_form_h);
             let form_rect =
                 egui::Rect::from_min_max(egui::pos2(rect.left(), rect.bottom() - form_h), rect.max);
@@ -632,12 +628,7 @@ impl App for SecretsApp {
                     }
                 });
 
-                if wrap_hints {
-                    HintBar::new(&hints[..2]).show(ui, colors);
-                    HintBar::new(&hints[2..]).show(ui, colors);
-                } else {
-                    HintBar::new(&hints).show(ui, colors);
-                }
+                HintBar::new(&hints).show(ui, colors);
             });
 
             if form_rect.top() > list_top + 1.0 {

--- a/src/ui/hints.rs
+++ b/src/ui/hints.rs
@@ -1,6 +1,7 @@
 use crate::ui::shortcuts;
 use crate::ui::style;
 use crate::ui::theme::Colors;
+use std::ops::Range;
 
 pub(crate) struct HintGroup<'a> {
     combos: HintCombos<'a>,
@@ -60,6 +61,14 @@ impl<'a> HintBar<'a> {
         Self { groups }
     }
 
+    /// Extra vertical space needed beyond the first row at `available_width`.
+    /// Fixed-height callers can reserve this without duplicating the packing
+    /// policy that `show` uses.
+    pub(crate) fn additional_height(&self, ui: &egui::Ui, available_width: f32) -> f32 {
+        self.rows(ui, available_width).len().saturating_sub(1) as f32
+            * (hint_row_height(ui) + ui.spacing().item_spacing.y)
+    }
+
     pub(crate) fn show(self, ui: &mut egui::Ui, colors: &Colors) {
         let full = ui.available_width();
 
@@ -69,15 +78,77 @@ impl<'a> HintBar<'a> {
         // own bottom padding closes them out symmetrically.
         ui.add_space(style::SPACE_MD);
 
-        // Center the hint groups in the footer.
-        let total: f32 = self.groups.iter().map(|g| g.width(ui)).sum::<f32>()
-            + style::SPACE_MD * self.groups.len().saturating_sub(1) as f32;
-        ui.horizontal(|ui| {
-            ui.spacing_mut().item_spacing.x = style::SPACE_MD;
-            ui.add_space(((full - total) / 2.0).max(0.0));
-            for group in self.groups {
-                group.show(ui, colors);
-            }
-        });
+        let widths: Vec<f32> = self.groups.iter().map(|group| group.width(ui)).collect();
+        for row in hint_rows(&widths, full, style::SPACE_MD) {
+            let total = widths[row.clone()].iter().sum::<f32>()
+                + style::SPACE_MD * row.len().saturating_sub(1) as f32;
+            ui.horizontal(|ui| {
+                ui.spacing_mut().item_spacing.x = style::SPACE_MD;
+                ui.add_space(((full - total) / 2.0).max(0.0));
+                for group in &self.groups[row] {
+                    group.show(ui, colors);
+                }
+            });
+        }
+    }
+
+    fn rows(&self, ui: &egui::Ui, available_width: f32) -> Vec<Range<usize>> {
+        let widths: Vec<f32> = self.groups.iter().map(|group| group.width(ui)).collect();
+        hint_rows(&widths, available_width, style::SPACE_MD)
+    }
+}
+
+fn hint_row_height(ui: &egui::Ui) -> f32 {
+    ui.fonts_mut(|fonts| {
+        fonts
+            .layout_no_wrap(
+                "M".to_owned(),
+                egui::FontId::monospace(style::TEXT_CAPTION),
+                egui::Color32::WHITE,
+            )
+            .size()
+            .y
+    }) + style::KEYCHIP_PAD_V * 2.0
+}
+
+fn hint_rows(widths: &[f32], available: f32, gap: f32) -> Vec<Range<usize>> {
+    let mut rows = Vec::new();
+    let mut start = 0;
+    let mut row_width = 0.0;
+
+    for (index, width) in widths.iter().enumerate() {
+        let next_width = if index == start {
+            *width
+        } else {
+            row_width + gap + width
+        };
+        if index > start && next_width > available {
+            rows.push(start..index);
+            start = index;
+            row_width = *width;
+        } else {
+            row_width = next_width;
+        }
+    }
+    if start < widths.len() {
+        rows.push(start..widths.len());
+    }
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn row_packing_keeps_groups_intact_and_uses_one_row_when_they_fit() {
+        assert_eq!(
+            hint_rows(&[72.0, 64.0, 80.0], 240.0, style::SPACE_MD),
+            vec![0..3]
+        );
+        assert_eq!(
+            hint_rows(&[72.0, 64.0, 80.0], 160.0, style::SPACE_MD),
+            vec![0..2, 2..3]
+        );
     }
 }

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -996,7 +996,7 @@ mod tests {
     }
 
     #[test]
-    fn ui_gallery_overlay_smoke() {
+    fn screenshot_ui_gallery_hint_bar_stays_centered_at_wide_width() {
         let mut h = PlexiUiHarness::new_sized(900.0, 640.0);
         h.step();
         h.with_app_mut(|app| {
@@ -1009,7 +1009,28 @@ mod tests {
         // Modal title and the first section header are real ui.label widgets.
         h.harness().get_by_label("Host UI Gallery");
         h.harness().get_by_label("Chrome primitives");
-        h.save_screenshot("/tmp/plexi_ui_gallery.png")
+        h.harness().get_by_label("palette");
+        h.harness().get_by_label("help");
+        h.harness().get_by_label("dismiss");
+        h.save_screenshot("/tmp/plexi_ui_gallery_hint_bar_wide.png")
+            .expect("render failed");
+    }
+
+    #[test]
+    fn screenshot_ui_gallery_hint_bar_wraps_at_narrow_width() {
+        let mut h = PlexiUiHarness::new_sized(290.0, 640.0);
+        h.step();
+        h.harness().set_size(egui::vec2(290.0, 640.0));
+        h.with_app_mut(|app| {
+            app.show_ui_gallery = true;
+        });
+        h.run_steps(2);
+
+        h.harness().get_by_label("Host UI Gallery");
+        h.harness().get_by_label("palette");
+        h.harness().get_by_label("help");
+        h.harness().get_by_label("dismiss");
+        h.save_screenshot("/tmp/plexi_ui_gallery_hint_bar_narrow.png")
             .expect("render failed");
     }
 


### PR DESCRIPTION
## Summary

Implements stint 0492. No linked GitHub issue; stint is authoritative.

- Pack HintBar groups into centered rows when one row exceeds the available width.
- Let fixed-height Secrets forms reserve the primitive-measured extra row height.
- Cover the host UI gallery at narrow and wide widths.

## Done When

The shared HintBar keeps complete key and label groups readable at constrained widths, without callers duplicating the overflow policy. The Secrets add form remains readable.

**Test evidence (attempt 1):**
- cargo test: targeted packing 1 passed; narrow and wide gallery screenshots 2 passed.
- PlexiUiHarness render: inspected narrow and wide Host UI Gallery renders; each shows palette, help, and dismiss hints without clipped trailing labels.
- cargo fmt --all --check: passed.
- Full stripped-environment cargo test baseline: 1549 passed, 5 failed, 2 ignored; the same five workspace-root failures reproduce on alpha.
- Conclusion: binary install required for visible host UI behavior.