### PR TITLE
feat(editor): extract Ferrite-derived shared editor core (stint 0317)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3999,6 +3999,7 @@ dependencies = [
  "regex",
  "rfd",
  "rodio",
+ "ropey",
  "schemars",
  "security-framework",
  "serde",
@@ -4013,6 +4014,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "toml_edit 0.22.27",
+ "unicode-segmentation",
  "ureq",
  "url",
  "uuid",
@@ -4549,6 +4551,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ropey"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
+dependencies = [
+ "smallvec",
+ "str_indices",
+]
+
+[[package]]
 name = "rtrb"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5078,6 +5090,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "str_indices"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
+
+[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5331,7 +5349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ egui_tiles = { version = "0.15.0", features = ["serde"] }
 # Vendored because Plexi's terminal owns keyboard focus and input extraction;
 # upstream egui_term still routes those events through egui's shared queue.
 egui_term = { path = "deps/egui_term" }
+# Shared editor core (stint 0317): rope buffer + grapheme-aware caret movement.
+ropey = "1.6"
+unicode-segmentation = "1.11"
 dirs = "6"
 fern = "0.7"
 log = "0.4"

--- a/src/editor/LICENSE-ferrite
+++ b/src/editor/LICENSE-ferrite
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2025 OlaProeis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -1,0 +1,147 @@
+//! Rope-backed text buffer.
+//!
+//! Adapted from Ferrite <https://github.com/OlaProeis/Ferrite>
+//! @ 3ba085c561670342d72c560efbf6b0b92b5c0b46, MIT.
+
+use ropey::Rope;
+use std::borrow::Cow;
+
+/// A text buffer backed by a rope for O(log n) edits and index conversion.
+///
+/// All indices are char indices unless a method name says otherwise.
+/// Mutation is `pub(crate)`: outside this module tree, edits must go through
+/// the transaction API ([`crate::editor::Document`]).
+#[derive(Debug, Clone, Default)]
+pub struct TextBuffer {
+    rope: Rope,
+}
+
+impl TextBuffer {
+    #[must_use]
+    pub fn from_string(content: &str) -> Self {
+        Self {
+            rope: Rope::from_str(content),
+        }
+    }
+
+    /// Inserts `text` at char position `pos`. Panics if out of bounds;
+    /// callers validate via the transaction API.
+    pub(crate) fn insert(&mut self, pos: usize, text: &str) {
+        self.rope.insert(pos, text);
+    }
+
+    /// Removes `len` chars starting at `pos`. Panics if out of bounds;
+    /// callers validate via the transaction API.
+    pub(crate) fn remove(&mut self, pos: usize, len: usize) {
+        if len > 0 {
+            self.rope.remove(pos..pos + len);
+        }
+    }
+
+    /// Returns the text between char positions `start_char..end_char`,
+    /// clamped to the buffer.
+    #[must_use]
+    pub fn slice(&self, start_char: usize, end_char: usize) -> String {
+        let start = start_char.min(self.len());
+        let end = end_char.min(self.len());
+        if start >= end {
+            return String::new();
+        }
+        self.rope.slice(start..end).to_string()
+    }
+
+    /// Line content including any trailing newline. `None` when out of bounds.
+    #[must_use]
+    pub fn get_line(&self, line_idx: usize) -> Option<Cow<'_, str>> {
+        self.rope.get_line(line_idx).map(Into::into)
+    }
+
+    /// Total number of lines; an empty buffer has one empty line.
+    #[must_use]
+    pub fn line_count(&self) -> usize {
+        self.rope.len_lines()
+    }
+
+    /// Char offset where `line_idx` begins. Panics if out of bounds.
+    #[must_use]
+    pub fn line_to_char(&self, line_idx: usize) -> usize {
+        self.rope.line_to_char(line_idx)
+    }
+
+    /// Line index containing char `char_idx` (may be one past the end).
+    /// Panics if out of bounds.
+    #[must_use]
+    pub fn char_to_line(&self, char_idx: usize) -> usize {
+        self.rope.char_to_line(char_idx)
+    }
+
+    /// Total number of chars.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.rope.len_chars()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rope.len_chars() == 0
+    }
+}
+
+impl std::fmt::Display for TextBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.rope)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_buffer_has_one_line() {
+        let buffer = TextBuffer::default();
+        assert_eq!(buffer.len(), 0);
+        assert!(buffer.is_empty());
+        assert_eq!(buffer.line_count(), 1);
+    }
+
+    #[test]
+    fn insert_and_remove_round_trip() {
+        let mut buffer = TextBuffer::from_string("Hello World");
+        buffer.insert(5, " Beautiful");
+        assert_eq!(buffer.to_string(), "Hello Beautiful World");
+        buffer.remove(5, 10);
+        assert_eq!(buffer.to_string(), "Hello World");
+        buffer.remove(2, 0); // zero-length no-op
+        assert_eq!(buffer.to_string(), "Hello World");
+    }
+
+    #[test]
+    fn line_and_char_conversions() {
+        let buffer = TextBuffer::from_string("Hello\nWorld\nTest");
+        assert_eq!(buffer.line_count(), 3);
+        assert_eq!(buffer.line_to_char(1), 6);
+        assert_eq!(buffer.char_to_line(5), 0);
+        assert_eq!(buffer.char_to_line(6), 1);
+        assert_eq!(buffer.get_line(0).unwrap().as_ref(), "Hello\n");
+        assert_eq!(buffer.get_line(2).unwrap().as_ref(), "Test");
+        assert!(buffer.get_line(3).is_none());
+    }
+
+    #[test]
+    fn slice_clamps_to_bounds() {
+        let buffer = TextBuffer::from_string("Hello, World!");
+        assert_eq!(buffer.slice(7, 12), "World");
+        assert_eq!(buffer.slice(7, 100), "World!");
+        assert_eq!(buffer.slice(5, 5), "");
+    }
+
+    #[test]
+    fn unicode_char_indexing() {
+        let buffer = TextBuffer::from_string("こんにちは\n世界");
+        assert_eq!(buffer.len(), 8);
+        assert_eq!(buffer.line_count(), 2);
+        assert_eq!(buffer.get_line(1).unwrap().as_ref(), "世界");
+        assert_eq!(buffer.slice(6, 8), "世界");
+    }
+}

