### PR TITLE
fix(testing): deterministic headless guest-death probe (stint 0501)

### DIFF
--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -631,17 +631,23 @@ impl HeadlessPythonSession {
                         return Ok(());
                     }
                 }
-                let stderr = self.runtime.drain_stderr();
-                return Err(WasmPythonError::BridgeJson(format!(
-                    "app exited before responding{}",
-                    if stderr.trim().is_empty() {
-                        String::new()
-                    } else {
-                        format!("\n  stderr:\n{stderr}")
-                    }
-                )));
+                return Err(self.guest_death_error());
             }
             if std::time::Instant::now() > deadline {
+                // A guest that crashed right at the deadline must still be
+                // reported as a death, not a timeout: re-check the process-exit
+                // signal before falling back to the timeout message. Under
+                // parallel-test CPU contention the poll can reach the deadline
+                // in the same window the guest thread is unwinding, and the
+                // cause the caller sees must not flip based on that race.
+                if self.runtime.is_finished() {
+                    for message in self.runtime.drain_messages()? {
+                        if matches(&message) {
+                            return Ok(());
+                        }
+                    }
+                    return Err(self.guest_death_error());
+                }
                 let stderr = self.runtime.drain_stderr();
                 return Err(WasmPythonError::BridgeJson(format!(
                     "timed out waiting for app response after {HEADLESS_DEFAULT_TIMEOUT:?}{}",
@@ -654,6 +660,20 @@ impl HeadlessPythonSession {
             }
             std::thread::sleep(std::time::Duration::from_millis(2));
         }
+    }
+
+    /// The error returned when the guest thread has exited before producing the
+    /// awaited message. Drains stderr so the crash traceback rides along.
+    fn guest_death_error(&self) -> WasmPythonError {
+        let stderr = self.runtime.drain_stderr();
+        WasmPythonError::BridgeJson(format!(
+            "app exited before responding{}",
+            if stderr.trim().is_empty() {
+                String::new()
+            } else {
+                format!("\n  stderr:\n{stderr}")
+            }
+        ))
     }
 }
 
@@ -4062,18 +4082,20 @@ mod tests {
             capabilities: Vec::new(),
             allowed_hosts: Vec::new(),
         };
-        let started = std::time::Instant::now();
         let err = run_headless_frame(&config, (480.0, 320.0), None)
             .expect_err("an entry that raises at import must fail the headless probe");
-        let elapsed = started.elapsed();
-        let message = format!("{err:?}");
+        // The invariant is the *cause*, not the wall clock: a guest that raises
+        // at import is detected via its process-exit signal and reported as a
+        // death, never mistaken for a live app or a poll timeout. Asserting on
+        // elapsed time flakes under parallel-test CPU contention (the crash can
+        // legitimately take longer than the poll budget to surface), so this
+        // checks the error path itself.
+        let WasmPythonError::BridgeJson(message) = &err else {
+            panic!("guest death must surface as a BridgeJson error, got {err:?}");
+        };
         assert!(
             message.contains("app exited before responding"),
-            "must take the guest-death fast path, not the {HEADLESS_DEFAULT_TIMEOUT:?} timeout: {message}"
-        );
-        assert!(
-            elapsed < HEADLESS_DEFAULT_TIMEOUT,
-            "broken guest must fail before the poll timeout, took {elapsed:?}"
+            "broken guest must take the process-exit death path, not the timeout backstop: {message}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes stint **0501** (P2). No linked GitHub issue — stint is authoritative.

`host::wasm_python::tests::headless_frame_fails_fast_when_the_guest_dies_at_import` passed in isolation but flaked under full-suite `cargo test --bin plexi` load, and could stack into a multi-minute apparent hang.

## Root cause

Not a racy fast-path. `WasmPythonRuntime::is_finished()` (a `JoinHandle` process-exit signal) is already a correct, immediate death signal, checked every 2ms in `wait_for` and returned instantly on death. The flake was two things:

1. The test asserted a **wall-clock bound** (`elapsed < HEADLESS_DEFAULT_TIMEOUT`). The CPython-in-WASM interpreter boot is the dominant cost — ~13s even in isolation against the 15s budget — so under 6-way CPU contention boot+crash legitimately approaches/exceeds the budget and the timing assertion flakes.
2. When boot+crash overruns the 15s deadline, `wait_for`'s deadline branch reported a **"timed out"** error instead of the guest-death error, so the `contains("app exited before responding")` assertion could flip to the timeout path even though the guest had died. Each such call also blocked the full 15s, and several stacked into the observed long hang.

## Fix

- **Deadline branch now re-checks `is_finished()`** before falling back to the timeout message. A guest that crashes right at the deadline is reported as a death (`app exited before responding`), never mistaken for a timeout — accurate cause reporting that also removes the message nondeterminism. Extracted the shared guest-death error into `guest_death_error()`.
- **Test asserts the error path/type, not the wall clock**: matches `WasmPythonError::BridgeJson` and the guest-death message; the fragile `elapsed` assertion is gone.

The production timeout value and success path are unchanged (per task non-scope).

## Root-cause note for reviewers

The residual theoretical case is boot itself exceeding 15s with the thread still running at the deadline — genuinely indistinguishable from a hung-but-alive guest, so timing out there is correct. A follow-up could give the headless probe a larger or configurable budget if CPython boot latency keeps creeping toward 15s, but that is out of scope for this determinism fix.

## Test evidence

- `cargo build --bin plexi`: clean (pre-existing `__eh_frame` linker warning only).
- `cargo test --bin plexi headless_frame_fails_fast_when_the_guest_dies_at_import`: **pass** in isolation (13.2s).
- `cargo test --bin plexi host::wasm_python::tests::` (default parallelism): **69 passed, 0 failed, 1 ignored** (14.9s).
- Codex review vs alpha: clean, no actionable regressions.
- Host-logic-only change; no UI surface, no render screenshot required.