### PR TITLE
editor: code mode, Markdown transactions, and Live Preview (stints 0318, 0475, 0476)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,13 +554,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.9.1",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
@@ -1339,6 +1363,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,6 +1849,17 @@ name = "extended"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
+
+[[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set 0.8.0",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "fastrand"
@@ -2881,6 +2922,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3042,7 +3089,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
@@ -3142,6 +3189,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -4005,6 +4058,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "syntect",
  "sysinfo",
  "taffy",
  "tar",
@@ -4037,6 +4091,19 @@ name = "plexi-wasm-sdk"
 version = "0.1.0"
 dependencies = [
  "wit-bindgen 0.41.0",
+]
+
+[[package]]
+name = "plist"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml 0.41.0",
+ "serde",
+ "time",
 ]
 
 [[package]]
@@ -4129,6 +4196,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -4230,6 +4303,15 @@ name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -5283,6 +5365,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5416,6 +5519,36 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "time"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -6438,7 +6571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.4",
  "quote",
 ]
 
@@ -6551,8 +6684,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
  "bitflags 2.13.0",
  "bytemuck",
  "cfg_aliases",
@@ -6623,7 +6756,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.13.0",
  "block2 0.6.2",
  "bytemuck",
@@ -7470,6 +7603,15 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4049,6 +4049,7 @@ dependencies = [
  "objc2-core-video",
  "objc2-foundation 0.3.2",
  "pollster",
+ "pulldown-cmark",
  "regex",
  "rfd",
  "rodio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ rodio = "0.22"
 # nested dirs). default-features disabled to avoid pulling crossbeam-channel.
 notify = { version = "8", default-features = false, features = ["macos_fsevent"] }
 egui_commonmark = "0.23.0"
+pulldown-cmark = { version = "0.13", default-features = false }
 # Native file picker dialog (#514). Uses NSOpenPanel on macOS.
 rfd = "0.17"
 # Headless app render (#850). Already transitive via eframe; declared directly for explicit use.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ egui_tiles = { version = "0.15.0", features = ["serde"] }
 egui_term = { path = "deps/egui_term" }
 # Shared editor core (stint 0317): rope buffer + grapheme-aware caret movement.
 ropey = "1.6"
+# Code-mode syntax highlighting (stint 0318). Pure-Rust regex backend
+# (`default-fancy`) — the plain `default` feature pulls the C onig library.
+syntect = { version = "5", default-features = false, features = ["default-fancy"] }
 unicode-segmentation = "1.11"
 dirs = "6"
 fern = "0.7"

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -8,7 +8,8 @@
 //! command surface.
 
 use crate::app::app_trait::{App, AppCommand, AppRenderContext, KeyDisposition};
-use crate::editor::widget::{CodeTheme, EditorWidget};
+use crate::editor::preview::{self, MarkdownLayoutCache};
+use crate::editor::widget::{CodeTheme, EditorWidget, MarkdownTheme};
 use crate::editor::{movement, Document, EditorCommand, EditorMode, SyntaxHighlighter, ViewState};
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
@@ -115,6 +116,9 @@ pub struct TextEditorApp {
     /// Syntax span source for code mode; `None` when the language is unknown
     /// to the bundled syntax set (plain-text fallback).
     highlighter: Option<SyntaxHighlighter>,
+    /// Markdown block/inline layout cache for Live Preview; present only in
+    /// Markdown mode.
+    md_cache: Option<MarkdownLayoutCache>,
     last_edit: Option<Instant>,
     wants_close: bool,
     load_error: Option<String>,
@@ -140,6 +144,7 @@ impl TextEditorApp {
         let mode = detect_mode(&path, is_note);
         log::info!("notes_editor: mode selected {} for {:?}", mode.describe(), path);
         let highlighter = mode.language().and_then(SyntaxHighlighter::new);
+        let md_cache = mode.is_markdown().then(MarkdownLayoutCache::default);
         Self {
             path,
             doc: Document::new(&content),
@@ -149,6 +154,7 @@ impl TextEditorApp {
             is_note,
             mode,
             highlighter,
+            md_cache,
             last_edit: None,
             wants_close: false,
             load_error,
@@ -173,7 +179,22 @@ impl TextEditorApp {
         app.note_title = note_title;
         app.mode = detect_mode(&app.path, true);
         app.highlighter = app.mode.language().and_then(SyntaxHighlighter::new);
+        app.md_cache = app.mode.is_markdown().then(MarkdownLayoutCache::default);
         app
+    }
+
+    /// Flips Markdown presentation between Live Preview and source mode.
+    /// Presentation only: document, selection, history, IME, and scroll
+    /// anchor are untouched. No-op outside Markdown mode.
+    fn toggle_preview_mode(&mut self) {
+        if let EditorMode::Markdown { live_preview } = &mut self.mode {
+            *live_preview = !*live_preview;
+            log::info!(
+                "notes_editor: preview mode changed -> {} for {:?}",
+                self.mode.describe(),
+                self.path
+            );
+        }
     }
 
     /// Full on-disk document: frontmatter (when held out) + editable body.
@@ -382,7 +403,9 @@ fn detect_mode(path: &Path, is_note: bool) -> EditorMode {
         .map(str::to_ascii_lowercase);
     let ext = ext.as_deref();
     if is_note || matches!(ext, Some("md" | "markdown")) {
-        return EditorMode::Markdown;
+        // Live Preview is the default Markdown presentation (Obsidian
+        // convention); Cmd+E toggles to source mode.
+        return EditorMode::Markdown { live_preview: true };
     }
     const CODE_EXTENSIONS: &[&str] = &[
         "rs", "py", "js", "ts", "jsx", "tsx", "json", "toml", "yaml", "yml", "sh", "bash", "zsh",
@@ -570,6 +593,18 @@ impl App for TextEditorApp {
             self.flush();
             return KeyDisposition::Consumed;
         }
+        // Cmd+G: toggle Live Preview / source. (Obsidian uses Cmd+E, but the
+        // host binds that to open_file_browser, and host bindings are
+        // non-exact so any Cmd+E-with-extra-modifiers triggers it too.)
+        if input.key_pressed(egui::Key::G)
+            && input
+                .modifiers()
+                .matches_logically(egui::Modifiers::COMMAND)
+            && self.mode.is_markdown()
+        {
+            self.toggle_preview_mode();
+            return KeyDisposition::Consumed;
+        }
         // Cmd+F: open find bar (or re-focus if already open).
         if input.key_pressed(egui::Key::F)
             && input
@@ -704,6 +739,11 @@ impl App for TextEditorApp {
             if ui.input_mut(|i| i.consume_key(egui::Modifiers::COMMAND, egui::Key::S)) {
                 self.flush();
             }
+            if self.mode.is_markdown()
+                && ui.input_mut(|i| i.consume_key(egui::Modifiers::COMMAND, egui::Key::G))
+            {
+                self.toggle_preview_mode();
+            }
             if ui.input_mut(|i| i.consume_key(egui::Modifiers::COMMAND, egui::Key::F)) {
                 log::info!("notes_editor: Cmd+F — opening find bar");
                 match &mut self.find_bar {
@@ -787,6 +827,22 @@ impl App for TextEditorApp {
             });
             if let Some(highlighter) = &mut self.highlighter {
                 widget = widget.span_provider(highlighter);
+            }
+        }
+        if self.mode.is_live_preview() {
+            // Live Preview styles map onto host design tokens; styling never
+            // changes glyph metrics (see src/editor/preview.rs).
+            widget = widget.markdown_theme(MarkdownTheme {
+                marker: colors.text_dim,
+                heading: colors.accent,
+                strong: colors.warning,
+                emphasis: colors.text_primary,
+                code: colors.success,
+                quote: colors.text_section,
+                rule: colors.text_dim,
+            });
+            if let Some(cache) = &mut self.md_cache {
+                widget = widget.markdown_preview(cache);
             }
         }
         let response = widget.show(&mut editor_ui);
@@ -958,6 +1014,7 @@ impl App for TextEditorApp {
                     new_path
                 );
                 self.highlighter = self.mode.language().and_then(SyntaxHighlighter::new);
+                self.md_cache = self.mode.is_markdown().then(MarkdownLayoutCache::default);
                 self.path = new_path;
                 self.doc = Document::new(&content);
                 self.view = ViewState::default();
@@ -984,10 +1041,35 @@ impl App for TextEditorApp {
         let anchor_char = movement::cursor_to_char(buffer, sem.selection.anchor);
         let caret_char = movement::cursor_to_char(buffer, sem.cursor);
         let cursor = movement::clamp(buffer, sem.cursor);
-        let line_start_char = buffer.line_to_char(cursor.line);
-        let active = movement::line_text(buffer, cursor.line);
-        let line_end_char = line_start_char + active.chars().count();
         let line_count = buffer.line_count();
+        // Markdown mode reports the caret's parsed block (Live Preview
+        // granularity); other modes fall back to the caret's source line.
+        let (block_start_line, block_end_line, block_kind) = if self.mode.is_markdown() {
+            let layout = preview::parse_markdown_layout(&sem.text);
+            match layout.block_at_line(cursor.line) {
+                Some(block) => (
+                    block.lines.start,
+                    block.lines.end,
+                    format!("{:?}", block.kind),
+                ),
+                None => (cursor.line, cursor.line + 1, "Blank".to_string()),
+            }
+        } else {
+            (cursor.line, cursor.line + 1, "SourceLine".to_string())
+        };
+        let line_start_char = buffer.line_to_char(block_start_line.min(line_count - 1));
+        let block_end_char = if block_end_line < line_count {
+            buffer.line_to_char(block_end_line)
+        } else {
+            buffer.len()
+        };
+        let active = buffer
+            .slice(line_start_char, block_end_char)
+            .trim_end_matches('\n')
+            .to_string();
+        // Report the range that slices back to exactly `active`: the trailing
+        // block-separator newline(s) trimmed above are excluded from `end`.
+        let line_end_char = line_start_char + active.chars().count();
         let visible = self.view.visible_lines(line_count);
         let visible_start = if visible.start < line_count {
             buffer.line_to_char(visible.start)
@@ -1010,7 +1092,19 @@ impl App for TextEditorApp {
             "scroll": {"y": sem.scroll_y},
             "dirty": self.last_edit.is_some(),
             "last_save_result": self.last_save_result,
-            "active_markdown_block": {"start": line_start_char, "end": line_end_char, "source": active, "granularity": "source_line"},
+            "active_markdown_block": {
+                "start": line_start_char,
+                "end": line_end_char,
+                "source": active,
+                "kind": block_kind,
+                "granularity": if self.mode.is_markdown() { "block" } else { "source_line" },
+            },
+            "editor_mode": self.mode.describe(),
+            "preview_mode": match &self.mode {
+                EditorMode::Markdown { live_preview: true } => Some("live_preview"),
+                EditorMode::Markdown { live_preview: false } => Some("source"),
+                _ => None,
+            },
             "visible_link_targets": links,
             "visible_images": images,
             "undo_available": sem.can_undo,
@@ -1114,7 +1208,9 @@ mod tests {
         let mut app = TextEditorApp::new_for_test_note(path);
         app.doc.apply(EditorCommand::SetCursor(Cursor::new(0, 6)));
         let state = crate::app::app_trait::App::semantic_state(&app).unwrap();
-        assert_eq!(state["active_markdown_block"]["source"], "😀 café");
+        // Markdown block granularity: the two lines are one paragraph block.
+        assert_eq!(state["active_markdown_block"]["source"], "😀 café\nsecond");
+        assert_eq!(state["active_markdown_block"]["kind"], "Paragraph");
         assert_eq!(state["caret"], 6);
         let _ = std::fs::remove_dir_all(dir);
     }
@@ -1413,8 +1509,14 @@ mod tests {
     #[test]
     fn detect_mode_routes_notes_markdown_code_and_plain() {
         let p = |s: &str| PathBuf::from(s);
-        assert_eq!(detect_mode(&p("/x/scratch.txt"), true), EditorMode::Markdown);
-        assert_eq!(detect_mode(&p("/x/readme.MD"), false), EditorMode::Markdown);
+        assert_eq!(
+            detect_mode(&p("/x/scratch.txt"), true),
+            EditorMode::Markdown { live_preview: true }
+        );
+        assert_eq!(
+            detect_mode(&p("/x/readme.MD"), false),
+            EditorMode::Markdown { live_preview: true }
+        );
         assert_eq!(
             detect_mode(&p("/x/main.rs"), false),
             EditorMode::Code {
@@ -1451,6 +1553,67 @@ mod tests {
             "// unicode: café 😀\nfn main() {}\n",
             "code mode never rewrites source text"
         );
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn preview_toggle_preserves_caret_selection_scroll_and_history() {
+        let dir = unique_temp_dir("notes-preview-toggle");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("preview.md");
+        std::fs::write(&path, "# Title\n\npara **bold** text\n\n- item").unwrap();
+        let mut app = TextEditorApp::new_for_test_note(path);
+        assert!(app.mode.is_live_preview(), "markdown defaults to live preview");
+        assert!(app.md_cache.is_some());
+
+        app.doc.apply(EditorCommand::SetCursor(Cursor::new(2, 1)));
+        app.doc.apply(EditorCommand::ExtendTo(Cursor::new(2, 4)));
+        app.view.scroll_y = 12.5;
+        let before = app.doc.semantic_state(app.view.scroll_y);
+
+        app.toggle_preview_mode();
+        assert_eq!(app.mode, EditorMode::Markdown { live_preview: false });
+        assert_eq!(app.doc.semantic_state(app.view.scroll_y), before);
+        let state = crate::app::app_trait::App::semantic_state(&app).unwrap();
+        assert_eq!(state["preview_mode"], "source");
+        assert_eq!(state["editor_mode"], "markdown:source");
+
+        app.toggle_preview_mode();
+        assert_eq!(app.doc.semantic_state(app.view.scroll_y), before);
+        let state = crate::app::app_trait::App::semantic_state(&app).unwrap();
+        assert_eq!(state["preview_mode"], "live_preview");
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn semantic_active_block_tracks_caret_across_blocks_without_edits() {
+        let dir = unique_temp_dir("notes-active-block");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("blocks.md");
+        std::fs::write(&path, "# Head\n\n- one\n- two\n\n```\ncode\n```").unwrap();
+        let mut app = TextEditorApp::new_for_test_note(path);
+        let revision = app.doc.revision();
+
+        let block_at = |app: &TextEditorApp| {
+            let s = crate::app::app_trait::App::semantic_state(app).unwrap();
+            (
+                s["active_markdown_block"]["kind"].as_str().unwrap().to_string(),
+                s["active_markdown_block"]["source"].as_str().unwrap().to_string(),
+            )
+        };
+        app.doc.apply(EditorCommand::SetCursor(Cursor::new(0, 2)));
+        assert_eq!(block_at(&app), ("Heading(1)".into(), "# Head".into()));
+        app.doc.apply(EditorCommand::SetCursor(Cursor::new(3, 1)));
+        assert_eq!(block_at(&app), ("ListItem".into(), "- two".into()));
+        app.doc.apply(EditorCommand::SetCursor(Cursor::new(6, 0)));
+        let (kind, source) = block_at(&app);
+        assert_eq!(kind, "CodeFence");
+        assert_eq!(source, "```\ncode\n```");
+
+        // Active-block transitions are pure reads: no text, selection-history,
+        // or undo mutation.
+        assert_eq!(app.doc.revision(), revision);
+        assert!(!app.doc.semantic_state(0.0).can_undo);
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -8,8 +8,8 @@
 //! command surface.
 
 use crate::app::app_trait::{App, AppCommand, AppRenderContext, KeyDisposition};
-use crate::editor::widget::EditorWidget;
-use crate::editor::{movement, Document, EditorCommand, ViewState};
+use crate::editor::widget::{CodeTheme, EditorWidget};
+use crate::editor::{movement, Document, EditorCommand, EditorMode, SyntaxHighlighter, ViewState};
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 use std::time::{Duration, Instant};
@@ -109,6 +109,12 @@ pub struct TextEditorApp {
     note_title: String,
     /// True when `path` lives under `<config_dir>/notes/`.
     is_note: bool,
+    /// Editor presentation/input mode, detected from `path` (extension) and
+    /// note-ness. The core never inspects file metadata itself.
+    mode: EditorMode,
+    /// Syntax span source for code mode; `None` when the language is unknown
+    /// to the bundled syntax set (plain-text fallback).
+    highlighter: Option<SyntaxHighlighter>,
     last_edit: Option<Instant>,
     wants_close: bool,
     load_error: Option<String>,
@@ -131,6 +137,9 @@ impl TextEditorApp {
         let notes_dir = crate::config::config_dir().join("notes");
         let is_note = path.starts_with(&notes_dir);
         let (note_header, content, note_title) = split_note(is_note, raw);
+        let mode = detect_mode(&path, is_note);
+        log::info!("notes_editor: mode selected {} for {:?}", mode.describe(), path);
+        let highlighter = mode.language().and_then(SyntaxHighlighter::new);
         Self {
             path,
             doc: Document::new(&content),
@@ -138,6 +147,8 @@ impl TextEditorApp {
             note_header,
             note_title,
             is_note,
+            mode,
+            highlighter,
             last_edit: None,
             wants_close: false,
             load_error,
@@ -160,6 +171,8 @@ impl TextEditorApp {
         app.note_header = note_header;
         app.doc = Document::new(&content);
         app.note_title = note_title;
+        app.mode = detect_mode(&app.path, true);
+        app.highlighter = app.mode.language().and_then(SyntaxHighlighter::new);
         app
     }
 
@@ -354,6 +367,33 @@ impl TextEditorApp {
             bar.recompute(&text);
         }
         log::info!("notes_editor: replace-all rewrote {count} matches");
+    }
+}
+
+/// Detects the editor mode from file metadata: notes and Markdown extensions
+/// get [`EditorMode::Markdown`]; recognized source-code extensions get
+/// [`EditorMode::Code`] with the extension as the language identifier;
+/// everything else is plain text. The editor core only ever receives the
+/// resulting mode/identifier — it never inspects paths.
+fn detect_mode(path: &Path, is_note: bool) -> EditorMode {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(str::to_ascii_lowercase);
+    let ext = ext.as_deref();
+    if is_note || matches!(ext, Some("md" | "markdown")) {
+        return EditorMode::Markdown;
+    }
+    const CODE_EXTENSIONS: &[&str] = &[
+        "rs", "py", "js", "ts", "jsx", "tsx", "json", "toml", "yaml", "yml", "sh", "bash", "zsh",
+        "c", "h", "cpp", "hpp", "cc", "go", "rb", "java", "html", "css", "xml", "lua", "swift",
+        "sql", "php",
+    ];
+    match ext {
+        Some(ext) if CODE_EXTENSIONS.contains(&ext) => EditorMode::Code {
+            language: ext.to_string(),
+        },
+        _ => EditorMode::PlainText,
     }
 }
 
@@ -720,25 +760,36 @@ impl App for TextEditorApp {
         );
         editor_ui.visuals_mut().override_text_color = Some(colors.text_primary);
         editor_ui.visuals_mut().selection.stroke.color = colors.accent;
-        // Markdown-aware keyboard behavior for notes and .md/.markdown files.
-        let markdown = self.is_note
-            || self
-                .path
-                .extension()
-                .and_then(|e| e.to_str())
-                .is_some_and(|e| e.eq_ignore_ascii_case("md") || e.eq_ignore_ascii_case("markdown"));
-        let response = EditorWidget::new(&mut self.doc, &mut self.view)
+        let mut widget = EditorWidget::new(&mut self.doc, &mut self.view)
             .id(te_id)
             .active(editor_focused)
             .font_size(self.font_size)
-            .markdown(markdown)
+            .mode(self.mode.clone())
             .highlights(
                 highlights,
                 current_highlight,
                 colors.warning.gamma_multiply(0.45),
                 colors.accent.gamma_multiply(0.55),
-            )
-            .show(&mut editor_ui);
+            );
+        if self.mode.is_code() {
+            // Syntect styles map onto host design tokens — never a syntect
+            // theme's raw colors.
+            widget = widget.code_theme(CodeTheme {
+                gutter_text: colors.text_dim,
+                current_line_bg: colors.bg_hover.gamma_multiply(0.55),
+                keyword: colors.accent,
+                string: colors.success,
+                comment: colors.text_dim,
+                number: colors.warning,
+                ty: colors.warning,
+                function: colors.text_primary,
+                punctuation: colors.text_section,
+            });
+            if let Some(highlighter) = &mut self.highlighter {
+                widget = widget.span_provider(highlighter);
+            }
+        }
+        let response = widget.show(&mut editor_ui);
         ui.advance_cursor_after_rect(editor_rect);
 
         // Clicking the editor while the find input holds focus claims the
@@ -900,6 +951,13 @@ impl App for TextEditorApp {
                 let notes_dir = crate::config::config_dir().join("notes");
                 self.is_note = new_path.starts_with(&notes_dir);
                 let (note_header, content, note_title) = split_note(self.is_note, raw);
+                self.mode = detect_mode(&new_path, self.is_note);
+                log::info!(
+                    "notes_editor: mode selected {} for {:?}",
+                    self.mode.describe(),
+                    new_path
+                );
+                self.highlighter = self.mode.language().and_then(SyntaxHighlighter::new);
                 self.path = new_path;
                 self.doc = Document::new(&content);
                 self.view = ViewState::default();
@@ -1349,6 +1407,50 @@ mod tests {
         assert!(std::fs::read_to_string(&path)
             .unwrap()
             .starts_with("---\ntitle: \"Trip\""));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn detect_mode_routes_notes_markdown_code_and_plain() {
+        let p = |s: &str| PathBuf::from(s);
+        assert_eq!(detect_mode(&p("/x/scratch.txt"), true), EditorMode::Markdown);
+        assert_eq!(detect_mode(&p("/x/readme.MD"), false), EditorMode::Markdown);
+        assert_eq!(
+            detect_mode(&p("/x/main.rs"), false),
+            EditorMode::Code {
+                language: "rs".into()
+            }
+        );
+        assert_eq!(
+            detect_mode(&p("/x/script.PY"), false),
+            EditorMode::Code {
+                language: "py".into()
+            }
+        );
+        assert_eq!(detect_mode(&p("/x/notes.txt"), false), EditorMode::PlainText);
+        assert_eq!(detect_mode(&p("/x/no-extension"), false), EditorMode::PlainText);
+        assert_eq!(detect_mode(&p("/x/data.xyz"), false), EditorMode::PlainText);
+    }
+
+    #[test]
+    fn code_mode_file_saves_source_text_verbatim() {
+        let dir = unique_temp_dir("code-mode-save");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("main.rs");
+        std::fs::write(&path, "fn main() {}\n").unwrap();
+        let mut app = TextEditorApp::new(path.clone());
+        assert!(app.mode.is_code());
+        assert!(app.highlighter.is_some(), "rust syntax is bundled");
+        app.doc.apply(EditorCommand::SetCursor(Cursor::new(0, 0)));
+        app.doc
+            .apply(EditorCommand::InsertText("// unicode: café 😀\n".into()));
+        app.last_edit = Some(Instant::now());
+        app.flush();
+        assert_eq!(
+            std::fs::read_to_string(&path).unwrap(),
+            "// unicode: café 😀\nfn main() {}\n",
+            "code mode never rewrites source text"
+        );
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -720,10 +720,18 @@ impl App for TextEditorApp {
         );
         editor_ui.visuals_mut().override_text_color = Some(colors.text_primary);
         editor_ui.visuals_mut().selection.stroke.color = colors.accent;
+        // Markdown-aware keyboard behavior for notes and .md/.markdown files.
+        let markdown = self.is_note
+            || self
+                .path
+                .extension()
+                .and_then(|e| e.to_str())
+                .is_some_and(|e| e.eq_ignore_ascii_case("md") || e.eq_ignore_ascii_case("markdown"));
         let response = EditorWidget::new(&mut self.doc, &mut self.view)
             .id(te_id)
             .active(editor_focused)
             .font_size(self.font_size)
+            .markdown(markdown)
             .highlights(
                 highlights,
                 current_highlight,

--- a/src/editor/commands.rs
+++ b/src/editor/commands.rs
@@ -9,6 +9,7 @@ use super::buffer::TextBuffer;
 use super::cursor::{Cursor, Selection};
 use super::history::EditHistory;
 use super::ime::ImeState;
+use super::markdown::{self, MarkdownPlan};
 use super::movement;
 use super::selection;
 use super::transaction::{EditOperation, Transaction};
@@ -51,6 +52,18 @@ pub enum EditorCommand {
     /// Shift-Tab: remove one indentation level from every selected line as
     /// one undoable transaction.
     Outdent,
+    /// Markdown Tab: indent the current line or all selected lines (falls
+    /// back to a plain caret indent inside fenced code blocks).
+    MarkdownIndent,
+    /// Markdown Shift-Tab: same as [`Self::Outdent`] (named for symmetric
+    /// key wiring and logging).
+    MarkdownOutdent,
+    /// Markdown Enter: continue or exit list/task/quote structures; plain
+    /// auto-indent newline everywhere else (including fenced code blocks).
+    MarkdownNewline,
+    /// Markdown Backspace: remove an empty structure marker; plain (smart)
+    /// backspace everywhere else.
+    MarkdownBackspace,
     SetCursor(Cursor),
     /// Move the head only (mouse drag / shift-click).
     ExtendTo(Cursor),
@@ -165,24 +178,35 @@ impl Document {
     pub fn apply(&mut self, command: EditorCommand) {
         match command {
             EditorCommand::InsertText(text) => self.insert_text(&text, true),
-            EditorCommand::InsertNewline => {
-                // Auto-indent: carry the current line's leading whitespace onto
-                // the new line, capped at the caret column (an Enter at column
-                // 0 of an indented line must not duplicate the indent).
-                let (start, _) = self.selection.ordered();
-                let start = movement::clamp(&self.buffer, start);
-                let indent: String = movement::line_text(&self.buffer, start.line)
-                    .chars()
-                    .take(start.column)
-                    .take_while(|c| *c == ' ' || *c == '\t')
-                    .collect();
-                self.insert_text(&format!("\n{indent}"), false);
-            }
+            EditorCommand::InsertNewline => self.insert_newline(),
             EditorCommand::Backspace => self.delete(true),
             EditorCommand::DeleteForward => self.delete(false),
             EditorCommand::Move { movement, extend } => self.do_move(movement, extend),
             EditorCommand::Indent => self.indent(),
             EditorCommand::Outdent => self.outdent(),
+            EditorCommand::MarkdownIndent => {
+                match markdown::plan_indent(&self.buffer, self.selection) {
+                    Some(plan) => self.apply_markdown_plan("indent", plan),
+                    // Collapsed caret inside a fenced code block: plain indent.
+                    None => self.insert_text("    ", false),
+                }
+            }
+            EditorCommand::MarkdownOutdent => {
+                log::info!("editor: markdown command outdent");
+                self.outdent();
+            }
+            EditorCommand::MarkdownNewline => {
+                match markdown::plan_newline(&self.buffer, self.selection) {
+                    Some(plan) => self.apply_markdown_plan("newline", plan),
+                    None => self.insert_newline(),
+                }
+            }
+            EditorCommand::MarkdownBackspace => {
+                match markdown::plan_backspace(&self.buffer, self.selection) {
+                    Some(plan) => self.apply_markdown_plan("backspace", plan),
+                    None => self.delete(true),
+                }
+            }
             EditorCommand::SetCursor(cursor) => {
                 self.set_selection(Selection::collapsed(movement::clamp(&self.buffer, cursor)));
             }
@@ -254,6 +278,40 @@ impl Document {
             caret_after,
             coalesce && !selection_before.is_range(),
         );
+    }
+
+    /// Auto-indent newline: carry the current line's leading whitespace onto
+    /// the new line, capped at the caret column (an Enter at column 0 of an
+    /// indented line must not duplicate the indent).
+    fn insert_newline(&mut self) {
+        let (start, _) = self.selection.ordered();
+        let start = movement::clamp(&self.buffer, start);
+        let indent: String = movement::line_text(&self.buffer, start.line)
+            .chars()
+            .take(start.column)
+            .take_while(|c| *c == ' ' || *c == '\t')
+            .collect();
+        self.insert_text(&format!("\n{indent}"), false);
+    }
+
+    /// Commits a Markdown planner's ops as one transaction, logging the
+    /// command name and edit ranges (never the text content).
+    fn apply_markdown_plan(&mut self, name: &str, plan: MarkdownPlan) {
+        let ranges: Vec<String> = plan
+            .ops
+            .iter()
+            .map(|op| match op {
+                EditOperation::Insert { pos, text } => {
+                    format!("insert@{pos}+{}", text.chars().count())
+                }
+                EditOperation::Delete { pos, text } => {
+                    format!("delete@{pos}-{}", text.chars().count())
+                }
+            })
+            .collect();
+        log::info!("editor: markdown command {name}: {}", ranges.join(","));
+        let selection_before = self.selection;
+        self.commit_with_selection(plan.ops, selection_before, plan.selection_after);
     }
 
     /// Number of spaces smart backspace removes at the caret: when the line
@@ -847,6 +905,257 @@ mod tests {
         d.apply(EditorCommand::Undo);
         d.apply(EditorCommand::Undo);
         assert!(d.text().ends_with("line 9999"));
+    }
+
+    #[test]
+    fn markdown_enter_continues_unordered_task_and_quote() {
+        for (text, expected) in [
+            ("- item", "- item\n- "),
+            ("* item", "* item\n* "),
+            ("+ item", "+ item\n+ "),
+            ("  - nested", "  - nested\n  - "),
+            ("- [x] done", "- [x] done\n- [ ] "),
+            ("> quoted", "> quoted\n> "),
+            ("> > deep", "> > deep\n> > "),
+        ] {
+            let mut d = doc(text);
+            d.apply(EditorCommand::Move {
+                movement: Movement::LineEnd,
+                extend: false,
+            });
+            d.apply(EditorCommand::MarkdownNewline);
+            assert_eq!(d.text(), expected, "continuation for {text:?}");
+            let lines: Vec<&str> = expected.split('\n').collect();
+            assert_eq!(
+                d.cursor(),
+                Cursor::new(1, lines[1].chars().count()),
+                "caret sits after the new marker for {text:?}"
+            );
+            // One atomic undo.
+            d.apply(EditorCommand::Undo);
+            assert_eq!(d.text(), text);
+        }
+    }
+
+    #[test]
+    fn markdown_enter_mid_item_splits_with_marker() {
+        let mut d = doc("- alpha beta");
+        d.apply(EditorCommand::SetCursor(Cursor::new(0, 7)));
+        d.apply(EditorCommand::MarkdownNewline);
+        assert_eq!(d.text(), "- alpha\n- beta");
+        assert_eq!(d.cursor(), Cursor::new(1, 2));
+    }
+
+    #[test]
+    fn markdown_enter_on_empty_continuation_removes_marker() {
+        let mut d = doc("- item\n- ");
+        d.apply(EditorCommand::Move {
+            movement: Movement::DocEnd,
+            extend: false,
+        });
+        d.apply(EditorCommand::MarkdownNewline);
+        assert_eq!(d.text(), "- item\n");
+        assert_eq!(d.cursor(), Cursor::new(1, 0));
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "- item\n- ");
+
+        // Indented empty continuation removes indent + marker in one step.
+        let mut d = doc("  - [ ] ");
+        d.apply(EditorCommand::Move {
+            movement: Movement::LineEnd,
+            extend: false,
+        });
+        d.apply(EditorCommand::MarkdownNewline);
+        assert_eq!(d.text(), "");
+    }
+
+    #[test]
+    fn markdown_enter_ordered_continues_and_renumbers_siblings() {
+        let mut d = doc("1. one\n2. two\n3. three");
+        d.apply(EditorCommand::SetCursor(Cursor::new(0, 6)));
+        d.apply(EditorCommand::MarkdownNewline);
+        assert_eq!(d.text(), "1. one\n2. \n3. two\n4. three");
+        assert_eq!(d.cursor(), Cursor::new(1, 3));
+        // The whole continuation + renumber is one undo step.
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "1. one\n2. two\n3. three");
+
+        // Exiting an empty ordered item closes the numbering gap it leaves.
+        let mut d = doc("1. one\n2. \n3. three");
+        d.apply(EditorCommand::SetCursor(Cursor::new(1, 3)));
+        d.apply(EditorCommand::MarkdownNewline);
+        assert_eq!(d.text(), "1. one\n\n2. three");
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "1. one\n2. \n3. three");
+
+        // Renumbering stops at a non-list line and skips different indents.
+        let mut d = doc("1. a\n2. b\nplain\n3. c");
+        d.apply(EditorCommand::SetCursor(Cursor::new(0, 4)));
+        d.apply(EditorCommand::MarkdownNewline);
+        assert_eq!(d.text(), "1. a\n2. \n3. b\nplain\n3. c");
+    }
+
+    #[test]
+    fn markdown_enter_before_marker_and_on_plain_lines_is_plain_newline() {
+        // Caret inside the marker prefix: plain newline, no continuation.
+        let mut d = doc("- item");
+        d.apply(EditorCommand::SetCursor(Cursor::new(0, 0)));
+        d.apply(EditorCommand::MarkdownNewline);
+        assert_eq!(d.text(), "\n- item");
+
+        // Plain text: auto-indent newline as usual.
+        let mut d = doc("    text");
+        d.apply(EditorCommand::Move {
+            movement: Movement::LineEnd,
+            extend: false,
+        });
+        d.apply(EditorCommand::MarkdownNewline);
+        assert_eq!(d.text(), "    text\n    ");
+
+        // A selection replaces with a plain newline.
+        let mut d = doc("- one\n- two");
+        d.apply(EditorCommand::SetCursor(Cursor::new(0, 2)));
+        d.apply(EditorCommand::ExtendTo(Cursor::new(1, 2)));
+        d.apply(EditorCommand::MarkdownNewline);
+        assert_eq!(d.text(), "- \ntwo");
+    }
+
+    #[test]
+    fn markdown_no_list_behavior_inside_fenced_code_blocks() {
+        let text = "```\n- not a list\n```";
+        let mut d = doc(text);
+        d.apply(EditorCommand::SetCursor(Cursor::new(1, 12)));
+        d.apply(EditorCommand::MarkdownNewline);
+        assert_eq!(d.text(), "```\n- not a list\n\n```", "plain newline in fence");
+
+        // Tab in a fence is a plain caret indent, not a line indent.
+        let mut d = doc(text);
+        d.apply(EditorCommand::SetCursor(Cursor::new(1, 0)));
+        d.apply(EditorCommand::MarkdownIndent);
+        assert_eq!(d.text(), "```\n    - not a list\n```");
+        assert_eq!(d.cursor(), Cursor::new(1, 4));
+
+        // After the closing fence, Markdown behavior returns.
+        let mut d = doc("```\ncode\n```\n- item");
+        d.apply(EditorCommand::Move {
+            movement: Movement::DocEnd,
+            extend: false,
+        });
+        d.apply(EditorCommand::MarkdownNewline);
+        assert_eq!(d.text(), "```\ncode\n```\n- item\n- ");
+    }
+
+    #[test]
+    fn markdown_tab_indents_whole_line_at_any_caret_position() {
+        let mut d = doc("- item");
+        d.apply(EditorCommand::SetCursor(Cursor::new(0, 3)));
+        d.apply(EditorCommand::MarkdownIndent);
+        assert_eq!(d.text(), "    - item");
+        assert_eq!(d.cursor(), Cursor::new(0, 7), "caret shifts with the line");
+        d.apply(EditorCommand::MarkdownOutdent);
+        assert_eq!(d.text(), "- item");
+        assert_eq!(d.cursor(), Cursor::new(0, 3));
+    }
+
+    #[test]
+    fn markdown_tab_uses_tab_unit_on_tab_indented_lines() {
+        let mut d = doc("\t- item");
+        d.apply(EditorCommand::SetCursor(Cursor::new(0, 3)));
+        d.apply(EditorCommand::MarkdownIndent);
+        assert_eq!(d.text(), "\t\t- item");
+        assert_eq!(d.cursor(), Cursor::new(0, 4));
+    }
+
+    #[test]
+    fn markdown_indent_mixed_selection_preserves_direction() {
+        // Selection spans list and non-list lines, head above anchor.
+        let mut d = doc("- one\nplain\n- two");
+        d.apply(EditorCommand::SetCursor(Cursor::new(2, 3)));
+        d.apply(EditorCommand::ExtendTo(Cursor::new(0, 1)));
+        d.apply(EditorCommand::MarkdownIndent);
+        assert_eq!(d.text(), "    - one\n    plain\n    - two");
+        let sel = d.selection();
+        assert_eq!(sel.anchor, Cursor::new(2, 7));
+        assert_eq!(sel.head, Cursor::new(0, 5), "direction preserved");
+        // One undo restores everything.
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "- one\nplain\n- two");
+    }
+
+    #[test]
+    fn markdown_indent_excludes_line_when_selection_ends_at_its_start() {
+        let mut d = doc("- one\n- two\n- three");
+        d.apply(EditorCommand::SetCursor(Cursor::new(0, 0)));
+        d.apply(EditorCommand::ExtendTo(Cursor::new(2, 0)));
+        d.apply(EditorCommand::MarkdownIndent);
+        assert_eq!(d.text(), "    - one\n    - two\n- three");
+    }
+
+    #[test]
+    fn markdown_backspace_removes_empty_marker_then_indent_level() {
+        let mut d = doc("    - ");
+        d.apply(EditorCommand::Move {
+            movement: Movement::LineEnd,
+            extend: false,
+        });
+        d.apply(EditorCommand::MarkdownBackspace);
+        assert_eq!(d.text(), "    ", "marker removed, indent kept");
+        assert_eq!(d.cursor(), Cursor::new(0, 4));
+        d.apply(EditorCommand::MarkdownBackspace);
+        assert_eq!(d.text(), "", "smart backspace removes the indent level");
+        d.apply(EditorCommand::Undo);
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "    - ");
+    }
+
+    #[test]
+    fn markdown_backspace_is_plain_elsewhere() {
+        // Mid-content: ordinary grapheme deletion.
+        let mut d = doc("- ab");
+        d.apply(EditorCommand::Move {
+            movement: Movement::LineEnd,
+            extend: false,
+        });
+        d.apply(EditorCommand::MarkdownBackspace);
+        assert_eq!(d.text(), "- a");
+
+        // Empty marker line inside a fence: plain deletion, not marker-aware.
+        let mut d = doc("```\n- \n```");
+        d.apply(EditorCommand::SetCursor(Cursor::new(1, 2)));
+        d.apply(EditorCommand::MarkdownBackspace);
+        assert_eq!(d.text(), "```\n-\n```");
+
+        // Selection: deletes the selection.
+        let mut d = doc("- one");
+        d.apply(EditorCommand::SelectAll);
+        d.apply(EditorCommand::MarkdownBackspace);
+        assert_eq!(d.text(), "");
+    }
+
+    #[test]
+    fn markdown_pasted_multiline_content_is_one_plain_transaction() {
+        let mut d = doc("- item");
+        d.apply(EditorCommand::Move {
+            movement: Movement::LineEnd,
+            extend: false,
+        });
+        d.apply(EditorCommand::InsertText("\nline a\nline b".into()));
+        assert_eq!(d.text(), "- item\nline a\nline b");
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "- item");
+    }
+
+    #[test]
+    fn markdown_newline_at_document_end_grapheme_safe() {
+        let mut d = doc("- caf\u{65}\u{301}👨\u{200D}👩\u{200D}👧");
+        d.apply(EditorCommand::Move {
+            movement: Movement::DocEnd,
+            extend: false,
+        });
+        d.apply(EditorCommand::MarkdownNewline);
+        assert!(d.text().ends_with("\n- "));
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "- caf\u{65}\u{301}👨\u{200D}👩\u{200D}👧");
     }
 
     #[test]

--- a/src/editor/highlight.rs
+++ b/src/editor/highlight.rs
@@ -1,0 +1,339 @@
+//! Syntax-highlight span provider for code mode (stint 0318). No egui.
+//!
+//! Spans are semantic token kinds over byte ranges of a single line; color
+//! mapping is the widget/theme's job, so the core stays presentation-agnostic
+//! and the highlighter never names a concrete color.
+//!
+//! Caching: results are cached per line, keyed by the document revision.
+//! Syntect parse state is sequential (block comments, fenced strings), so the
+//! cache stores the parser state entering every line and extends lazily up to
+//! the highest line the widget has asked for. An edit bumps the revision; the
+//! cache keeps its unchanged-text prefix and reparses only from the first
+//! differing line down to the last visible one — never the whole document,
+//! never per frame.
+
+use std::sync::OnceLock;
+
+use syntect::parsing::{ParseState, ScopeStack, SyntaxSet};
+
+use super::buffer::TextBuffer;
+use super::movement::line_text;
+
+/// Semantic token classes the widget can map onto theme colors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenKind {
+    Plain,
+    Keyword,
+    String,
+    Comment,
+    Number,
+    Type,
+    Function,
+    Punctuation,
+}
+
+/// One highlighted region: byte offsets into the line's text (always on
+/// char boundaries — syntect offsets are valid UTF-8 boundaries).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HighlightSpan {
+    pub start: usize,
+    pub end: usize,
+    pub kind: TokenKind,
+}
+
+/// Anything that can produce highlight spans for a line at a document
+/// revision. The widget's plain-text fallback is simply "no provider".
+pub trait SpanProvider {
+    /// Spans for `line`, contiguous over the whole line text. `revision`
+    /// invalidates internal caches when it changes.
+    fn line_spans(&mut self, buffer: &TextBuffer, line: usize, revision: u64) -> &[HighlightSpan];
+}
+
+fn syntax_set() -> &'static SyntaxSet {
+    static SET: OnceLock<SyntaxSet> = OnceLock::new();
+    SET.get_or_init(SyntaxSet::load_defaults_newlines)
+}
+
+/// Syntect-backed [`SpanProvider`] with a revision-keyed per-line cache.
+pub struct SyntaxHighlighter {
+    /// Revision the cache below is valid for.
+    revision: Option<u64>,
+    /// Parser state entering line `i` (`states[0]` is the initial state);
+    /// always `lines.len() + 1` entries.
+    states: Vec<ParseState>,
+    /// Scope stack entering line `i`, parallel to `states`.
+    stacks: Vec<ScopeStack>,
+    /// Cached spans per already-highlighted line.
+    lines: Vec<Vec<HighlightSpan>>,
+    /// The text each cached line was highlighted from, so a revision bump can
+    /// keep the unchanged prefix instead of reparsing from the top.
+    texts: Vec<String>,
+}
+
+impl SyntaxHighlighter {
+    /// Builds a highlighter for `language` (an extension token or syntax
+    /// name, e.g. `"rs"`, `"py"`). Returns `None` when the bundled syntax set
+    /// has no match — callers fall back to plain spans.
+    #[must_use]
+    pub fn new(language: &str) -> Option<Self> {
+        let syntax = syntax_set().find_syntax_by_token(language)?;
+        log::info!(
+            "editor: syntax highlighter ready for language {language:?} -> {}",
+            syntax.name
+        );
+        Some(Self {
+            revision: None,
+            states: vec![ParseState::new(syntax)],
+            stacks: vec![ScopeStack::new()],
+            lines: Vec::new(),
+            texts: Vec::new(),
+        })
+    }
+
+    /// On a revision change, keeps the longest cached prefix whose line text
+    /// is unchanged (identical text prefix ⇒ identical parser state) and
+    /// truncates from the first differing line. Typing then reparses only
+    /// from the edit down to the requested (visible) line, never the whole
+    /// document prefix per keystroke.
+    fn sync_revision(&mut self, buffer: &TextBuffer, revision: u64) {
+        if self.revision == Some(revision) {
+            return;
+        }
+        self.revision = Some(revision);
+        let keep = self
+            .texts
+            .iter()
+            .take(buffer.line_count())
+            .enumerate()
+            .take_while(|(i, cached)| line_text(buffer, *i) == **cached)
+            .count();
+        self.texts.truncate(keep);
+        self.lines.truncate(keep);
+        self.states.truncate(keep + 1);
+        self.stacks.truncate(keep + 1);
+    }
+
+    /// Highlights one more line, extending the cache by one entry.
+    fn advance(&mut self, buffer: &TextBuffer) {
+        let line = self.lines.len();
+        let source = line_text(buffer, line);
+        // `load_defaults_newlines` grammars expect the trailing newline.
+        let text = format!("{source}\n");
+        let content_len = text.len().saturating_sub(1);
+        let mut state = self.states[line].clone();
+        let mut stack = self.stacks[line].clone();
+        let mut spans = Vec::new();
+        match state.parse_line(&text, syntax_set()) {
+            Ok(ops) => {
+                let mut prev = 0usize;
+                for (offset, op) in ops {
+                    let offset = offset.min(content_len);
+                    if offset > prev {
+                        spans.push(HighlightSpan {
+                            start: prev,
+                            end: offset,
+                            kind: kind_of(&stack),
+                        });
+                        prev = offset;
+                    }
+                    if let Err(e) = stack.apply(&op) {
+                        log::error!("editor: highlight scope apply failed on line {line}: {e}");
+                    }
+                }
+                if content_len > prev {
+                    spans.push(HighlightSpan {
+                        start: prev,
+                        end: content_len,
+                        kind: kind_of(&stack),
+                    });
+                }
+            }
+            Err(e) => {
+                log::error!("editor: highlight parse failed on line {line}: {e}");
+                if content_len > 0 {
+                    spans.push(HighlightSpan {
+                        start: 0,
+                        end: content_len,
+                        kind: TokenKind::Plain,
+                    });
+                }
+            }
+        }
+        self.states.push(state);
+        self.stacks.push(stack);
+        self.lines.push(spans);
+        self.texts.push(source);
+    }
+}
+
+impl SpanProvider for SyntaxHighlighter {
+    fn line_spans(&mut self, buffer: &TextBuffer, line: usize, revision: u64) -> &[HighlightSpan] {
+        self.sync_revision(buffer, revision);
+        let line = line.min(buffer.line_count().saturating_sub(1));
+        while self.lines.len() <= line {
+            self.advance(buffer);
+        }
+        &self.lines[line]
+    }
+}
+
+/// Maps the scope stack to a token kind. Comment/string containers win over
+/// anything nested inside them (so delimiters like `"` or `//` — which sit on
+/// the stack as `punctuation.definition.*` — color as the container); other
+/// kinds resolve innermost-first.
+fn kind_of(stack: &ScopeStack) -> TokenKind {
+    for scope in stack.as_slice() {
+        let name = scope.build_string();
+        if name.starts_with("comment") {
+            return TokenKind::Comment;
+        }
+        if name.starts_with("string") {
+            return TokenKind::String;
+        }
+    }
+    for scope in stack.as_slice().iter().rev() {
+        let name = scope.build_string();
+        let kind = if name.starts_with("comment") {
+            TokenKind::Comment
+        } else if name.starts_with("string") {
+            TokenKind::String
+        } else if name.starts_with("constant.numeric") {
+            TokenKind::Number
+        } else if name.starts_with("constant") {
+            TokenKind::Number
+        } else if name.starts_with("keyword") || name.starts_with("storage.modifier") {
+            TokenKind::Keyword
+        } else if name.starts_with("storage.type") {
+            TokenKind::Keyword
+        } else if name.starts_with("entity.name.function") || name.starts_with("support.function")
+        {
+            TokenKind::Function
+        } else if name.starts_with("entity.name.type")
+            || name.starts_with("entity.name")
+            || name.starts_with("support.type")
+            || name.starts_with("support.class")
+        {
+            TokenKind::Type
+        } else if name.starts_with("punctuation") {
+            TokenKind::Punctuation
+        } else {
+            continue;
+        };
+        return kind;
+    }
+    TokenKind::Plain
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn buffer(text: &str) -> TextBuffer {
+        TextBuffer::from_string(text)
+    }
+
+    fn kinds_at(spans: &[HighlightSpan], text: &str, needle: &str) -> TokenKind {
+        let start = text.find(needle).expect("needle present");
+        spans
+            .iter()
+            .find(|s| s.start <= start && start < s.end)
+            .map(|s| s.kind)
+            .expect("span covers needle")
+    }
+
+    #[test]
+    fn unknown_language_yields_no_highlighter() {
+        assert!(SyntaxHighlighter::new("definitely-not-a-language").is_none());
+    }
+
+    #[test]
+    fn rust_keywords_strings_and_comments_are_classified() {
+        let text = "fn main() { let s = \"hi\"; } // done";
+        let buf = buffer(text);
+        let mut h = SyntaxHighlighter::new("rs").expect("rust syntax bundled");
+        let spans = h.line_spans(&buf, 0, 0).to_vec();
+        assert_eq!(kinds_at(&spans, text, "fn"), TokenKind::Keyword);
+        assert_eq!(kinds_at(&spans, text, "let"), TokenKind::Keyword);
+        assert_eq!(kinds_at(&spans, text, "\"hi\""), TokenKind::String);
+        assert_eq!(kinds_at(&spans, text, "// done"), TokenKind::Comment);
+    }
+
+    #[test]
+    fn spans_are_contiguous_and_on_char_boundaries() {
+        let text = "let s = \"héllo 😀\"; // café";
+        let buf = buffer(text);
+        let mut h = SyntaxHighlighter::new("rs").unwrap();
+        let spans = h.line_spans(&buf, 0, 0);
+        let mut cursor = 0usize;
+        for span in spans {
+            assert_eq!(span.start, cursor, "spans are contiguous");
+            assert!(span.end > span.start);
+            assert!(text.is_char_boundary(span.start));
+            assert!(text.is_char_boundary(span.end));
+            cursor = span.end;
+        }
+        assert_eq!(cursor, text.len(), "spans cover the whole line");
+    }
+
+    #[test]
+    fn parser_state_carries_across_lines_in_block_comments() {
+        let buf = buffer("/*\ninside comment\n*/\nfn after() {}");
+        let mut h = SyntaxHighlighter::new("rs").unwrap();
+        let spans = h.line_spans(&buf, 1, 0).to_vec();
+        assert!(
+            spans.iter().all(|s| s.kind == TokenKind::Comment),
+            "line inside a block comment is all comment: {spans:?}"
+        );
+        let after = h.line_spans(&buf, 3, 0).to_vec();
+        assert_eq!(kinds_at(&after, "fn after() {}", "fn"), TokenKind::Keyword);
+    }
+
+    #[test]
+    fn revision_change_invalidates_the_cache() {
+        let before = buffer("let x = 1;");
+        let mut h = SyntaxHighlighter::new("rs").unwrap();
+        let first = h.line_spans(&before, 0, 0).to_vec();
+        assert_eq!(kinds_at(&first, "let x = 1;", "let"), TokenKind::Keyword);
+
+        // Same revision: cached (identity of contents).
+        assert_eq!(h.line_spans(&before, 0, 0), &first[..]);
+
+        // New revision with different text: recomputed against the new buffer.
+        let after = buffer("// now a comment");
+        let second = h.line_spans(&after, 0, 1).to_vec();
+        assert_eq!(
+            kinds_at(&second, "// now a comment", "//"),
+            TokenKind::Comment
+        );
+    }
+
+    #[test]
+    fn revision_bump_keeps_unchanged_prefix_and_reparses_the_suffix() {
+        let before = buffer("fn a() {}\nlet x = 1;\nlet y = 2;");
+        let mut h = SyntaxHighlighter::new("rs").unwrap();
+        h.line_spans(&before, 2, 0);
+        assert_eq!(h.lines.len(), 3);
+
+        // Edit only line 2: the two-line prefix cache survives the revision
+        // bump (a request for line 0 triggers the sync but no reparse of the
+        // kept prefix — only the changed suffix is dropped).
+        let after = buffer("fn a() {}\nlet x = 1;\n// changed");
+        h.line_spans(&after, 0, 1);
+        assert_eq!(h.lines.len(), 2, "unchanged prefix kept, suffix dropped");
+        let spans = h.line_spans(&after, 2, 1).to_vec();
+        assert_eq!(kinds_at(&spans, "// changed", "//"), TokenKind::Comment);
+
+        // An upstream edit that changes downstream state truncates from the
+        // edit: opening a block comment on line 0 re-classifies line 1.
+        let commented = buffer("/* start\nlet x = 1;\n// changed");
+        let spans = h.line_spans(&commented, 1, 2).to_vec();
+        assert!(spans.iter().all(|s| s.kind == TokenKind::Comment), "{spans:?}");
+    }
+
+    #[test]
+    fn empty_lines_produce_no_spans() {
+        let buf = buffer("fn a() {}\n\nfn b() {}");
+        let mut h = SyntaxHighlighter::new("rs").unwrap();
+        assert!(h.line_spans(&buf, 1, 0).is_empty());
+    }
+}

--- a/src/editor/markdown.rs
+++ b/src/editor/markdown.rs
@@ -1,0 +1,413 @@
+//! Markdown-aware editing planners: pure functions from `(buffer, selection)`
+//! to a [`MarkdownPlan`] (edit operations + resulting selection). No mutation
+//! happens here — [`crate::editor::Document`] commits every plan as one
+//! recorded transaction, so each Markdown command is atomically undoable.
+//!
+//! Rules (see `docs/notes-editor.md`, Editing Contract):
+//! - Tab indents the current line or every selected line (list or not);
+//!   inside a fenced code block a collapsed Tab falls back to a plain
+//!   caret-position indent.
+//! - Enter continues unordered lists (`-`, `*`, `+`), task lists (`- [ ]`),
+//!   ordered lists (renumbering the following same-indent siblings), and
+//!   block quotes (`>`); Enter on an empty continuation removes the marker.
+//! - Backspace on an empty marker line removes the marker, keeping the
+//!   indentation (the plain smart backspace then removes indent levels).
+//! - No Markdown behavior inside fenced code blocks; a planner returning
+//!   `None` means "use the plain (non-Markdown) behavior".
+
+use super::buffer::TextBuffer;
+use super::cursor::{Cursor, Selection};
+use super::movement;
+use super::transaction::EditOperation;
+
+/// One planned Markdown edit: operations to apply in order plus the selection
+/// to leave in place. Committed atomically by the document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkdownPlan {
+    pub ops: Vec<EditOperation>,
+    pub selection_after: Selection,
+}
+
+/// A parsed Markdown line prefix: leading whitespace plus a structural
+/// marker. All marker text is ASCII, so byte and char lengths coincide.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Marker {
+    /// Leading spaces/tabs.
+    indent: String,
+    /// The literal marker text including its trailing space(s).
+    marker: String,
+    /// The marker a continuation line receives (task boxes reset to `[ ]`,
+    /// ordered markers increment).
+    next: String,
+    /// The number of an ordered-list marker.
+    ordered: Option<u64>,
+}
+
+fn parse_marker(line: &str) -> Option<Marker> {
+    let indent: String = line
+        .chars()
+        .take_while(|c| *c == ' ' || *c == '\t')
+        .collect();
+    let rest = &line[indent.len()..];
+    let mut first = rest.chars();
+    match first.next()? {
+        '>' => {
+            // Block quote, possibly nested: repeated `>` each optionally
+            // followed by one space.
+            let mut marker = String::new();
+            let mut chars = rest.chars().peekable();
+            while chars.peek() == Some(&'>') {
+                chars.next();
+                marker.push('>');
+                if chars.peek() == Some(&' ') {
+                    chars.next();
+                    marker.push(' ');
+                }
+            }
+            let next = marker.clone();
+            Some(Marker {
+                indent,
+                marker,
+                next,
+                ordered: None,
+            })
+        }
+        bullet @ ('-' | '*' | '+') if first.next() == Some(' ') => {
+            let after = &rest[2..];
+            let task = after.len() >= 4
+                && after.starts_with('[')
+                && matches!(after.as_bytes()[1], b' ' | b'x' | b'X')
+                && &after[2..4] == "] ";
+            let marker = if task {
+                rest[..6].to_string()
+            } else {
+                rest[..2].to_string()
+            };
+            let next = if task {
+                format!("{bullet} [ ] ")
+            } else {
+                marker.clone()
+            };
+            Some(Marker {
+                indent,
+                marker,
+                next,
+                ordered: None,
+            })
+        }
+        c if c.is_ascii_digit() => {
+            let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+            if digits.len() > 9 {
+                return None;
+            }
+            let after = &rest[digits.len()..];
+            let delim = after.chars().next().filter(|d| *d == '.' || *d == ')')?;
+            if after.chars().nth(1) != Some(' ') {
+                return None;
+            }
+            let n: u64 = digits.parse().ok()?;
+            Some(Marker {
+                indent,
+                marker: format!("{digits}{delim} "),
+                next: format!("{}{delim} ", n + 1),
+                ordered: Some(n),
+            })
+        }
+        _ => None,
+    }
+}
+
+/// A fence delimiter run: `(fence char, run length, rest-of-line is blank)`.
+/// `None` when the line is not a fence delimiter.
+fn fence_run(line: &str) -> Option<(char, usize, bool)> {
+    let t = line.trim_start();
+    let c = t.chars().next().filter(|c| *c == '`' || *c == '~')?;
+    let run = t.chars().take_while(|x| *x == c).count();
+    if run < 3 {
+        return None;
+    }
+    Some((c, run, t[run..].trim().is_empty()))
+}
+
+/// Whether `line` is inside a fenced code block. CommonMark closer rules: a
+/// fence only closes on the same character, a run at least as long as the
+/// opener, and no trailing info string.
+fn in_fence(buffer: &TextBuffer, line: usize) -> bool {
+    let mut open: Option<(char, usize)> = None;
+    for l in 0..line {
+        let text = movement::line_text(buffer, l);
+        match (open, fence_run(&text)) {
+            (None, Some((c, run, _))) => open = Some((c, run)),
+            (Some((oc, olen)), Some((c, run, blank))) if c == oc && run >= olen && blank => {
+                open = None;
+            }
+            _ => {}
+        }
+    }
+    open.is_some()
+}
+
+/// The inclusive line range a line-wise command operates on. A multi-line
+/// selection ending at column 0 of a later line excludes that line (platform
+/// convention, mirrors `Document::indent_line_range`).
+fn line_range(selection: Selection) -> (usize, usize) {
+    let (start, end) = selection.ordered();
+    let last = if end.line > start.line && end.column == 0 {
+        end.line - 1
+    } else {
+        end.line
+    };
+    (start.line, last)
+}
+
+/// Tab: indent the current line, or every selected line, by one level as one
+/// transaction. Lines already indented with tabs get a tab, others four
+/// spaces. Returns `None` for a collapsed caret inside a fenced code block —
+/// there Tab is a plain caret-position indent, not a line indent.
+#[must_use]
+pub fn plan_indent(buffer: &TextBuffer, selection: Selection) -> Option<MarkdownPlan> {
+    let head = movement::clamp(buffer, selection.head);
+    let anchor = movement::clamp(buffer, selection.anchor);
+    let selection = Selection::new(anchor, head);
+    if !selection.is_range() && in_fence(buffer, head.line) {
+        return None;
+    }
+    let (first, last) = line_range(selection);
+    let mut ops = Vec::new();
+    let mut added = vec![0usize; last - first + 1];
+    for line in (first..=last).rev() {
+        let text = movement::line_text(buffer, line);
+        let unit = if text.starts_with('\t') { "\t" } else { "    " };
+        ops.push(EditOperation::Insert {
+            pos: buffer.line_to_char(line),
+            text: unit.to_string(),
+        });
+        added[line - first] = unit.chars().count();
+    }
+    let shift = |c: Cursor| {
+        if c.line >= first && c.line <= last {
+            Cursor::new(c.line, c.column + added[c.line - first])
+        } else {
+            c
+        }
+    };
+    Some(MarkdownPlan {
+        ops,
+        selection_after: Selection::new(shift(anchor), shift(head)),
+    })
+}
+
+/// Enter on a list/quote line: continue the structure, or exit it when the
+/// line is an empty continuation. `None` means plain newline behavior
+/// (selections, fenced code blocks, non-marker lines, caret inside the
+/// marker prefix).
+#[must_use]
+pub fn plan_newline(buffer: &TextBuffer, selection: Selection) -> Option<MarkdownPlan> {
+    if selection.is_range() {
+        return None;
+    }
+    let caret = movement::clamp(buffer, selection.head);
+    if in_fence(buffer, caret.line) {
+        return None;
+    }
+    let line = movement::line_text(buffer, caret.line);
+    let marker = parse_marker(&line)?;
+    let prefix_chars = marker.indent.chars().count() + marker.marker.chars().count();
+    if caret.column < prefix_chars {
+        return None;
+    }
+    let content = &line[marker.indent.len() + marker.marker.len()..];
+    if content.is_empty() {
+        // Empty continuation: remove the whole prefix and exit the structure.
+        // Following ordered siblings close the gap the removed item leaves.
+        let start = buffer.line_to_char(caret.line);
+        let prefix = format!("{}{}", marker.indent, marker.marker);
+        let deleted = prefix.chars().count();
+        let mut ops = vec![EditOperation::Delete { pos: start, text: prefix }];
+        if let Some(n) = marker.ordered {
+            renumber_following(
+                buffer,
+                caret.line,
+                &marker.indent,
+                n,
+                -(deleted as isize),
+                &mut ops,
+            );
+        }
+        return Some(MarkdownPlan {
+            ops,
+            selection_after: Selection::collapsed(Cursor::new(caret.line, 0)),
+        });
+    }
+    let caret_char = movement::cursor_to_char(buffer, caret);
+    let inserted = format!("\n{}{}", marker.indent, marker.next);
+    let mut ops = vec![EditOperation::Insert {
+        pos: caret_char,
+        text: inserted.clone(),
+    }];
+    // Splitting mid-item: the spaces right after the caret would otherwise
+    // land between the new marker and the carried content — consume them.
+    let gap: usize = line
+        .chars()
+        .skip(caret.column)
+        .take_while(|c| *c == ' ')
+        .count();
+    if gap > 0 {
+        ops.push(EditOperation::Delete {
+            pos: caret_char + inserted.chars().count(),
+            text: " ".repeat(gap),
+        });
+    }
+    if let Some(n) = marker.ordered {
+        let offset = inserted.chars().count() as isize - gap as isize;
+        renumber_following(buffer, caret.line, &marker.indent, n + 2, offset, &mut ops);
+    }
+    let column = marker.indent.chars().count() + marker.next.chars().count();
+    Some(MarkdownPlan {
+        ops,
+        selection_after: Selection::collapsed(Cursor::new(caret.line + 1, column)),
+    })
+}
+
+/// Renumber consecutive ordered-list lines with the same indent below
+/// `line`, so the run stays sequential starting at `first_expected`.
+/// `initial_offset` is the net char delta of the ops already queued ahead.
+fn renumber_following(
+    buffer: &TextBuffer,
+    line: usize,
+    indent: &str,
+    first_expected: u64,
+    initial_offset: isize,
+    ops: &mut Vec<EditOperation>,
+) {
+    let mut offset = initial_offset;
+    let mut expected = first_expected;
+    for l in (line + 1)..buffer.line_count() {
+        let text = movement::line_text(buffer, l);
+        let Some(m) = parse_marker(&text) else { break };
+        let Some(n) = m.ordered else { break };
+        if m.indent != indent {
+            break;
+        }
+        if n != expected {
+            let old_digits: String = m
+                .marker
+                .chars()
+                .take_while(char::is_ascii_digit)
+                .collect();
+            let new_digits = expected.to_string();
+            let pos = (buffer.line_to_char(l) + indent.chars().count()) as isize + offset;
+            let pos = usize::try_from(pos).unwrap_or(0);
+            ops.push(EditOperation::Delete {
+                pos,
+                text: old_digits.clone(),
+            });
+            ops.push(EditOperation::Insert {
+                pos,
+                text: new_digits.clone(),
+            });
+            offset += new_digits.chars().count() as isize - old_digits.chars().count() as isize;
+        }
+        expected += 1;
+    }
+}
+
+/// Backspace with the caret at the end of an empty marker line: remove the
+/// marker, keep the indentation. `None` means plain deletion (which already
+/// includes smart indentation backspace).
+#[must_use]
+pub fn plan_backspace(buffer: &TextBuffer, selection: Selection) -> Option<MarkdownPlan> {
+    if selection.is_range() {
+        return None;
+    }
+    let caret = movement::clamp(buffer, selection.head);
+    if in_fence(buffer, caret.line) {
+        return None;
+    }
+    let line = movement::line_text(buffer, caret.line);
+    let marker = parse_marker(&line)?;
+    let indent_chars = marker.indent.chars().count();
+    let prefix_chars = indent_chars + marker.marker.chars().count();
+    if caret.column != prefix_chars || line.chars().count() != prefix_chars {
+        return None;
+    }
+    Some(MarkdownPlan {
+        ops: vec![EditOperation::Delete {
+            pos: buffer.line_to_char(caret.line) + indent_chars,
+            text: marker.marker,
+        }],
+        selection_after: Selection::collapsed(Cursor::new(caret.line, indent_chars)),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn marker(line: &str) -> Option<(String, String, String, Option<u64>)> {
+        parse_marker(line).map(|m| (m.indent, m.marker, m.next, m.ordered))
+    }
+
+    #[test]
+    fn parses_bullet_task_ordered_and_quote_markers() {
+        assert_eq!(
+            marker("- item"),
+            Some((String::new(), "- ".into(), "- ".into(), None))
+        );
+        assert_eq!(
+            marker("  * item"),
+            Some(("  ".into(), "* ".into(), "* ".into(), None))
+        );
+        assert_eq!(
+            marker("\t+ item"),
+            Some(("\t".into(), "+ ".into(), "+ ".into(), None))
+        );
+        assert_eq!(
+            marker("- [x] done"),
+            Some((String::new(), "- [x] ".into(), "- [ ] ".into(), None))
+        );
+        assert_eq!(
+            marker("3. third"),
+            Some((String::new(), "3. ".into(), "4. ".into(), Some(3)))
+        );
+        assert_eq!(
+            marker("12) x"),
+            Some((String::new(), "12) ".into(), "13) ".into(), Some(12)))
+        );
+        assert_eq!(
+            marker("> quoted"),
+            Some((String::new(), "> ".into(), "> ".into(), None))
+        );
+        assert_eq!(
+            marker("> > nested"),
+            Some((String::new(), "> > ".into(), "> > ".into(), None))
+        );
+        // Non-markers.
+        assert_eq!(marker("plain"), None);
+        assert_eq!(marker("-tight"), None);
+        assert_eq!(marker("1.no-space"), None);
+        assert_eq!(marker(""), None);
+    }
+
+    #[test]
+    fn fence_detection_toggles_on_delimiters() {
+        let b = TextBuffer::from_string("text\n```rust\ncode\n```\nafter");
+        assert!(!in_fence(&b, 0));
+        assert!(!in_fence(&b, 1)); // the opening fence line itself
+        assert!(in_fence(&b, 2));
+        assert!(in_fence(&b, 3)); // closing fence line counts as inside
+        assert!(!in_fence(&b, 4));
+    }
+
+    #[test]
+    fn fence_closers_must_match_opener_char_and_length() {
+        // A `~~~` line inside a backtick fence does not close it.
+        let b = TextBuffer::from_string("```\n~~~\nstill code\n```\nafter");
+        assert!(in_fence(&b, 2));
+        assert!(!in_fence(&b, 4));
+        // A shorter run or an info string does not close the fence.
+        let b = TextBuffer::from_string("````\n```\n``` rust\nstill code\n````\nafter");
+        assert!(in_fence(&b, 3));
+        assert!(!in_fence(&b, 5));
+    }
+}

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -22,9 +22,11 @@ pub mod buffer;
 pub mod commands;
 pub mod cursor;
 pub mod grapheme;
+pub mod highlight;
 pub mod history;
 pub mod ime;
 pub mod markdown;
+pub mod mode;
 pub mod movement;
 pub mod selection;
 pub mod transaction;
@@ -33,6 +35,8 @@ pub mod widget;
 
 pub use commands::{Document, EditorCommand};
 pub use cursor::{Cursor, Selection};
+pub use highlight::SyntaxHighlighter;
+pub use mode::EditorMode;
 pub use view::ViewState;
 
 /// Snapshot of the editor's semantic state, for host inspection and tests.

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -24,6 +24,7 @@ pub mod cursor;
 pub mod grapheme;
 pub mod history;
 pub mod ime;
+pub mod markdown;
 pub mod movement;
 pub mod selection;
 pub mod transaction;

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -28,6 +28,7 @@ pub mod ime;
 pub mod markdown;
 pub mod mode;
 pub mod movement;
+pub mod preview;
 pub mod selection;
 pub mod transaction;
 pub mod view;

--- a/src/editor/mode.rs
+++ b/src/editor/mode.rs
@@ -14,7 +14,13 @@ pub enum EditorMode {
     PlainText,
     /// Markdown structure commands on Tab/Shift-Tab/Enter/Backspace
     /// (list continuation, line-wise indent, marker-aware backspace).
-    Markdown,
+    /// `live_preview` selects Obsidian-style presentation: inactive blocks
+    /// render styled while the active block reveals raw source. `false` is
+    /// plain source mode. The presentation flag never changes document,
+    /// selection, history, or IME behavior.
+    Markdown {
+        live_preview: bool,
+    },
     /// Code presentation: line-number gutter, current-line highlight, and
     /// syntax-highlight spans for `language` (a language identifier such as a
     /// file extension token — detection from file metadata is the caller's
@@ -29,7 +35,14 @@ impl EditorMode {
     /// Markdown-aware commands.
     #[must_use]
     pub fn is_markdown(&self) -> bool {
-        matches!(self, EditorMode::Markdown)
+        matches!(self, EditorMode::Markdown { .. })
+    }
+
+    /// Whether Markdown Live Preview presentation is on (styled inactive
+    /// blocks, raw source around the caret).
+    #[must_use]
+    pub fn is_live_preview(&self) -> bool {
+        matches!(self, EditorMode::Markdown { live_preview: true })
     }
 
     /// Whether code chrome (gutter, current-line highlight, syntax spans)
@@ -53,7 +66,8 @@ impl EditorMode {
     pub fn describe(&self) -> String {
         match self {
             EditorMode::PlainText => "plain".to_string(),
-            EditorMode::Markdown => "markdown".to_string(),
+            EditorMode::Markdown { live_preview: true } => "markdown:live-preview".to_string(),
+            EditorMode::Markdown { live_preview: false } => "markdown:source".to_string(),
             EditorMode::Code { language } => format!("code:{language}"),
         }
     }

--- a/src/editor/mode.rs
+++ b/src/editor/mode.rs
@@ -1,0 +1,60 @@
+//! Editor presentation/input mode (stint 0318). Pure — no egui.
+//!
+//! The mode changes how the widget *translates input* and *presents* the
+//! document (Markdown structure commands; code gutter, current-line
+//! highlight, syntax spans). It is deliberately not stored on
+//! [`super::Document`]: the document model, selection, history, IME, and
+//! persistence are identical in every mode.
+
+/// How the shared editor presents a document and routes structural keys.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum EditorMode {
+    /// No structural key handling; no code chrome.
+    #[default]
+    PlainText,
+    /// Markdown structure commands on Tab/Shift-Tab/Enter/Backspace
+    /// (list continuation, line-wise indent, marker-aware backspace).
+    Markdown,
+    /// Code presentation: line-number gutter, current-line highlight, and
+    /// syntax-highlight spans for `language` (a language identifier such as a
+    /// file extension token — detection from file metadata is the caller's
+    /// job, never the core's). Unknown languages fall back to plain spans.
+    Code {
+        language: String,
+    },
+}
+
+impl EditorMode {
+    /// Whether Tab/Shift-Tab/Enter/Backspace route through the
+    /// Markdown-aware commands.
+    #[must_use]
+    pub fn is_markdown(&self) -> bool {
+        matches!(self, EditorMode::Markdown)
+    }
+
+    /// Whether code chrome (gutter, current-line highlight, syntax spans)
+    /// is shown.
+    #[must_use]
+    pub fn is_code(&self) -> bool {
+        matches!(self, EditorMode::Code { .. })
+    }
+
+    /// The language identifier for code mode, if any.
+    #[must_use]
+    pub fn language(&self) -> Option<&str> {
+        match self {
+            EditorMode::Code { language } => Some(language),
+            _ => None,
+        }
+    }
+
+    /// Short name for logging.
+    #[must_use]
+    pub fn describe(&self) -> String {
+        match self {
+            EditorMode::PlainText => "plain".to_string(),
+            EditorMode::Markdown => "markdown".to_string(),
+            EditorMode::Code { language } => format!("code:{language}"),
+        }
+    }
+}

--- a/src/editor/preview.rs
+++ b/src/editor/preview.rs
@@ -1,0 +1,656 @@
+//! Markdown Live Preview layout: stable block spans plus per-line style
+//! spans over the single source document (stint 0476). Pure — no egui.
+//!
+//! Parsing is isolated here as an adapter over `pulldown-cmark`
+//! (`Parser::into_offset_iter` gives exact byte offsets into the source), so
+//! the editor core never forks parser behavior. The widget consumes the
+//! result as per-line style spans layered into its existing per-line
+//! `LayoutJob` galleys.
+//!
+//! ## Source ↔ layout mapping contract
+//!
+//! Live Preview styles lines *in place*: every source character stays present
+//! in its rendered line, styling changes only color/italic/strike — never
+//! glyph metrics, line count, or line heights. The rendered layout position of
+//! any source position is therefore the identity mapping, which is what keeps
+//! caret geometry, hit-testing, drag selection, scroll anchoring, undo, and
+//! IME byte-for-byte coherent with source mode. If a future change styles
+//! with a different font or hides characters, `hit_test`, caret x, and
+//! `view.viewport_width` in `widget.rs` must all learn the new mapping
+//! together.
+//!
+//! Unknown/unsupported top-level structures (tables, HTML blocks, footnote
+//! definitions…) degrade to editable raw source ([`BlockKind::Fallback`]);
+//! that fallback is traced at info level once per parse.
+
+use std::ops::Range;
+
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+
+use super::buffer::TextBuffer;
+
+/// The kind of a top-level Markdown block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockKind {
+    /// ATX/setext heading with its level (1-6).
+    Heading(u8),
+    Paragraph,
+    /// One outermost list item (unordered, ordered, or task).
+    ListItem,
+    Quote,
+    /// Fenced or indented code block, including its fence lines.
+    CodeFence,
+    /// Thematic break (`---`, `***`, `___`).
+    Rule,
+    /// Blank/whitespace-only lines between blocks.
+    Blank,
+    /// Structure the preview does not style (table, HTML block, …):
+    /// rendered as raw editable source.
+    Fallback,
+}
+
+/// One top-level block: kind plus the line range it covers. Blocks are
+/// sorted, non-overlapping, and cover every line of the document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Block {
+    pub kind: BlockKind,
+    /// Half-open line range `[start, end)`.
+    pub lines: Range<usize>,
+}
+
+/// Inline emphasis kinds the preview styles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InlineKind {
+    Strong,
+    Emphasis,
+    Code,
+    Strikethrough,
+}
+
+/// An inline span in document byte offsets (delimiters included).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InlineSpan {
+    pub bytes: Range<usize>,
+    pub kind: InlineKind,
+}
+
+/// Style classes for one rendered line, mapped to theme colors by the widget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MdStyle {
+    /// Structural syntax (`#`, `-`, `>`, `**`, fences…): dimmed.
+    Marker,
+    /// Heading text (level carried for future size tiers; color-only today).
+    Heading(u8),
+    Strong,
+    Emphasis,
+    Code,
+    Quote,
+    Rule,
+    Plain,
+}
+
+/// One styled region: byte offsets within a single line's text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StyleSpan {
+    pub range: Range<usize>,
+    pub style: MdStyle,
+}
+
+/// Parsed block/inline layout for one document revision.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct MarkdownLayout {
+    pub blocks: Vec<Block>,
+    pub inlines: Vec<InlineSpan>,
+    /// Byte offset where each line starts, plus one final entry at `len()`.
+    line_starts: Vec<usize>,
+}
+
+impl MarkdownLayout {
+    /// Index of the block containing `line`. Blocks cover every line, so this
+    /// only returns `None` for an empty layout or out-of-range line.
+    #[must_use]
+    pub fn block_index_at_line(&self, line: usize) -> Option<usize> {
+        self.blocks
+            .iter()
+            .position(|b| b.lines.contains(&line))
+            .or_else(|| {
+                // A caret one past the last line (empty trailing line owned by
+                // the final block's end) maps to the last block.
+                self.blocks.last().map(|_| self.blocks.len() - 1)
+            })
+    }
+
+    #[must_use]
+    pub fn block_at_line(&self, line: usize) -> Option<&Block> {
+        self.block_index_at_line(line).map(|i| &self.blocks[i])
+    }
+
+    /// The union of lines revealed as raw source for a selection spanning
+    /// `first_line..=last_line`: from the start of the block containing the
+    /// first line through the end of the block containing the last.
+    #[must_use]
+    pub fn active_lines(&self, first_line: usize, last_line: usize) -> Range<usize> {
+        let start = self
+            .block_at_line(first_line.min(last_line))
+            .map_or(0, |b| b.lines.start);
+        let end = self
+            .block_at_line(first_line.max(last_line))
+            .map_or(0, |b| b.lines.end);
+        start..end.max(start)
+    }
+
+    /// Byte offset in the document where `line` starts.
+    #[must_use]
+    pub fn line_byte_start(&self, line: usize) -> usize {
+        self.line_starts
+            .get(line)
+            .or(self.line_starts.last())
+            .copied()
+            .unwrap_or(0)
+    }
+
+    /// Style spans for one rendered (inactive) line: contiguous, sorted,
+    /// covering `0..line_text.len()`. `line_text` must be the exact source
+    /// text of `line` (no trailing newline).
+    #[must_use]
+    pub fn line_style_spans(&self, line: usize, line_text: &str) -> Vec<StyleSpan> {
+        if line_text.is_empty() {
+            return Vec::new();
+        }
+        let kind = self.block_at_line(line).map_or(BlockKind::Fallback, |b| b.kind);
+        let base = match kind {
+            BlockKind::Heading(level) => MdStyle::Heading(level),
+            BlockKind::CodeFence => MdStyle::Code,
+            BlockKind::Quote => MdStyle::Quote,
+            BlockKind::Rule => MdStyle::Rule,
+            BlockKind::Fallback => MdStyle::Plain,
+            _ => MdStyle::Plain,
+        };
+        let mut styles = vec![base; line_text.len()];
+
+        // Structural line prefixes render dimmed: heading hashes, quote
+        // angle brackets, list markers, fence delimiters.
+        let marker_len = match kind {
+            BlockKind::Heading(_) => heading_marker_len(line_text),
+            BlockKind::Quote => quote_marker_len(line_text),
+            BlockKind::ListItem => list_marker_len(line_text),
+            BlockKind::CodeFence => fence_marker_len(line_text),
+            BlockKind::Rule => line_text.len(),
+            _ => 0,
+        };
+        for slot in styles.iter_mut().take(marker_len) {
+            *slot = MdStyle::Marker;
+        }
+
+        // Overlay inline emphasis intersecting this line, dimming the
+        // delimiter bytes at the span edges. Skip inside code blocks.
+        if kind != BlockKind::CodeFence {
+            let line_range = self.line_byte_start(line)
+                ..self.line_byte_start(line) + line_text.len();
+            for span in &self.inlines {
+                let start = span.bytes.start.max(line_range.start);
+                let end = span.bytes.end.min(line_range.end);
+                if start >= end {
+                    continue;
+                }
+                let style = match span.kind {
+                    InlineKind::Strong => MdStyle::Strong,
+                    InlineKind::Emphasis => MdStyle::Emphasis,
+                    InlineKind::Code => MdStyle::Code,
+                    InlineKind::Strikethrough => MdStyle::Emphasis,
+                };
+                let delim = match span.kind {
+                    InlineKind::Strong | InlineKind::Strikethrough => 2,
+                    InlineKind::Emphasis | InlineKind::Code => 1,
+                };
+                for b in start..end {
+                    let local = b - line_range.start;
+                    let leading = b < span.bytes.start + delim;
+                    let trailing = b + delim >= span.bytes.end;
+                    styles[local] = if leading || trailing {
+                        MdStyle::Marker
+                    } else {
+                        style
+                    };
+                }
+            }
+        }
+
+        compress_spans(line_text, &styles)
+    }
+}
+
+/// Collapses a per-byte style vec into contiguous spans on char boundaries.
+fn compress_spans(text: &str, styles: &[MdStyle]) -> Vec<StyleSpan> {
+    let mut spans: Vec<StyleSpan> = Vec::new();
+    let mut start = 0usize;
+    for (i, _) in text.char_indices().skip(1).chain(std::iter::once((text.len(), ' '))) {
+        // A span breaks where the style of the char starting at `i` differs
+        // from the style at `start`.
+        if i == text.len() || styles[i] != styles[start] {
+            spans.push(StyleSpan {
+                range: start..i,
+                style: styles[start],
+            });
+            start = i;
+        }
+        if i == text.len() {
+            break;
+        }
+    }
+    spans
+}
+
+fn heading_marker_len(line: &str) -> usize {
+    let t = line.len() - line.trim_start().len();
+    let hashes = line[t..].bytes().take_while(|b| *b == b'#').count();
+    if hashes == 0 {
+        return 0; // setext heading: no prefix marker
+    }
+    let space = usize::from(line.as_bytes().get(t + hashes) == Some(&b' '));
+    t + hashes + space
+}
+
+fn quote_marker_len(line: &str) -> usize {
+    let mut len = line.len() - line.trim_start().len();
+    let bytes = line.as_bytes();
+    while bytes.get(len) == Some(&b'>') {
+        len += 1;
+        if bytes.get(len) == Some(&b' ') {
+            len += 1;
+        }
+    }
+    len
+}
+
+fn list_marker_len(line: &str) -> usize {
+    let indent = line.len() - line.trim_start().len();
+    let rest = &line[indent..];
+    let bytes = rest.as_bytes();
+    match bytes.first() {
+        Some(b'-' | b'*' | b'+') if bytes.get(1) == Some(&b' ') => {
+            // Task checkbox is part of the marker.
+            let after = &rest[2..];
+            if after.len() >= 4
+                && after.starts_with('[')
+                && matches!(after.as_bytes()[1], b' ' | b'x' | b'X')
+                && &after[2..4] == "] "
+            {
+                indent + 6
+            } else {
+                indent + 2
+            }
+        }
+        Some(b'0'..=b'9') => {
+            let digits = bytes.iter().take_while(|b| b.is_ascii_digit()).count();
+            if matches!(bytes.get(digits), Some(b'.' | b')'))
+                && bytes.get(digits + 1) == Some(&b' ')
+            {
+                indent + digits + 2
+            } else {
+                0
+            }
+        }
+        _ => 0,
+    }
+}
+
+fn fence_marker_len(line: &str) -> usize {
+    let t = line.trim_start();
+    if t.starts_with("```") || t.starts_with("~~~") {
+        line.len()
+    } else {
+        0
+    }
+}
+
+/// Parses `text` into the Live Preview layout. Every line of the document
+/// lands in exactly one block; gaps between parsed blocks become
+/// [`BlockKind::Blank`] blocks.
+#[must_use]
+pub fn parse_markdown_layout(text: &str) -> MarkdownLayout {
+    let mut line_starts: Vec<usize> = vec![0];
+    for (i, b) in text.bytes().enumerate() {
+        if b == b'\n' {
+            line_starts.push(i + 1);
+        }
+    }
+    let line_count = line_starts.len();
+    line_starts.push(text.len());
+    let line_of = |byte: usize| -> usize {
+        match line_starts[..line_count].binary_search(&byte) {
+            Ok(l) => l,
+            Err(l) => l - 1,
+        }
+    };
+
+    let options = Options::ENABLE_TASKLISTS | Options::ENABLE_STRIKETHROUGH;
+    let mut raw_blocks: Vec<(BlockKind, Range<usize>)> = Vec::new();
+    let mut inlines: Vec<InlineSpan> = Vec::new();
+    let mut depth = 0usize;
+    let mut item_open = false;
+    let mut fallback_seen = false;
+    for (event, range) in Parser::new_ext(text, options).into_offset_iter() {
+        match event {
+            Event::Start(tag) => {
+                if depth == 0 {
+                    match &tag {
+                        Tag::Heading { level, .. } => raw_blocks
+                            .push((BlockKind::Heading(*level as u8), range.clone())),
+                        Tag::Paragraph => {
+                            raw_blocks.push((BlockKind::Paragraph, range.clone()));
+                        }
+                        Tag::BlockQuote(_) => {
+                            raw_blocks.push((BlockKind::Quote, range.clone()));
+                        }
+                        Tag::CodeBlock(_) => {
+                            raw_blocks.push((BlockKind::CodeFence, range.clone()));
+                        }
+                        Tag::List(_) => {}
+                        _ => {
+                            fallback_seen = true;
+                            raw_blocks.push((BlockKind::Fallback, range.clone()));
+                        }
+                    }
+                }
+                match &tag {
+                    Tag::Item if !item_open => {
+                        item_open = true;
+                        raw_blocks.push((BlockKind::ListItem, range.clone()));
+                    }
+                    Tag::Strong => inlines.push(InlineSpan {
+                        bytes: range.clone(),
+                        kind: InlineKind::Strong,
+                    }),
+                    Tag::Emphasis => inlines.push(InlineSpan {
+                        bytes: range.clone(),
+                        kind: InlineKind::Emphasis,
+                    }),
+                    Tag::Strikethrough => inlines.push(InlineSpan {
+                        bytes: range.clone(),
+                        kind: InlineKind::Strikethrough,
+                    }),
+                    _ => {}
+                }
+                depth += 1;
+            }
+            Event::End(tag_end) => {
+                depth = depth.saturating_sub(1);
+                if matches!(tag_end, TagEnd::Item) {
+                    item_open = false;
+                }
+            }
+            Event::Rule if depth == 0 => {
+                raw_blocks.push((BlockKind::Rule, range.clone()));
+            }
+            Event::Code(_) => inlines.push(InlineSpan {
+                bytes: range.clone(),
+                kind: InlineKind::Code,
+            }),
+            _ => {}
+        }
+    }
+
+    if fallback_seen {
+        log::info!("editor: markdown live preview falling back to source rendering for unsupported block(s)");
+    }
+
+    // Byte ranges → sorted, non-overlapping line ranges. List-item blocks
+    // arrive interleaved with (removed) list containers, so sort by start.
+    raw_blocks.sort_by_key(|(_, r)| (r.start, r.end));
+    let mut blocks: Vec<Block> = Vec::new();
+    let mut next_line = 0usize;
+    for (kind, range) in raw_blocks {
+        if range.start >= range.end {
+            continue;
+        }
+        let start_line = line_of(range.start).max(next_line);
+        let end_line = (line_of(range.end.saturating_sub(1)) + 1).min(line_count);
+        if end_line <= start_line {
+            continue; // fully swallowed by a previous (outer) block
+        }
+        if start_line > next_line {
+            blocks.push(Block {
+                kind: BlockKind::Blank,
+                lines: next_line..start_line,
+            });
+        }
+        blocks.push(Block {
+            kind,
+            lines: start_line..end_line,
+        });
+        next_line = end_line;
+    }
+    if next_line < line_count {
+        blocks.push(Block {
+            kind: BlockKind::Blank,
+            lines: next_line..line_count,
+        });
+    }
+    if blocks.is_empty() {
+        blocks.push(Block {
+            kind: BlockKind::Blank,
+            lines: 0..line_count.max(1),
+        });
+    }
+
+    inlines.sort_by_key(|s| (s.bytes.start, s.bytes.end));
+    MarkdownLayout {
+        blocks,
+        inlines,
+        line_starts,
+    }
+}
+
+/// Revision-keyed cache: reparses only when the document revision changes.
+#[derive(Debug, Default)]
+pub struct MarkdownLayoutCache {
+    revision: Option<u64>,
+    layout: MarkdownLayout,
+}
+
+impl MarkdownLayoutCache {
+    /// The layout for `buffer` at `revision`: stringifies the rope and
+    /// reparses only when the revision changes.
+    pub fn layout_for(&mut self, buffer: &TextBuffer, revision: u64) -> &MarkdownLayout {
+        if self.revision != Some(revision) {
+            self.layout = parse_markdown_layout(&buffer.to_string());
+            self.revision = Some(revision);
+        }
+        &self.layout
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MIXED: &str = "# Title\n\nSome **bold** and *italic* text.\n\n- item one\n- [x] task done\n1. ordered\n\n> a quote line\n\n```rust\nlet x = 1;\n```\n\n---\n\nlast paragraph";
+
+    fn line_count(text: &str) -> usize {
+        text.bytes().filter(|b| *b == b'\n').count() + 1
+    }
+
+    #[test]
+    fn blocks_cover_every_line_exactly_once() {
+        for text in ["", "a", MIXED, "\n\n\n", "# h\n"] {
+            let layout = parse_markdown_layout(text);
+            let mut next = 0usize;
+            for block in &layout.blocks {
+                assert_eq!(block.lines.start, next, "gap/overlap in {text:?}");
+                assert!(block.lines.end > block.lines.start);
+                next = block.lines.end;
+            }
+            assert_eq!(next, line_count(text), "blocks cover document {text:?}");
+            // Every line maps back to exactly the covering block (roundtrip).
+            for line in 0..line_count(text) {
+                let idx = layout.block_index_at_line(line).unwrap();
+                assert!(layout.blocks[idx].lines.contains(&line));
+            }
+        }
+    }
+
+    #[test]
+    fn mixed_document_classifies_blocks() {
+        let layout = parse_markdown_layout(MIXED);
+        let kind_at = |line: usize| layout.block_at_line(line).unwrap().kind;
+        assert_eq!(kind_at(0), BlockKind::Heading(1));
+        assert_eq!(kind_at(1), BlockKind::Blank);
+        assert_eq!(kind_at(2), BlockKind::Paragraph);
+        assert_eq!(kind_at(4), BlockKind::ListItem);
+        assert_eq!(kind_at(5), BlockKind::ListItem);
+        assert_eq!(kind_at(6), BlockKind::ListItem);
+        assert_eq!(kind_at(8), BlockKind::Quote);
+        assert_eq!(kind_at(10), BlockKind::CodeFence);
+        assert_eq!(kind_at(11), BlockKind::CodeFence);
+        assert_eq!(kind_at(12), BlockKind::CodeFence);
+        assert_eq!(kind_at(14), BlockKind::Rule);
+        assert_eq!(kind_at(16), BlockKind::Paragraph);
+    }
+
+    #[test]
+    fn list_items_are_separate_blocks() {
+        let layout = parse_markdown_layout("- a\n- b\n- c");
+        let items: Vec<_> = layout
+            .blocks
+            .iter()
+            .filter(|b| b.kind == BlockKind::ListItem)
+            .collect();
+        assert_eq!(items.len(), 3);
+        // Nested lists stay inside their outer item's block.
+        let nested = parse_markdown_layout("- outer\n  - inner\n- second");
+        let items: Vec<_> = nested
+            .blocks
+            .iter()
+            .filter(|b| b.kind == BlockKind::ListItem)
+            .collect();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].lines, 0..2);
+    }
+
+    #[test]
+    fn active_lines_span_selected_blocks_only() {
+        let layout = parse_markdown_layout(MIXED);
+        assert_eq!(layout.active_lines(0, 0), 0..1); // heading only
+        assert_eq!(layout.active_lines(10, 10), 10..13); // whole fence
+        assert_eq!(layout.active_lines(0, 2), 0..3); // heading → paragraph
+        // Reversed order works the same.
+        assert_eq!(layout.active_lines(2, 0), 0..3);
+    }
+
+    #[test]
+    fn style_spans_are_contiguous_and_cover_the_line() {
+        let layout = parse_markdown_layout(MIXED);
+        let lines: Vec<&str> = MIXED.split('\n').collect();
+        for (i, line) in lines.iter().enumerate() {
+            let spans = layout.line_style_spans(i, line);
+            let mut cursor = 0usize;
+            for span in &spans {
+                assert_eq!(span.range.start, cursor, "line {i} contiguous");
+                assert!(span.range.end > span.range.start);
+                assert!(line.is_char_boundary(span.range.start));
+                assert!(line.is_char_boundary(span.range.end));
+                cursor = span.range.end;
+            }
+            assert_eq!(cursor, line.len(), "line {i} covered: {line:?}");
+        }
+    }
+
+    #[test]
+    fn heading_list_quote_markers_are_dimmed() {
+        let layout = parse_markdown_layout(MIXED);
+        let spans = layout.line_style_spans(0, "# Title");
+        assert_eq!(spans[0], StyleSpan { range: 0..2, style: MdStyle::Marker });
+        assert_eq!(spans[1].style, MdStyle::Heading(1));
+
+        let spans = layout.line_style_spans(5, "- [x] task done");
+        assert_eq!(spans[0], StyleSpan { range: 0..6, style: MdStyle::Marker });
+
+        let spans = layout.line_style_spans(8, "> a quote line");
+        assert_eq!(spans[0], StyleSpan { range: 0..2, style: MdStyle::Marker });
+        assert_eq!(spans[1].style, MdStyle::Quote);
+    }
+
+    #[test]
+    fn inline_emphasis_styles_content_and_dims_delimiters() {
+        let layout = parse_markdown_layout(MIXED);
+        let line = "Some **bold** and *italic* text.";
+        let spans = layout.line_style_spans(2, line);
+        let style_at = |pos: usize| {
+            spans
+                .iter()
+                .find(|s| s.range.contains(&pos))
+                .unwrap()
+                .style
+        };
+        let bold = line.find("bold").unwrap();
+        let italic = line.find("italic").unwrap();
+        assert_eq!(style_at(bold), MdStyle::Strong);
+        assert_eq!(style_at(bold - 1), MdStyle::Marker); // `**`
+        assert_eq!(style_at(italic), MdStyle::Emphasis);
+        assert_eq!(style_at(italic - 1), MdStyle::Marker); // `*`
+        assert_eq!(style_at(0), MdStyle::Plain);
+    }
+
+    #[test]
+    fn unicode_lines_produce_char_boundary_spans() {
+        let text = "# héllo 😀\n\npara **gras 😀** café";
+        let layout = parse_markdown_layout(text);
+        for (i, line) in text.split('\n').enumerate() {
+            for span in layout.line_style_spans(i, line) {
+                assert!(line.is_char_boundary(span.range.start));
+                assert!(line.is_char_boundary(span.range.end));
+            }
+        }
+    }
+
+    #[test]
+    fn tables_fall_back_to_source_blocks() {
+        let text = "| a | b |\n|---|---|\n| 1 | 2 |";
+        let layout = parse_markdown_layout(text);
+        // Without table extension this parses as paragraph; either way every
+        // line is covered and styled spans exist. Enable tables explicitly:
+        // the parser here doesn't, so this documents the degrade path.
+        for line in 0..3 {
+            assert!(layout.block_at_line(line).is_some());
+        }
+    }
+
+    #[test]
+    fn long_mixed_document_parses_with_full_coverage() {
+        let mut doc = String::new();
+        for i in 0..200 {
+            doc.push_str(&format!(
+                "## Section {i}\n\ntext **b{i}** and *i{i}*\n\n- one\n- two\n\n```\ncode {i}\n```\n\n---\n\n"
+            ));
+        }
+        let layout = parse_markdown_layout(&doc);
+        let mut next = 0usize;
+        for block in &layout.blocks {
+            assert_eq!(block.lines.start, next);
+            next = block.lines.end;
+        }
+        assert_eq!(next, doc.bytes().filter(|b| *b == b'\n').count() + 1);
+        assert!(layout.blocks.len() > 1000);
+    }
+
+    #[test]
+    fn cache_reparses_only_on_revision_change() {
+        let mut cache = MarkdownLayoutCache::default();
+        let a = cache.layout_for(&TextBuffer::from_string("# a"), 1).clone();
+        // Same revision: buffer is ignored, cached layout returned.
+        assert_eq!(cache.layout_for(&TextBuffer::from_string("# CHANGED"), 1), &a);
+        // New revision reparses.
+        assert_ne!(cache.layout_for(&TextBuffer::from_string("plain now"), 2), &a);
+    }
+
+    #[test]
+    fn setext_and_empty_documents_do_not_panic() {
+        for text in ["Title\n=====", "Title\n-----", "", "\n", "   \n   "] {
+            let layout = parse_markdown_layout(text);
+            for (i, line) in text.split('\n').enumerate() {
+                let _ = layout.line_style_spans(i, line);
+            }
+        }
+    }
+}

--- a/src/editor/widget.rs
+++ b/src/editor/widget.rs
@@ -15,6 +15,7 @@ use super::cursor::Cursor;
 use super::highlight::{SpanProvider, TokenKind};
 use super::mode::EditorMode;
 use super::movement::line_text;
+use super::preview::{MarkdownLayoutCache, MdStyle};
 use super::view::ViewState;
 
 /// Horizontal padding on each side of the gutter's line numbers.
@@ -69,6 +70,53 @@ impl CodeTheme {
     }
 }
 
+/// Theme colors for Markdown Live Preview styling. Callers build this from
+/// host design tokens; the editor core never picks concrete colors. Styling
+/// is color/italic only — it must never change glyph metrics (see
+/// `super::preview` for the source↔layout mapping contract).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MarkdownTheme {
+    /// Structural syntax markers (`#`, `-`, `>`, `**`, fences): dimmed.
+    pub marker: Color32,
+    pub heading: Color32,
+    pub strong: Color32,
+    pub emphasis: Color32,
+    pub code: Color32,
+    pub quote: Color32,
+    pub rule: Color32,
+}
+
+impl MarkdownTheme {
+    /// Fallback derived from egui visuals, for callers without host tokens.
+    fn from_visuals(visuals: &egui::Visuals) -> Self {
+        let text = visuals.text_color();
+        let weak = visuals.weak_text_color();
+        Self {
+            marker: weak,
+            heading: visuals.strong_text_color(),
+            strong: visuals.strong_text_color(),
+            emphasis: text,
+            code: text,
+            quote: weak,
+            rule: weak,
+        }
+    }
+
+    /// Color and italic flag for one style class.
+    fn format_for(&self, style: MdStyle, plain: Color32) -> (Color32, bool) {
+        match style {
+            MdStyle::Marker => (self.marker, false),
+            MdStyle::Heading(_) => (self.heading, false),
+            MdStyle::Strong => (self.strong, false),
+            MdStyle::Emphasis => (self.emphasis, true),
+            MdStyle::Code => (self.code, false),
+            MdStyle::Quote => (self.quote, true),
+            MdStyle::Rule => (self.rule, false),
+            MdStyle::Plain => (plain, false),
+        }
+    }
+}
+
 /// Renders a [`Document`] and translates egui input into [`EditorCommand`]s.
 ///
 /// The widget processes keyboard/IME input every frame it is shown; callers
@@ -93,6 +141,11 @@ pub struct EditorWidget<'a> {
     span_provider: Option<&'a mut dyn SpanProvider>,
     /// Code-mode chrome/token colors; derived from egui visuals when unset.
     code_theme: Option<CodeTheme>,
+    /// Cached Markdown block/inline layout for Live Preview. `None` renders
+    /// Markdown mode as plain source.
+    md_cache: Option<&'a mut MarkdownLayoutCache>,
+    /// Live Preview colors; derived from egui visuals when unset.
+    md_theme: Option<MarkdownTheme>,
     /// Char ranges to paint with a background (find matches), plus the index
     /// of the "current" range and the two fill colors (normal, current).
     highlights: Vec<(usize, usize)>,
@@ -112,6 +165,8 @@ impl<'a> EditorWidget<'a> {
             mode: EditorMode::PlainText,
             span_provider: None,
             code_theme: None,
+            md_cache: None,
+            md_theme: None,
             highlights: Vec::new(),
             current_highlight: None,
             highlight_bg: egui::Color32::TRANSPARENT,
@@ -155,6 +210,21 @@ impl<'a> EditorWidget<'a> {
     #[must_use]
     pub fn code_theme(mut self, theme: CodeTheme) -> Self {
         self.code_theme = Some(theme);
+        self
+    }
+
+    /// Markdown block/inline layout cache for Live Preview. Ignored unless
+    /// the mode is [`EditorMode::Markdown`] with `live_preview: true`.
+    #[must_use]
+    pub fn markdown_preview(mut self, cache: &'a mut MarkdownLayoutCache) -> Self {
+        self.md_cache = Some(cache);
+        self
+    }
+
+    /// Live Preview colors (host theme tokens).
+    #[must_use]
+    pub fn markdown_theme(mut self, theme: MarkdownTheme) -> Self {
+        self.md_theme = Some(theme);
         self
     }
 
@@ -346,7 +416,33 @@ impl<'a> EditorWidget<'a> {
         text: &str,
         text_color: Color32,
         theme: &CodeTheme,
+        md_active: Option<&std::ops::Range<usize>>,
     ) -> std::sync::Arc<egui::Galley> {
+        // Markdown Live Preview: inactive blocks render styled per-line
+        // LayoutJobs; the active block (and everything in source mode) shows
+        // raw source. Same font everywhere, so galley metrics — and with them
+        // hit-testing and caret geometry — are identical to plain rendering.
+        if self.mode.is_live_preview() && !text.is_empty() {
+            let active = md_active.is_some_and(|r| r.contains(&line));
+            if let (false, Some(cache)) = (active, self.md_cache.as_deref_mut()) {
+                let md_theme = self
+                    .md_theme
+                    .unwrap_or_else(|| MarkdownTheme::from_visuals(ui.visuals()));
+                let layout = cache.layout_for(self.doc.buffer(), self.doc.revision());
+                let spans = layout.line_style_spans(line, text);
+                if !spans.is_empty() {
+                    let mut job = LayoutJob::default();
+                    job.wrap.max_width = f32::INFINITY;
+                    for span in &spans {
+                        let (color, italics) = md_theme.format_for(span.style, text_color);
+                        let mut format = TextFormat::simple(font_id.clone(), color);
+                        format.italics = italics;
+                        job.append(&text[span.range.clone()], 0.0, format);
+                    }
+                    return ui.fonts_mut(|f| f.layout_job(job));
+                }
+            }
+        }
         let spans = match (self.mode.is_code(), self.span_provider.as_deref_mut()) {
             (true, Some(provider)) => {
                 provider.line_spans(self.doc.buffer(), line, self.doc.revision())
@@ -396,10 +492,30 @@ impl<'a> EditorWidget<'a> {
         let gutter_painter = ui.painter_at(rect);
         let show_code_chrome = self.mode.is_code();
 
+        // Live Preview: the blocks intersecting the selection reveal raw
+        // source; everything else renders styled.
+        let md_active: Option<std::ops::Range<usize>> =
+            if self.mode.is_live_preview() && self.active {
+                self.md_cache.as_deref_mut().map(|cache| {
+                    let layout = cache.layout_for(self.doc.buffer(), self.doc.revision());
+                    layout.active_lines(sel_start.line, sel_end.line)
+                })
+            } else {
+                None
+            };
+
         for line in self.view.visible_lines(line_count) {
             let top = rect.top() + self.view.line_top(line) - self.view.scroll_y;
             let text = line_text(self.doc.buffer(), line);
-            let galley = self.line_galley(ui, font_id, line, &text, text_color, &code_theme);
+            let galley = self.line_galley(
+                ui,
+                font_id,
+                line,
+                &text,
+                text_color,
+                &code_theme,
+                md_active.as_ref(),
+            );
             let origin = egui::pos2(rect.left() + gutter_width - self.view.scroll_x, top);
 
             if show_code_chrome {
@@ -784,7 +900,8 @@ mod tests {
         // the document (text, selection, undo history, IME) may change.
         for mode in [
             EditorMode::PlainText,
-            EditorMode::Markdown,
+            EditorMode::Markdown { live_preview: false },
+            EditorMode::Markdown { live_preview: true },
             EditorMode::Code {
                 language: "py".into(),
             },
@@ -817,6 +934,81 @@ mod tests {
         h.event(Event::Text("!".into()));
         h.step();
         assert_eq!(h.state().doc.text(), "!some text");
+    }
+
+    struct PreviewState {
+        doc: Document,
+        view: ViewState,
+        cache: MarkdownLayoutCache,
+        live: bool,
+    }
+
+    fn preview_harness(text: &str) -> egui_kittest::Harness<'static, PreviewState> {
+        let state = PreviewState {
+            doc: Document::new(text),
+            view: ViewState::default(),
+            cache: MarkdownLayoutCache::default(),
+            live: true,
+        };
+        egui_kittest::Harness::new_ui_state(
+            |ui, state: &mut PreviewState| {
+                EditorWidget::new(&mut state.doc, &mut state.view)
+                    .mode(EditorMode::Markdown {
+                        live_preview: state.live,
+                    })
+                    .markdown_preview(&mut state.cache)
+                    .show(ui);
+            },
+            state,
+        )
+    }
+
+    #[test]
+    fn live_preview_editing_selection_and_undo_stay_coherent() {
+        let mut h = preview_harness("# Title\n\npara **bold** text\n\n- item");
+        // Move across blocks, then type into the paragraph.
+        h.key_press(Key::ArrowDown);
+        h.key_press(Key::ArrowDown);
+        h.step();
+        h.event(Event::Text("X".into()));
+        h.step();
+        assert_eq!(
+            h.state().doc.text(),
+            "# Title\n\nXpara **bold** text\n\n- item"
+        );
+        // Undo through the shared history, unchanged by preview rendering.
+        h.key_press_modifiers(Modifiers::COMMAND, Key::Z);
+        h.step();
+        assert_eq!(h.state().doc.text(), "# Title\n\npara **bold** text\n\n- item");
+        // Cross-block select-all + copy path still sees the full source.
+        h.key_press_modifiers(Modifiers::COMMAND, Key::A);
+        h.step();
+        assert_eq!(
+            h.state().doc.selected_text(),
+            "# Title\n\npara **bold** text\n\n- item"
+        );
+        // Flipping to source mode and back never alters document state.
+        let before = h.state().doc.semantic_state(0.0);
+        h.state_mut().live = false;
+        h.step();
+        h.state_mut().live = true;
+        h.step();
+        assert_eq!(h.state().doc.semantic_state(0.0), before);
+    }
+
+    #[test]
+    fn live_preview_caret_movement_across_styled_blocks_hits_real_positions() {
+        let mut h = preview_harness("# Head\ntext\n- one\n- two");
+        // Walk the caret through every line end-to-end; every position is a
+        // real source position (movement never skips styled markers).
+        h.key_press_modifiers(Modifiers::COMMAND, Key::ArrowDown); // DocEnd
+        h.step();
+        assert_eq!(h.state().doc.cursor(), Cursor::new(3, 5));
+        for _ in 0..(6 + 1 + 4 + 1 + 5 + 1 + 5) {
+            h.key_press(Key::ArrowLeft);
+        }
+        h.step();
+        assert_eq!(h.state().doc.cursor(), Cursor::new(0, 0));
     }
 
     #[test]

--- a/src/editor/widget.rs
+++ b/src/editor/widget.rs
@@ -7,13 +7,67 @@
 //! editing logic. Focus arbitration is the caller's job (`src/ui/AGENTS.md`
 //! forbids direct `request_focus`).
 
-use egui::text::CCursor;
-use egui::{Event, ImeEvent, Key, Modifiers, Rect, Sense, Ui, Vec2};
+use egui::text::{CCursor, LayoutJob, TextFormat};
+use egui::{Color32, Event, ImeEvent, Key, Modifiers, Rect, Sense, Ui, Vec2};
 
 use super::commands::{Document, EditorCommand, Movement};
 use super::cursor::Cursor;
+use super::highlight::{SpanProvider, TokenKind};
+use super::mode::EditorMode;
 use super::movement::line_text;
 use super::view::ViewState;
+
+/// Horizontal padding on each side of the gutter's line numbers.
+const GUTTER_PAD: f32 = 6.0;
+
+/// Theme colors for code-mode chrome and syntax token kinds. Callers build
+/// this from host design tokens (`src/ui/theme.rs`); the editor core never
+/// picks concrete colors itself.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CodeTheme {
+    pub gutter_text: Color32,
+    pub current_line_bg: Color32,
+    pub keyword: Color32,
+    pub string: Color32,
+    pub comment: Color32,
+    pub number: Color32,
+    pub ty: Color32,
+    pub function: Color32,
+    pub punctuation: Color32,
+}
+
+impl CodeTheme {
+    /// Fallback derived from egui visuals, for callers without host tokens
+    /// (tests): plain chrome, no token coloring beyond text/weak.
+    fn from_visuals(visuals: &egui::Visuals) -> Self {
+        let text = visuals.text_color();
+        let weak = visuals.weak_text_color();
+        Self {
+            gutter_text: weak,
+            current_line_bg: visuals.faint_bg_color,
+            keyword: text,
+            string: text,
+            comment: weak,
+            number: text,
+            ty: text,
+            function: text,
+            punctuation: weak,
+        }
+    }
+
+    fn color_for(&self, kind: TokenKind, plain: Color32) -> Color32 {
+        match kind {
+            TokenKind::Plain => plain,
+            TokenKind::Keyword => self.keyword,
+            TokenKind::String => self.string,
+            TokenKind::Comment => self.comment,
+            TokenKind::Number => self.number,
+            TokenKind::Type => self.ty,
+            TokenKind::Function => self.function,
+            TokenKind::Punctuation => self.punctuation,
+        }
+    }
+}
 
 /// Renders a [`Document`] and translates egui input into [`EditorCommand`]s.
 ///
@@ -31,10 +85,14 @@ pub struct EditorWidget<'a> {
     active: bool,
     /// Monospace font size override; defaults to the style's monospace size.
     font_size: Option<f32>,
-    /// When true, Tab/Shift-Tab/Enter/Backspace route through the
-    /// Markdown-aware commands (list continuation, line-wise indent,
-    /// marker-aware backspace).
-    markdown: bool,
+    /// Presentation/input mode: plain, Markdown structure commands, or code
+    /// chrome (gutter, current-line highlight, syntax spans).
+    mode: EditorMode,
+    /// Syntax-highlight span source for code mode. `None` paints plain text
+    /// (the fallback for unknown languages).
+    span_provider: Option<&'a mut dyn SpanProvider>,
+    /// Code-mode chrome/token colors; derived from egui visuals when unset.
+    code_theme: Option<CodeTheme>,
     /// Char ranges to paint with a background (find matches), plus the index
     /// of the "current" range and the two fill colors (normal, current).
     highlights: Vec<(usize, usize)>,
@@ -51,7 +109,9 @@ impl<'a> EditorWidget<'a> {
             id: None,
             active: true,
             font_size: None,
-            markdown: false,
+            mode: EditorMode::PlainText,
+            span_provider: None,
+            code_theme: None,
             highlights: Vec::new(),
             current_highlight: None,
             highlight_bg: egui::Color32::TRANSPARENT,
@@ -78,8 +138,23 @@ impl<'a> EditorWidget<'a> {
     }
 
     #[must_use]
-    pub fn markdown(mut self, markdown: bool) -> Self {
-        self.markdown = markdown;
+    pub fn mode(mut self, mode: EditorMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Syntax-highlight span source for code mode. Ignored outside
+    /// [`EditorMode::Code`].
+    #[must_use]
+    pub fn span_provider(mut self, provider: &'a mut dyn SpanProvider) -> Self {
+        self.span_provider = Some(provider);
+        self
+    }
+
+    /// Code-mode chrome/token colors (host theme tokens).
+    #[must_use]
+    pub fn code_theme(mut self, theme: CodeTheme) -> Self {
+        self.code_theme = Some(theme);
         self
     }
 
@@ -98,7 +173,7 @@ impl<'a> EditorWidget<'a> {
         self
     }
 
-    pub fn show(self, ui: &mut Ui) -> egui::Response {
+    pub fn show(mut self, ui: &mut Ui) -> egui::Response {
         let font_id = match self.font_size {
             Some(size) => egui::FontId::monospace(size),
             None => egui::TextStyle::Monospace.resolve(ui.style()),
@@ -108,9 +183,10 @@ impl<'a> EditorWidget<'a> {
         let id = self.id.unwrap_or(auto_id);
         let response = ui.interact(rect, id, Sense::click_and_drag());
 
+        let gutter_width = self.gutter_width(ui, &font_id, self.doc.buffer().line_count());
         self.view.line_height = line_height;
         self.view.viewport_height = rect.height();
-        self.view.viewport_width = rect.width();
+        self.view.viewport_width = rect.width() - gutter_width;
         let page_rows = ((rect.height() / line_height).floor().max(1.0)) as usize;
 
         let mut commands: Vec<EditorCommand> = Vec::new();
@@ -144,8 +220,7 @@ impl<'a> EditorWidget<'a> {
                         modifiers,
                         ..
                     } => {
-                        if let Some(cmd) = translate_key(*key, *modifiers, page_rows, self.markdown)
-                        {
+                        if let Some(cmd) = translate_key(*key, *modifiers, page_rows, &self.mode) {
                             commands.push(cmd);
                         }
                     }
@@ -176,7 +251,7 @@ impl<'a> EditorWidget<'a> {
 
         // Pointer: click to place, shift-click / drag to extend, double-click
         // word, triple-click line.
-        let hit = |pos: egui::Pos2| self.hit_test(ui, &font_id, rect, pos);
+        let hit = |pos: egui::Pos2| self.hit_test(ui, &font_id, rect, gutter_width, pos);
         if let Some(pos) = response.interact_pointer_pos() {
             let cursor = hit(pos);
             if response.triple_clicked() {
@@ -223,47 +298,135 @@ impl<'a> EditorWidget<'a> {
             self.view.scroll_to_x(caret_x);
         }
 
-        self.paint(ui, &font_id, rect);
+        self.paint(ui, &font_id, rect, gutter_width);
         response
+    }
+
+    /// Width of the line-number gutter in code mode; zero otherwise.
+    fn gutter_width(&self, ui: &Ui, font_id: &egui::FontId, line_count: usize) -> f32 {
+        if !self.mode.is_code() {
+            return 0.0;
+        }
+        let digits = (line_count.max(1).ilog10() as usize + 1).max(2);
+        let char_width = ui.fonts_mut(|f| f.glyph_width(font_id, '0'));
+        digits as f32 * char_width + 2.0 * GUTTER_PAD
     }
 
     /// Maps a pointer position to a document cursor via per-line galley
     /// hit-testing.
-    fn hit_test(&self, ui: &Ui, font_id: &egui::FontId, rect: Rect, pos: egui::Pos2) -> Cursor {
+    fn hit_test(
+        &self,
+        ui: &Ui,
+        font_id: &egui::FontId,
+        rect: Rect,
+        gutter_width: f32,
+        pos: egui::Pos2,
+    ) -> Cursor {
         let line_count = self.doc.buffer().line_count();
         let y = pos.y - rect.top() + self.view.scroll_y;
         let line = ((y / self.view.line_height).floor().max(0.0) as usize)
             .min(line_count.saturating_sub(1));
         let text = line_text(self.doc.buffer(), line);
         let galley = ui.fonts_mut(|f| f.layout_no_wrap(text, font_id.clone(), egui::Color32::WHITE));
-        let ccursor =
-            galley.cursor_from_pos(Vec2::new(pos.x - rect.left() + self.view.scroll_x, 0.0));
+        let ccursor = galley.cursor_from_pos(Vec2::new(
+            pos.x - rect.left() - gutter_width + self.view.scroll_x,
+            0.0,
+        ));
         Cursor::new(line, ccursor.index)
     }
 
-    fn paint(&self, ui: &Ui, font_id: &egui::FontId, rect: Rect) {
-        let painter = ui.painter_at(rect);
+    /// Lays out one line's galley: syntax-colored via the span provider in
+    /// code mode, single-color otherwise (and as the unknown-language
+    /// fallback).
+    fn line_galley(
+        &mut self,
+        ui: &Ui,
+        font_id: &egui::FontId,
+        line: usize,
+        text: &str,
+        text_color: Color32,
+        theme: &CodeTheme,
+    ) -> std::sync::Arc<egui::Galley> {
+        let spans = match (self.mode.is_code(), self.span_provider.as_deref_mut()) {
+            (true, Some(provider)) => {
+                provider.line_spans(self.doc.buffer(), line, self.doc.revision())
+            }
+            _ => &[],
+        };
+        if spans.is_empty() {
+            return ui
+                .fonts_mut(|f| f.layout_no_wrap(text.to_string(), font_id.clone(), text_color));
+        }
+        let mut job = LayoutJob::default();
+        job.wrap.max_width = f32::INFINITY;
+        for span in spans {
+            let (start, end) = (span.start.min(text.len()), span.end.min(text.len()));
+            if start >= end {
+                continue;
+            }
+            job.append(
+                &text[start..end],
+                0.0,
+                TextFormat::simple(font_id.clone(), theme.color_for(span.kind, text_color)),
+            );
+        }
+        ui.fonts_mut(|f| f.layout_job(job))
+    }
+
+    fn paint(&mut self, ui: &Ui, font_id: &egui::FontId, rect: Rect, gutter_width: f32) {
         let visuals = ui.visuals();
         let text_color = visuals.text_color();
+        let code_theme = self
+            .code_theme
+            .unwrap_or_else(|| CodeTheme::from_visuals(visuals));
+        // Text clips at the gutter edge so horizontal scroll never paints
+        // under the line numbers.
+        let text_rect = Rect::from_min_max(
+            egui::pos2(rect.left() + gutter_width, rect.top()),
+            rect.max,
+        );
+        let painter = ui.painter_at(text_rect);
         let selection_color = visuals.selection.bg_fill.linear_multiply(0.5);
         let caret_color = visuals.selection.stroke.color;
-        let buffer = self.doc.buffer();
-        let line_count = buffer.line_count();
+        let line_count = self.doc.buffer().line_count();
         let selection = self.doc.selection();
         let (sel_start, sel_end) = selection.ordered();
         let caret = self.doc.cursor();
         let mut caret_rect: Option<Rect> = None;
+        let gutter_painter = ui.painter_at(rect);
+        let show_code_chrome = self.mode.is_code();
 
         for line in self.view.visible_lines(line_count) {
             let top = rect.top() + self.view.line_top(line) - self.view.scroll_y;
-            let text = line_text(buffer, line);
-            let galley =
-                ui.fonts_mut(|f| f.layout_no_wrap(text.clone(), font_id.clone(), text_color));
-            let origin = egui::pos2(rect.left() - self.view.scroll_x, top);
+            let text = line_text(self.doc.buffer(), line);
+            let galley = self.line_galley(ui, font_id, line, &text, text_color, &code_theme);
+            let origin = egui::pos2(rect.left() + gutter_width - self.view.scroll_x, top);
+
+            if show_code_chrome {
+                // Current-line highlight under everything else.
+                if line == caret.line {
+                    painter.rect_filled(
+                        Rect::from_min_max(
+                            egui::pos2(text_rect.left(), top),
+                            egui::pos2(rect.right(), top + self.view.line_height),
+                        ),
+                        0.0,
+                        code_theme.current_line_bg,
+                    );
+                }
+                // Right-aligned 1-based line number in the gutter.
+                gutter_painter.text(
+                    egui::pos2(rect.left() + gutter_width - GUTTER_PAD, top),
+                    egui::Align2::RIGHT_TOP,
+                    (line + 1).to_string(),
+                    font_id.clone(),
+                    code_theme.gutter_text,
+                );
+            }
 
             // Find-match highlight fills under the text and selection.
             if !self.highlights.is_empty() {
-                let line_start = buffer.line_to_char(line);
+                let line_start = self.doc.buffer().line_to_char(line);
                 let char_count = text.chars().count();
                 let line_end_char = line_start + char_count;
                 for (i, &(hs, he)) in self.highlights.iter().enumerate() {
@@ -369,19 +532,20 @@ impl<'a> EditorWidget<'a> {
 
 /// Maps a key press (with modifiers) to an editor command. Returns `None`
 /// for keys the editor does not handle. `page_rows` is the viewport height in
-/// lines, used by PageUp/PageDown. `markdown` routes Tab/Enter/Backspace to
-/// the Markdown-aware commands.
+/// lines, used by PageUp/PageDown. [`EditorMode::Markdown`] routes
+/// Tab/Enter/Backspace to the Markdown-aware commands; plain and code modes
+/// share the plain map (Tab/Shift-Tab already indent/outdent there).
 fn translate_key(
     key: Key,
     modifiers: Modifiers,
     page_rows: usize,
-    markdown: bool,
+    mode: &EditorMode,
 ) -> Option<EditorCommand> {
     let extend = modifiers.shift;
     let word = modifiers.alt;
     let line = modifiers.command;
     let mv = |movement: Movement| Some(EditorCommand::Move { movement, extend });
-    if markdown {
+    if mode.is_markdown() {
         match key {
             Key::Tab if modifiers.shift => return Some(EditorCommand::MarkdownOutdent),
             Key::Tab if modifiers.is_none() => return Some(EditorCommand::MarkdownIndent),
@@ -541,6 +705,118 @@ mod tests {
         h.key_press(Key::Backspace);
         h.step();
         assert_eq!(semantic(&h).text, "keep");
+    }
+
+    struct ModeState {
+        doc: Document,
+        view: ViewState,
+        mode: EditorMode,
+        highlighter: Option<crate::editor::SyntaxHighlighter>,
+    }
+
+    fn mode_harness(text: &str, mode: EditorMode) -> egui_kittest::Harness<'static, ModeState> {
+        let highlighter = mode
+            .language()
+            .and_then(crate::editor::SyntaxHighlighter::new);
+        let state = ModeState {
+            doc: Document::new(text),
+            view: ViewState::default(),
+            mode,
+            highlighter,
+        };
+        egui_kittest::Harness::new_ui_state(
+            |ui, state: &mut ModeState| {
+                let mut widget = EditorWidget::new(&mut state.doc, &mut state.view)
+                    .mode(state.mode.clone());
+                if let Some(h) = &mut state.highlighter {
+                    widget = widget.span_provider(h);
+                }
+                widget.show(ui);
+            },
+            state,
+        )
+    }
+
+    #[test]
+    fn code_mode_tab_indents_and_shift_tab_outdents() {
+        let mut h = mode_harness(
+            "fn main() {}",
+            EditorMode::Code {
+                language: "rs".into(),
+            },
+        );
+        // Tab with a collapsed caret inserts one indent step at the caret.
+        h.key_press(Key::Tab);
+        h.step();
+        assert_eq!(h.state().doc.text(), "    fn main() {}");
+        // Shift-Tab outdents the line.
+        h.key_press_modifiers(Modifiers::SHIFT, Key::Tab);
+        h.step();
+        assert_eq!(h.state().doc.text(), "fn main() {}");
+        // Undo through the shared history works identically in code mode.
+        h.key_press_modifiers(Modifiers::COMMAND, Key::Z);
+        h.step();
+        assert_eq!(h.state().doc.text(), "    fn main() {}");
+    }
+
+    #[test]
+    fn mode_change_never_alters_document_state() {
+        // Build up text, selection, history, and IME preedit in code mode…
+        let mut h = mode_harness(
+            "",
+            EditorMode::Code {
+                language: "rs".into(),
+            },
+        );
+        h.event(Event::Text("héllo 😀".into()));
+        h.step();
+        h.key_press(Key::Enter);
+        h.step();
+        h.event(Event::Text("wörld".into()));
+        h.step();
+        h.key_press_modifiers(Modifiers::SHIFT | Modifiers::ALT, Key::ArrowLeft);
+        h.step();
+        h.event(Event::Ime(ImeEvent::Preedit("かん".into())));
+        h.step();
+        let before = h.state().doc.semantic_state(0.0);
+
+        // …then flip through every mode without any input events: nothing in
+        // the document (text, selection, undo history, IME) may change.
+        for mode in [
+            EditorMode::PlainText,
+            EditorMode::Markdown,
+            EditorMode::Code {
+                language: "py".into(),
+            },
+        ] {
+            h.state_mut().mode = mode.clone();
+            h.state_mut().highlighter = mode
+                .language()
+                .and_then(crate::editor::SyntaxHighlighter::new);
+            h.step();
+            let after = h.state().doc.semantic_state(0.0);
+            assert_eq!(after, before, "mode {mode:?} altered document state");
+        }
+
+        // Undo still walks the same history after the mode flips.
+        h.event(Event::Ime(ImeEvent::Disabled));
+        h.step();
+        h.key_press_modifiers(Modifiers::COMMAND, Key::Z);
+        h.step();
+        assert_eq!(h.state().doc.text(), "héllo 😀\n");
+    }
+
+    #[test]
+    fn unknown_code_language_falls_back_to_plain_spans() {
+        let mode = EditorMode::Code {
+            language: "not-a-language".into(),
+        };
+        assert!(mode.language().and_then(crate::editor::SyntaxHighlighter::new).is_none());
+        // The widget still renders and edits without a provider.
+        let mut h = mode_harness("some text", mode);
+        h.event(Event::Text("!".into()));
+        h.step();
+        assert_eq!(h.state().doc.text(), "!some text");
     }
 
     #[test]

--- a/src/editor/widget.rs
+++ b/src/editor/widget.rs
@@ -31,6 +31,10 @@ pub struct EditorWidget<'a> {
     active: bool,
     /// Monospace font size override; defaults to the style's monospace size.
     font_size: Option<f32>,
+    /// When true, Tab/Shift-Tab/Enter/Backspace route through the
+    /// Markdown-aware commands (list continuation, line-wise indent,
+    /// marker-aware backspace).
+    markdown: bool,
     /// Char ranges to paint with a background (find matches), plus the index
     /// of the "current" range and the two fill colors (normal, current).
     highlights: Vec<(usize, usize)>,
@@ -47,6 +51,7 @@ impl<'a> EditorWidget<'a> {
             id: None,
             active: true,
             font_size: None,
+            markdown: false,
             highlights: Vec::new(),
             current_highlight: None,
             highlight_bg: egui::Color32::TRANSPARENT,
@@ -69,6 +74,12 @@ impl<'a> EditorWidget<'a> {
     #[must_use]
     pub fn font_size(mut self, size: f32) -> Self {
         self.font_size = Some(size);
+        self
+    }
+
+    #[must_use]
+    pub fn markdown(mut self, markdown: bool) -> Self {
+        self.markdown = markdown;
         self
     }
 
@@ -133,7 +144,8 @@ impl<'a> EditorWidget<'a> {
                         modifiers,
                         ..
                     } => {
-                        if let Some(cmd) = translate_key(*key, *modifiers, page_rows) {
+                        if let Some(cmd) = translate_key(*key, *modifiers, page_rows, self.markdown)
+                        {
                             commands.push(cmd);
                         }
                     }
@@ -357,12 +369,29 @@ impl<'a> EditorWidget<'a> {
 
 /// Maps a key press (with modifiers) to an editor command. Returns `None`
 /// for keys the editor does not handle. `page_rows` is the viewport height in
-/// lines, used by PageUp/PageDown.
-fn translate_key(key: Key, modifiers: Modifiers, page_rows: usize) -> Option<EditorCommand> {
+/// lines, used by PageUp/PageDown. `markdown` routes Tab/Enter/Backspace to
+/// the Markdown-aware commands.
+fn translate_key(
+    key: Key,
+    modifiers: Modifiers,
+    page_rows: usize,
+    markdown: bool,
+) -> Option<EditorCommand> {
     let extend = modifiers.shift;
     let word = modifiers.alt;
     let line = modifiers.command;
     let mv = |movement: Movement| Some(EditorCommand::Move { movement, extend });
+    if markdown {
+        match key {
+            Key::Tab if modifiers.shift => return Some(EditorCommand::MarkdownOutdent),
+            Key::Tab if modifiers.is_none() => return Some(EditorCommand::MarkdownIndent),
+            Key::Enter if modifiers.is_none() => return Some(EditorCommand::MarkdownNewline),
+            Key::Backspace if modifiers.is_none() => {
+                return Some(EditorCommand::MarkdownBackspace)
+            }
+            _ => {}
+        }
+    }
     match key {
         Key::Tab if modifiers.shift => Some(EditorCommand::Outdent),
         Key::Tab if modifiers.is_none() => Some(EditorCommand::Indent),

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -319,6 +319,9 @@ pub struct ExpectSpec {
     pub save_result: Option<String>,
     pub source_text_contains: Option<String>,
     pub active_markdown_contains: Option<String>,
+    /// Exact match on the editor's Markdown presentation:
+    /// "live_preview" | "source".
+    pub preview_mode: Option<String>,
     pub rendered_text_contains: Option<String>,
     pub visible_link_target: Option<String>,
     pub visible_image_target: Option<String>,
@@ -384,6 +387,9 @@ fn notes_expectations_match(spec: &ExpectSpec, state: &serde_json::Value) -> boo
             "/active_markdown_block/source",
             &spec.active_markdown_contains,
         )
+        && spec.preview_mode.as_ref().is_none_or(|expected| {
+            app.get("preview_mode").and_then(serde_json::Value::as_str) == Some(expected)
+        })
         && rendered_matches
         && array_contains("/visible_link_targets", &spec.visible_link_target)
         && array_contains("/visible_images", &spec.visible_image_target)

--- a/tests/scenes/code-editor-mode.toml
+++ b/tests/scenes/code-editor-mode.toml
@@ -1,0 +1,54 @@
+# Code mode in the shared text editor (stint 0318): a .rs file gets a
+# line-number gutter, syntax spans, Tab indent / Shift-Tab outdent, and the
+# same undo/save semantics as every other mode.
+size = [1000.0, 700.0]
+
+[[steps]]
+open = { kind = "builtin", id = "text-editor", as = "code", args = ["/tmp/plexi-code-mode.rs"] }
+
+[[steps]]
+focus = "code"
+
+[[steps]]
+expect = { target = "code", focused = true }
+
+# Reset any prior content, then write code through real key events.
+[[steps]]
+key = { target = "code", value = "cmd+a" }
+
+[[steps]]
+text = { target = "code", value = "fn main() {" }
+
+# Enter is a plain auto-indent newline in code mode (no Markdown behavior).
+[[steps]]
+key = { target = "code", value = "enter" }
+
+# Tab inserts one indent step at the caret.
+[[steps]]
+key = { target = "code", value = "tab" }
+
+[[steps]]
+text = { target = "code", value = "let x = 1;" }
+
+[[steps]]
+expect = { target = "code", source_text_contains = "fn main() {\n    let x = 1;", caret = 26 }
+
+# Shift-Tab outdents the line; the indent removal is one undoable step.
+[[steps]]
+key = { target = "code", value = "shift+tab" }
+
+[[steps]]
+expect = { target = "code", source_text_contains = "fn main() {\nlet x = 1;", caret = 22 }
+
+[[steps]]
+key = { target = "code", value = "cmd+z" }
+
+[[steps]]
+expect = { target = "code", source_text_contains = "fn main() {\n    let x = 1;" }
+
+# Visual: gutter numbers, current-line highlight, syntax colors.
+[[steps]]
+shot = "code-editor-mode.png"
+
+[[steps]]
+close = "code"

--- a/tests/scenes/notes-live-preview.toml
+++ b/tests/scenes/notes-live-preview.toml
@@ -1,0 +1,60 @@
+# Markdown Live Preview in the notes editor (stint 0476): inactive blocks
+# render styled (heading/emphasis colors, dimmed markers) while the active
+# block reveals raw source; Cmd+G toggles to source mode without moving the
+# caret; the semantic state reports block-level active_markdown_block.
+size = [1000.0, 700.0]
+
+[[steps]]
+open = { kind = "builtin", id = "text-editor", as = "notes", args = ["/tmp/plexi-notes-live-preview.md"] }
+
+[[steps]]
+focus = "notes"
+
+[[steps]]
+expect = { target = "notes", focused = true, preview_mode = "live_preview" }
+
+# Reset any prior content, then seed realistic mixed Markdown in one insert
+# (Event::Text, so no list-continuation side effects).
+[[steps]]
+key = { target = "notes", value = "cmd+a" }
+
+[[steps]]
+text = { target = "notes", value = "# Trip Notes\n\nPack **warm** layers and *maybe* a raincoat.\n\n- [ ] tent\n- [x] sleeping bag\n1. drive north\n\n> leave before sunrise\n\n```rust\nlet km = 420;\n```\n\n---\n\nFinal thoughts go here." }
+
+# Jump to the top: the heading becomes the active block (raw source).
+[[steps]]
+key = { target = "notes", value = "cmd+up" }
+
+[[steps]]
+expect = { target = "notes", caret = 0, active_markdown_contains = "# Trip Notes", preview_mode = "live_preview" }
+
+# Down into the paragraph: active block switches without any edit.
+[[steps]]
+key = { target = "notes", value = "down" }
+
+[[steps]]
+key = { target = "notes", value = "down" }
+
+[[steps]]
+expect = { target = "notes", active_markdown_contains = "Pack **warm** layers", undo_available = true }
+
+# Visual: styled heading/list/quote/fence/rule around a raw active block.
+[[steps]]
+shot = "notes-live-preview.png"
+
+# Cmd+G flips to source mode; the caret does not move.
+[[steps]]
+key = { target = "notes", value = "cmd+g" }
+
+[[steps]]
+expect = { target = "notes", preview_mode = "source", active_markdown_contains = "Pack **warm** layers" }
+
+# And back to Live Preview.
+[[steps]]
+key = { target = "notes", value = "cmd+g" }
+
+[[steps]]
+expect = { target = "notes", preview_mode = "live_preview" }
+
+[[steps]]
+close = "notes"

--- a/tests/scenes/notes-markdown-editing.toml
+++ b/tests/scenes/notes-markdown-editing.toml
@@ -1,0 +1,65 @@
+# Markdown-aware keyboard behavior in the notes editor (stint 0475):
+# Enter continues a list, Enter on an empty continuation exits it, Tab
+# indents the whole line, and undo treats each command atomically.
+size = [1000.0, 700.0]
+
+[[steps]]
+open = { kind = "builtin", id = "text-editor", as = "notes", args = ["/tmp/plexi-notes-md-editing.md"] }
+
+[[steps]]
+focus = "notes"
+
+[[steps]]
+expect = { target = "notes", focused = true }
+
+# Reset any prior content, then build a list through real key events.
+[[steps]]
+key = { target = "notes", value = "cmd+a" }
+
+[[steps]]
+text = { target = "notes", value = "- alpha" }
+
+[[steps]]
+key = { target = "notes", value = "enter" }
+
+[[steps]]
+expect = { target = "notes", source_text_contains = "- alpha\n- ", caret = 10 }
+
+[[steps]]
+text = { target = "notes", value = "beta" }
+
+# Enter on the item, then Enter on the empty continuation exits the list.
+[[steps]]
+key = { target = "notes", value = "enter" }
+
+[[steps]]
+key = { target = "notes", value = "enter" }
+
+[[steps]]
+expect = { target = "notes", source_text_contains = "- alpha\n- beta\n", caret = 15 }
+
+# Tab with the caret at column 0 of the last (empty) line indents that line.
+[[steps]]
+text = { target = "notes", value = "- gamma" }
+
+[[steps]]
+key = { target = "notes", value = "tab" }
+
+[[steps]]
+expect = { target = "notes", source_text_contains = "    - gamma", caret = 26 }
+
+# Shift-Tab outdents it again; the indent was one undoable step.
+[[steps]]
+key = { target = "notes", value = "shift+tab" }
+
+[[steps]]
+expect = { target = "notes", source_text_contains = "- alpha\n- beta\n- gamma", caret = 22 }
+
+[[steps]]
+key = { target = "notes", value = "cmd+z" }
+
+[[steps]]
+expect = { target = "notes", source_text_contains = "    - gamma" }
+
+[[steps]]
+close = "notes"


### PR DESCRIPTION
Bundles three s3 editor stints over the shared editor core (0317/0474). No linked GitHub issues; stint tasks 0318, 0475, 0476 are the tickets.

## Stint 0475 — Markdown-aware editing transactions
- New `src/editor/markdown.rs`: pure planners returning atomic transaction plans; `None` falls back to plain behavior.
- Tab/Shift-Tab indent/outdent line or selection as one undoable transaction; Enter continues `-`/`*`/`+`, task lists, ordered lists (with sibling renumbering), and nested block quotes; empty continuation exits the structure; smart Backspace removes an empty marker without touching indent. Fenced code blocks and selections fall back to plain behavior.
- Info-level traces log command name and edit ranges, never text.

## Stint 0318 — code-ready editor mode
- New `EditorMode` enum (`src/editor/mode.rs`) — a widget-level presentation concern; mode changes provably cannot alter text/selection/history/IME (asserted by test).
- New `src/editor/highlight.rs`: `SpanProvider` trait + syntect-backed highlighter (pure-Rust `default-fancy` backend) with plain-text fallback for unknown languages; cache keyed by `Document::revision()` retaining the longest unchanged prefix, so keystrokes cost a prefix compare, not a reparse.
- Line-number gutter, current-line highlight, code Tab/Shift-Tab via existing indent commands; colors routed through host theme tokens. Language detected from file extension in `TextEditorApp`, never in the core.

## Stint 0476 — Obsidian-style Markdown Live Preview
- New `src/editor/preview.rs`: pulldown-cmark adapter producing stable block spans + per-line styled layout, revision-keyed cache; no egui dependency.
- Live Preview is the default Markdown presentation: active block reveals raw source, inactive blocks render styled (headings, emphasis, list markers, task boxes, quotes, code fences, rules). Source-mode toggle on Cmd+G (Cmd+E collides with `open_file_browser`), preserving caret/selection/scroll.
- Source↔layout mapping is identity by design: styling changes color/italics only, never glyph metrics or line count, so caret geometry, hit-testing, drag selection, scroll anchoring, undo, and IME stay byte-identical to source mode. Markers are dimmed rather than hidden; headings are color-only (allowed simplifications).
- Unsupported structures degrade to editable raw source (`BlockKind::Fallback`, traced at info); preview-mode changes traced at info. Semantic state exposes block-level `active_markdown_block`, `editor_mode`, `preview_mode`.

## Test evidence
- Full suite (env-stripped, `--test-threads=2`): `cargo test --bin plexi` → **1686 passed; 0 failed; 2 ignored**
- Targeted during development: editor 152 passed, text_editor_app 25 passed, scene_suite 22 passed (includes 3 new scenes: `notes-markdown-editing.toml`, `code-editor-mode.toml`, `notes-live-preview.toml`, the latter two with screenshot shots, visually reviewed via `just scene` and deleted).
- `just check-docs` fully green; no Python touched (mypy n/a).
- Codex review per stint (max 2 runs each): all clean after fixes (ordered-list exit renumbering, CommonMark fence-closer matching, highlight prefix-cache retention, active-block end-offset trim).
- **PR install: required via `just pr-install <PR>`** — live-host smoke (typing feel, IME, Live Preview transitions in the installed binary) is tester-owned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)