--- a/src/editor/commands.rs
+++ b/src/editor/commands.rs
@@ -1,0 +1,512 @@
+//! `Document` state machine and its `EditorCommand` dispatch.
+//!
+//! Adapted from Ferrite <https://github.com/OlaProeis/Ferrite>
+//! @ 3ba085c561670342d72c560efbf6b0b92b5c0b46 (editor.rs command handling),
+//! MIT. Diverges from upstream: the 4k-line orchestrator is replaced by this
+//! explicit command API; every buffer mutation is a recorded [`Transaction`].
+
+use super::buffer::TextBuffer;
+use super::cursor::{Cursor, Selection};
+use super::history::EditHistory;
+use super::ime::ImeState;
+use super::movement;
+use super::selection;
+use super::transaction::{EditOperation, Transaction};
+use super::EditorSemanticState;
+
+/// Directional caret movements. `extend: true` moves only the head
+/// (shift-selection).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Movement {
+    Left,
+    Right,
+    Up,
+    Down,
+    WordLeft,
+    WordRight,
+    LineStart,
+    LineEnd,
+    DocStart,
+    DocEnd,
+}
+
+/// Everything the widget (or a test) can ask a [`Document`] to do.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditorCommand {
+    /// Insert text at the caret, replacing any selection.
+    InsertText(String),
+    InsertNewline,
+    /// Delete selection, or one grapheme left of the caret.
+    Backspace,
+    /// Delete selection, or one grapheme right of the caret.
+    DeleteForward,
+    Move { movement: Movement, extend: bool },
+    SetCursor(Cursor),
+    /// Move the head only (mouse drag / shift-click).
+    ExtendTo(Cursor),
+    SelectAll,
+    /// Double-click word selection at a position.
+    SelectWordAt(Cursor),
+    /// Triple-click line selection.
+    SelectLineAt(usize),
+    Undo,
+    Redo,
+    /// IME composition text changed (not inserted into the buffer).
+    ImePreedit(String),
+    /// IME composition committed: inserts the text as one transaction.
+    ImeCommit(String),
+    /// IME composition cancelled.
+    ImeCancel,
+}
+
+/// An editable document: rope buffer, selection, transaction history, and
+/// IME state. All mutation flows through [`Document::apply`].
+#[derive(Debug, Clone)]
+pub struct Document {
+    buffer: TextBuffer,
+    selection: Selection,
+    history: EditHistory,
+    ime: ImeState,
+    /// Column the caret aims for during vertical movement across short lines.
+    goal_column: Option<usize>,
+}
+
+impl Document {
+    #[must_use]
+    pub fn new(text: &str) -> Self {
+        let buffer = TextBuffer::from_string(text);
+        log::info!(
+            "editor: document constructed ({} chars, {} lines)",
+            buffer.len(),
+            buffer.line_count()
+        );
+        Self {
+            buffer,
+            selection: Selection::default(),
+            history: EditHistory::default(),
+            ime: ImeState::default(),
+            goal_column: None,
+        }
+    }
+
+    #[must_use]
+    pub fn buffer(&self) -> &TextBuffer {
+        &self.buffer
+    }
+
+    #[must_use]
+    pub fn selection(&self) -> Selection {
+        self.selection
+    }
+
+    /// The caret position (selection head).
+    #[must_use]
+    pub fn cursor(&self) -> Cursor {
+        self.selection.head
+    }
+
+    #[must_use]
+    pub fn text(&self) -> String {
+        self.buffer.to_string()
+    }
+
+    /// The currently selected text (empty when collapsed).
+    #[must_use]
+    pub fn selected_text(&self) -> String {
+        let (start, end) = self.selection.ordered();
+        self.buffer.slice(
+            movement::cursor_to_char(&self.buffer, start),
+            movement::cursor_to_char(&self.buffer, end),
+        )
+    }
+
+    #[must_use]
+    pub fn ime(&self) -> &ImeState {
+        &self.ime
+    }
+
+    /// Semantic snapshot for host inspection and tests. `scroll_y` comes from
+    /// the caller's view state.
+    #[must_use]
+    pub fn semantic_state(&self, scroll_y: f32) -> EditorSemanticState {
+        EditorSemanticState {
+            text: self.text(),
+            selection: self.selection,
+            cursor: self.cursor(),
+            undo_depth: self.history.undo_depth(),
+            can_undo: self.history.can_undo(),
+            can_redo: self.history.can_redo(),
+            ime_composition: self.ime.preedit().map(str::to_string),
+            scroll_y,
+        }
+    }
+
+    /// Applies a command. The single entry point for all document mutation.
+    pub fn apply(&mut self, command: EditorCommand) {
+        match command {
+            EditorCommand::InsertText(text) => self.insert_text(&text, true),
+            EditorCommand::InsertNewline => self.insert_text("\n", false),
+            EditorCommand::Backspace => self.delete(true),
+            EditorCommand::DeleteForward => self.delete(false),
+            EditorCommand::Move { movement, extend } => self.do_move(movement, extend),
+            EditorCommand::SetCursor(cursor) => {
+                self.set_selection(Selection::collapsed(movement::clamp(&self.buffer, cursor)));
+            }
+            EditorCommand::ExtendTo(cursor) => {
+                let head = movement::clamp(&self.buffer, cursor);
+                self.set_selection(Selection::new(self.selection.anchor, head));
+            }
+            EditorCommand::SelectAll => self.set_selection(selection::select_all(&self.buffer)),
+            EditorCommand::SelectWordAt(cursor) => {
+                let cursor = movement::clamp(&self.buffer, cursor);
+                self.set_selection(selection::word_boundaries(&self.buffer, cursor));
+            }
+            EditorCommand::SelectLineAt(line) => {
+                self.set_selection(selection::line_selection(&self.buffer, line));
+            }
+            EditorCommand::Undo => {
+                if let Some(sel) = self.history.undo(&mut self.buffer) {
+                    self.selection = clamp_selection(&self.buffer, sel);
+                }
+                self.goal_column = None;
+            }
+            EditorCommand::Redo => {
+                if let Some(sel) = self.history.redo(&mut self.buffer) {
+                    self.selection = clamp_selection(&self.buffer, sel);
+                }
+                self.goal_column = None;
+            }
+            EditorCommand::ImePreedit(text) => self.ime.set_preedit(text),
+            EditorCommand::ImeCommit(text) => {
+                self.ime.clear();
+                if !text.is_empty() {
+                    self.insert_text(&text, false);
+                }
+            }
+            EditorCommand::ImeCancel => self.ime.clear(),
+        }
+    }
+
+    fn set_selection(&mut self, selection: Selection) {
+        self.selection = selection;
+        self.goal_column = None;
+        self.history.break_group();
+    }
+
+    /// Inserts `text` at the caret (replacing any selection) as one
+    /// transaction. `coalesce` groups rapid typing into one undo step.
+    fn insert_text(&mut self, text: &str, coalesce: bool) {
+        let selection_before = self.selection;
+        let mut ops = Vec::new();
+        let (start, end) = self.selection.ordered();
+        let start_char = movement::cursor_to_char(&self.buffer, start);
+        if self.selection.is_range() {
+            let end_char = movement::cursor_to_char(&self.buffer, end);
+            ops.push(EditOperation::Delete {
+                pos: start_char,
+                text: self.buffer.slice(start_char, end_char),
+            });
+        }
+        ops.push(EditOperation::Insert {
+            pos: start_char,
+            text: text.to_string(),
+        });
+        let caret_after = start_char + text.chars().count();
+        self.commit(
+            ops,
+            selection_before,
+            caret_after,
+            coalesce && !selection_before.is_range(),
+        );
+    }
+
+    /// Deletes the selection, or one grapheme backward/forward of the caret.
+    fn delete(&mut self, backward: bool) {
+        let selection_before = self.selection;
+        let (start_char, end_char) = if self.selection.is_range() {
+            let (start, end) = self.selection.ordered();
+            (
+                movement::cursor_to_char(&self.buffer, start),
+                movement::cursor_to_char(&self.buffer, end),
+            )
+        } else {
+            let caret = movement::clamp(&self.buffer, self.selection.head);
+            let other = if backward {
+                movement::left(&self.buffer, caret)
+            } else {
+                movement::right(&self.buffer, caret)
+            };
+            let a = movement::cursor_to_char(&self.buffer, other);
+            let b = movement::cursor_to_char(&self.buffer, caret);
+            (a.min(b), a.max(b))
+        };
+        if start_char == end_char {
+            return;
+        }
+        let ops = vec![EditOperation::Delete {
+            pos: start_char,
+            text: self.buffer.slice(start_char, end_char),
+        }];
+        self.commit(ops, selection_before, start_char, false);
+    }
+
+    /// Applies `ops` as one transaction, records it, and moves the caret to
+    /// `caret_after` (a char index). Invalid transactions are logged and
+    /// dropped without mutating anything.
+    fn commit(
+        &mut self,
+        ops: Vec<EditOperation>,
+        selection_before: Selection,
+        caret_after: usize,
+        coalesce: bool,
+    ) {
+        let mut transaction = Transaction {
+            ops,
+            selection_before,
+            selection_after: selection_before,
+        };
+        if let Err(e) = transaction.apply(&mut self.buffer) {
+            log::error!("editor: invalid transaction application: {e}");
+            return;
+        }
+        let caret = movement::char_to_cursor(&self.buffer, caret_after);
+        transaction.selection_after = Selection::collapsed(caret);
+        self.selection = transaction.selection_after;
+        self.goal_column = None;
+        self.history.record(transaction, coalesce);
+    }
+
+    fn do_move(&mut self, m: Movement, extend: bool) {
+        let head = self.selection.head;
+        let goal = match m {
+            Movement::Up | Movement::Down => *self.goal_column.get_or_insert(head.column),
+            _ => head.column,
+        };
+        let new_head = match m {
+            Movement::Left => movement::left(&self.buffer, head),
+            Movement::Right => movement::right(&self.buffer, head),
+            Movement::Up => movement::up(&self.buffer, head, goal),
+            Movement::Down => movement::down(&self.buffer, head, goal),
+            Movement::WordLeft => movement::word_left(&self.buffer, head),
+            Movement::WordRight => movement::word_right(&self.buffer, head),
+            Movement::LineStart => movement::line_start(head),
+            Movement::LineEnd => movement::line_end(&self.buffer, head),
+            Movement::DocStart => movement::doc_start(),
+            Movement::DocEnd => movement::doc_end(&self.buffer),
+        };
+        // Collapsing a selection with plain left/right jumps to its edge.
+        let new_head = if !extend
+            && self.selection.is_range()
+            && matches!(m, Movement::Left | Movement::Right)
+        {
+            let (start, end) = self.selection.ordered();
+            if m == Movement::Left {
+                start
+            } else {
+                end
+            }
+        } else {
+            new_head
+        };
+        self.selection = if extend {
+            Selection::new(self.selection.anchor, new_head)
+        } else {
+            Selection::collapsed(new_head)
+        };
+        if !matches!(m, Movement::Up | Movement::Down) {
+            self.goal_column = None;
+        }
+        self.history.break_group();
+    }
+}
+
+fn clamp_selection(buffer: &TextBuffer, sel: Selection) -> Selection {
+    Selection::new(
+        movement::clamp(buffer, sel.anchor),
+        movement::clamp(buffer, sel.head),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn doc(s: &str) -> Document {
+        Document::new(s)
+    }
+
+    #[test]
+    fn typing_inserts_and_moves_caret() {
+        let mut d = doc("");
+        d.apply(EditorCommand::InsertText("héllo".into()));
+        assert_eq!(d.text(), "héllo");
+        assert_eq!(d.cursor(), Cursor::new(0, 5));
+    }
+
+    #[test]
+    fn insert_replaces_selection_atomically() {
+        let mut d = doc("Hello World");
+        d.apply(EditorCommand::SetCursor(Cursor::new(0, 6)));
+        d.apply(EditorCommand::ExtendTo(Cursor::new(0, 11)));
+        d.apply(EditorCommand::InsertText("Plexi".into()));
+        assert_eq!(d.text(), "Hello Plexi");
+        // Single undo restores both delete and insert.
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "Hello World");
+        assert_eq!(d.selection().ordered().1, Cursor::new(0, 11));
+    }
+
+    #[test]
+    fn backspace_deletes_grapheme_cluster() {
+        let mut d = doc("a👨\u{200D}👩\u{200D}👧");
+        d.apply(EditorCommand::Move {
+            movement: Movement::DocEnd,
+            extend: false,
+        });
+        d.apply(EditorCommand::Backspace);
+        assert_eq!(d.text(), "a");
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "a👨\u{200D}👩\u{200D}👧");
+    }
+
+    #[test]
+    fn backspace_at_line_start_joins_lines() {
+        let mut d = doc("ab\ncd");
+        d.apply(EditorCommand::SetCursor(Cursor::new(1, 0)));
+        d.apply(EditorCommand::Backspace);
+        assert_eq!(d.text(), "abcd");
+        assert_eq!(d.cursor(), Cursor::new(0, 2));
+    }
+
+    #[test]
+    fn delete_forward_on_empty_doc_is_noop() {
+        let mut d = doc("");
+        d.apply(EditorCommand::DeleteForward);
+        d.apply(EditorCommand::Backspace);
+        assert_eq!(d.text(), "");
+        assert!(!d.semantic_state(0.0).can_undo);
+    }
+
+    #[test]
+    fn typing_coalesces_but_movement_breaks_group() {
+        let mut d = doc("");
+        d.apply(EditorCommand::InsertText("a".into()));
+        d.apply(EditorCommand::InsertText("b".into()));
+        d.apply(EditorCommand::Move {
+            movement: Movement::Left,
+            extend: false,
+        });
+        d.apply(EditorCommand::InsertText("c".into()));
+        assert_eq!(d.text(), "acb");
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "ab");
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "");
+    }
+
+    #[test]
+    fn redo_invalidated_by_new_edit() {
+        let mut d = doc("");
+        d.apply(EditorCommand::InsertText("a".into()));
+        d.apply(EditorCommand::Undo);
+        assert!(d.semantic_state(0.0).can_redo);
+        d.apply(EditorCommand::InsertText("z".into()));
+        let state = d.semantic_state(0.0);
+        assert!(!state.can_redo);
+        assert_eq!(state.text, "z");
+    }
+
+    #[test]
+    fn multiline_selection_delete() {
+        let mut d = doc("one\ntwo\nthree");
+        d.apply(EditorCommand::SetCursor(Cursor::new(0, 2)));
+        d.apply(EditorCommand::ExtendTo(Cursor::new(2, 3)));
+        assert_eq!(d.selected_text(), "e\ntwo\nthr");
+        d.apply(EditorCommand::Backspace);
+        assert_eq!(d.text(), "onee");
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "one\ntwo\nthree");
+    }
+
+    #[test]
+    fn select_all_and_word_and_line() {
+        let mut d = doc("foo bar\nbaz");
+        d.apply(EditorCommand::SelectAll);
+        assert_eq!(d.selected_text(), "foo bar\nbaz");
+        d.apply(EditorCommand::SelectWordAt(Cursor::new(0, 5)));
+        assert_eq!(d.selected_text(), "bar");
+        d.apply(EditorCommand::SelectLineAt(0));
+        assert_eq!(d.selected_text(), "foo bar\n");
+    }
+
+    #[test]
+    fn vertical_movement_keeps_goal_column() {
+        let mut d = doc("longest line\nab\nanother long");
+        d.apply(EditorCommand::SetCursor(Cursor::new(0, 8)));
+        d.apply(EditorCommand::Move {
+            movement: Movement::Down,
+            extend: false,
+        });
+        assert_eq!(d.cursor(), Cursor::new(1, 2));
+        d.apply(EditorCommand::Move {
+            movement: Movement::Down,
+            extend: false,
+        });
+        assert_eq!(d.cursor(), Cursor::new(2, 8));
+    }
+
+    #[test]
+    fn shift_movement_extends_selection() {
+        let mut d = doc("hello world");
+        d.apply(EditorCommand::Move {
+            movement: Movement::WordRight,
+            extend: true,
+        });
+        assert_eq!(d.selected_text(), "hello");
+        // Plain right collapses to selection end.
+        d.apply(EditorCommand::Move {
+            movement: Movement::Right,
+            extend: false,
+        });
+        assert!(!d.selection().is_range());
+        assert_eq!(d.cursor(), Cursor::new(0, 5));
+    }
+
+    #[test]
+    fn ime_commit_and_cancel() {
+        let mut d = doc("x");
+        d.apply(EditorCommand::SetCursor(Cursor::new(0, 1)));
+        d.apply(EditorCommand::ImePreedit("かん".into()));
+        // Preedit never touches the buffer.
+        assert_eq!(d.text(), "x");
+        assert_eq!(
+            d.semantic_state(0.0).ime_composition,
+            Some("かん".to_string())
+        );
+        d.apply(EditorCommand::ImeCommit("漢字".into()));
+        assert_eq!(d.text(), "x漢字");
+        assert_eq!(d.semantic_state(0.0).ime_composition, None);
+
+        d.apply(EditorCommand::ImePreedit("あ".into()));
+        d.apply(EditorCommand::ImeCancel);
+        assert_eq!(d.text(), "x漢字");
+        assert!(!d.ime().is_composing());
+        // Commit is undoable like any transaction.
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "x");
+    }
+
+    #[test]
+    fn undo_restores_selection() {
+        let mut d = doc("abc");
+        d.apply(EditorCommand::SelectAll);
+        d.apply(EditorCommand::InsertText("z".into()));
+        assert_eq!(d.text(), "z");
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "abc");
+        assert_eq!(d.selected_text(), "abc");
+        d.apply(EditorCommand::Redo);
+        assert_eq!(d.text(), "z");
+        assert_eq!(d.cursor(), Cursor::new(0, 1));
+    }
+}

