### PR TITLE
fix(testing): isolate HostHarness workspace root to stop ambient-state test leak (stint 0500)

### DIFF
--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -77,6 +77,12 @@ pub struct HostHarness {
     pub last_platform_output: egui::PlatformOutput,
     /// Keeps the per-test tempdir alive for the harness lifetime; auto-deletes on drop.
     _profile_dir: tempfile::TempDir,
+    /// Isolated workspace root for panes the harness creates. Held alive for the
+    /// harness lifetime and auto-deleted on drop, so any channel dir a pane
+    /// writes (e.g. the assistant's `AssistantStore`) lands here — never in the
+    /// shared `std::env::temp_dir()` root, where it would leak into the walk-up
+    /// path of every other test's tempdir.
+    _workspace_dir: tempfile::TempDir,
     /// Keeps the thread-local profile dir override active for the harness lifetime.
     _profile_guard: crate::config::TestProfileDirGuard,
 }
@@ -85,6 +91,8 @@ impl HostHarness {
     /// Create a harness with an empty `PlexiApp` and a 1280×800 viewport.
     pub fn new() -> Self {
         let profile_dir = tempfile::TempDir::new().expect("failed to create test profile tempdir");
+        let workspace_dir =
+            tempfile::TempDir::new().expect("failed to create test workspace tempdir");
         let profile_guard = set_test_profile_dir(profile_dir.path().to_path_buf());
         let ctx = egui::Context::default();
         let frame_tick = Arc::new(AtomicU64::new(0));
@@ -96,6 +104,7 @@ impl HostHarness {
             ipc_tx,
             last_platform_output: egui::PlatformOutput::default(),
             _profile_dir: profile_dir,
+            _workspace_dir: workspace_dir,
             _profile_guard: profile_guard,
         }
     }
@@ -167,7 +176,7 @@ impl HostHarness {
 
         let pane_id = self.next_pane_id;
         self.next_pane_id += 1;
-        let workspace_root = std::env::temp_dir();
+        let workspace_root = self._workspace_dir.path().to_path_buf();
         let assistant = crate::assistant::AssistantApp::new(
             workspace_root.clone(),
             Arc::new(InertBroker),


### PR DESCRIPTION
Fixes stint 0500 (P0). No linked GitHub issue — stint is authoritative.

## Root cause
`resolve_workspace_root()` walks up the filesystem for the channel dir and stops only at `$HOME` or `/`. `HostHarness::split_focused` created the assistant's `AssistantApp` with `std::env::temp_dir()` (the SHARED macOS `$TMPDIR/T` root) as its workspace root, so the assistant store wrote `$TMPDIR/T/.plexi-<hash>`. That leaked channel dir sits in the common ancestor of every `tempfile::tempdir()`, so the five "should return None" workspace-resolution tests instead found it and returned `Some($TMPDIR/T)`.

## Fix
`HostHarness` now owns an isolated per-test `_workspace_dir: TempDir` (held for the harness lifetime, auto-deleted on drop) and hands panes that path instead of the shared temp root. Test-isolation only — no production behavior change to `resolve_workspace_root` or `save_workspace`.

## Test evidence
- The 5 previously-failing tests (`walk_up_stops_at_home`, `no_plexi_dir_in_tree_returns_none`, `workspace_root_returns_none_when_no_dot_plexi`, `registry_loaded_workspace_is_none_outside_workspace`, `plexi_path_arg_with_no_dotplexi_sets_context_path`): all green, `$TMPDIR` clean after.
- `ui_tests::` module (suspected co-polluter): 41 passed, 0 leaked — confirms it uses uuid'd subdirs, not the shared root.
- Diff is `src/testing/mod.rs` only. Install skippable — test-infrastructure change, no runtime/UI behavior.

## Note
`host::wasm_python::tests::headless_frame_fails_fast_when_the_guest_dies_at_import` flakes under full-suite `--test-threads=6` load but passes deterministically in isolation (9.46s). Pre-existing, unrelated to this diff (timing-sensitive fail-fast assertion under parallel contention).