--- a/src/editor/cursor.rs
+++ b/src/editor/cursor.rs
@@ -1,0 +1,114 @@
+//! Cursor position and anchor/head selection model.
+//!
+//! Adapted from Ferrite <https://github.com/OlaProeis/Ferrite>
+//! @ 3ba085c561670342d72c560efbf6b0b92b5c0b46, MIT.
+
+/// Caret position: zero-indexed (line, char column).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Cursor {
+    pub line: usize,
+    pub column: usize,
+}
+
+impl Cursor {
+    #[must_use]
+    pub fn new(line: usize, column: usize) -> Self {
+        Self { line, column }
+    }
+}
+
+impl PartialOrd for Cursor {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Cursor {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (self.line, self.column).cmp(&(other.line, other.column))
+    }
+}
+
+/// Selection between an `anchor` (fixed) and `head` (moving caret).
+/// Anchor and head may be in either document order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Selection {
+    pub anchor: Cursor,
+    pub head: Cursor,
+}
+
+impl Selection {
+    #[must_use]
+    pub fn new(anchor: Cursor, head: Cursor) -> Self {
+        Self { anchor, head }
+    }
+
+    /// Cursor with no range.
+    #[must_use]
+    pub fn collapsed(cursor: Cursor) -> Self {
+        Self {
+            anchor: cursor,
+            head: cursor,
+        }
+    }
+
+    #[must_use]
+    pub fn is_range(&self) -> bool {
+        self.anchor != self.head
+    }
+
+    /// Returns (start, end) in document order.
+    #[must_use]
+    pub fn ordered(&self) -> (Cursor, Cursor) {
+        if self.anchor <= self.head {
+            (self.anchor, self.head)
+        } else {
+            (self.head, self.anchor)
+        }
+    }
+
+    /// True when `line` intersects the selection's line span.
+    #[must_use]
+    pub fn touches_line(&self, line: usize) -> bool {
+        let (start, end) = self.ordered();
+        line >= start.line && line <= end.line
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_ordering_is_line_then_column() {
+        assert!(Cursor::new(0, 5) < Cursor::new(0, 10));
+        assert!(Cursor::new(0, 10) < Cursor::new(1, 0));
+        assert_eq!(Cursor::new(2, 3), Cursor::new(2, 3));
+    }
+
+    #[test]
+    fn ordered_normalizes_backward_selection() {
+        let sel = Selection::new(Cursor::new(2, 5), Cursor::new(0, 3));
+        let (start, end) = sel.ordered();
+        assert_eq!(start, Cursor::new(0, 3));
+        assert_eq!(end, Cursor::new(2, 5));
+        assert!(sel.is_range());
+    }
+
+    #[test]
+    fn collapsed_selection_has_no_range() {
+        let sel = Selection::collapsed(Cursor::new(1, 4));
+        assert!(!sel.is_range());
+        assert_eq!(sel.anchor, sel.head);
+    }
+
+    #[test]
+    fn touches_line_spans_multiline_selection() {
+        let sel = Selection::new(Cursor::new(2, 5), Cursor::new(4, 1));
+        assert!(!sel.touches_line(1));
+        assert!(sel.touches_line(2));
+        assert!(sel.touches_line(3));
+        assert!(sel.touches_line(4));
+        assert!(!sel.touches_line(5));
+    }
+}

--- a/src/editor/grapheme.rs
+++ b/src/editor/grapheme.rs
@@ -1,0 +1,138 @@
+//! Grapheme cluster boundary helpers for caret navigation.
+//!
+//! Adapted from Ferrite <https://github.com/OlaProeis/Ferrite>
+//! @ 3ba085c561670342d72c560efbf6b0b92b5c0b46, MIT.
+
+use unicode_segmentation::UnicodeSegmentation;
+
+/// Char-column of the previous grapheme cluster boundary (snaps backward when
+/// `char_col` falls inside a cluster; 0 at the start).
+#[must_use]
+pub fn prev_grapheme_boundary(line_text: &str, char_col: usize) -> usize {
+    let mut prev_start = 0;
+    let mut char_offset = 0;
+    for grapheme in line_text.graphemes(true) {
+        if char_offset >= char_col {
+            return prev_start;
+        }
+        prev_start = char_offset;
+        char_offset += grapheme.chars().count();
+    }
+    prev_start
+}
+
+/// Char-column just past the grapheme cluster containing `char_col`
+/// (total char count at the end).
+#[must_use]
+pub fn next_grapheme_boundary(line_text: &str, char_col: usize) -> usize {
+    let mut char_offset = 0;
+    for grapheme in line_text.graphemes(true) {
+        let grapheme_end = char_offset + grapheme.chars().count();
+        if char_col < grapheme_end {
+            return grapheme_end;
+        }
+        char_offset = grapheme_end;
+    }
+    char_offset
+}
+
+/// Snaps `char_col` to the start of the grapheme cluster containing it
+/// (identity when already on a boundary; total char count when past the end).
+#[must_use]
+pub fn snap_to_boundary(line_text: &str, char_col: usize) -> usize {
+    let mut offset = 0;
+    for grapheme in line_text.graphemes(true) {
+        let end = offset + grapheme.chars().count();
+        if char_col < end {
+            return offset;
+        }
+        offset = end;
+    }
+    offset
+}
+
+/// Line text with exactly one trailing `\n` / `\r\n` terminator stripped, as
+/// returned by `TextBuffer::get_line`. A `\r` that is document content (not
+/// part of a CRLF terminator) is preserved.
+#[must_use]
+pub fn line_text_stripped(line: &str) -> &str {
+    if let Some(s) = line.strip_suffix("\r\n") {
+        s
+    } else {
+        line.strip_suffix('\n').unwrap_or(line)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latin_boundaries() {
+        assert_eq!(prev_grapheme_boundary("Hello", 3), 2);
+        assert_eq!(prev_grapheme_boundary("Hello", 0), 0);
+        assert_eq!(next_grapheme_boundary("Hello", 2), 3);
+        assert_eq!(next_grapheme_boundary("Hello", 5), 5);
+    }
+
+    #[test]
+    fn emoji_zwj_family_is_single_cluster() {
+        // 👨‍👩‍👧 = 5 chars, 1 grapheme
+        let s = "👨\u{200D}👩\u{200D}👧";
+        assert_eq!(s.chars().count(), 5);
+        assert_eq!(next_grapheme_boundary(s, 0), 5);
+        assert_eq!(prev_grapheme_boundary(s, 5), 0);
+        // Mid-cluster snaps
+        assert_eq!(prev_grapheme_boundary(s, 2), 0);
+        assert_eq!(next_grapheme_boundary(s, 2), 5);
+    }
+
+    #[test]
+    fn emoji_with_surrounding_latin() {
+        let s = "ab👨\u{200D}👩\u{200D}👧cd";
+        assert_eq!(next_grapheme_boundary(s, 1), 2);
+        assert_eq!(next_grapheme_boundary(s, 2), 7);
+        assert_eq!(prev_grapheme_boundary(s, 7), 2);
+        assert_eq!(prev_grapheme_boundary(s, 2), 1);
+    }
+
+    #[test]
+    fn combining_diacritics_are_one_cluster() {
+        // "e" + combining acute = 2 chars, 1 grapheme
+        let s = "e\u{0301}";
+        assert_eq!(next_grapheme_boundary(s, 0), 2);
+        assert_eq!(prev_grapheme_boundary(s, 2), 0);
+    }
+
+    #[test]
+    fn korean_conjoining_jamo() {
+        let s = "\u{1112}\u{1161}\u{11AB}"; // 3 chars, 1 grapheme
+        assert_eq!(next_grapheme_boundary(s, 0), 3);
+        assert_eq!(prev_grapheme_boundary(s, 3), 0);
+    }
+
+    #[test]
+    fn empty_string_boundaries() {
+        assert_eq!(prev_grapheme_boundary("", 0), 0);
+        assert_eq!(next_grapheme_boundary("", 0), 0);
+    }
+
+    #[test]
+    fn strips_exactly_one_line_terminator() {
+        assert_eq!(line_text_stripped("Hello\n"), "Hello");
+        assert_eq!(line_text_stripped("Hello\r\n"), "Hello");
+        assert_eq!(line_text_stripped("Hello"), "Hello");
+        // A bare trailing \r is content, not a terminator.
+        assert_eq!(line_text_stripped("Hello\r"), "Hello\r");
+    }
+
+    #[test]
+    fn snap_to_boundary_lands_on_cluster_starts() {
+        let s = "e\u{0301}x"; // é(2 chars) + x
+        assert_eq!(snap_to_boundary(s, 0), 0);
+        assert_eq!(snap_to_boundary(s, 1), 0); // inside the cluster
+        assert_eq!(snap_to_boundary(s, 2), 2);
+        assert_eq!(snap_to_boundary(s, 3), 3);
+        assert_eq!(snap_to_boundary(s, 99), 3);
+    }
+}

--- a/src/editor/history.rs
+++ b/src/editor/history.rs
@@ -1,0 +1,202 @@
+//! Grouped undo/redo over transactions, with typing coalescing.
+//!
+//! Adapted from Ferrite <https://github.com/OlaProeis/Ferrite>
+//! @ 3ba085c561670342d72c560efbf6b0b92b5c0b46 (history.rs), MIT.
+//! Diverges from upstream: groups hold [`Transaction`]s (which carry
+//! selections), and consecutive coalescible records merge into the open group
+//! until [`EditHistory::break_group`] is called.
+
+use super::buffer::TextBuffer;
+use super::cursor::Selection;
+use super::transaction::Transaction;
+
+/// Maximum retained undo groups; operations are small so this can be large.
+const MAX_GROUPS: usize = 500;
+
+#[derive(Debug, Clone)]
+struct Group {
+    transactions: Vec<Transaction>,
+}
+
+/// Undo/redo stacks of transaction groups. Each group is one user-visible
+/// undo step; recording clears the redo stack.
+#[derive(Debug, Clone, Default)]
+pub struct EditHistory {
+    undo_stack: Vec<Group>,
+    redo_stack: Vec<Group>,
+    /// When true, the top undo group may absorb the next coalescible record.
+    group_open: bool,
+}
+
+impl EditHistory {
+    /// Records a transaction. When `coalesce` is true and the current group is
+    /// open, the transaction merges into the top group (rapid typing = one
+    /// undo step). Any record invalidates the redo stack.
+    pub fn record(&mut self, transaction: Transaction, coalesce: bool) {
+        self.redo_stack.clear();
+        if coalesce && self.group_open {
+            if let Some(top) = self.undo_stack.last_mut() {
+                top.transactions.push(transaction);
+                return;
+            }
+        }
+        self.undo_stack.push(Group {
+            transactions: vec![transaction],
+        });
+        if self.undo_stack.len() > MAX_GROUPS {
+            self.undo_stack.remove(0);
+        }
+        self.group_open = coalesce;
+    }
+
+    /// Ends the current coalescing group; the next record starts a new
+    /// undo step. Called on cursor movement, clicks, and focus changes.
+    pub fn break_group(&mut self) {
+        self.group_open = false;
+    }
+
+    /// Undoes the top group. Returns the selection to restore, or `None` when
+    /// the undo stack is empty or the buffer no longer matches the recorded
+    /// operations (the group is dropped and an error logged).
+    pub fn undo(&mut self, buffer: &mut TextBuffer) -> Option<Selection> {
+        self.group_open = false;
+        let group = self.undo_stack.pop()?;
+        for t in group.transactions.iter().rev() {
+            if let Err(e) = t.revert(buffer) {
+                log::error!("editor undo: invalid transaction application: {e}");
+                return None;
+            }
+        }
+        let selection = group.transactions.first().map(|t| t.selection_before);
+        self.redo_stack.push(group);
+        selection
+    }
+
+    /// Redoes the last undone group. Returns the selection to restore, or
+    /// `None` when empty or invalid (see [`Self::undo`]).
+    pub fn redo(&mut self, buffer: &mut TextBuffer) -> Option<Selection> {
+        self.group_open = false;
+        let group = self.redo_stack.pop()?;
+        for t in &group.transactions {
+            if let Err(e) = t.apply(buffer) {
+                log::error!("editor redo: invalid transaction application: {e}");
+                return None;
+            }
+        }
+        let selection = group.transactions.last().map(|t| t.selection_after);
+        self.undo_stack.push(group);
+        selection
+    }
+
+    #[must_use]
+    pub fn can_undo(&self) -> bool {
+        !self.undo_stack.is_empty()
+    }
+
+    #[must_use]
+    pub fn can_redo(&self) -> bool {
+        !self.redo_stack.is_empty()
+    }
+
+    /// Number of undoable groups.
+    #[must_use]
+    pub fn undo_depth(&self) -> usize {
+        self.undo_stack.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editor::cursor::{Cursor, Selection};
+    use crate::editor::transaction::EditOperation;
+
+    fn insert_tx(pos: usize, text: &str) -> Transaction {
+        Transaction {
+            ops: vec![EditOperation::Insert {
+                pos,
+                text: text.into(),
+            }],
+            selection_before: Selection::collapsed(Cursor::new(0, pos)),
+            selection_after: Selection::collapsed(Cursor::new(0, pos + text.chars().count())),
+        }
+    }
+
+    #[test]
+    fn undo_redo_round_trip() {
+        let mut buffer = TextBuffer::from_string("Hello");
+        let mut history = EditHistory::default();
+        let t = insert_tx(5, " World");
+        t.apply(&mut buffer).unwrap();
+        history.record(t, false);
+
+        let sel = history.undo(&mut buffer).unwrap();
+        assert_eq!(buffer.to_string(), "Hello");
+        assert_eq!(sel.head, Cursor::new(0, 5));
+        assert!(history.can_redo());
+
+        let sel = history.redo(&mut buffer).unwrap();
+        assert_eq!(buffer.to_string(), "Hello World");
+        assert_eq!(sel.head, Cursor::new(0, 11));
+    }
+
+    #[test]
+    fn typing_coalesces_into_one_undo_step() {
+        let mut buffer = TextBuffer::default();
+        let mut history = EditHistory::default();
+        for (i, ch) in ["a", "b", "c"].iter().enumerate() {
+            let t = insert_tx(i, ch);
+            t.apply(&mut buffer).unwrap();
+            history.record(t, true);
+        }
+        assert_eq!(buffer.to_string(), "abc");
+        assert_eq!(history.undo_depth(), 1);
+        history.undo(&mut buffer);
+        assert_eq!(buffer.to_string(), "");
+    }
+
+    #[test]
+    fn break_group_splits_undo_steps() {
+        let mut buffer = TextBuffer::default();
+        let mut history = EditHistory::default();
+        let t = insert_tx(0, "a");
+        t.apply(&mut buffer).unwrap();
+        history.record(t, true);
+        history.break_group();
+        let t = insert_tx(1, "b");
+        t.apply(&mut buffer).unwrap();
+        history.record(t, true);
+
+        assert_eq!(history.undo_depth(), 2);
+        history.undo(&mut buffer);
+        assert_eq!(buffer.to_string(), "a");
+        history.undo(&mut buffer);
+        assert_eq!(buffer.to_string(), "");
+    }
+
+    #[test]
+    fn new_edit_invalidates_redo() {
+        let mut buffer = TextBuffer::default();
+        let mut history = EditHistory::default();
+        let t = insert_tx(0, "a");
+        t.apply(&mut buffer).unwrap();
+        history.record(t, false);
+        history.undo(&mut buffer);
+        assert!(history.can_redo());
+
+        let t = insert_tx(0, "z");
+        t.apply(&mut buffer).unwrap();
+        history.record(t, false);
+        assert!(!history.can_redo());
+        assert_eq!(buffer.to_string(), "z");
+    }
+
+    #[test]
+    fn undo_on_empty_stack_is_none() {
+        let mut buffer = TextBuffer::default();
+        let mut history = EditHistory::default();
+        assert!(history.undo(&mut buffer).is_none());
+        assert!(history.redo(&mut buffer).is_none());
+        assert!(!history.can_undo());
+    }
+}

--- a/src/editor/ime.rs
+++ b/src/editor/ime.rs
@@ -1,0 +1,55 @@
+//! IME composition state.
+//!
+//! Adapted from Ferrite <https://github.com/OlaProeis/Ferrite>
+//! @ 3ba085c561670342d72c560efbf6b0b92b5c0b46 (editor.rs IME handling), MIT.
+//! Diverges from upstream: preedit text is never inserted into the buffer —
+//! it lives here and is painted as an overlay at the caret, so the buffer
+//! only mutates through committed transactions.
+
+/// In-progress IME composition. `None` when not composing.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ImeState {
+    preedit: Option<String>,
+}
+
+impl ImeState {
+    /// Replaces the current preedit text. An empty string keeps the
+    /// composition session open with nothing to paint.
+    pub fn set_preedit(&mut self, text: String) {
+        self.preedit = Some(text);
+    }
+
+    /// Ends composition (after commit or cancel).
+    pub fn clear(&mut self) {
+        self.preedit = None;
+    }
+
+    /// The composition text to paint at the caret, if composing.
+    #[must_use]
+    pub fn preedit(&self) -> Option<&str> {
+        self.preedit.as_deref()
+    }
+
+    #[must_use]
+    pub fn is_composing(&self) -> bool {
+        self.preedit.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preedit_lifecycle() {
+        let mut ime = ImeState::default();
+        assert!(!ime.is_composing());
+        ime.set_preedit("か".into());
+        assert_eq!(ime.preedit(), Some("か"));
+        ime.set_preedit("かん".into());
+        assert_eq!(ime.preedit(), Some("かん"));
+        ime.clear();
+        assert!(!ime.is_composing());
+        assert_eq!(ime.preedit(), None);
+    }
+}

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1,0 +1,55 @@
+//! Shared editor core, derived from Ferrite.
+//!
+//! Upstream: <https://github.com/OlaProeis/Ferrite>
+//! Commit: 3ba085c561670342d72c560efbf6b0b92b5c0b46
+//! License: MIT (see `src/editor/LICENSE-ferrite`, © 2024-2025 OlaProeis).
+//!
+//! Divergence from upstream:
+//! - Only the pure editing core is ported (buffer, cursor/selection, grapheme
+//!   boundaries, movement, transaction-grouped undo/redo, viewport math).
+//!   Syntax highlighting, folding, minimap, vim mode, search/replace, line
+//!   numbers, gutter, outline, and stats were dropped.
+//! - Ferrite's 4k-line `editor.rs` orchestrator is replaced by a small
+//!   `Document` state machine ([`commands`]) with an explicit
+//!   [`EditorCommand`] API; all mutation routes through recorded
+//!   [`Transaction`]s ([`transaction`], [`history`]).
+//! - IME preedit text is never inserted into the buffer; it lives in
+//!   [`ime::ImeState`] and is painted as an overlay, so the buffer only ever
+//!   changes through transactions.
+//! - `widget.rs` is the only egui-dependent file.
+
+pub mod buffer;
+pub mod commands;
+pub mod cursor;
+pub mod grapheme;
+pub mod history;
+pub mod ime;
+pub mod movement;
+pub mod selection;
+pub mod transaction;
+pub mod view;
+pub mod widget;
+
+pub use commands::{Document, EditorCommand};
+pub use cursor::{Cursor, Selection};
+pub use transaction::Transaction;
+pub use view::ViewState;
+
+/// Snapshot of the editor's semantic state, for host inspection and tests.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EditorSemanticState {
+    /// Full document text.
+    pub text: String,
+    /// Current selection (anchor/head).
+    pub selection: Selection,
+    /// Caret position (selection head).
+    pub cursor: Cursor,
+    /// Number of undoable groups.
+    pub undo_depth: usize,
+    pub can_undo: bool,
+    pub can_redo: bool,
+    /// In-progress IME composition text, if any.
+    pub ime_composition: Option<String>,
+    /// Vertical scroll offset in points.
+    pub scroll_y: f32,
+}

--- a/src/editor/movement.rs
+++ b/src/editor/movement.rs
@@ -1,0 +1,309 @@
+//! Pure caret movement over a `TextBuffer`.
+//!
+//! Adapted from Ferrite <https://github.com/OlaProeis/Ferrite>
+//! @ 3ba085c561670342d72c560efbf6b0b92b5c0b46 (input/keyboard.rs), MIT.
+
+use super::buffer::TextBuffer;
+use super::cursor::Cursor;
+use super::grapheme::{line_text_stripped, next_grapheme_boundary, prev_grapheme_boundary};
+
+/// Char length of `line` excluding the trailing newline.
+#[must_use]
+pub fn line_len(buffer: &TextBuffer, line: usize) -> usize {
+    buffer
+        .get_line(line)
+        .map(|l| line_text_stripped(&l).chars().count())
+        .unwrap_or(0)
+}
+
+/// Stripped text of `line` (empty when out of bounds).
+#[must_use]
+pub fn line_text(buffer: &TextBuffer, line: usize) -> String {
+    buffer
+        .get_line(line)
+        .map(|l| line_text_stripped(&l).to_string())
+        .unwrap_or_default()
+}
+
+/// Clamps a cursor to valid (line, column) coordinates and snaps the column
+/// to a grapheme boundary, so externally supplied positions (pointer
+/// hit-tests, `SetCursor`) can never split a cluster.
+#[must_use]
+pub fn clamp(buffer: &TextBuffer, cursor: Cursor) -> Cursor {
+    let line = cursor.line.min(buffer.line_count().saturating_sub(1));
+    let text = line_text(buffer, line);
+    let column = super::grapheme::snap_to_boundary(&text, cursor.column);
+    Cursor::new(line, column)
+}
+
+/// Converts a cursor to an absolute char index.
+#[must_use]
+pub fn cursor_to_char(buffer: &TextBuffer, cursor: Cursor) -> usize {
+    let cursor = clamp(buffer, cursor);
+    buffer.line_to_char(cursor.line) + cursor.column
+}
+
+/// Converts an absolute char index to a cursor.
+#[must_use]
+pub fn char_to_cursor(buffer: &TextBuffer, char_idx: usize) -> Cursor {
+    let char_idx = char_idx.min(buffer.len());
+    let line = buffer.char_to_line(char_idx);
+    Cursor::new(line, char_idx - buffer.line_to_char(line))
+}
+
+/// One grapheme left, wrapping to the previous line end.
+#[must_use]
+pub fn left(buffer: &TextBuffer, cursor: Cursor) -> Cursor {
+    let cursor = clamp(buffer, cursor);
+    if cursor.column > 0 {
+        let text = line_text(buffer, cursor.line);
+        Cursor::new(cursor.line, prev_grapheme_boundary(&text, cursor.column))
+    } else if cursor.line > 0 {
+        Cursor::new(cursor.line - 1, line_len(buffer, cursor.line - 1))
+    } else {
+        cursor
+    }
+}
+
+/// One grapheme right, wrapping to the next line start.
+#[must_use]
+pub fn right(buffer: &TextBuffer, cursor: Cursor) -> Cursor {
+    let cursor = clamp(buffer, cursor);
+    let len = line_len(buffer, cursor.line);
+    if cursor.column < len {
+        let text = line_text(buffer, cursor.line);
+        Cursor::new(cursor.line, next_grapheme_boundary(&text, cursor.column))
+    } else if cursor.line + 1 < buffer.line_count() {
+        Cursor::new(cursor.line + 1, 0)
+    } else {
+        cursor
+    }
+}
+
+/// One line up, keeping `goal_column` (the column the user is aiming for
+/// across short lines). Clamps to the target line's length.
+/// On the first line, jumps to the document start (macOS convention).
+#[must_use]
+pub fn up(buffer: &TextBuffer, cursor: Cursor, goal_column: usize) -> Cursor {
+    if cursor.line == 0 {
+        return Cursor::new(0, 0);
+    }
+    clamp(buffer, Cursor::new(cursor.line - 1, goal_column))
+}
+
+/// One line down, keeping `goal_column`. Clamps to the target line's length.
+/// On the last line, jumps to the document end (macOS convention).
+#[must_use]
+pub fn down(buffer: &TextBuffer, cursor: Cursor, goal_column: usize) -> Cursor {
+    if cursor.line + 1 >= buffer.line_count() {
+        return Cursor::new(cursor.line, line_len(buffer, cursor.line));
+    }
+    clamp(buffer, Cursor::new(cursor.line + 1, goal_column))
+}
+
+/// Char class of a grapheme cluster (by its first char): word, whitespace,
+/// or punctuation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CharClass {
+    Word,
+    Whitespace,
+    Punctuation,
+}
+
+fn classify(c: char) -> CharClass {
+    if c.is_alphanumeric() || c == '_' {
+        CharClass::Word
+    } else if c.is_whitespace() {
+        CharClass::Whitespace
+    } else {
+        CharClass::Punctuation
+    }
+}
+
+/// (start char-column, class) for each grapheme cluster of `text`, plus the
+/// total char count. Word movement operates on whole clusters so the caret
+/// never lands inside one (e.g. between a base char and a combining mark).
+fn grapheme_classes(text: &str) -> (Vec<(usize, CharClass)>, usize) {
+    use unicode_segmentation::UnicodeSegmentation;
+    let mut clusters = Vec::new();
+    let mut col = 0;
+    for g in text.graphemes(true) {
+        let class = classify(g.chars().next().unwrap_or(' '));
+        clusters.push((col, class));
+        col += g.chars().count();
+    }
+    (clusters, col)
+}
+
+/// Start of the previous word (skips whitespace backward, then the word).
+#[must_use]
+pub fn word_left(buffer: &TextBuffer, cursor: Cursor) -> Cursor {
+    let mut cursor = clamp(buffer, cursor);
+    if cursor.column == 0 {
+        return left(buffer, cursor);
+    }
+    let (clusters, _) = grapheme_classes(&line_text(buffer, cursor.line));
+    // Index of the first cluster at or past the caret.
+    let mut i = clusters.partition_point(|(start, _)| *start < cursor.column);
+    while i > 0 && clusters[i - 1].1 == CharClass::Whitespace {
+        i -= 1;
+    }
+    if i > 0 {
+        let class = clusters[i - 1].1;
+        while i > 0 && clusters[i - 1].1 == class {
+            i -= 1;
+        }
+    }
+    cursor.column = clusters.get(i).map_or(0, |(start, _)| *start);
+    cursor
+}
+
+/// End of the next word (skips whitespace forward, then the word).
+#[must_use]
+pub fn word_right(buffer: &TextBuffer, cursor: Cursor) -> Cursor {
+    let mut cursor = clamp(buffer, cursor);
+    let (clusters, total) = grapheme_classes(&line_text(buffer, cursor.line));
+    if cursor.column >= total {
+        return right(buffer, cursor);
+    }
+    // Index of the cluster containing the caret.
+    let mut i = clusters
+        .partition_point(|(start, _)| *start <= cursor.column)
+        .saturating_sub(1);
+    while i < clusters.len() && clusters[i].1 == CharClass::Whitespace {
+        i += 1;
+    }
+    if i < clusters.len() {
+        let class = clusters[i].1;
+        while i < clusters.len() && clusters[i].1 == class {
+            i += 1;
+        }
+    }
+    cursor.column = clusters.get(i).map_or(total, |(start, _)| *start);
+    cursor
+}
+
+/// Column 0 of the current line.
+#[must_use]
+pub fn line_start(cursor: Cursor) -> Cursor {
+    Cursor::new(cursor.line, 0)
+}
+
+/// End of the current line.
+#[must_use]
+pub fn line_end(buffer: &TextBuffer, cursor: Cursor) -> Cursor {
+    let cursor = clamp(buffer, cursor);
+    Cursor::new(cursor.line, line_len(buffer, cursor.line))
+}
+
+/// Start of the document.
+#[must_use]
+pub fn doc_start() -> Cursor {
+    Cursor::default()
+}
+
+/// End of the document.
+#[must_use]
+pub fn doc_end(buffer: &TextBuffer) -> Cursor {
+    let line = buffer.line_count().saturating_sub(1);
+    Cursor::new(line, line_len(buffer, line))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buf(s: &str) -> TextBuffer {
+        TextBuffer::from_string(s)
+    }
+
+    #[test]
+    fn left_right_wrap_across_lines() {
+        let b = buf("ab\ncd");
+        assert_eq!(right(&b, Cursor::new(0, 2)), Cursor::new(1, 0));
+        assert_eq!(left(&b, Cursor::new(1, 0)), Cursor::new(0, 2));
+        assert_eq!(left(&b, Cursor::new(0, 0)), Cursor::new(0, 0));
+        assert_eq!(right(&b, Cursor::new(1, 2)), Cursor::new(1, 2));
+    }
+
+    #[test]
+    fn left_right_move_by_grapheme() {
+        let b = buf("a👨\u{200D}👩\u{200D}👧b");
+        assert_eq!(right(&b, Cursor::new(0, 1)), Cursor::new(0, 6));
+        assert_eq!(left(&b, Cursor::new(0, 6)), Cursor::new(0, 1));
+    }
+
+    #[test]
+    fn up_down_respect_goal_column() {
+        let b = buf("longest line\nab\nanother long");
+        // Down from col 8 clamps to short line, goal restores on next down.
+        let c = down(&b, Cursor::new(0, 8), 8);
+        assert_eq!(c, Cursor::new(1, 2));
+        let c = down(&b, c, 8);
+        assert_eq!(c, Cursor::new(2, 8));
+        let c = up(&b, c, 8);
+        assert_eq!(c, Cursor::new(1, 2));
+    }
+
+    #[test]
+    fn down_on_last_line_goes_to_line_end() {
+        let b = buf("hello");
+        assert_eq!(down(&b, Cursor::new(0, 2), 2), Cursor::new(0, 5));
+    }
+
+    #[test]
+    fn word_movement() {
+        let b = buf("foo bar_baz  qux");
+        assert_eq!(word_right(&b, Cursor::new(0, 0)), Cursor::new(0, 3));
+        assert_eq!(word_right(&b, Cursor::new(0, 3)), Cursor::new(0, 11));
+        assert_eq!(word_left(&b, Cursor::new(0, 16)), Cursor::new(0, 13));
+        assert_eq!(word_left(&b, Cursor::new(0, 11)), Cursor::new(0, 4));
+    }
+
+    #[test]
+    fn word_movement_stays_on_grapheme_boundaries() {
+        // "é" as e + combining acute (2 chars, 1 grapheme) followed by "x".
+        let b = buf("e\u{0301}x y");
+        assert_eq!(word_right(&b, Cursor::new(0, 0)), Cursor::new(0, 3));
+        assert_eq!(word_left(&b, Cursor::new(0, 5)), Cursor::new(0, 4));
+        assert_eq!(word_left(&b, Cursor::new(0, 3)), Cursor::new(0, 0));
+    }
+
+    #[test]
+    fn word_movement_wraps_at_line_edges() {
+        let b = buf("foo\nbar");
+        assert_eq!(word_right(&b, Cursor::new(0, 3)), Cursor::new(1, 0));
+        assert_eq!(word_left(&b, Cursor::new(1, 0)), Cursor::new(0, 3));
+    }
+
+    #[test]
+    fn line_and_doc_movement() {
+        let b = buf("one\ntwo three");
+        assert_eq!(line_start(Cursor::new(1, 5)), Cursor::new(1, 0));
+        assert_eq!(line_end(&b, Cursor::new(1, 0)), Cursor::new(1, 9));
+        assert_eq!(doc_start(), Cursor::new(0, 0));
+        assert_eq!(doc_end(&b), Cursor::new(1, 9));
+    }
+
+    #[test]
+    fn char_index_round_trip() {
+        let b = buf("héllo\nwörld");
+        let c = Cursor::new(1, 3);
+        assert_eq!(char_to_cursor(&b, cursor_to_char(&b, c)), c);
+        assert_eq!(cursor_to_char(&b, Cursor::new(1, 0)), 6);
+    }
+
+    #[test]
+    fn clamp_out_of_bounds() {
+        let b = buf("ab\ncd");
+        assert_eq!(clamp(&b, Cursor::new(9, 9)), Cursor::new(1, 2));
+        assert_eq!(clamp(&b, Cursor::new(0, 9)), Cursor::new(0, 2));
+    }
+
+    #[test]
+    fn clamp_snaps_inside_grapheme_cluster() {
+        let b = buf("e\u{0301}x");
+        assert_eq!(clamp(&b, Cursor::new(0, 1)), Cursor::new(0, 0));
+        assert_eq!(clamp(&b, Cursor::new(0, 2)), Cursor::new(0, 2));
+    }
+}

--- a/src/editor/selection.rs
+++ b/src/editor/selection.rs
@@ -1,0 +1,112 @@
+//! Selection helpers: select-all, word and line selection.
+//!
+//! Adapted from Ferrite <https://github.com/OlaProeis/Ferrite>
+//! @ 3ba085c561670342d72c560efbf6b0b92b5c0b46 (selection.rs), MIT.
+
+use super::buffer::TextBuffer;
+use super::cursor::{Cursor, Selection};
+use super::movement::{doc_end, line_len, line_text};
+
+/// Selection spanning the whole document.
+#[must_use]
+pub fn select_all(buffer: &TextBuffer) -> Selection {
+    Selection::new(Cursor::default(), doc_end(buffer))
+}
+
+/// Word boundaries around `cursor`, classifying chars as word
+/// (alphanumeric/`_`), whitespace, or punctuation. Used for double-click.
+#[must_use]
+pub fn word_boundaries(buffer: &TextBuffer, cursor: Cursor) -> Selection {
+    let chars: Vec<char> = line_text(buffer, cursor.line).chars().collect();
+    let col = cursor.column.min(chars.len());
+    if chars.is_empty() {
+        return Selection::collapsed(Cursor::new(cursor.line, 0));
+    }
+    let probe = if col < chars.len() {
+        chars[col]
+    } else {
+        chars[col - 1]
+    };
+
+    let class = |c: char| -> u8 {
+        if c.is_alphanumeric() || c == '_' {
+            0
+        } else if c.is_whitespace() {
+            1
+        } else {
+            2
+        }
+    };
+    let target = class(probe);
+
+    let mut start = col;
+    while start > 0 && class(chars[start - 1]) == target {
+        start -= 1;
+    }
+    let mut end = col;
+    while end < chars.len() && class(chars[end]) == target {
+        end += 1;
+    }
+    Selection::new(
+        Cursor::new(cursor.line, start),
+        Cursor::new(cursor.line, end),
+    )
+}
+
+/// Full-line selection for `line`, including the trailing newline when one
+/// exists (head lands at the start of the next line). Used for triple-click.
+#[must_use]
+pub fn line_selection(buffer: &TextBuffer, line: usize) -> Selection {
+    let line = line.min(buffer.line_count().saturating_sub(1));
+    let anchor = Cursor::new(line, 0);
+    let head = if line + 1 < buffer.line_count() {
+        Cursor::new(line + 1, 0)
+    } else {
+        Cursor::new(line, line_len(buffer, line))
+    };
+    Selection::new(anchor, head)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn select_all_spans_document() {
+        let b = TextBuffer::from_string("one\ntwo\nthree");
+        let sel = select_all(&b);
+        assert_eq!(sel.anchor, Cursor::new(0, 0));
+        assert_eq!(sel.head, Cursor::new(2, 5));
+    }
+
+    #[test]
+    fn word_boundaries_on_word_and_punctuation() {
+        let b = TextBuffer::from_string("foo bar_baz, qux");
+        let sel = word_boundaries(&b, Cursor::new(0, 5));
+        assert_eq!((sel.anchor.column, sel.head.column), (4, 11));
+        // On the comma: punctuation run
+        let sel = word_boundaries(&b, Cursor::new(0, 11));
+        assert_eq!((sel.anchor.column, sel.head.column), (11, 12));
+        // At end of line: uses preceding char
+        let sel = word_boundaries(&b, Cursor::new(0, 16));
+        assert_eq!((sel.anchor.column, sel.head.column), (13, 16));
+    }
+
+    #[test]
+    fn word_boundaries_on_empty_line() {
+        let b = TextBuffer::from_string("a\n\nb");
+        let sel = word_boundaries(&b, Cursor::new(1, 0));
+        assert!(!sel.is_range());
+    }
+
+    #[test]
+    fn line_selection_includes_newline() {
+        let b = TextBuffer::from_string("one\ntwo");
+        let sel = line_selection(&b, 0);
+        assert_eq!(sel.anchor, Cursor::new(0, 0));
+        assert_eq!(sel.head, Cursor::new(1, 0));
+        // Last line has no trailing newline
+        let sel = line_selection(&b, 1);
+        assert_eq!(sel.head, Cursor::new(1, 3));
+    }
+}

--- a/src/editor/transaction.rs
+++ b/src/editor/transaction.rs
@@ -1,0 +1,264 @@
+//! Edit operations and transactions — the single mutation path.
+//!
+//! Adapted from Ferrite <https://github.com/OlaProeis/Ferrite>
+//! @ 3ba085c561670342d72c560efbf6b0b92b5c0b46 (history.rs), MIT.
+
+use super::buffer::TextBuffer;
+use super::cursor::Selection;
+
+/// A single reversible edit. Positions are char indices.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditOperation {
+    Insert { pos: usize, text: String },
+    Delete { pos: usize, text: String },
+}
+
+impl EditOperation {
+    /// The inverse operation (insert ↔ delete).
+    #[must_use]
+    pub fn inverse(&self) -> Self {
+        match self {
+            Self::Insert { pos, text } => Self::Delete {
+                pos: *pos,
+                text: text.clone(),
+            },
+            Self::Delete { pos, text } => Self::Insert {
+                pos: *pos,
+                text: text.clone(),
+            },
+        }
+    }
+
+    /// Applies this operation, validating bounds and (for deletes) that the
+    /// buffer actually contains the recorded text.
+    pub fn apply(&self, buffer: &mut TextBuffer) -> Result<(), String> {
+        match self {
+            Self::Insert { pos, text } => {
+                if *pos > buffer.len() {
+                    return Err(format!(
+                        "insert at {pos} out of bounds (len {})",
+                        buffer.len()
+                    ));
+                }
+                buffer.insert(*pos, text);
+                Ok(())
+            }
+            Self::Delete { pos, text } => {
+                let n = text.chars().count();
+                if pos + n > buffer.len() {
+                    return Err(format!(
+                        "delete {pos}..{} out of bounds (len {})",
+                        pos + n,
+                        buffer.len()
+                    ));
+                }
+                let actual = buffer.slice(*pos, pos + n);
+                if actual != *text {
+                    return Err(format!(
+                        "delete at {pos} mismatch: expected {text:?}, buffer has {actual:?}"
+                    ));
+                }
+                buffer.remove(*pos, n);
+                Ok(())
+            }
+        }
+    }
+}
+
+/// One user-visible edit step: an ordered batch of operations plus the
+/// selection to restore on undo (`selection_before`) and redo
+/// (`selection_after`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Transaction {
+    pub ops: Vec<EditOperation>,
+    pub selection_before: Selection,
+    pub selection_after: Selection,
+}
+
+impl Transaction {
+    /// Applies all operations in order.
+    pub fn apply(&self, buffer: &mut TextBuffer) -> Result<(), String> {
+        for op in &self.ops {
+            op.apply(buffer)?;
+        }
+        Ok(())
+    }
+
+    /// Applies the inverse of all operations in reverse order (undo).
+    pub fn revert(&self, buffer: &mut TextBuffer) -> Result<(), String> {
+        for op in self.ops.iter().rev() {
+            op.inverse().apply(buffer)?;
+        }
+        Ok(())
+    }
+}
+
+/// Minimal edit operations transforming `old` into `new` via prefix/suffix
+/// matching: at most one Delete followed by one Insert. Char-indexed.
+#[must_use]
+pub fn compute_edit_ops(old: &str, new: &str) -> Vec<EditOperation> {
+    if old == new {
+        return Vec::new();
+    }
+
+    let old_chars: Vec<char> = old.chars().collect();
+    let new_chars: Vec<char> = new.chars().collect();
+
+    let prefix = old_chars
+        .iter()
+        .zip(&new_chars)
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let max_suffix = old_chars.len().min(new_chars.len()).saturating_sub(prefix);
+    let suffix = old_chars
+        .iter()
+        .rev()
+        .zip(new_chars.iter().rev())
+        .take(max_suffix)
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let del_end = old_chars.len() - suffix;
+    let ins_end = new_chars.len() - suffix;
+
+    let mut ops = Vec::new();
+    if del_end > prefix {
+        ops.push(EditOperation::Delete {
+            pos: prefix,
+            text: old_chars[prefix..del_end].iter().collect(),
+        });
+    }
+    if ins_end > prefix {
+        ops.push(EditOperation::Insert {
+            pos: prefix,
+            text: new_chars[prefix..ins_end].iter().collect(),
+        });
+    }
+    ops
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editor::cursor::{Cursor, Selection};
+
+    fn tx(ops: Vec<EditOperation>) -> Transaction {
+        Transaction {
+            ops,
+            selection_before: Selection::collapsed(Cursor::default()),
+            selection_after: Selection::collapsed(Cursor::default()),
+        }
+    }
+
+    #[test]
+    fn inverse_round_trips() {
+        let op = EditOperation::Insert {
+            pos: 3,
+            text: "abc".into(),
+        };
+        assert_eq!(op.inverse().inverse(), op);
+    }
+
+    #[test]
+    fn transaction_apply_revert_round_trip() {
+        let mut buffer = TextBuffer::from_string("Hello World");
+        let t = tx(vec![
+            EditOperation::Delete {
+                pos: 5,
+                text: " World".into(),
+            },
+            EditOperation::Insert {
+                pos: 5,
+                text: ", Plexi".into(),
+            },
+        ]);
+        t.apply(&mut buffer).unwrap();
+        assert_eq!(buffer.to_string(), "Hello, Plexi");
+        t.revert(&mut buffer).unwrap();
+        assert_eq!(buffer.to_string(), "Hello World");
+    }
+
+    #[test]
+    fn unicode_transaction_round_trip() {
+        let mut buffer = TextBuffer::from_string("héllo 🌍");
+        let t = tx(vec![EditOperation::Delete {
+            pos: 6,
+            text: "🌍".into(),
+        }]);
+        t.apply(&mut buffer).unwrap();
+        assert_eq!(buffer.to_string(), "héllo ");
+        t.revert(&mut buffer).unwrap();
+        assert_eq!(buffer.to_string(), "héllo 🌍");
+    }
+
+    #[test]
+    fn apply_rejects_out_of_bounds_insert() {
+        let mut buffer = TextBuffer::from_string("hi");
+        let op = EditOperation::Insert {
+            pos: 5,
+            text: "x".into(),
+        };
+        assert!(op.apply(&mut buffer).is_err());
+        assert_eq!(buffer.to_string(), "hi");
+    }
+
+    #[test]
+    fn apply_rejects_mismatched_delete() {
+        let mut buffer = TextBuffer::from_string("hello");
+        let op = EditOperation::Delete {
+            pos: 0,
+            text: "world".into(),
+        };
+        assert!(op.apply(&mut buffer).is_err());
+        assert_eq!(buffer.to_string(), "hello");
+    }
+
+    #[test]
+    fn compute_edit_ops_replace() {
+        let ops = compute_edit_ops("Hello World", "Hello Plexi");
+        assert_eq!(
+            ops,
+            vec![
+                EditOperation::Delete {
+                    pos: 6,
+                    text: "World".into()
+                },
+                EditOperation::Insert {
+                    pos: 6,
+                    text: "Plexi".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn compute_edit_ops_identity_and_pure_edits() {
+        assert!(compute_edit_ops("same", "same").is_empty());
+        assert_eq!(
+            compute_edit_ops("ab", "axb"),
+            vec![EditOperation::Insert {
+                pos: 1,
+                text: "x".into()
+            }]
+        );
+        assert_eq!(
+            compute_edit_ops("axb", "ab"),
+            vec![EditOperation::Delete {
+                pos: 1,
+                text: "x".into()
+            }]
+        );
+    }
+
+    #[test]
+    fn compute_edit_ops_applies_to_produce_new() {
+        let old = "line one\nline two\nline three";
+        let new = "line one\nLINE 2\nline three";
+        let mut buffer = TextBuffer::from_string(old);
+        for op in compute_edit_ops(old, new) {
+            op.apply(&mut buffer).unwrap();
+        }
+        assert_eq!(buffer.to_string(), new);
+    }
+}

--- a/src/editor/view.rs
+++ b/src/editor/view.rs
@@ -1,0 +1,145 @@
+//! Virtual scrolling viewport math. Pure — no egui.
+//!
+//! Adapted from Ferrite <https://github.com/OlaProeis/Ferrite>
+//! @ 3ba085c561670342d72c560efbf6b0b92b5c0b46 (view.rs), MIT.
+//! Diverges from upstream: no soft-wrap; uniform line height.
+
+use std::ops::Range;
+
+/// Extra lines laid out above/below the viewport so partially visible rows
+/// paint fully during scroll.
+const OVERSCAN_LINES: usize = 1;
+
+/// Scroll/viewport state for a uniform-line-height document view.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ViewState {
+    /// Vertical scroll offset in points (0 = top).
+    pub scroll_y: f32,
+    /// Visible height in points.
+    pub viewport_height: f32,
+    /// Height of one line in points.
+    pub line_height: f32,
+}
+
+impl Default for ViewState {
+    fn default() -> Self {
+        Self {
+            scroll_y: 0.0,
+            viewport_height: 0.0,
+            line_height: 16.0,
+        }
+    }
+}
+
+impl ViewState {
+    /// Total content height for `line_count` lines.
+    #[must_use]
+    pub fn content_height(&self, line_count: usize) -> f32 {
+        line_count as f32 * self.line_height
+    }
+
+    /// The window of lines to lay out, with overscan, clamped to the document.
+    #[must_use]
+    pub fn visible_lines(&self, line_count: usize) -> Range<usize> {
+        if self.line_height <= 0.0 || line_count == 0 {
+            return 0..0;
+        }
+        let first = (self.scroll_y / self.line_height).floor().max(0.0) as usize;
+        let visible = (self.viewport_height / self.line_height).ceil() as usize + 1;
+        let start = first.saturating_sub(OVERSCAN_LINES);
+        let end = (first + visible + OVERSCAN_LINES).min(line_count);
+        start..end.max(start)
+    }
+
+    /// Top y-offset of `line` relative to the content origin.
+    #[must_use]
+    pub fn line_top(&self, line: usize) -> f32 {
+        line as f32 * self.line_height
+    }
+
+    /// Clamps `scroll_y` to the scrollable range for `line_count` lines.
+    pub fn clamp_scroll(&mut self, line_count: usize) {
+        let max = (self.content_height(line_count) - self.viewport_height).max(0.0);
+        self.scroll_y = self.scroll_y.clamp(0.0, max);
+    }
+
+    /// Adjusts `scroll_y` minimally so `line` is fully visible.
+    pub fn scroll_to_line(&mut self, line: usize, line_count: usize) {
+        let top = self.line_top(line);
+        let bottom = top + self.line_height;
+        if top < self.scroll_y {
+            self.scroll_y = top;
+        } else if bottom > self.scroll_y + self.viewport_height {
+            self.scroll_y = bottom - self.viewport_height;
+        }
+        self.clamp_scroll(line_count);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn view() -> ViewState {
+        ViewState {
+            scroll_y: 0.0,
+            viewport_height: 100.0,
+            line_height: 10.0,
+        }
+    }
+
+    #[test]
+    fn visible_lines_windows_large_document() {
+        let mut v = view();
+        let lines = 10_000;
+        assert_eq!(v.visible_lines(lines), 0..12);
+
+        v.scroll_y = 50_000.0; // line 5000 at top
+        let r = v.visible_lines(lines);
+        assert_eq!(r, 4999..5012);
+        // Windowing: never proportional to document size.
+        assert!(r.len() < 20);
+
+        // Scrolled to the very bottom.
+        v.scroll_y = v.content_height(lines) - v.viewport_height;
+        let r = v.visible_lines(lines);
+        assert_eq!(r.end, lines);
+        assert!(r.len() < 20);
+    }
+
+    #[test]
+    fn visible_lines_empty_and_degenerate() {
+        let v = view();
+        assert_eq!(v.visible_lines(0), 0..0);
+        let z = ViewState {
+            line_height: 0.0,
+            ..view()
+        };
+        assert_eq!(z.visible_lines(100), 0..0);
+    }
+
+    #[test]
+    fn clamp_scroll_bounds() {
+        let mut v = view();
+        v.scroll_y = -5.0;
+        v.clamp_scroll(50);
+        assert_eq!(v.scroll_y, 0.0);
+        v.scroll_y = 1e9;
+        v.clamp_scroll(50);
+        assert_eq!(v.scroll_y, 400.0); // 500 content - 100 viewport
+        // Content shorter than viewport pins to 0.
+        v.clamp_scroll(5);
+        assert_eq!(v.scroll_y, 0.0);
+    }
+
+    #[test]
+    fn scroll_to_line_moves_minimally() {
+        let mut v = view();
+        v.scroll_to_line(5, 100); // already visible
+        assert_eq!(v.scroll_y, 0.0);
+        v.scroll_to_line(20, 100); // below: bottom-align
+        assert_eq!(v.scroll_y, 110.0);
+        v.scroll_to_line(3, 100); // above: top-align
+        assert_eq!(v.scroll_y, 30.0);
+    }
+}

--- a/src/editor/widget.rs
+++ b/src/editor/widget.rs
@@ -1,0 +1,366 @@
+//! Minimal egui surface for the editor core — the only egui-dependent file.
+//!
+//! Adapted from Ferrite <https://github.com/OlaProeis/Ferrite>
+//! @ 3ba085c561670342d72c560efbf6b0b92b5c0b46 (editor.rs event translation,
+//! rendering/{cursor,text}.rs), MIT. Diverges from upstream: translates egui
+//! input into [`EditorCommand`]s and paints from [`ViewState`] layout; owns no
+//! editing logic. Focus arbitration is the caller's job (`src/ui/AGENTS.md`
+//! forbids direct `request_focus`).
+
+use egui::text::CCursor;
+use egui::{Event, ImeEvent, Key, Modifiers, Rect, Sense, Ui, Vec2};
+
+use super::commands::{Document, EditorCommand, Movement};
+use super::cursor::Cursor;
+use super::movement::line_text;
+use super::view::ViewState;
+
+/// Renders a [`Document`] and translates egui input into [`EditorCommand`]s.
+///
+/// The widget processes keyboard/IME input every frame it is shown; callers
+/// decide whether to show it (host focus model, stint 0474).
+pub struct EditorWidget<'a> {
+    doc: &'a mut Document,
+    view: &'a mut ViewState,
+}
+
+impl<'a> EditorWidget<'a> {
+    pub fn new(doc: &'a mut Document, view: &'a mut ViewState) -> Self {
+        Self { doc, view }
+    }
+
+    pub fn show(self, ui: &mut Ui) -> egui::Response {
+        let font_id = egui::TextStyle::Monospace.resolve(ui.style());
+        let line_height = ui.fonts_mut(|f| f.row_height(&font_id));
+        let (rect, response) =
+            ui.allocate_exact_size(ui.available_size_before_wrap(), Sense::click_and_drag());
+
+        self.view.line_height = line_height;
+        self.view.viewport_height = rect.height();
+
+        let mut commands: Vec<EditorCommand> = Vec::new();
+        let mut copy_requested = false;
+        let mut cut_requested = false;
+
+        let events = ui.input(|i| i.events.clone());
+        for event in &events {
+            match event {
+                Event::Text(text) => commands.push(EditorCommand::InsertText(text.clone())),
+                Event::Paste(text) => commands.push(EditorCommand::InsertText(text.clone())),
+                Event::Copy => copy_requested = true,
+                Event::Cut => cut_requested = true,
+                Event::Key {
+                    key,
+                    pressed: true,
+                    modifiers,
+                    ..
+                } => {
+                    if let Some(cmd) = translate_key(*key, *modifiers) {
+                        commands.push(cmd);
+                    }
+                }
+                Event::Ime(ime) => match ime {
+                    ImeEvent::Preedit(text) => {
+                        commands.push(EditorCommand::ImePreedit(text.clone()));
+                    }
+                    ImeEvent::Commit(text) => {
+                        commands.push(EditorCommand::ImeCommit(text.clone()));
+                    }
+                    ImeEvent::Disabled => commands.push(EditorCommand::ImeCancel),
+                    ImeEvent::Enabled => {}
+                },
+                _ => {}
+            }
+        }
+
+        if copy_requested || cut_requested {
+            let selected = self.doc.selected_text();
+            if !selected.is_empty() {
+                ui.ctx().copy_text(selected);
+                if cut_requested {
+                    commands.push(EditorCommand::Backspace);
+                }
+            }
+        }
+
+        // Pointer: click to place, shift-click / drag to extend, double-click
+        // word, triple-click line.
+        let hit = |pos: egui::Pos2| self.hit_test(ui, &font_id, rect, pos);
+        if let Some(pos) = response.interact_pointer_pos() {
+            let cursor = hit(pos);
+            if response.triple_clicked() {
+                commands.push(EditorCommand::SelectLineAt(cursor.line));
+            } else if response.double_clicked() {
+                commands.push(EditorCommand::SelectWordAt(cursor));
+            } else if response.drag_started() || response.clicked() {
+                if ui.input(|i| i.modifiers.shift) {
+                    commands.push(EditorCommand::ExtendTo(cursor));
+                } else {
+                    commands.push(EditorCommand::SetCursor(cursor));
+                }
+            } else if response.dragged() {
+                commands.push(EditorCommand::ExtendTo(cursor));
+            }
+        }
+
+        let edited = !commands.is_empty();
+        for command in commands {
+            self.doc.apply(command);
+        }
+
+        // Scrolling: wheel when hovered, then keep the caret visible after
+        // any command.
+        let line_count = self.doc.buffer().line_count();
+        if response.hovered() {
+            let scroll = ui.input(|i| i.smooth_scroll_delta.y);
+            if scroll != 0.0 {
+                self.view.scroll_y -= scroll;
+            }
+        }
+        self.view.clamp_scroll(line_count);
+        if edited {
+            self.view.scroll_to_line(self.doc.cursor().line, line_count);
+        }
+
+        self.paint(ui, &font_id, rect);
+        response
+    }
+
+    /// Maps a pointer position to a document cursor via per-line galley
+    /// hit-testing.
+    fn hit_test(&self, ui: &Ui, font_id: &egui::FontId, rect: Rect, pos: egui::Pos2) -> Cursor {
+        let line_count = self.doc.buffer().line_count();
+        let y = pos.y - rect.top() + self.view.scroll_y;
+        let line = ((y / self.view.line_height).floor().max(0.0) as usize)
+            .min(line_count.saturating_sub(1));
+        let text = line_text(self.doc.buffer(), line);
+        let galley = ui.fonts_mut(|f| f.layout_no_wrap(text, font_id.clone(), egui::Color32::WHITE));
+        let ccursor = galley.cursor_from_pos(Vec2::new(pos.x - rect.left(), 0.0));
+        Cursor::new(line, ccursor.index)
+    }
+
+    fn paint(&self, ui: &Ui, font_id: &egui::FontId, rect: Rect) {
+        let painter = ui.painter_at(rect);
+        let visuals = ui.visuals();
+        let text_color = visuals.text_color();
+        let selection_color = visuals.selection.bg_fill.linear_multiply(0.5);
+        let caret_color = visuals.selection.stroke.color;
+        let buffer = self.doc.buffer();
+        let line_count = buffer.line_count();
+        let selection = self.doc.selection();
+        let (sel_start, sel_end) = selection.ordered();
+        let caret = self.doc.cursor();
+        let mut caret_rect: Option<Rect> = None;
+
+        for line in self.view.visible_lines(line_count) {
+            let top = rect.top() + self.view.line_top(line) - self.view.scroll_y;
+            let text = line_text(buffer, line);
+            let galley =
+                ui.fonts_mut(|f| f.layout_no_wrap(text.clone(), font_id.clone(), text_color));
+            let origin = egui::pos2(rect.left(), top);
+
+            if selection.is_range() && selection.touches_line(line) {
+                let char_count = text.chars().count();
+                let from = if line == sel_start.line {
+                    sel_start.column.min(char_count)
+                } else {
+                    0
+                };
+                // Interior lines extend one column past the end to show the
+                // selected newline.
+                let (to, extend_newline) = if line == sel_end.line {
+                    (sel_end.column.min(char_count), false)
+                } else {
+                    (char_count, true)
+                };
+                let x0 = galley.pos_from_cursor(CCursor::new(from)).left();
+                let mut x1 = galley.pos_from_cursor(CCursor::new(to)).left();
+                if extend_newline {
+                    x1 += self.view.line_height * 0.5;
+                }
+                painter.rect_filled(
+                    Rect::from_min_max(
+                        egui::pos2(origin.x + x0, top),
+                        egui::pos2(origin.x + x1, top + self.view.line_height),
+                    ),
+                    0.0,
+                    selection_color,
+                );
+            }
+
+            painter.galley(origin, galley.clone(), text_color);
+
+            if line == caret.line {
+                let x = galley
+                    .pos_from_cursor(CCursor::new(caret.column.min(text.chars().count())))
+                    .left();
+                let caret_x = origin.x + x;
+
+                // IME preedit paints as underlined overlay text at the caret.
+                if let Some(preedit) = self.doc.ime().preedit().filter(|p| !p.is_empty()) {
+                    let preedit_galley = ui.fonts_mut(|f| {
+                        f.layout_no_wrap(preedit.to_string(), font_id.clone(), text_color)
+                    });
+                    let width = preedit_galley.size().x;
+                    painter.galley(egui::pos2(caret_x, top), preedit_galley, text_color);
+                    painter.line_segment(
+                        [
+                            egui::pos2(caret_x, top + self.view.line_height - 1.0),
+                            egui::pos2(caret_x + width, top + self.view.line_height - 1.0),
+                        ],
+                        egui::Stroke::new(1.0_f32, text_color),
+                    );
+                    caret_rect = Some(Rect::from_min_size(
+                        egui::pos2(caret_x + width, top),
+                        Vec2::new(1.0, self.view.line_height),
+                    ));
+                } else {
+                    caret_rect = Some(Rect::from_min_size(
+                        egui::pos2(caret_x, top),
+                        Vec2::new(1.0, self.view.line_height),
+                    ));
+                }
+            }
+        }
+
+        if let Some(caret_rect) = caret_rect {
+            painter.rect_filled(caret_rect, 0.0, caret_color);
+            // Position the OS IME candidate window at the caret.
+            ui.ctx().output_mut(|o| {
+                o.ime = Some(egui::output::IMEOutput {
+                    rect,
+                    cursor_rect: caret_rect,
+                });
+            });
+        }
+    }
+}
+
+/// Maps a key press (with modifiers) to an editor command. Returns `None`
+/// for keys the editor does not handle.
+fn translate_key(key: Key, modifiers: Modifiers) -> Option<EditorCommand> {
+    let extend = modifiers.shift;
+    let word = modifiers.alt;
+    let line = modifiers.command;
+    let mv = |movement: Movement| Some(EditorCommand::Move { movement, extend });
+    match key {
+        Key::ArrowLeft if line => mv(Movement::LineStart),
+        Key::ArrowLeft if word => mv(Movement::WordLeft),
+        Key::ArrowLeft => mv(Movement::Left),
+        Key::ArrowRight if line => mv(Movement::LineEnd),
+        Key::ArrowRight if word => mv(Movement::WordRight),
+        Key::ArrowRight => mv(Movement::Right),
+        Key::ArrowUp if line => mv(Movement::DocStart),
+        Key::ArrowUp => mv(Movement::Up),
+        Key::ArrowDown if line => mv(Movement::DocEnd),
+        Key::ArrowDown => mv(Movement::Down),
+        Key::Home => mv(Movement::LineStart),
+        Key::End => mv(Movement::LineEnd),
+        Key::Backspace => Some(EditorCommand::Backspace),
+        Key::Delete => Some(EditorCommand::DeleteForward),
+        Key::Enter => Some(EditorCommand::InsertNewline),
+        Key::A if modifiers.command => Some(EditorCommand::SelectAll),
+        Key::Z if modifiers.command && modifiers.shift => Some(EditorCommand::Redo),
+        Key::Z if modifiers.command => Some(EditorCommand::Undo),
+        Key::Y if modifiers.command => Some(EditorCommand::Redo),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editor::EditorSemanticState;
+
+    struct TestState {
+        doc: Document,
+        view: ViewState,
+    }
+
+    fn harness(text: &str) -> egui_kittest::Harness<'static, TestState> {
+        let state = TestState {
+            doc: Document::new(text),
+            view: ViewState::default(),
+        };
+        egui_kittest::Harness::new_ui_state(
+            |ui, state: &mut TestState| {
+                EditorWidget::new(&mut state.doc, &mut state.view).show(ui);
+            },
+            state,
+        )
+    }
+
+    fn semantic(h: &egui_kittest::Harness<'static, TestState>) -> EditorSemanticState {
+        h.state().doc.semantic_state(h.state().view.scroll_y)
+    }
+
+    #[test]
+    fn typing_keys_and_text_events_edit_document() {
+        let mut h = harness("");
+        h.event(Event::Text("hello".into()));
+        h.step();
+        h.key_press(Key::Enter);
+        h.step();
+        h.event(Event::Text("world".into()));
+        h.step();
+
+        let state = semantic(&h);
+        assert_eq!(state.text, "hello\nworld");
+        assert_eq!(state.cursor, Cursor::new(1, 5));
+
+        // Backspace deletes; cmd+Z undoes the whole coalesced group.
+        h.key_press(Key::Backspace);
+        h.step();
+        assert_eq!(semantic(&h).text, "hello\nworl");
+        h.key_press_modifiers(Modifiers::COMMAND, Key::Z);
+        h.step();
+        assert_eq!(semantic(&h).text, "hello\nworld");
+        assert!(semantic(&h).can_redo);
+    }
+
+    #[test]
+    fn shift_arrows_select_and_semantic_state_agrees() {
+        let mut h = harness("abc def");
+        h.key_press_modifiers(Modifiers::COMMAND, Key::A);
+        h.step();
+        let state = semantic(&h);
+        assert_eq!(state.selection.ordered().1, Cursor::new(0, 7));
+
+        h.key_press(Key::ArrowRight); // collapse to end
+        h.step();
+        h.key_press_modifiers(Modifiers::SHIFT | Modifiers::ALT, Key::ArrowLeft);
+        h.step();
+        let state = semantic(&h);
+        assert_eq!(state.cursor, Cursor::new(0, 4));
+        assert!(state.selection.is_range());
+    }
+
+    #[test]
+    fn ime_events_compose_and_commit() {
+        let mut h = harness("");
+        h.event(Event::Ime(ImeEvent::Enabled));
+        h.event(Event::Ime(ImeEvent::Preedit("かん".into())));
+        h.step();
+        let state = semantic(&h);
+        assert_eq!(state.ime_composition, Some("かん".to_string()));
+        assert_eq!(state.text, "");
+
+        h.event(Event::Ime(ImeEvent::Commit("漢字".into())));
+        h.event(Event::Ime(ImeEvent::Disabled));
+        h.step();
+        let state = semantic(&h);
+        assert_eq!(state.text, "漢字");
+        assert_eq!(state.ime_composition, None);
+        assert_eq!(state.cursor, Cursor::new(0, 2));
+    }
+
+    #[test]
+    fn paste_event_inserts_text() {
+        let mut h = harness("ab");
+        h.key_press(Key::ArrowRight);
+        h.step();
+        h.event(Event::Paste("XY".into()));
+        h.step();
+        assert_eq!(semantic(&h).text, "aXYb");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,10 @@
 pub mod app_protocol;
 #[path = "cli/args.rs"]
 pub mod cli_args;
+/// Shared Ferrite-derived editor core (stint 0317). Lives in the lib target
+/// so its public API is the wiring until host integration (stint 0474);
+/// the bin consumes it as `plexi::editor`.
+pub mod editor;
 pub mod protocol;
 
 // Stub modules: only the types used by app_protocol via crate:: references.


### PR DESCRIPTION
Stint task **0317** (no linked GitHub issue).

Extracts a Plexi-owned text-editing core from a pinned revision of Ferrite's MIT-licensed editor, per `docs/notes-editor.md`. Replaces the per-line `TextEdit` direction with one coherent document, selection, transaction, and history model that Notes (stint 0474) and a future code editor share.

## Provenance
- Upstream: https://github.com/OlaProeis/Ferrite @ `3ba085c561670342d72c560efbf6b0b92b5c0b46` (MIT, license vendored at `src/editor/LICENSE-ferrite`; divergences documented in `src/editor/mod.rs`)

## What's in
- `src/editor/`: rope-backed `TextBuffer` (ropey), grapheme-safe `Cursor`/`Selection` (unicode-segmentation), single-transaction mutation API (`Document` + `EditorCommand`), grouped undo/redo with typing coalescing and redo invalidation, keyboard movement (char/word/line/doc with goal column), virtual-scroll `ViewState` with scroll-to-caret, IME composition state (preedit never touches the buffer), and `widget.rs` — the only egui-dependent file — translating egui input events to commands and painting text/selection/caret.
- Lives in the lib target (`plexi::editor`); integration into Notes is stint 0474, deliberately untouched here.

## Out of scope (per task)
Markdown/Notes integration, find/replace, LSP, multi-cursor, Ferrite's app shell/config/theme. Tab/Shift-Tab indent and PageUp/PageDown command mapping deferred to 0474 with the rest of integration.

**Test evidence:**
- cargo test --bin plexi: 1560 passed, 0 failed (full bin suite)
- cargo test --lib: 151 passed, 0 failed (includes 67 editor tests: Unicode graphemes/ZWJ emoji/combining marks, multiline selection, word/line movement, transaction inversion round-trip, undo coalescing + break_group, redo invalidation, IME commit/cancel, 10k-line viewport windowing; 4 egui_kittest widget tests driving key/text/IME events and asserting `EditorSemanticState`)
- mypy sdk/python/plexi_sdk/: clean (no SDK changes; ran per gate)
- Codex review vs alpha: 2 runs; fixed grapheme-splitting word movement, grapheme-splitting cursor clamp, over-eager terminator stripping. No findings remaining.
- Conclusion: install skippable — pure library core with no host surface until 0474; full coverage via unit/property/kittest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)