### PR TITLE
Pure DAW + video edit-model crates with seeded gate fuzzers (stint 0514, 0523)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4080,6 +4080,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "plexi-daw-model"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "plexi-video-model"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "plexi-wasm-sdk"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["tools/gen_schema", "tools/gen_cli_docs", "tools/gen_config_docs", "sdk/wasm"]
+members = ["tools/gen_schema", "tools/gen_cli_docs", "tools/gen_config_docs", "sdk/wasm", "crates/daw-model", "crates/video-model"]
 exclude = ["apps/wasm-poc"]
 resolver = "2"
 

--- a/crates/daw-model/Cargo.toml
+++ b/crates/daw-model/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "plexi-daw-model"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+log = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/daw-model/src/commands.rs
+++ b/crates/daw-model/src/commands.rs
@@ -1,0 +1,77 @@
+//! The DAW command surface: the API downstream agents build against.
+//!
+//! Every command is self-contained — all data a handler needs is in the
+//! command's own fields, never looked up from ambient state.
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::{ClipId, SourceId, TrackId, TrackKind};
+
+/// Result of [`crate::DawModel::apply`].
+///
+/// - `Applied`: state changed; revision bumped; undoable edits recorded.
+/// - `Rejected`: missing id, invalid geometry, or non-finite float — state
+///   untouched, no history entry, no revision bump; the reason names what
+///   failed.
+/// - `NoOp`: valid but changed nothing — no history entry, no revision bump.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ApplyOutcome {
+    Applied,
+    Rejected(String),
+    NoOp,
+}
+
+/// Every edit, mixer, transport, and history command the DAW model accepts.
+///
+/// Edits to project data (tracks, clips, sources, mixer, tempo) are
+/// undoable. Transport commands (`Play`, `Stop`, `Seek`, `SetLoop`) are not
+/// undoable and are never restored by `Undo`, but they do bump the revision
+/// when they change state.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum DawCommand {
+    /// Set the project tempo. Non-finite is rejected; the value clamps to
+    /// [`crate::TEMPO_MIN`]..=[`crate::TEMPO_MAX`].
+    SetTempo { bpm: f64 },
+
+    AddTrack { kind: TrackKind, name: String },
+    RemoveTrack { track: TrackId },
+    RenameTrack { track: TrackId, name: String },
+
+    /// Register a media source. `duration` is in ticks.
+    AddSource { kind: TrackKind, path: String, duration: u64 },
+    /// Remove a source and every clip referencing it, in one undo group.
+    RemoveSource { source: SourceId },
+
+    /// Place a clip on a track. The source kind must match the track kind;
+    /// `source_offset + length` must fit inside the source. Clips may
+    /// overlap on a DAW track.
+    AddClip {
+        track: TrackId,
+        source: SourceId,
+        position: u64,
+        length: u64,
+        source_offset: u64,
+    },
+    RemoveClip { clip: ClipId },
+    /// Move a clip, possibly to another track when the kinds match.
+    MoveClip { clip: ClipId, track: TrackId, position: u64 },
+    ResizeClip { clip: ClipId, length: u64, source_offset: u64 },
+
+    /// Mixer sets validate finiteness up front and clamp on apply.
+    /// Consecutive sets of the same variant on the same track coalesce into
+    /// one undo group until any other command breaks it.
+    SetTrackVolume { track: TrackId, volume: f32 },
+    SetTrackPan { track: TrackId, pan: f32 },
+    SetTrackMute { track: TrackId, mute: bool },
+    SetTrackSolo { track: TrackId, solo: bool },
+
+    Play,
+    /// Stops playback only; the position is untouched (use `Seek`).
+    Stop,
+    Seek { position: u64 },
+    /// `start < end` is required whenever `enabled` is true.
+    SetLoop { enabled: bool, start: u64, end: u64 },
+
+    Undo,
+    Redo,
+}

--- a/crates/daw-model/src/gate.rs
+++ b/crates/daw-model/src/gate.rs
@@ -14,8 +14,8 @@ use std::time::Instant;
 use crate::commands::{ApplyOutcome, DawCommand};
 use crate::history::MAX_GROUPS;
 use crate::model::{
-    ClipId, DawModel, Project, SourceId, TrackId, TrackKind, PAN_MAX, PAN_MIN, TEMPO_MAX,
-    TEMPO_MIN, TICKS_PER_BEAT, VOLUME_MAX, VOLUME_MIN,
+    ClipId, DawModel, Project, SourceId, TrackId, TrackKind, Transport, ValidationError,
+    TEMPO_MIN, TICKS_PER_BEAT, VOLUME_MAX,
 };
 
 /// Environment variable that pins `gate_randomized_commands` to one seed.
@@ -720,74 +720,12 @@ pub fn gate_cases() -> Vec<GateCase> {
 // ─── Invariants ──────────────────────────────────────────────────────────────
 
 /// Read-only invariants that must hold after every applied command.
+/// State validity delegates to the product's shared [`DawModel::validate`]
+/// path (the same checks bundle loading runs); only the test-only extras —
+/// revision monotonicity and undo-depth consistency — live here.
 /// `prev_revision` is the revision observed before the command.
 pub fn check_invariants(model: &DawModel, prev_revision: u64) -> Result<(), String> {
-    let project = model.project();
-    if !project.tempo_bpm.is_finite() || !(TEMPO_MIN..=TEMPO_MAX).contains(&project.tempo_bpm) {
-        return Err(format!("tempo {} out of range", project.tempo_bpm));
-    }
-    let mut ids: Vec<u64> = Vec::new();
-    for track in &project.tracks {
-        ids.push(track.id.0);
-        let mixer = track.mixer;
-        if !mixer.volume.is_finite() || !(VOLUME_MIN..=VOLUME_MAX).contains(&mixer.volume) {
-            return Err(format!("track {} volume {} out of range", track.id.0, mixer.volume));
-        }
-        if !mixer.pan.is_finite() || !(PAN_MIN..=PAN_MAX).contains(&mixer.pan) {
-            return Err(format!("track {} pan {} out of range", track.id.0, mixer.pan));
-        }
-        for clip in &track.clips {
-            ids.push(clip.id.0);
-            let Some(source) = project.source(clip.source) else {
-                return Err(format!(
-                    "clip {} references missing source {}",
-                    clip.id.0, clip.source.0
-                ));
-            };
-            if source.kind != track.kind {
-                return Err(format!(
-                    "clip {} source kind {:?} mismatches track kind {:?}",
-                    clip.id.0, source.kind, track.kind
-                ));
-            }
-            if clip.length == 0 {
-                return Err(format!("clip {} has zero length", clip.id.0));
-            }
-            match clip.source_offset.checked_add(clip.length) {
-                Some(end) if end <= source.duration => {}
-                _ => {
-                    return Err(format!(
-                        "clip {} window {}+{} exceeds source duration {}",
-                        clip.id.0, clip.source_offset, clip.length, source.duration
-                    ));
-                }
-            }
-            if clip.position.checked_add(clip.length).is_none() {
-                return Err(format!("clip {} timeline end overflows u64", clip.id.0));
-            }
-        }
-    }
-    for source in &project.sources {
-        ids.push(source.id.0);
-    }
-    ids.sort_unstable();
-    if ids.windows(2).any(|w| w[0] == w[1]) {
-        return Err("duplicate entity id".to_string());
-    }
-    if ids.last().is_some_and(|&max| max >= project.next_id) {
-        return Err(format!(
-            "id {} >= next_id {}; allocator lost monotonicity",
-            ids.last().unwrap(),
-            project.next_id
-        ));
-    }
-    let transport = model.transport();
-    if transport.loop_enabled && transport.loop_start >= transport.loop_end {
-        return Err(format!(
-            "loop enabled with start {} >= end {}",
-            transport.loop_start, transport.loop_end
-        ));
-    }
+    model.validate().map_err(|e| e.to_string())?;
     if model.revision() < prev_revision {
         return Err(format!(
             "revision went backwards: {} -> {}",
@@ -916,8 +854,9 @@ fn run_long_sequence() -> Result<usize, String> {
         ));
     }
     // Settle any leftover interleaved-undo residue first so "final" is
-    // well-defined, then: full undo walks back to the default project (the
-    // id allocator alone survives); full redo restores the exact final JSON.
+    // well-defined, then: full undo walks back to the default project —
+    // except `next_id`, which is pinned monotonic across undo (see the
+    // `Project::next_id` doc) — and full redo restores the exact final JSON.
     while model.can_redo() {
         model.apply(DawCommand::Redo);
     }
@@ -1574,7 +1513,8 @@ fn gate_restore_from_parts() {
     let mut restored = DawModel::from_parts(
         Project::from_json(&json).expect("deserialize"),
         *model.transport(),
-    );
+    )
+    .expect("valid persisted state must restore");
     assert_eq!(restored.project(), model.project());
     assert_eq!(restored.transport(), model.transport());
     assert_eq!(restored.undo_depth(), 0, "undo never spans sessions");
@@ -1582,4 +1522,62 @@ fn gate_restore_from_parts() {
     assert_eq!(restored.apply(midi_track("Keys")), ApplyOutcome::Applied);
     let new_track = restored.project().tracks.last().expect("new track");
     assert_eq!(new_track.id, TrackId(4), "id allocation resumes past restored ids");
+}
+
+#[test]
+fn gate_from_parts_rejects_invalid_state() {
+    // Tester repro: a hand-edited bundle with an out-of-range tempo must be
+    // rejected by the shared validation path, not silently accepted.
+    let corrupted = Project {
+        tempo_bpm: 1000.0,
+        ..Project::default()
+    };
+    match DawModel::from_parts(corrupted, Transport::default()) {
+        Err(ValidationError::TempoOutOfRange { tempo_bpm }) => assert_eq!(tempo_bpm, 1000.0),
+        other => panic!("expected TempoOutOfRange, got {other:?}"),
+    }
+    // An enabled loop with inverted bounds is invalid transport state.
+    let inverted = Transport {
+        loop_enabled: true,
+        loop_start: 200,
+        loop_end: 100,
+        ..Transport::default()
+    };
+    match DawModel::from_parts(Project::default(), inverted) {
+        Err(ValidationError::LoopInverted { start: 200, end: 100 }) => {}
+        other => panic!("expected LoopInverted, got {other:?}"),
+    }
+}
+
+#[test]
+fn full_undo_preserves_monotonic_next_id() {
+    // Pinned design decision: `next_id` is NOT restored by undo. After full
+    // undo the project is semantically the initial state except the
+    // strictly advanced allocator — stale external ids stay detectable
+    // instead of silently rebinding to post-undo objects.
+    let mut model = DawModel::new();
+    let initial_next_id = model.project().next_id;
+    for command in [
+        audio_track("Drums"),
+        audio_source(4 * TICKS_PER_BEAT),
+        clip(1, 2, 0, TICKS_PER_BEAT, 0),
+    ] {
+        assert_eq!(model.apply(command), ApplyOutcome::Applied);
+    }
+    while model.can_undo() {
+        model.apply(DawCommand::Undo);
+    }
+    assert!(
+        model.project().next_id > initial_next_id,
+        "next_id must stay advanced after full undo"
+    );
+    let expected = Project {
+        next_id: model.project().next_id,
+        ..Project::default()
+    };
+    assert_eq!(
+        model.project(),
+        &expected,
+        "everything except next_id must equal the initial state"
+    );
 }

--- a/crates/daw-model/src/gate.rs
+++ b/crates/daw-model/src/gate.rs
@@ -1,0 +1,1585 @@
+//! DAW model release gate (stint 0514): a table-driven command matrix, a long
+//! deterministic stress sequence, and seeded randomized command fuzzing over
+//! the pure [`DawModel`] state machine — with per-command invariant checks
+//! and a machine-readable qualification artifact.
+//!
+//! Compiled only under `cfg(test)`: the gate is test infrastructure, never
+//! product code. Mirrors the editor gate (`src/editor/gate.rs` in the host
+//! crate) in structure, seeds, minimizer, and artifact schema shape.
+#![cfg(test)]
+
+use std::path::Path;
+use std::time::Instant;
+
+use crate::commands::{ApplyOutcome, DawCommand};
+use crate::history::MAX_GROUPS;
+use crate::model::{
+    ClipId, DawModel, Project, SourceId, TrackId, TrackKind, PAN_MAX, PAN_MIN, TEMPO_MAX,
+    TEMPO_MIN, TICKS_PER_BEAT, VOLUME_MAX, VOLUME_MIN,
+};
+
+/// Environment variable that pins `gate_randomized_commands` to one seed.
+pub const GATE_SEED_ENV: &str = "PLEXI_DAW_GATE_SEED";
+
+const DEFAULT_SEEDS: [u64; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+/// Kept modest (vs the editor's 2000): snapshot history makes state clones
+/// the dominant cost, and a sibling agent shares this machine's memory.
+const RANDOM_COMMANDS_PER_SEED: usize = 1500;
+/// Past this many clips the fuzzer biases hard toward shrinking commands.
+const FUZZ_CLIP_SOFT_CAP: usize = 200;
+
+// ─── Case table ──────────────────────────────────────────────────────────────
+
+/// Expected outcome kind of one gate step (`Rejected` matches any reason).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Expect {
+    Applied,
+    Rejected,
+    NoOp,
+}
+
+fn outcome_kind(outcome: &ApplyOutcome) -> Expect {
+    match outcome {
+        ApplyOutcome::Applied => Expect::Applied,
+        ApplyOutcome::Rejected(_) => Expect::Rejected,
+        ApplyOutcome::NoOp => Expect::NoOp,
+    }
+}
+
+/// One step of a gate case: the command and the outcome it must produce.
+#[derive(Debug)]
+pub struct GateStep {
+    pub command: DawCommand,
+    pub expect: Expect,
+}
+
+/// One named gate case: a step sequence applied to a fresh [`DawModel`] and
+/// a final-state check. Ids in the steps are deterministic: the model's
+/// allocator starts at 1, so the Nth allocating command yields id N.
+pub struct GateCase {
+    pub name: &'static str,
+    pub steps: Vec<GateStep>,
+    pub check: fn(&DawModel) -> Result<(), String>,
+}
+
+fn a(command: DawCommand) -> GateStep {
+    GateStep {
+        command,
+        expect: Expect::Applied,
+    }
+}
+
+fn r(command: DawCommand) -> GateStep {
+    GateStep {
+        command,
+        expect: Expect::Rejected,
+    }
+}
+
+fn n(command: DawCommand) -> GateStep {
+    GateStep {
+        command,
+        expect: Expect::NoOp,
+    }
+}
+
+fn audio_track(name: &str) -> DawCommand {
+    DawCommand::AddTrack {
+        kind: TrackKind::Audio,
+        name: name.to_string(),
+    }
+}
+
+fn midi_track(name: &str) -> DawCommand {
+    DawCommand::AddTrack {
+        kind: TrackKind::Midi,
+        name: name.to_string(),
+    }
+}
+
+fn audio_source(duration: u64) -> DawCommand {
+    DawCommand::AddSource {
+        kind: TrackKind::Audio,
+        path: "samples/kick.wav".to_string(),
+        duration,
+    }
+}
+
+fn midi_source(duration: u64) -> DawCommand {
+    DawCommand::AddSource {
+        kind: TrackKind::Midi,
+        path: "midi/lead.mid".to_string(),
+        duration,
+    }
+}
+
+fn clip(track: u64, source: u64, position: u64, length: u64, source_offset: u64) -> DawCommand {
+    DawCommand::AddClip {
+        track: TrackId(track),
+        source: SourceId(source),
+        position,
+        length,
+        source_offset,
+    }
+}
+
+fn vol(track: u64, volume: f32) -> DawCommand {
+    DawCommand::SetTrackVolume {
+        track: TrackId(track),
+        volume,
+    }
+}
+
+fn pan(track: u64, value: f32) -> DawCommand {
+    DawCommand::SetTrackPan {
+        track: TrackId(track),
+        pan: value,
+    }
+}
+
+/// Steps shared by clip cases: one audio track (id 1) and one 4-beat audio
+/// source (id 2); the next allocated id is 3.
+fn setup_track_source() -> Vec<GateStep> {
+    vec![a(audio_track("Audio 1")), a(audio_source(4 * TICKS_PER_BEAT))]
+}
+
+fn with_setup(extra: Vec<GateStep>) -> Vec<GateStep> {
+    let mut steps = setup_track_source();
+    steps.extend(extra);
+    steps
+}
+
+fn first_track(model: &DawModel) -> Result<&crate::model::Track, String> {
+    model
+        .project()
+        .tracks
+        .first()
+        .ok_or_else(|| "expected at least one track".to_string())
+}
+
+/// The release-gate matrix: every case is small, named, and independently
+/// replayable through a fresh [`DawModel`].
+#[must_use]
+pub fn gate_cases() -> Vec<GateCase> {
+    vec![
+        GateCase {
+            name: "add_track",
+            steps: vec![a(audio_track("Drums"))],
+            check: |m| {
+                let t = first_track(m)?;
+                if t.name != "Drums" || t.kind != TrackKind::Audio || t.id != TrackId(1) {
+                    return Err(format!("unexpected track {t:?}"));
+                }
+                if m.undo_depth() != 1 || m.revision() != 1 {
+                    return Err(format!(
+                        "expected depth 1 / revision 1, got {} / {}",
+                        m.undo_depth(),
+                        m.revision()
+                    ));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "remove_track",
+            steps: vec![
+                a(audio_track("Drums")),
+                a(DawCommand::RemoveTrack { track: TrackId(1) }),
+            ],
+            check: |m| {
+                if !m.project().tracks.is_empty() || m.undo_depth() != 2 {
+                    return Err(format!(
+                        "expected no tracks / depth 2, got {} tracks / depth {}",
+                        m.project().tracks.len(),
+                        m.undo_depth()
+                    ));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "remove_missing_track_rejected",
+            steps: vec![r(DawCommand::RemoveTrack { track: TrackId(42) })],
+            check: |m| {
+                if m.undo_depth() != 0 || m.revision() != 0 {
+                    return Err("rejection must leave history and revision untouched".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "rename_track_and_noop",
+            steps: vec![
+                a(audio_track("A")),
+                a(DawCommand::RenameTrack {
+                    track: TrackId(1),
+                    name: "Lead".to_string(),
+                }),
+                n(DawCommand::RenameTrack {
+                    track: TrackId(1),
+                    name: "Lead".to_string(),
+                }),
+            ],
+            check: |m| {
+                if first_track(m)?.name != "Lead" || m.undo_depth() != 2 {
+                    return Err("expected renamed track and depth 2".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "add_source_and_clip",
+            steps: with_setup(vec![a(clip(1, 2, 0, TICKS_PER_BEAT, 0))]),
+            check: |m| {
+                let t = first_track(m)?;
+                let c = t
+                    .clips
+                    .first()
+                    .ok_or_else(|| "expected one clip".to_string())?;
+                if c.id != ClipId(3) || c.length != TICKS_PER_BEAT || m.undo_depth() != 3 {
+                    return Err(format!("unexpected clip {c:?} / depth {}", m.undo_depth()));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "clip_offset_beyond_source_rejected",
+            steps: with_setup(vec![r(clip(1, 2, 0, TICKS_PER_BEAT, 4 * TICKS_PER_BEAT))]),
+            check: |m| {
+                if m.project().clip_count() != 0 || m.undo_depth() != 2 {
+                    return Err("rejected clip must not exist or record history".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "clip_zero_length_rejected",
+            steps: with_setup(vec![r(clip(1, 2, 0, 0, 0))]),
+            check: |m| {
+                if m.project().clip_count() != 0 || m.undo_depth() != 2 {
+                    return Err("zero-length clip must be rejected without history".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "clip_missing_ids_rejected",
+            steps: with_setup(vec![
+                r(clip(9, 2, 0, TICKS_PER_BEAT, 0)),
+                r(clip(1, 9, 0, TICKS_PER_BEAT, 0)),
+            ]),
+            check: |m| {
+                if m.project().clip_count() != 0 || m.undo_depth() != 2 || m.revision() != 2 {
+                    return Err("missing-id clips must leave state untouched".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "clip_kind_mismatch_rejected",
+            steps: vec![
+                a(audio_track("A")),
+                a(midi_source(4 * TICKS_PER_BEAT)),
+                r(clip(1, 2, 0, TICKS_PER_BEAT, 0)),
+            ],
+            check: |m| {
+                if m.project().clip_count() != 0 {
+                    return Err("MIDI source must not land on an audio track".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "clip_position_overflow_rejected",
+            steps: with_setup(vec![r(clip(1, 2, u64::MAX, TICKS_PER_BEAT, 0))]),
+            check: |m| {
+                if m.project().clip_count() != 0 {
+                    return Err("overflowing clip must be rejected".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "move_clip_same_track",
+            steps: with_setup(vec![
+                a(clip(1, 2, 0, TICKS_PER_BEAT, 0)),
+                a(DawCommand::MoveClip {
+                    clip: ClipId(3),
+                    track: TrackId(1),
+                    position: 2 * TICKS_PER_BEAT,
+                }),
+                n(DawCommand::MoveClip {
+                    clip: ClipId(3),
+                    track: TrackId(1),
+                    position: 2 * TICKS_PER_BEAT,
+                }),
+            ]),
+            check: |m| {
+                let c = &first_track(m)?.clips[0];
+                if c.position != 2 * TICKS_PER_BEAT || m.undo_depth() != 4 {
+                    return Err(format!("unexpected position {} after move", c.position));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "move_clip_cross_track",
+            steps: vec![
+                a(audio_track("A")),
+                a(audio_track("B")),
+                a(audio_source(4 * TICKS_PER_BEAT)),
+                a(clip(1, 3, 0, TICKS_PER_BEAT, 0)),
+                a(DawCommand::MoveClip {
+                    clip: ClipId(4),
+                    track: TrackId(2),
+                    position: TICKS_PER_BEAT,
+                }),
+            ],
+            check: |m| {
+                let p = m.project();
+                if !p.tracks[0].clips.is_empty() || p.tracks[1].clips.len() != 1 {
+                    return Err("clip must have moved from track 1 to track 2".to_string());
+                }
+                if p.tracks[1].clips[0].position != TICKS_PER_BEAT {
+                    return Err("moved clip has wrong position".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "move_clip_kind_mismatch_rejected",
+            steps: vec![
+                a(audio_track("A")),
+                a(midi_track("M")),
+                a(audio_source(4 * TICKS_PER_BEAT)),
+                a(clip(1, 3, 0, TICKS_PER_BEAT, 0)),
+                r(DawCommand::MoveClip {
+                    clip: ClipId(4),
+                    track: TrackId(2),
+                    position: 0,
+                }),
+            ],
+            check: |m| {
+                let p = m.project();
+                if p.tracks[0].clips.len() != 1 || !p.tracks[1].clips.is_empty() {
+                    return Err("cross-kind move must be rejected in place".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "resize_clip",
+            steps: with_setup(vec![
+                a(clip(1, 2, 0, TICKS_PER_BEAT, 0)),
+                a(DawCommand::ResizeClip {
+                    clip: ClipId(3),
+                    length: 2 * TICKS_PER_BEAT,
+                    source_offset: TICKS_PER_BEAT,
+                }),
+                // 960 + 3840 exceeds the 3840-tick source.
+                r(DawCommand::ResizeClip {
+                    clip: ClipId(3),
+                    length: 4 * TICKS_PER_BEAT,
+                    source_offset: TICKS_PER_BEAT,
+                }),
+                n(DawCommand::ResizeClip {
+                    clip: ClipId(3),
+                    length: 2 * TICKS_PER_BEAT,
+                    source_offset: TICKS_PER_BEAT,
+                }),
+            ]),
+            check: |m| {
+                let c = &first_track(m)?.clips[0];
+                if c.length != 2 * TICKS_PER_BEAT || c.source_offset != TICKS_PER_BEAT {
+                    return Err(format!("unexpected clip window {c:?}"));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "volume_set_and_clamp",
+            steps: vec![
+                a(audio_track("A")),
+                a(vol(1, 5.0)),
+                r(vol(1, f32::NAN)),
+                r(vol(9, 0.5)),
+            ],
+            check: |m| {
+                let v = first_track(m)?.mixer.volume;
+                if v != VOLUME_MAX || m.undo_depth() != 2 {
+                    return Err(format!("expected clamped volume {VOLUME_MAX}, got {v}"));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "volume_coalesces_one_group",
+            steps: vec![a(audio_track("A")), a(vol(1, 0.5)), a(vol(1, 0.7))],
+            check: |m| {
+                // Two consecutive volume sets on the same track = one group.
+                if m.undo_depth() != 2 || first_track(m)?.mixer.volume != 0.7 {
+                    return Err(format!(
+                        "expected depth 2 / volume 0.7, got {} / {}",
+                        m.undo_depth(),
+                        first_track(m)?.mixer.volume
+                    ));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "volume_coalesced_undo_restores_original",
+            steps: vec![
+                a(audio_track("A")),
+                a(vol(1, 0.5)),
+                a(vol(1, 0.7)),
+                a(DawCommand::Undo),
+            ],
+            check: |m| {
+                if first_track(m)?.mixer.volume != 1.0 || !m.can_redo() {
+                    return Err("one undo must restore the pre-run volume".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "coalescing_broken_by_other_edit",
+            steps: vec![
+                a(audio_track("A")),
+                a(vol(1, 0.5)),
+                a(DawCommand::SetTrackMute {
+                    track: TrackId(1),
+                    mute: true,
+                }),
+                a(vol(1, 0.7)),
+            ],
+            check: |m| {
+                if m.undo_depth() != 4 {
+                    return Err(format!(
+                        "mute must split the volume groups; depth {}",
+                        m.undo_depth()
+                    ));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "coalescing_broken_by_transport",
+            steps: vec![
+                a(audio_track("A")),
+                a(vol(1, 0.5)),
+                a(DawCommand::Seek {
+                    position: TICKS_PER_BEAT,
+                }),
+                a(vol(1, 0.7)),
+            ],
+            check: |m| {
+                // Track add + two volume groups; the seek records nothing.
+                if m.undo_depth() != 3 {
+                    return Err(format!(
+                        "seek must break the volume group; depth {}",
+                        m.undo_depth()
+                    ));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "pan_clamp_and_coalesce",
+            steps: vec![
+                a(audio_track("A")),
+                a(pan(1, -3.0)),
+                a(pan(1, 0.25)),
+                r(pan(1, f32::INFINITY)),
+            ],
+            check: |m| {
+                let p = first_track(m)?.mixer.pan;
+                if p != 0.25 || m.undo_depth() != 2 {
+                    return Err(format!("expected coalesced pan 0.25, got {p}"));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "mute_solo_noop",
+            steps: vec![
+                a(audio_track("A")),
+                a(DawCommand::SetTrackMute {
+                    track: TrackId(1),
+                    mute: true,
+                }),
+                n(DawCommand::SetTrackMute {
+                    track: TrackId(1),
+                    mute: true,
+                }),
+                a(DawCommand::SetTrackSolo {
+                    track: TrackId(1),
+                    solo: true,
+                }),
+                n(DawCommand::SetTrackSolo {
+                    track: TrackId(1),
+                    solo: true,
+                }),
+            ],
+            check: |m| {
+                let mixer = first_track(m)?.mixer;
+                if !mixer.mute || !mixer.solo || m.undo_depth() != 3 {
+                    return Err("mute/solo must stick; repeats must be NoOp".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "tempo_set_clamp_noop",
+            steps: vec![
+                a(DawCommand::SetTempo { bpm: 150.0 }),
+                n(DawCommand::SetTempo { bpm: 150.0 }),
+                a(DawCommand::SetTempo { bpm: 5.0 }),
+                r(DawCommand::SetTempo { bpm: f64::NAN }),
+            ],
+            check: |m| {
+                if m.project().tempo_bpm != TEMPO_MIN || m.undo_depth() != 2 {
+                    return Err(format!(
+                        "expected tempo clamped to {TEMPO_MIN}, got {}",
+                        m.project().tempo_bpm
+                    ));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "remove_source_cascades_one_group",
+            steps: with_setup(vec![
+                a(clip(1, 2, 0, TICKS_PER_BEAT, 0)),
+                a(clip(1, 2, 2 * TICKS_PER_BEAT, TICKS_PER_BEAT, 0)),
+                a(DawCommand::RemoveSource { source: SourceId(2) }),
+                a(DawCommand::Undo),
+            ]),
+            check: |m| {
+                // One undo restores the source and both cascaded clips.
+                let p = m.project();
+                if p.sources.len() != 1 || p.clip_count() != 2 {
+                    return Err(format!(
+                        "cascade undo must restore source + 2 clips, got {} sources / {} clips",
+                        p.sources.len(),
+                        p.clip_count()
+                    ));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "transport_not_undoable_empty_history",
+            steps: vec![
+                a(DawCommand::Play),
+                a(DawCommand::Seek {
+                    position: TICKS_PER_BEAT,
+                }),
+                n(DawCommand::Undo),
+            ],
+            check: |m| {
+                let t = m.transport();
+                if !t.playing || t.position != TICKS_PER_BEAT {
+                    return Err("undo with empty history must not touch transport".to_string());
+                }
+                if m.undo_depth() != 0 || m.revision() != 2 {
+                    return Err("transport commands must not record history".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "transport_survives_undo",
+            steps: vec![
+                a(audio_track("A")),
+                a(DawCommand::Play),
+                a(DawCommand::Seek { position: 480 }),
+                a(DawCommand::Undo),
+            ],
+            check: |m| {
+                let t = m.transport();
+                if !m.project().tracks.is_empty() {
+                    return Err("undo must remove the track".to_string());
+                }
+                if !t.playing || t.position != 480 {
+                    return Err("undo must not restore transport state".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "loop_validation",
+            steps: vec![
+                r(DawCommand::SetLoop {
+                    enabled: true,
+                    start: 100,
+                    end: 100,
+                }),
+                r(DawCommand::SetLoop {
+                    enabled: true,
+                    start: 200,
+                    end: 100,
+                }),
+                a(DawCommand::SetLoop {
+                    enabled: true,
+                    start: 0,
+                    end: 4 * TICKS_PER_BEAT,
+                }),
+                n(DawCommand::SetLoop {
+                    enabled: true,
+                    start: 0,
+                    end: 4 * TICKS_PER_BEAT,
+                }),
+                a(DawCommand::SetLoop {
+                    enabled: false,
+                    start: 0,
+                    end: 4 * TICKS_PER_BEAT,
+                }),
+            ],
+            check: |m| {
+                if m.transport().loop_enabled {
+                    return Err("loop must end disabled".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "stop_does_not_rewind",
+            steps: vec![
+                a(DawCommand::Play),
+                a(DawCommand::Seek { position: 500 }),
+                a(DawCommand::Stop),
+                n(DawCommand::Stop),
+            ],
+            check: |m| {
+                let t = m.transport();
+                if t.playing || t.position != 500 {
+                    return Err("stop must clear playing and keep the position".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "undo_redo_round_trip",
+            steps: vec![
+                a(audio_track("A")),
+                a(DawCommand::RenameTrack {
+                    track: TrackId(1),
+                    name: "B".to_string(),
+                }),
+                a(DawCommand::Undo),
+                a(DawCommand::Redo),
+            ],
+            check: |m| {
+                if first_track(m)?.name != "B" || m.undo_depth() != 2 || m.can_redo() {
+                    return Err("undo+redo must restore the rename".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "redo_invalidated_by_new_edit",
+            steps: vec![
+                a(audio_track("A")),
+                a(DawCommand::Undo),
+                a(midi_track("M")),
+            ],
+            check: |m| {
+                if m.can_redo() || m.project().tracks.len() != 1 {
+                    return Err("new edit after undo must clear redo".to_string());
+                }
+                if first_track(m)?.kind != TrackKind::Midi {
+                    return Err("surviving track must be the new MIDI track".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "undo_to_empty",
+            steps: vec![
+                a(audio_track("A")),
+                a(audio_source(TICKS_PER_BEAT)),
+                a(DawCommand::Undo),
+                a(DawCommand::Undo),
+                n(DawCommand::Undo),
+            ],
+            check: |m| {
+                let p = m.project();
+                if !p.tracks.is_empty() || !p.sources.is_empty() || m.undo_depth() != 0 {
+                    return Err("full undo must restore the empty project".to_string());
+                }
+                if !m.can_redo() {
+                    return Err("redo must be available after full undo".to_string());
+                }
+                Ok(())
+            },
+        },
+    ]
+}
+
+// ─── Invariants ──────────────────────────────────────────────────────────────
+
+/// Read-only invariants that must hold after every applied command.
+/// `prev_revision` is the revision observed before the command.
+pub fn check_invariants(model: &DawModel, prev_revision: u64) -> Result<(), String> {
+    let project = model.project();
+    if !project.tempo_bpm.is_finite() || !(TEMPO_MIN..=TEMPO_MAX).contains(&project.tempo_bpm) {
+        return Err(format!("tempo {} out of range", project.tempo_bpm));
+    }
+    let mut ids: Vec<u64> = Vec::new();
+    for track in &project.tracks {
+        ids.push(track.id.0);
+        let mixer = track.mixer;
+        if !mixer.volume.is_finite() || !(VOLUME_MIN..=VOLUME_MAX).contains(&mixer.volume) {
+            return Err(format!("track {} volume {} out of range", track.id.0, mixer.volume));
+        }
+        if !mixer.pan.is_finite() || !(PAN_MIN..=PAN_MAX).contains(&mixer.pan) {
+            return Err(format!("track {} pan {} out of range", track.id.0, mixer.pan));
+        }
+        for clip in &track.clips {
+            ids.push(clip.id.0);
+            let Some(source) = project.source(clip.source) else {
+                return Err(format!(
+                    "clip {} references missing source {}",
+                    clip.id.0, clip.source.0
+                ));
+            };
+            if source.kind != track.kind {
+                return Err(format!(
+                    "clip {} source kind {:?} mismatches track kind {:?}",
+                    clip.id.0, source.kind, track.kind
+                ));
+            }
+            if clip.length == 0 {
+                return Err(format!("clip {} has zero length", clip.id.0));
+            }
+            match clip.source_offset.checked_add(clip.length) {
+                Some(end) if end <= source.duration => {}
+                _ => {
+                    return Err(format!(
+                        "clip {} window {}+{} exceeds source duration {}",
+                        clip.id.0, clip.source_offset, clip.length, source.duration
+                    ));
+                }
+            }
+            if clip.position.checked_add(clip.length).is_none() {
+                return Err(format!("clip {} timeline end overflows u64", clip.id.0));
+            }
+        }
+    }
+    for source in &project.sources {
+        ids.push(source.id.0);
+    }
+    ids.sort_unstable();
+    if ids.windows(2).any(|w| w[0] == w[1]) {
+        return Err("duplicate entity id".to_string());
+    }
+    if ids.last().is_some_and(|&max| max >= project.next_id) {
+        return Err(format!(
+            "id {} >= next_id {}; allocator lost monotonicity",
+            ids.last().unwrap(),
+            project.next_id
+        ));
+    }
+    let transport = model.transport();
+    if transport.loop_enabled && transport.loop_start >= transport.loop_end {
+        return Err(format!(
+            "loop enabled with start {} >= end {}",
+            transport.loop_start, transport.loop_end
+        ));
+    }
+    if model.revision() < prev_revision {
+        return Err(format!(
+            "revision went backwards: {} -> {}",
+            prev_revision,
+            model.revision()
+        ));
+    }
+    if model.can_undo() != (model.undo_depth() > 0) {
+        return Err(format!(
+            "undo_depth {} inconsistent with can_undo {}",
+            model.undo_depth(),
+            model.can_undo()
+        ));
+    }
+    Ok(())
+}
+
+/// History round-trip invariant: when undo is available, Undo then Redo must
+/// restore the exact serialized project. Mutates only history bookkeeping
+/// (breaks the open coalescing group), so callers run it where coalescing no
+/// longer matters. Transport is deliberately outside the compare — it is not
+/// part of history.
+pub fn check_history_round_trip(model: &mut DawModel) -> Result<(), String> {
+    if !model.can_undo() {
+        return Ok(());
+    }
+    let before = model.project().to_json()?;
+    model.apply(DawCommand::Undo);
+    model.apply(DawCommand::Redo);
+    let after = model.project().to_json()?;
+    if before != after {
+        return Err(format!(
+            "undo/redo round trip did not restore the project:\nbefore: {before}\nafter: {after}"
+        ));
+    }
+    Ok(())
+}
+
+// ─── Case runner ─────────────────────────────────────────────────────────────
+
+/// Final-state summary recorded in the qualification artifact.
+#[derive(Debug, serde::Serialize)]
+pub struct GateFinalState {
+    pub revision: u64,
+    pub undo_depth: usize,
+    pub can_redo: bool,
+}
+
+fn run_case(case: &GateCase) -> Result<GateFinalState, String> {
+    let mut model = DawModel::new();
+    let mut prev_revision = model.revision();
+    for (index, step) in case.steps.iter().enumerate() {
+        let outcome = model.apply(step.command.clone());
+        if outcome_kind(&outcome) != step.expect {
+            return Err(format!(
+                "step[{index}] {:?}: expected {:?}, got {outcome:?}",
+                step.command, step.expect
+            ));
+        }
+        check_invariants(&model, prev_revision)
+            .map_err(|e| format!("step[{index}] {:?}: {e}", step.command))?;
+        prev_revision = model.revision();
+    }
+    (case.check)(&model)?;
+    check_history_round_trip(&mut model)?;
+    Ok(GateFinalState {
+        revision: model.revision(),
+        undo_depth: model.undo_depth(),
+        can_redo: model.can_redo(),
+    })
+}
+
+// ─── Deterministic long sequence ─────────────────────────────────────────────
+
+const LONG_SEQUENCE_REPS: usize = 10;
+/// Guard band under [`MAX_GROUPS`]: the full-undo-to-empty assertion is only
+/// valid while no undo group was ever evicted.
+const MAX_OBSERVED_DEPTH: usize = MAX_GROUPS - 20;
+
+fn run_long_sequence() -> Result<usize, String> {
+    let mut model = DawModel::new();
+    let mut prev_revision = model.revision();
+    let mut applied = 0usize;
+    let mut max_depth = 0usize;
+    let cases = gate_cases();
+    for rep in 0..LONG_SEQUENCE_REPS {
+        for case in &cases {
+            for step in &case.steps {
+                // Outcomes differ in the shared model (ids drift); only the
+                // invariants and history behavior are under test here.
+                model.apply(step.command.clone());
+                applied += 1;
+                check_invariants(&model, prev_revision)
+                    .map_err(|e| format!("rep {rep} case {} @{applied}: {e}", case.name))?;
+                prev_revision = model.revision();
+                max_depth = max_depth.max(model.undo_depth());
+                // Interleaved undo/redo passes keep the history exercised
+                // (and pruned: an edit after an undo drops the redone group).
+                if applied % 5 == 0 {
+                    model.apply(DawCommand::Undo);
+                    check_invariants(&model, prev_revision)
+                        .map_err(|e| format!("interleaved undo @{applied}: {e}"))?;
+                    prev_revision = model.revision();
+                }
+                if applied % 13 == 0 {
+                    model.apply(DawCommand::Redo);
+                    check_invariants(&model, prev_revision)
+                        .map_err(|e| format!("interleaved redo @{applied}: {e}"))?;
+                    prev_revision = model.revision();
+                }
+                if applied % 97 == 0 {
+                    check_history_round_trip(&mut model)
+                        .map_err(|e| format!("round trip @{applied}: {e}"))?;
+                }
+            }
+        }
+    }
+    if applied < 1000 {
+        return Err(format!(
+            "long sequence too short ({applied} commands) to qualify as a stress pass"
+        ));
+    }
+    if max_depth >= MAX_OBSERVED_DEPTH {
+        return Err(format!(
+            "undo depth reached {max_depth}; retention cap invalidates full-undo assertion"
+        ));
+    }
+    // Settle any leftover interleaved-undo residue first so "final" is
+    // well-defined, then: full undo walks back to the default project (the
+    // id allocator alone survives); full redo restores the exact final JSON.
+    while model.can_redo() {
+        model.apply(DawCommand::Redo);
+    }
+    let final_json = model.project().to_json()?;
+    let mut guard = 0usize;
+    while model.can_undo() {
+        model.apply(DawCommand::Undo);
+        guard += 1;
+        if guard > 100_000 {
+            return Err("full undo did not terminate".to_string());
+        }
+    }
+    let empty = Project {
+        next_id: model.project().next_id,
+        ..Project::default()
+    };
+    if model.project() != &empty {
+        return Err(format!(
+            "full undo did not restore the default project; residue: {:?}",
+            model.project()
+        ));
+    }
+    while model.can_redo() {
+        model.apply(DawCommand::Redo);
+    }
+    if model.project().to_json()? != final_json {
+        return Err("full redo did not restore the final project".to_string());
+    }
+    Ok(applied)
+}
+
+// ─── Deterministic PRNG + randomized commands ────────────────────────────────
+
+/// SplitMix64: tiny, deterministic, dependency-free PRNG.
+pub struct SplitMix64(u64);
+
+impl SplitMix64 {
+    #[must_use]
+    pub fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    pub fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform value in `0..n` (`n > 0`).
+    pub fn below(&mut self, n: u64) -> u64 {
+        self.next_u64() % n
+    }
+}
+
+/// Existing id, or (1-in-8, and always when empty) a deliberately bogus one.
+fn pick_id(rng: &mut SplitMix64, ids: &[u64]) -> u64 {
+    if ids.is_empty() || rng.below(8) == 0 {
+        1_000_000 + rng.below(1000)
+    } else {
+        ids[rng.below(ids.len() as u64) as usize]
+    }
+}
+
+fn track_ids(project: &Project) -> Vec<u64> {
+    project.tracks.iter().map(|t| t.id.0).collect()
+}
+
+fn source_ids(project: &Project) -> Vec<u64> {
+    project.sources.iter().map(|s| s.id.0).collect()
+}
+
+fn clip_ids(project: &Project) -> Vec<u64> {
+    project
+        .tracks
+        .iter()
+        .flat_map(|t| t.clips.iter().map(|c| c.id.0))
+        .collect()
+}
+
+fn random_kind(rng: &mut SplitMix64) -> TrackKind {
+    if rng.below(2) == 0 {
+        TrackKind::Audio
+    } else {
+        TrackKind::Midi
+    }
+}
+
+/// Positions mix ordinary grid values with near-overflow extremes.
+fn random_position(rng: &mut SplitMix64) -> u64 {
+    if rng.below(16) == 0 {
+        u64::MAX - rng.below(2 * TICKS_PER_BEAT)
+    } else {
+        rng.below(64) * (TICKS_PER_BEAT / 2)
+    }
+}
+
+/// Lengths include zero and absurd values so geometry rejection stays hot.
+fn random_length(rng: &mut SplitMix64) -> u64 {
+    match rng.below(8) {
+        0 => 0,
+        1 => 100 * TICKS_PER_BEAT,
+        _ => (1 + rng.below(8)) * (TICKS_PER_BEAT / 2),
+    }
+}
+
+/// Finite values spanning past both clamp edges, plus NaN/±inf injections.
+fn random_f32(rng: &mut SplitMix64) -> f32 {
+    match rng.below(16) {
+        0 => f32::NAN,
+        1 => f32::INFINITY,
+        2 => f32::NEG_INFINITY,
+        _ => (rng.below(600) as f32) / 100.0 - 2.0,
+    }
+}
+
+fn random_tempo(rng: &mut SplitMix64) -> f64 {
+    match rng.below(16) {
+        0 => f64::NAN,
+        1 => f64::INFINITY,
+        _ => rng.below(1200) as f64,
+    }
+}
+
+/// Weighted random command generator over the full [`DawCommand`] surface,
+/// including deliberately invalid ids, geometry, and non-finite floats.
+pub fn random_command(rng: &mut SplitMix64, model: &DawModel) -> DawCommand {
+    let project = model.project();
+    let tracks = track_ids(project);
+    let sources = source_ids(project);
+    let clips = clip_ids(project);
+    // Memory discipline: past the soft cap, bias hard toward shrinking
+    // commands so fuzz state (and its history snapshots) stays bounded.
+    if clips.len() > FUZZ_CLIP_SOFT_CAP {
+        return match rng.below(10) {
+            0..=4 => DawCommand::RemoveClip {
+                clip: ClipId(pick_id(rng, &clips)),
+            },
+            5..=6 => DawCommand::Undo,
+            7 => DawCommand::RemoveTrack {
+                track: TrackId(pick_id(rng, &tracks)),
+            },
+            8 => DawCommand::RemoveSource {
+                source: SourceId(pick_id(rng, &sources)),
+            },
+            _ => DawCommand::RemoveClip {
+                clip: ClipId(pick_id(rng, &clips)),
+            },
+        };
+    }
+    match rng.below(100) {
+        0..=7 => DawCommand::AddTrack {
+            kind: random_kind(rng),
+            name: format!("Track {}", rng.below(1000)),
+        },
+        8..=10 => DawCommand::RemoveTrack {
+            track: TrackId(pick_id(rng, &tracks)),
+        },
+        11..=13 => DawCommand::RenameTrack {
+            track: TrackId(pick_id(rng, &tracks)),
+            name: format!("Renamed {}", rng.below(100)),
+        },
+        14..=21 => DawCommand::AddSource {
+            kind: random_kind(rng),
+            path: format!("media/{}.wav", rng.below(50)),
+            duration: rng.below(16) * TICKS_PER_BEAT,
+        },
+        22..=24 => DawCommand::RemoveSource {
+            source: SourceId(pick_id(rng, &sources)),
+        },
+        25..=42 => DawCommand::AddClip {
+            track: TrackId(pick_id(rng, &tracks)),
+            source: SourceId(pick_id(rng, &sources)),
+            position: random_position(rng),
+            length: random_length(rng),
+            source_offset: rng.below(8) * TICKS_PER_BEAT,
+        },
+        43..=47 => DawCommand::RemoveClip {
+            clip: ClipId(pick_id(rng, &clips)),
+        },
+        48..=53 => DawCommand::MoveClip {
+            clip: ClipId(pick_id(rng, &clips)),
+            track: TrackId(pick_id(rng, &tracks)),
+            position: random_position(rng),
+        },
+        54..=59 => DawCommand::ResizeClip {
+            clip: ClipId(pick_id(rng, &clips)),
+            length: random_length(rng),
+            source_offset: rng.below(8) * TICKS_PER_BEAT,
+        },
+        60..=65 => DawCommand::SetTrackVolume {
+            track: TrackId(pick_id(rng, &tracks)),
+            volume: random_f32(rng),
+        },
+        66..=70 => DawCommand::SetTrackPan {
+            track: TrackId(pick_id(rng, &tracks)),
+            pan: random_f32(rng),
+        },
+        71..=73 => DawCommand::SetTrackMute {
+            track: TrackId(pick_id(rng, &tracks)),
+            mute: rng.below(2) == 0,
+        },
+        74..=75 => DawCommand::SetTrackSolo {
+            track: TrackId(pick_id(rng, &tracks)),
+            solo: rng.below(2) == 0,
+        },
+        76..=78 => DawCommand::SetTempo {
+            bpm: random_tempo(rng),
+        },
+        79 => DawCommand::Play,
+        80 => DawCommand::Stop,
+        81..=82 => DawCommand::Seek {
+            position: random_position(rng),
+        },
+        83..=85 => {
+            // Sometimes inverted so loop validation stays exercised.
+            let a = rng.below(8) * TICKS_PER_BEAT;
+            let b = rng.below(8) * TICKS_PER_BEAT;
+            DawCommand::SetLoop {
+                enabled: rng.below(2) == 0,
+                start: a,
+                end: b,
+            }
+        }
+        86..=92 => DawCommand::Undo,
+        _ => DawCommand::Redo,
+    }
+}
+
+/// Replays `commands` on a fresh model with per-command invariant checks
+/// plus the final history round trip — the same predicates the seed run
+/// applies, so any original failure mode reproduces during minimization.
+/// Returns the failing command index and message, if any.
+fn replay(commands: &[DawCommand]) -> Result<(), (usize, String)> {
+    let mut model = DawModel::new();
+    let mut prev_revision = model.revision();
+    for (index, command) in commands.iter().enumerate() {
+        model.apply(command.clone());
+        if let Err(e) = check_invariants(&model, prev_revision) {
+            return Err((index, e));
+        }
+        prev_revision = model.revision();
+    }
+    check_history_round_trip(&mut model)
+        .map_err(|e| (commands.len().saturating_sub(1), e))
+}
+
+/// Greedy sequence minimization: repeatedly drop commands while the failure
+/// still reproduces. Bounded passes keep worst-case cost predictable.
+fn minimize(mut commands: Vec<DawCommand>) -> (Vec<DawCommand>, String) {
+    let mut message = match replay(&commands) {
+        Err((index, message)) => {
+            commands.truncate(index + 1);
+            message
+        }
+        Ok(()) => return (commands, "failure did not reproduce on replay".to_string()),
+    };
+    for _pass in 0..6 {
+        let mut removed_any = false;
+        let mut i = commands.len();
+        while i > 0 {
+            i -= 1;
+            let mut candidate = commands.clone();
+            candidate.remove(i);
+            if let Err((_, m)) = replay(&candidate) {
+                commands = candidate;
+                message = m;
+                removed_any = true;
+            }
+        }
+        if !removed_any {
+            break;
+        }
+    }
+    (commands, message)
+}
+
+#[derive(serde::Serialize)]
+struct ReplayBundle {
+    seed: u64,
+    command_count: usize,
+    invariant_message: String,
+    minimized_commands: Vec<DawCommand>,
+}
+
+/// A rejected or no-op command must leave the model observationally
+/// untouched. Sampled (not per-command) because it serializes the project.
+fn frozen_state(model: &DawModel) -> Result<String, String> {
+    let transport = serde_json::to_string(model.transport())
+        .map_err(|e| format!("transport serialization failed: {e}"))?;
+    Ok(format!(
+        "{}|{}|{}|{}",
+        model.project().to_json()?,
+        transport,
+        model.revision(),
+        model.undo_depth()
+    ))
+}
+
+/// Runs one randomized seed. On invariant failure, minimizes the failing
+/// sequence and writes a replay bundle; returns the failure message.
+fn run_random_seed(seed: u64, command_count: usize) -> Result<(), String> {
+    let mut rng = SplitMix64::new(seed);
+    let mut model = DawModel::new();
+    let mut prev_revision = model.revision();
+    let mut applied: Vec<DawCommand> = Vec::with_capacity(command_count);
+    let mut failure: Option<String> = None;
+    for index in 0..command_count {
+        let command = random_command(&mut rng, &model);
+        // Sampled no-mutation check for Rejected/NoOp outcomes.
+        let watch = index % 16 == 0;
+        let before = if watch {
+            match frozen_state(&model) {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    failure = Some(e);
+                    break;
+                }
+            }
+        } else {
+            None
+        };
+        applied.push(command.clone());
+        let outcome = model.apply(command);
+        if let (Some(before), ApplyOutcome::Rejected(_) | ApplyOutcome::NoOp) = (before, &outcome)
+        {
+            match frozen_state(&model) {
+                Ok(after) if after != before => {
+                    failure = Some(format!("{outcome:?} outcome mutated state"));
+                    break;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    failure = Some(e);
+                    break;
+                }
+            }
+        }
+        if let Err(e) = check_invariants(&model, prev_revision) {
+            failure = Some(e);
+            break;
+        }
+        prev_revision = model.revision();
+        if (index + 1) % 250 == 0 {
+            if let Err(e) = check_history_round_trip(&mut model) {
+                failure = Some(format!("round trip @{index}: {e}"));
+                break;
+            }
+        }
+    }
+    if failure.is_none() {
+        if let Err(e) = check_history_round_trip(&mut model) {
+            failure = Some(e);
+        }
+    }
+    let Some(original_message) = failure else {
+        return Ok(());
+    };
+    let (minimized, message) = minimize(applied);
+    let bundle = ReplayBundle {
+        seed,
+        command_count: minimized.len(),
+        invariant_message: message.clone(),
+        minimized_commands: minimized,
+    };
+    let bundle_path = std::env::temp_dir().join(format!("plexi-daw-gate-failure-{seed}.json"));
+    match serde_json::to_vec_pretty(&bundle)
+        .map_err(|e| e.to_string())
+        .and_then(|json| std::fs::write(&bundle_path, json).map_err(|e| e.to_string()))
+    {
+        Ok(()) => {}
+        Err(e) => log::error!(
+            "daw_gate: failed to write replay bundle {}: {e}",
+            bundle_path.display()
+        ),
+    }
+    Err(format!(
+        "seed {seed} invariant failure: {original_message} (minimized: {message}). \
+         Replay bundle: {}. Reproduce with {GATE_SEED_ENV}={seed}",
+        bundle_path.display()
+    ))
+}
+
+fn seeds_under_test() -> Vec<u64> {
+    match std::env::var(GATE_SEED_ENV) {
+        Ok(raw) => {
+            let seed: u64 = raw
+                .parse()
+                .unwrap_or_else(|e| panic!("{GATE_SEED_ENV}={raw:?} is not a u64: {e}"));
+            vec![seed]
+        }
+        Err(_) => DEFAULT_SEEDS.to_vec(),
+    }
+}
+
+// ─── Qualification summary + artifact ────────────────────────────────────────
+
+#[derive(serde::Serialize)]
+pub struct GateCaseResult {
+    pub name: String,
+    pub passed: bool,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub final_state: Option<GateFinalState>,
+}
+
+#[derive(serde::Serialize)]
+pub struct GateRandomizedResult {
+    pub seed: u64,
+    pub commands: usize,
+    pub passed: bool,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+pub struct GateLongSequenceResult {
+    pub passed: bool,
+    pub commands: usize,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+pub struct GateTotals {
+    pub sections: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub duration_ms: u64,
+}
+
+#[derive(serde::Serialize)]
+pub struct GateSummary {
+    pub schema_version: u32,
+    pub cases: Vec<GateCaseResult>,
+    pub long_sequence: GateLongSequenceResult,
+    pub randomized: Vec<GateRandomizedResult>,
+    pub totals: GateTotals,
+}
+
+/// Runs the whole core gate (matrix + long sequence + default seeds), writes
+/// `daw-gate-core.json` into `out_dir`, and returns the summary.
+pub fn run_core_qualification(out_dir: &Path) -> GateSummary {
+    let seeds = seeds_under_test();
+    let cases = gate_cases();
+    log::info!(
+        "daw_gate: core qualification started cases={} seeds={}",
+        cases.len(),
+        seeds.len()
+    );
+    let start = Instant::now();
+
+    let case_results: Vec<GateCaseResult> = cases
+        .iter()
+        .map(|case| {
+            let t = Instant::now();
+            let result = run_case(case);
+            GateCaseResult {
+                name: case.name.to_string(),
+                passed: result.is_ok(),
+                duration_ms: t.elapsed().as_millis() as u64,
+                error: result.as_ref().err().cloned(),
+                final_state: result.ok(),
+            }
+        })
+        .collect();
+
+    let t = Instant::now();
+    let long_result = run_long_sequence();
+    let long_sequence = GateLongSequenceResult {
+        passed: long_result.is_ok(),
+        commands: *long_result.as_ref().unwrap_or(&0),
+        duration_ms: t.elapsed().as_millis() as u64,
+        error: long_result.err(),
+    };
+
+    let randomized: Vec<GateRandomizedResult> = seeds
+        .iter()
+        .map(|&seed| {
+            let t = Instant::now();
+            let result = run_random_seed(seed, RANDOM_COMMANDS_PER_SEED);
+            GateRandomizedResult {
+                seed,
+                commands: RANDOM_COMMANDS_PER_SEED,
+                passed: result.is_ok(),
+                duration_ms: t.elapsed().as_millis() as u64,
+                error: result.err(),
+            }
+        })
+        .collect();
+
+    let sections = case_results.len() + 1 + randomized.len();
+    let failed = case_results.iter().filter(|c| !c.passed).count()
+        + usize::from(!long_sequence.passed)
+        + randomized.iter().filter(|r| !r.passed).count();
+    let summary = GateSummary {
+        schema_version: 1,
+        cases: case_results,
+        long_sequence,
+        randomized,
+        totals: GateTotals {
+            sections,
+            passed: sections - failed,
+            failed,
+            duration_ms: start.elapsed().as_millis() as u64,
+        },
+    };
+
+    if let Err(e) = std::fs::create_dir_all(out_dir) {
+        log::error!("daw_gate: failed to create {}: {e}", out_dir.display());
+    } else {
+        let artifact = out_dir.join("daw-gate-core.json");
+        match serde_json::to_vec_pretty(&summary)
+            .map_err(|e| e.to_string())
+            .and_then(|json| std::fs::write(&artifact, json).map_err(|e| e.to_string()))
+        {
+            Ok(()) => log::info!("daw_gate: wrote artifact {}", artifact.display()),
+            Err(e) => log::error!(
+                "daw_gate: failed to write artifact {}: {e}",
+                artifact.display()
+            ),
+        }
+    }
+
+    log::info!(
+        "daw_gate: core qualification finished passed={} failed={} duration_ms={}",
+        summary.totals.passed,
+        summary.totals.failed,
+        summary.totals.duration_ms
+    );
+    println!(
+        "daw_gate: core qualification finished passed={} failed={} duration_ms={}",
+        summary.totals.passed, summary.totals.failed, summary.totals.duration_ms
+    );
+    summary
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn gate_core_matrix() {
+    for case in gate_cases() {
+        if let Err(e) = run_case(&case) {
+            panic!(
+                "daw gate case {:?} failed ({} steps): {e}",
+                case.name,
+                case.steps.len()
+            );
+        }
+    }
+}
+
+#[test]
+fn gate_deterministic_long_sequence() {
+    let applied = run_long_sequence().unwrap_or_else(|e| panic!("long sequence failed: {e}"));
+    assert!(applied >= 1000, "sequence must span thousands of commands");
+}
+
+#[test]
+fn gate_randomized_commands() {
+    // Seeds run sequentially, each on a fresh model: bounded memory.
+    for seed in seeds_under_test() {
+        if let Err(e) = run_random_seed(seed, RANDOM_COMMANDS_PER_SEED) {
+            panic!("{e}");
+        }
+    }
+}
+
+#[test]
+fn gate_core_qualification_artifact() {
+    let out_dir = std::env::temp_dir().join("plexi-daw-gate");
+    let summary = run_core_qualification(&out_dir);
+    assert_eq!(
+        summary.totals.failed,
+        0,
+        "core qualification reported failures; see {}",
+        out_dir.join("daw-gate-core.json").display()
+    );
+    assert!(out_dir.join("daw-gate-core.json").is_file());
+}
+
+#[test]
+fn gate_minimizer_shrinks_reproducible_failures() {
+    // Sanity for the minimizer itself: a healthy sequence has no failure to
+    // reproduce, so the greedy pass must return it unchanged and say so.
+    let commands = vec![
+        DawCommand::AddTrack {
+            kind: TrackKind::Audio,
+            name: "A".to_string(),
+        },
+        DawCommand::Undo,
+    ];
+    let (kept, message) = minimize(commands.clone());
+    assert_eq!(kept, commands, "healthy sequences must come back unchanged");
+    assert!(message.contains("did not reproduce"));
+}
+
+#[test]
+fn gate_serialization_round_trip() {
+    // Nontrivial project built through commands only, then
+    // serialize → deserialize → serialize must be byte-identical.
+    let mut model = DawModel::new();
+    for command in [
+        DawCommand::SetTempo { bpm: 133.7 },
+        audio_track("Drums"),
+        midi_track("Keys"),
+        audio_source(8 * TICKS_PER_BEAT),
+        midi_source(16 * TICKS_PER_BEAT),
+        clip(1, 3, 0, 2 * TICKS_PER_BEAT, TICKS_PER_BEAT),
+        DawCommand::AddClip {
+            track: TrackId(2),
+            source: SourceId(4),
+            position: 4 * TICKS_PER_BEAT,
+            length: 8 * TICKS_PER_BEAT,
+            source_offset: 0,
+        },
+        vol(1, 0.35),
+        pan(2, -0.5),
+        DawCommand::SetTrackMute {
+            track: TrackId(1),
+            mute: true,
+        },
+    ] {
+        assert_eq!(model.apply(command), ApplyOutcome::Applied);
+    }
+    let json1 = model.project().to_json().expect("serialize");
+    let restored = Project::from_json(&json1).expect("deserialize");
+    assert_eq!(&restored, model.project(), "semantic equality after round trip");
+    let json2 = restored.to_json().expect("re-serialize");
+    assert_eq!(json1, json2, "round trip must be byte-identical");
+}
+
+#[test]
+fn gate_restore_from_parts() {
+    // The load half of persistence: a model rebuilt from decoded project +
+    // transport must carry the exact state, satisfy invariants, keep the id
+    // allocator monotonic, and accept further edits with fresh history.
+    let mut model = DawModel::new();
+    for command in [
+        audio_track("Drums"),
+        audio_source(4 * TICKS_PER_BEAT),
+        clip(1, 2, 0, TICKS_PER_BEAT, 0),
+        DawCommand::Play,
+        DawCommand::Seek { position: 480 },
+    ] {
+        assert_eq!(model.apply(command), ApplyOutcome::Applied);
+    }
+    let json = model.project().to_json().expect("serialize");
+    let mut restored = DawModel::from_parts(
+        Project::from_json(&json).expect("deserialize"),
+        *model.transport(),
+    );
+    assert_eq!(restored.project(), model.project());
+    assert_eq!(restored.transport(), model.transport());
+    assert_eq!(restored.undo_depth(), 0, "undo never spans sessions");
+    check_invariants(&restored, 0).expect("restored model must satisfy invariants");
+    assert_eq!(restored.apply(midi_track("Keys")), ApplyOutcome::Applied);
+    let new_track = restored.project().tracks.last().expect("new track");
+    assert_eq!(new_track.id, TrackId(4), "id allocation resumes past restored ids");
+}

--- a/crates/daw-model/src/history.rs
+++ b/crates/daw-model/src/history.rs
@@ -1,0 +1,91 @@
+//! Snapshot-based grouped undo/redo, with mixer-set coalescing.
+//!
+//! Mirrors the editor's `EditHistory` group semantics (cap + coalescing +
+//! `break_group`), but each undo group stores a full clone of the project
+//! data instead of a transaction list — DAW edits are structural, and the
+//! project is small enough that snapshots stay cheap.
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::{Project, TrackId};
+
+/// Maximum retained undo groups; the oldest group is dropped beyond this.
+pub const MAX_GROUPS: usize = 500;
+
+/// Identity of an open coalescing group: consecutive `Applied` mixer sets of
+/// the same variant on the same track merge into one undo step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CoalesceKey {
+    Volume(TrackId),
+    Pan(TrackId),
+}
+
+/// Undo/redo stacks of project snapshots. Each entry is the project state
+/// *before* one user-visible undo step; recording clears the redo stack.
+#[derive(Debug, Clone, Default)]
+pub struct SnapshotHistory {
+    undo_stack: Vec<Project>,
+    redo_stack: Vec<Project>,
+    /// When set, the top undo group may absorb the next record carrying the
+    /// same key (the group's snapshot already predates the whole run).
+    open_key: Option<CoalesceKey>,
+}
+
+impl SnapshotHistory {
+    /// Records the pre-edit snapshot of one applied edit. When `key` matches
+    /// the open group, the record coalesces: the existing snapshot already
+    /// captures the state before the run of sets, so nothing is pushed. Any
+    /// record invalidates the redo stack.
+    pub fn record(&mut self, snapshot: Project, key: Option<CoalesceKey>) {
+        self.redo_stack.clear();
+        if key.is_some() && key == self.open_key {
+            return;
+        }
+        self.undo_stack.push(snapshot);
+        if self.undo_stack.len() > MAX_GROUPS {
+            self.undo_stack.remove(0);
+        }
+        self.open_key = key;
+    }
+
+    /// Ends the current coalescing group; the next record starts a new undo
+    /// step. Called by every applied non-coalescing command (including
+    /// transport changes).
+    pub fn break_group(&mut self) {
+        self.open_key = None;
+    }
+
+    /// Pops the top undo snapshot, pushing `current` onto the redo stack.
+    /// `None` when there is nothing to undo.
+    pub fn undo(&mut self, current: &Project) -> Option<Project> {
+        self.open_key = None;
+        let snapshot = self.undo_stack.pop()?;
+        self.redo_stack.push(current.clone());
+        Some(snapshot)
+    }
+
+    /// Pops the top redo snapshot, pushing `current` onto the undo stack.
+    /// `None` when there is nothing to redo.
+    pub fn redo(&mut self, current: &Project) -> Option<Project> {
+        self.open_key = None;
+        let snapshot = self.redo_stack.pop()?;
+        self.undo_stack.push(current.clone());
+        Some(snapshot)
+    }
+
+    #[must_use]
+    pub fn can_undo(&self) -> bool {
+        !self.undo_stack.is_empty()
+    }
+
+    #[must_use]
+    pub fn can_redo(&self) -> bool {
+        !self.redo_stack.is_empty()
+    }
+
+    /// Number of undoable groups.
+    #[must_use]
+    pub fn undo_depth(&self) -> usize {
+        self.undo_stack.len()
+    }
+}

--- a/crates/daw-model/src/lib.rs
+++ b/crates/daw-model/src/lib.rs
@@ -1,0 +1,22 @@
+//! Pure DAW edit model (stint 0514): commands in, state out.
+//!
+//! Zero egui, zero host types, zero I/O. The model owns project data
+//! (tracks, clips, sources, mixer, tempo), a transport, snapshot-based
+//! undo/redo, and a monotonic revision counter. Downstream engines convert
+//! ticks to samples; the model never does.
+//!
+//! Sibling crate: `plexi-video-model` (stint 0523) shares the same module
+//! shape and conventions.
+
+pub mod commands;
+pub mod history;
+pub mod model;
+
+mod gate;
+
+pub use commands::{ApplyOutcome, DawCommand};
+pub use history::{CoalesceKey, SnapshotHistory, MAX_GROUPS};
+pub use model::{
+    Clip, ClipId, DawModel, Mixer, Project, Source, SourceId, Track, TrackId, TrackKind,
+    Transport, PAN_MAX, PAN_MIN, TEMPO_MAX, TEMPO_MIN, TICKS_PER_BEAT, VOLUME_MAX, VOLUME_MIN,
+};

--- a/crates/daw-model/src/lib.rs
+++ b/crates/daw-model/src/lib.rs
@@ -18,5 +18,6 @@ pub use commands::{ApplyOutcome, DawCommand};
 pub use history::{CoalesceKey, SnapshotHistory, MAX_GROUPS};
 pub use model::{
     Clip, ClipId, DawModel, Mixer, Project, Source, SourceId, Track, TrackId, TrackKind,
-    Transport, PAN_MAX, PAN_MIN, TEMPO_MAX, TEMPO_MIN, TICKS_PER_BEAT, VOLUME_MAX, VOLUME_MIN,
+    Transport, ValidationError, PAN_MAX, PAN_MIN, TEMPO_MAX, TEMPO_MIN, TICKS_PER_BEAT,
+    VOLUME_MAX, VOLUME_MIN,
 };

--- a/crates/daw-model/src/model.rs
+++ b/crates/daw-model/src/model.rs
@@ -22,6 +22,84 @@ pub const VOLUME_MAX: f32 = 2.0;
 pub const PAN_MIN: f32 = -1.0;
 pub const PAN_MAX: f32 = 1.0;
 
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/// One state-validity violation, typed per violation class.
+///
+/// This is the single validation path for persisted or foreign state:
+/// [`DawModel::from_parts`] (bundle loading) and the release gate's
+/// invariant checks both run [`Project::validate`] / [`Transport::validate`]
+/// — the same rules everywhere, never a second hand-rolled checker.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ValidationError {
+    TempoOutOfRange { tempo_bpm: f64 },
+    VolumeOutOfRange { track: TrackId, volume: f32 },
+    PanOutOfRange { track: TrackId, pan: f32 },
+    MissingClipSource { clip: ClipId, source: SourceId },
+    ClipKindMismatch { clip: ClipId, track: TrackId },
+    ZeroLengthClip { clip: ClipId },
+    ClipWindowExceedsSource { clip: ClipId, source_offset: u64, length: u64, duration: u64 },
+    ClipTimelineOverflow { clip: ClipId },
+    DuplicateId { id: u64 },
+    IdNotBelowNextId { id: u64, next_id: u64 },
+    LoopInverted { start: u64, end: u64 },
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TempoOutOfRange { tempo_bpm } => write!(
+                f,
+                "tempo {tempo_bpm} is not finite or outside {TEMPO_MIN}..={TEMPO_MAX}"
+            ),
+            Self::VolumeOutOfRange { track, volume } => write!(
+                f,
+                "track {} volume {volume} is not finite or outside {VOLUME_MIN}..={VOLUME_MAX}",
+                track.0
+            ),
+            Self::PanOutOfRange { track, pan } => write!(
+                f,
+                "track {} pan {pan} is not finite or outside {PAN_MIN}..={PAN_MAX}",
+                track.0
+            ),
+            Self::MissingClipSource { clip, source } => write!(
+                f,
+                "clip {} references missing source {}",
+                clip.0, source.0
+            ),
+            Self::ClipKindMismatch { clip, track } => write!(
+                f,
+                "clip {} source kind does not match track {} kind",
+                clip.0, track.0
+            ),
+            Self::ZeroLengthClip { clip } => write!(f, "clip {} has zero length", clip.0),
+            Self::ClipWindowExceedsSource {
+                clip,
+                source_offset,
+                length,
+                duration,
+            } => write!(
+                f,
+                "clip {} window {source_offset}+{length} exceeds source duration {duration}",
+                clip.0
+            ),
+            Self::ClipTimelineOverflow { clip } => {
+                write!(f, "clip {} timeline end overflows u64", clip.0)
+            }
+            Self::DuplicateId { id } => write!(f, "duplicate entity id {id}"),
+            Self::IdNotBelowNextId { id, next_id } => write!(
+                f,
+                "id {id} >= next_id {next_id}; allocator lost monotonicity"
+            ),
+            Self::LoopInverted { start, end } => {
+                write!(f, "loop enabled with start {start} >= end {end}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
 // ─── Ids ─────────────────────────────────────────────────────────────────────
 
 /// Newtype ids allocated by [`Project::next_id`]; never reused, even across
@@ -108,8 +186,14 @@ pub struct Project {
     pub tempo_bpm: f64,
     pub tracks: Vec<Track>,
     pub sources: Vec<Source>,
-    /// Monotonic id allocator; part of serialized state, preserved across
-    /// undo/redo so ids are never reused.
+    /// Monotonic id allocator; part of serialized state, deliberately NOT
+    /// restored by undo/redo. Restoring it would let a post-undo edit mint
+    /// an id aliasing one already handed to external holders (assistant
+    /// tools, UI) from the undone branch — a stale reference would silently
+    /// rebind to a new object instead of failing as dangling. Monotonic ids
+    /// keep staleness detectable, and `next_id` stays a deterministic
+    /// function of the applied command history, so bundle serialization
+    /// stays deterministic.
     pub next_id: u64,
 }
 
@@ -164,6 +248,84 @@ impl Project {
         self.tracks.iter().map(|t| t.clips.len()).sum()
     }
 
+    /// Full state-validity check over the project data: clip geometry,
+    /// source references and kind matches, mixer/tempo ranges and
+    /// finiteness, id uniqueness and allocator monotonicity. The single
+    /// shared path for bundle loading ([`DawModel::from_parts`]) and the
+    /// release gate's invariants.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if !self.tempo_bpm.is_finite() || !(TEMPO_MIN..=TEMPO_MAX).contains(&self.tempo_bpm) {
+            return Err(ValidationError::TempoOutOfRange {
+                tempo_bpm: self.tempo_bpm,
+            });
+        }
+        let mut ids: Vec<u64> = Vec::new();
+        for track in &self.tracks {
+            ids.push(track.id.0);
+            let mixer = track.mixer;
+            if !mixer.volume.is_finite() || !(VOLUME_MIN..=VOLUME_MAX).contains(&mixer.volume) {
+                return Err(ValidationError::VolumeOutOfRange {
+                    track: track.id,
+                    volume: mixer.volume,
+                });
+            }
+            if !mixer.pan.is_finite() || !(PAN_MIN..=PAN_MAX).contains(&mixer.pan) {
+                return Err(ValidationError::PanOutOfRange {
+                    track: track.id,
+                    pan: mixer.pan,
+                });
+            }
+            for clip in &track.clips {
+                ids.push(clip.id.0);
+                let Some(source) = self.source(clip.source) else {
+                    return Err(ValidationError::MissingClipSource {
+                        clip: clip.id,
+                        source: clip.source,
+                    });
+                };
+                if source.kind != track.kind {
+                    return Err(ValidationError::ClipKindMismatch {
+                        clip: clip.id,
+                        track: track.id,
+                    });
+                }
+                if clip.length == 0 {
+                    return Err(ValidationError::ZeroLengthClip { clip: clip.id });
+                }
+                match clip.source_offset.checked_add(clip.length) {
+                    Some(end) if end <= source.duration => {}
+                    _ => {
+                        return Err(ValidationError::ClipWindowExceedsSource {
+                            clip: clip.id,
+                            source_offset: clip.source_offset,
+                            length: clip.length,
+                            duration: source.duration,
+                        });
+                    }
+                }
+                if clip.position.checked_add(clip.length).is_none() {
+                    return Err(ValidationError::ClipTimelineOverflow { clip: clip.id });
+                }
+            }
+        }
+        for source in &self.sources {
+            ids.push(source.id.0);
+        }
+        ids.sort_unstable();
+        if let Some(pair) = ids.windows(2).find(|w| w[0] == w[1]) {
+            return Err(ValidationError::DuplicateId { id: pair[0] });
+        }
+        if let Some(&max) = ids.last() {
+            if max >= self.next_id {
+                return Err(ValidationError::IdNotBelowNextId {
+                    id: max,
+                    next_id: self.next_id,
+                });
+            }
+        }
+        Ok(())
+    }
+
     fn track_index(&self, id: TrackId) -> Option<usize> {
         self.tracks.iter().position(|t| t.id == id)
     }
@@ -190,6 +352,20 @@ pub struct Transport {
     pub loop_end: u64,
 }
 
+impl Transport {
+    /// State-validity check for transport values; part of the shared
+    /// validation path (see [`Project::validate`]).
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.loop_enabled && self.loop_start >= self.loop_end {
+            return Err(ValidationError::LoopInverted {
+                start: self.loop_start,
+                end: self.loop_end,
+            });
+        }
+        Ok(())
+    }
+}
+
 // ─── Model ───────────────────────────────────────────────────────────────────
 
 /// The DAW edit model: project data plus transport, revision, and history.
@@ -212,16 +388,27 @@ impl DawModel {
 
     /// Restores a model from decoded state — the load half of persistence
     /// ([`Project::from_json`] plus the caller-persisted [`Transport`]).
-    /// History starts empty and the revision at 0: undo never spans
-    /// sessions, and the revision counts changes within one session only.
-    #[must_use]
-    pub fn from_parts(project: Project, transport: Transport) -> Self {
-        Self {
+    /// Rejects invariant-violating state (corrupted or hand-edited
+    /// bundles) through the shared [`Project::validate`] path. History
+    /// starts empty and the revision at 0: undo never spans sessions, and
+    /// the revision counts changes within one session only.
+    pub fn from_parts(project: Project, transport: Transport) -> Result<Self, ValidationError> {
+        let model = Self {
             project,
             transport,
             revision: 0,
             history: SnapshotHistory::default(),
-        }
+        };
+        model.validate()?;
+        Ok(model)
+    }
+
+    /// Full state-validity check over project data and transport — the
+    /// same rules [`from_parts`](Self::from_parts) enforces on load and the
+    /// release gate re-checks after every command.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        self.project.validate()?;
+        self.transport.validate()
     }
 
     #[must_use]

--- a/crates/daw-model/src/model.rs
+++ b/crates/daw-model/src/model.rs
@@ -1,0 +1,638 @@
+//! DAW project state and the pure `apply` state machine.
+//!
+//! [`Project`] is the serialized project data (tracks, clips, sources,
+//! tempo, id counter). [`DawModel`] wraps it with the transport, the
+//! revision counter, and the snapshot history — none of which belong in the
+//! serialized project or in undo snapshots.
+
+use serde::{Deserialize, Serialize};
+
+use crate::commands::{ApplyOutcome, DawCommand};
+use crate::history::{CoalesceKey, SnapshotHistory};
+
+/// Musical resolution: all DAW times are `u64` ticks at this rate.
+/// Conversion to samples/frames is the downstream engine's concern.
+pub const TICKS_PER_BEAT: u64 = 960;
+
+pub const TEMPO_MIN: f64 = 20.0;
+pub const TEMPO_MAX: f64 = 999.0;
+/// Linear gain range for [`Mixer::volume`].
+pub const VOLUME_MIN: f32 = 0.0;
+pub const VOLUME_MAX: f32 = 2.0;
+pub const PAN_MIN: f32 = -1.0;
+pub const PAN_MAX: f32 = 1.0;
+
+// ─── Ids ─────────────────────────────────────────────────────────────────────
+
+/// Newtype ids allocated by [`Project::next_id`]; never reused, even across
+/// undo (the counter survives snapshot restores).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct TrackId(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ClipId(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct SourceId(pub u64);
+
+// ─── Project data ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TrackKind {
+    Audio,
+    Midi,
+}
+
+/// Per-track mixer strip. Values clamp to the documented ranges on apply and
+/// are re-checked by the gate invariants.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct Mixer {
+    /// Linear gain, [`VOLUME_MIN`]..=[`VOLUME_MAX`].
+    pub volume: f32,
+    /// [`PAN_MIN`] (hard left)..=[`PAN_MAX`] (hard right).
+    pub pan: f32,
+    pub mute: bool,
+    pub solo: bool,
+}
+
+impl Default for Mixer {
+    fn default() -> Self {
+        Self {
+            volume: 1.0,
+            pan: 0.0,
+            mute: false,
+            solo: false,
+        }
+    }
+}
+
+/// A media source. `duration` is in ticks; a clip's window
+/// (`source_offset + length`) must fit inside it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Source {
+    pub id: SourceId,
+    pub kind: TrackKind,
+    pub path: String,
+    pub duration: u64,
+}
+
+/// A clip placed on a track. DAW clips may overlap on a track; the clip's
+/// source kind must match its track kind.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Clip {
+    pub id: ClipId,
+    pub source: SourceId,
+    /// Timeline start, in ticks.
+    pub position: u64,
+    /// Timeline (and source-window) length, in ticks; always > 0.
+    pub length: u64,
+    /// Offset into the source where the clip's window starts.
+    pub source_offset: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Track {
+    pub id: TrackId,
+    pub kind: TrackKind,
+    pub name: String,
+    pub mixer: Mixer,
+    pub clips: Vec<Clip>,
+}
+
+/// Serialized project data — exactly what undo snapshots clone and what
+/// [`Project::to_json`] emits. Transport, revision, and history live on
+/// [`DawModel`], outside this struct.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Project {
+    /// Clamped to [`TEMPO_MIN`]..=[`TEMPO_MAX`].
+    pub tempo_bpm: f64,
+    pub tracks: Vec<Track>,
+    pub sources: Vec<Source>,
+    /// Monotonic id allocator; part of serialized state, preserved across
+    /// undo/redo so ids are never reused.
+    pub next_id: u64,
+}
+
+impl Default for Project {
+    fn default() -> Self {
+        Self {
+            tempo_bpm: 120.0,
+            tracks: Vec::new(),
+            sources: Vec::new(),
+            next_id: 1,
+        }
+    }
+}
+
+impl Project {
+    /// Pretty JSON of the project data. Errors name the failure.
+    pub fn to_json(&self) -> Result<String, String> {
+        serde_json::to_string_pretty(self)
+            .map_err(|e| format!("daw project serialization failed: {e}"))
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, String> {
+        serde_json::from_str(json)
+            .map_err(|e| format!("daw project deserialization failed: {e}"))
+    }
+
+    #[must_use]
+    pub fn track(&self, id: TrackId) -> Option<&Track> {
+        self.tracks.iter().find(|t| t.id == id)
+    }
+
+    #[must_use]
+    pub fn source(&self, id: SourceId) -> Option<&Source> {
+        self.sources.iter().find(|s| s.id == id)
+    }
+
+    /// Locates a clip as `(track index, clip index)`.
+    #[must_use]
+    pub fn find_clip(&self, id: ClipId) -> Option<(usize, usize)> {
+        self.tracks.iter().enumerate().find_map(|(ti, track)| {
+            track
+                .clips
+                .iter()
+                .position(|c| c.id == id)
+                .map(|ci| (ti, ci))
+        })
+    }
+
+    /// Total clips across all tracks.
+    #[must_use]
+    pub fn clip_count(&self) -> usize {
+        self.tracks.iter().map(|t| t.clips.len()).sum()
+    }
+
+    fn track_index(&self, id: TrackId) -> Option<usize> {
+        self.tracks.iter().position(|t| t.id == id)
+    }
+
+    fn alloc_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+}
+
+// ─── Transport ───────────────────────────────────────────────────────────────
+
+/// Playback state. Not undoable and never part of undo snapshots, but
+/// changes bump the model revision.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Transport {
+    pub playing: bool,
+    /// Playhead position in ticks.
+    pub position: u64,
+    pub loop_enabled: bool,
+    /// `loop_start < loop_end` holds whenever `loop_enabled` is true.
+    pub loop_start: u64,
+    pub loop_end: u64,
+}
+
+// ─── Model ───────────────────────────────────────────────────────────────────
+
+/// The DAW edit model: project data plus transport, revision, and history.
+/// Commands in ([`DawCommand`]), state out — no I/O, no rendering.
+#[derive(Debug, Clone, Default)]
+pub struct DawModel {
+    project: Project,
+    transport: Transport,
+    /// Monotonic change counter, bumped on every `Applied` outcome
+    /// (including undo/redo and transport changes). Starts at 0.
+    revision: u64,
+    history: SnapshotHistory,
+}
+
+impl DawModel {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Restores a model from decoded state — the load half of persistence
+    /// ([`Project::from_json`] plus the caller-persisted [`Transport`]).
+    /// History starts empty and the revision at 0: undo never spans
+    /// sessions, and the revision counts changes within one session only.
+    #[must_use]
+    pub fn from_parts(project: Project, transport: Transport) -> Self {
+        Self {
+            project,
+            transport,
+            revision: 0,
+            history: SnapshotHistory::default(),
+        }
+    }
+
+    #[must_use]
+    pub fn project(&self) -> &Project {
+        &self.project
+    }
+
+    #[must_use]
+    pub fn transport(&self) -> &Transport {
+        &self.transport
+    }
+
+    #[must_use]
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    #[must_use]
+    pub fn can_undo(&self) -> bool {
+        self.history.can_undo()
+    }
+
+    #[must_use]
+    pub fn can_redo(&self) -> bool {
+        self.history.can_redo()
+    }
+
+    #[must_use]
+    pub fn undo_depth(&self) -> usize {
+        self.history.undo_depth()
+    }
+
+    /// Applies one command. See [`ApplyOutcome`] for the contract; on
+    /// `Rejected` the model is untouched.
+    pub fn apply(&mut self, cmd: DawCommand) -> ApplyOutcome {
+        match cmd {
+            DawCommand::SetTempo { bpm } => self.set_tempo(bpm),
+            DawCommand::AddTrack { kind, name } => self.add_track(kind, name),
+            DawCommand::RemoveTrack { track } => self.remove_track(track),
+            DawCommand::RenameTrack { track, name } => self.rename_track(track, name),
+            DawCommand::AddSource { kind, path, duration } => self.add_source(kind, path, duration),
+            DawCommand::RemoveSource { source } => self.remove_source(source),
+            DawCommand::AddClip {
+                track,
+                source,
+                position,
+                length,
+                source_offset,
+            } => self.add_clip(track, source, position, length, source_offset),
+            DawCommand::RemoveClip { clip } => self.remove_clip(clip),
+            DawCommand::MoveClip {
+                clip,
+                track,
+                position,
+            } => self.move_clip(clip, track, position),
+            DawCommand::ResizeClip {
+                clip,
+                length,
+                source_offset,
+            } => self.resize_clip(clip, length, source_offset),
+            DawCommand::SetTrackVolume { track, volume } => self.set_track_volume(track, volume),
+            DawCommand::SetTrackPan { track, pan } => self.set_track_pan(track, pan),
+            DawCommand::SetTrackMute { track, mute } => self.set_track_mute(track, mute),
+            DawCommand::SetTrackSolo { track, solo } => self.set_track_solo(track, solo),
+            DawCommand::Play => self.set_playing(true),
+            DawCommand::Stop => self.set_playing(false),
+            DawCommand::Seek { position } => self.seek(position),
+            DawCommand::SetLoop { enabled, start, end } => self.set_loop(enabled, start, end),
+            DawCommand::Undo => self.undo(),
+            DawCommand::Redo => self.redo(),
+        }
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────────
+
+    /// Records the pre-edit snapshot for one undoable edit.
+    fn record(&mut self, key: Option<CoalesceKey>) {
+        self.history.record(self.project.clone(), key);
+    }
+
+    fn applied(&mut self) -> ApplyOutcome {
+        self.revision += 1;
+        ApplyOutcome::Applied
+    }
+
+    fn set_tempo(&mut self, bpm: f64) -> ApplyOutcome {
+        if !bpm.is_finite() {
+            return ApplyOutcome::Rejected(format!("SetTempo: bpm {bpm:?} is not finite"));
+        }
+        let clamped = bpm.clamp(TEMPO_MIN, TEMPO_MAX);
+        if clamped == self.project.tempo_bpm {
+            return ApplyOutcome::NoOp;
+        }
+        self.record(None);
+        self.project.tempo_bpm = clamped;
+        self.applied()
+    }
+
+    fn add_track(&mut self, kind: TrackKind, name: String) -> ApplyOutcome {
+        self.record(None);
+        let id = TrackId(self.project.alloc_id());
+        self.project.tracks.push(Track {
+            id,
+            kind,
+            name,
+            mixer: Mixer::default(),
+            clips: Vec::new(),
+        });
+        self.applied()
+    }
+
+    fn remove_track(&mut self, track: TrackId) -> ApplyOutcome {
+        let Some(index) = self.project.track_index(track) else {
+            return ApplyOutcome::Rejected(format!("RemoveTrack: no track {}", track.0));
+        };
+        self.record(None);
+        self.project.tracks.remove(index);
+        self.applied()
+    }
+
+    fn rename_track(&mut self, track: TrackId, name: String) -> ApplyOutcome {
+        let Some(index) = self.project.track_index(track) else {
+            return ApplyOutcome::Rejected(format!("RenameTrack: no track {}", track.0));
+        };
+        if self.project.tracks[index].name == name {
+            return ApplyOutcome::NoOp;
+        }
+        self.record(None);
+        self.project.tracks[index].name = name;
+        self.applied()
+    }
+
+    fn add_source(&mut self, kind: TrackKind, path: String, duration: u64) -> ApplyOutcome {
+        self.record(None);
+        let id = SourceId(self.project.alloc_id());
+        self.project.sources.push(Source {
+            id,
+            kind,
+            path,
+            duration,
+        });
+        self.applied()
+    }
+
+    /// Removes the source and every clip referencing it — one undo group,
+    /// because the whole cascade sits behind a single pre-edit snapshot.
+    fn remove_source(&mut self, source: SourceId) -> ApplyOutcome {
+        let Some(index) = self.project.sources.iter().position(|s| s.id == source) else {
+            return ApplyOutcome::Rejected(format!("RemoveSource: no source {}", source.0));
+        };
+        self.record(None);
+        self.project.sources.remove(index);
+        for track in &mut self.project.tracks {
+            track.clips.retain(|c| c.source != source);
+        }
+        self.applied()
+    }
+
+    /// Validates one clip window against its source and the timeline:
+    /// `length > 0`, `source_offset + length <= duration`, and
+    /// `position + length` must not overflow.
+    fn check_clip_geometry(
+        what: &str,
+        source: &Source,
+        position: u64,
+        length: u64,
+        source_offset: u64,
+    ) -> Result<(), ApplyOutcome> {
+        if length == 0 {
+            return Err(ApplyOutcome::Rejected(format!("{what}: length must be > 0")));
+        }
+        match source_offset.checked_add(length) {
+            Some(end) if end <= source.duration => {}
+            _ => {
+                return Err(ApplyOutcome::Rejected(format!(
+                    "{what}: source window {source_offset}+{length} exceeds source {} duration {}",
+                    source.id.0, source.duration
+                )));
+            }
+        }
+        if position.checked_add(length).is_none() {
+            return Err(ApplyOutcome::Rejected(format!(
+                "{what}: position {position} + length {length} overflows u64"
+            )));
+        }
+        Ok(())
+    }
+
+    fn add_clip(
+        &mut self,
+        track: TrackId,
+        source: SourceId,
+        position: u64,
+        length: u64,
+        source_offset: u64,
+    ) -> ApplyOutcome {
+        let Some(track_index) = self.project.track_index(track) else {
+            return ApplyOutcome::Rejected(format!("AddClip: no track {}", track.0));
+        };
+        let Some(src) = self.project.source(source) else {
+            return ApplyOutcome::Rejected(format!("AddClip: no source {}", source.0));
+        };
+        if src.kind != self.project.tracks[track_index].kind {
+            return ApplyOutcome::Rejected(format!(
+                "AddClip: source {} kind {:?} does not match track {} kind {:?}",
+                source.0, src.kind, track.0, self.project.tracks[track_index].kind
+            ));
+        }
+        if let Err(rejected) =
+            Self::check_clip_geometry("AddClip", src, position, length, source_offset)
+        {
+            return rejected;
+        }
+        self.record(None);
+        let id = ClipId(self.project.alloc_id());
+        self.project.tracks[track_index].clips.push(Clip {
+            id,
+            source,
+            position,
+            length,
+            source_offset,
+        });
+        self.applied()
+    }
+
+    fn remove_clip(&mut self, clip: ClipId) -> ApplyOutcome {
+        let Some((track_index, clip_index)) = self.project.find_clip(clip) else {
+            return ApplyOutcome::Rejected(format!("RemoveClip: no clip {}", clip.0));
+        };
+        self.record(None);
+        self.project.tracks[track_index].clips.remove(clip_index);
+        self.applied()
+    }
+
+    fn move_clip(&mut self, clip: ClipId, track: TrackId, position: u64) -> ApplyOutcome {
+        let Some((from_track, clip_index)) = self.project.find_clip(clip) else {
+            return ApplyOutcome::Rejected(format!("MoveClip: no clip {}", clip.0));
+        };
+        let Some(to_track) = self.project.track_index(track) else {
+            return ApplyOutcome::Rejected(format!("MoveClip: no track {}", track.0));
+        };
+        let moving = self.project.tracks[from_track].clips[clip_index].clone();
+        let Some(src) = self.project.source(moving.source) else {
+            return ApplyOutcome::Rejected(format!(
+                "MoveClip: clip {} references missing source {}",
+                clip.0, moving.source.0
+            ));
+        };
+        if src.kind != self.project.tracks[to_track].kind {
+            return ApplyOutcome::Rejected(format!(
+                "MoveClip: clip {} kind {:?} does not match track {} kind {:?}",
+                clip.0, src.kind, track.0, self.project.tracks[to_track].kind
+            ));
+        }
+        if position.checked_add(moving.length).is_none() {
+            return ApplyOutcome::Rejected(format!(
+                "MoveClip: position {position} + length {} overflows u64",
+                moving.length
+            ));
+        }
+        if from_track == to_track && moving.position == position {
+            return ApplyOutcome::NoOp;
+        }
+        self.record(None);
+        self.project.tracks[from_track].clips.remove(clip_index);
+        let mut moved = moving;
+        moved.position = position;
+        self.project.tracks[to_track].clips.push(moved);
+        self.applied()
+    }
+
+    fn resize_clip(&mut self, clip: ClipId, length: u64, source_offset: u64) -> ApplyOutcome {
+        let Some((track_index, clip_index)) = self.project.find_clip(clip) else {
+            return ApplyOutcome::Rejected(format!("ResizeClip: no clip {}", clip.0));
+        };
+        let current = self.project.tracks[track_index].clips[clip_index].clone();
+        let Some(src) = self.project.source(current.source) else {
+            return ApplyOutcome::Rejected(format!(
+                "ResizeClip: clip {} references missing source {}",
+                clip.0, current.source.0
+            ));
+        };
+        if let Err(rejected) =
+            Self::check_clip_geometry("ResizeClip", src, current.position, length, source_offset)
+        {
+            return rejected;
+        }
+        if current.length == length && current.source_offset == source_offset {
+            return ApplyOutcome::NoOp;
+        }
+        self.record(None);
+        let target = &mut self.project.tracks[track_index].clips[clip_index];
+        target.length = length;
+        target.source_offset = source_offset;
+        self.applied()
+    }
+
+    fn set_track_volume(&mut self, track: TrackId, volume: f32) -> ApplyOutcome {
+        if !volume.is_finite() {
+            return ApplyOutcome::Rejected(format!(
+                "SetTrackVolume: volume {volume:?} is not finite"
+            ));
+        }
+        let Some(index) = self.project.track_index(track) else {
+            return ApplyOutcome::Rejected(format!("SetTrackVolume: no track {}", track.0));
+        };
+        let clamped = volume.clamp(VOLUME_MIN, VOLUME_MAX);
+        if clamped == self.project.tracks[index].mixer.volume {
+            return ApplyOutcome::NoOp;
+        }
+        self.record(Some(CoalesceKey::Volume(track)));
+        self.project.tracks[index].mixer.volume = clamped;
+        self.applied()
+    }
+
+    fn set_track_pan(&mut self, track: TrackId, pan: f32) -> ApplyOutcome {
+        if !pan.is_finite() {
+            return ApplyOutcome::Rejected(format!("SetTrackPan: pan {pan:?} is not finite"));
+        }
+        let Some(index) = self.project.track_index(track) else {
+            return ApplyOutcome::Rejected(format!("SetTrackPan: no track {}", track.0));
+        };
+        let clamped = pan.clamp(PAN_MIN, PAN_MAX);
+        if clamped == self.project.tracks[index].mixer.pan {
+            return ApplyOutcome::NoOp;
+        }
+        self.record(Some(CoalesceKey::Pan(track)));
+        self.project.tracks[index].mixer.pan = clamped;
+        self.applied()
+    }
+
+    fn set_track_mute(&mut self, track: TrackId, mute: bool) -> ApplyOutcome {
+        let Some(index) = self.project.track_index(track) else {
+            return ApplyOutcome::Rejected(format!("SetTrackMute: no track {}", track.0));
+        };
+        if self.project.tracks[index].mixer.mute == mute {
+            return ApplyOutcome::NoOp;
+        }
+        self.record(None);
+        self.project.tracks[index].mixer.mute = mute;
+        self.applied()
+    }
+
+    fn set_track_solo(&mut self, track: TrackId, solo: bool) -> ApplyOutcome {
+        let Some(index) = self.project.track_index(track) else {
+            return ApplyOutcome::Rejected(format!("SetTrackSolo: no track {}", track.0));
+        };
+        if self.project.tracks[index].mixer.solo == solo {
+            return ApplyOutcome::NoOp;
+        }
+        self.record(None);
+        self.project.tracks[index].mixer.solo = solo;
+        self.applied()
+    }
+
+    /// Transport changes bump the revision but never touch history —
+    /// except that they break an open mixer coalescing group, mirroring
+    /// how cursor movement breaks typing coalescing in the editor.
+    fn set_playing(&mut self, playing: bool) -> ApplyOutcome {
+        if self.transport.playing == playing {
+            return ApplyOutcome::NoOp;
+        }
+        self.history.break_group();
+        self.transport.playing = playing;
+        self.applied()
+    }
+
+    fn seek(&mut self, position: u64) -> ApplyOutcome {
+        if self.transport.position == position {
+            return ApplyOutcome::NoOp;
+        }
+        self.history.break_group();
+        self.transport.position = position;
+        self.applied()
+    }
+
+    fn set_loop(&mut self, enabled: bool, start: u64, end: u64) -> ApplyOutcome {
+        if enabled && start >= end {
+            return ApplyOutcome::Rejected(format!(
+                "SetLoop: start {start} must be < end {end} when enabled"
+            ));
+        }
+        if self.transport.loop_enabled == enabled
+            && self.transport.loop_start == start
+            && self.transport.loop_end == end
+        {
+            return ApplyOutcome::NoOp;
+        }
+        self.history.break_group();
+        self.transport.loop_enabled = enabled;
+        self.transport.loop_start = start;
+        self.transport.loop_end = end;
+        self.applied()
+    }
+
+    fn undo(&mut self) -> ApplyOutcome {
+        let Some(mut snapshot) = self.history.undo(&self.project) else {
+            return ApplyOutcome::NoOp;
+        };
+        // The id allocator is monotonic across undo: ids are never reused.
+        snapshot.next_id = self.project.next_id;
+        self.project = snapshot;
+        self.applied()
+    }
+
+    fn redo(&mut self) -> ApplyOutcome {
+        let Some(mut snapshot) = self.history.redo(&self.project) else {
+            return ApplyOutcome::NoOp;
+        };
+        snapshot.next_id = self.project.next_id;
+        self.project = snapshot;
+        self.applied()
+    }
+}

--- a/crates/video-model/Cargo.toml
+++ b/crates/video-model/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "plexi-video-model"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+log = "0.4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/video-model/src/commands.rs
+++ b/crates/video-model/src/commands.rs
@@ -1,0 +1,73 @@
+//! The video-editor command surface: the API downstream agents build
+//! against.
+//!
+//! Every command is self-contained — all data a handler needs is in the
+//! command's own fields, never looked up from ambient state.
+
+use serde::{Deserialize, Serialize};
+
+use crate::model::{ClipId, Fps, SourceId, TrackKind};
+
+/// Result of [`crate::VideoModel::apply`].
+///
+/// - `Applied`: state changed; revision bumped; undoable edits recorded.
+/// - `Rejected`: missing id, invalid geometry (overlap, `in >= out`,
+///   overflow), or invalid fps — state untouched, no history entry, no
+///   revision bump; the reason names what failed.
+/// - `NoOp`: valid but changed nothing — no history entry, no revision bump.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ApplyOutcome {
+    Applied,
+    Rejected(String),
+    NoOp,
+}
+
+/// Every edit, playhead, selection, and history command the video model
+/// accepts.
+///
+/// Edits to project data (sources, clips) are undoable. Playhead and
+/// selection changes are not undoable and are never restored by `Undo`, but
+/// they do bump the revision when they change state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum VideoCommand {
+    /// Register a media source. `duration` is in ticks (milliseconds).
+    AddSource { path: String, duration: u64, fps: Fps },
+    /// Remove a source and every clip referencing it on both tracks, in one
+    /// undo group. Clears the selection if it pointed at a removed clip.
+    RemoveSource { source: SourceId },
+
+    /// Place a clip on the fixed video or audio track. The timeline length
+    /// is `source_out - source_in` (no retime in v1). Rejected if it would
+    /// overlap an existing clip on that track — video-editor tracks never
+    /// overlap.
+    AddClip {
+        track: TrackKind,
+        source: SourceId,
+        source_in: u64,
+        source_out: u64,
+        position: u64,
+    },
+    /// Plain lift — leaves a gap.
+    RemoveClip { clip: ClipId },
+    /// Removes the clip and shifts every later clip on the same track left
+    /// by the removed clip's length, in one undo group.
+    RippleDelete { clip: ClipId },
+    /// Same-track move; rejected on overlap.
+    MoveClip { clip: ClipId, position: u64 },
+    /// Trim the clip's in point. Content stays timeline-aligned: the
+    /// position shifts by `new_in - old_in` (checked arithmetic).
+    TrimIn { clip: ClipId, source_in: u64 },
+    /// Trim the clip's out point. The position is fixed; the clip end moves.
+    TrimOut { clip: ClipId, source_out: u64 },
+    /// Split at a time strictly inside the clip's timeline span. Both
+    /// halves get fresh ids (ids are never aliased); the selection moves to
+    /// the left half if the split clip was selected.
+    SplitAt { clip: ClipId, time: u64 },
+
+    SetPlayhead { position: u64 },
+    /// `Some(id)` is rejected when the clip does not exist.
+    Select { clip: Option<ClipId> },
+
+    Undo,
+    Redo,
+}

--- a/crates/video-model/src/gate.rs
+++ b/crates/video-model/src/gate.rs
@@ -14,7 +14,9 @@ use std::time::Instant;
 
 use crate::commands::{ApplyOutcome, VideoCommand};
 use crate::history::MAX_GROUPS;
-use crate::model::{ClipId, CutEntry, Fps, Project, SourceId, TrackKind, VideoModel};
+use crate::model::{
+    ClipId, CutEntry, Fps, Project, Source, SourceId, TrackKind, ValidationError, VideoModel,
+};
 
 /// Environment variable that pins `gate_randomized_commands` to one seed.
 pub const GATE_SEED_ENV: &str = "PLEXI_VIDEO_GATE_SEED";
@@ -683,80 +685,13 @@ pub fn gate_cases() -> Vec<GateCase> {
 // ─── Invariants ──────────────────────────────────────────────────────────────
 
 /// Read-only invariants that must hold after every applied command.
-/// `prev_revision` is the revision observed before the command.
+/// State validity delegates to the product's shared
+/// [`VideoModel::validate`] path (the same checks bundle loading runs);
+/// only the test-only extras — revision monotonicity and undo-depth
+/// consistency — live here. `prev_revision` is the revision observed
+/// before the command.
 pub fn check_invariants(model: &VideoModel, prev_revision: u64) -> Result<(), String> {
-    let project = model.project();
-    for source in &project.sources {
-        if source.fps.num == 0 || source.fps.den == 0 {
-            return Err(format!(
-                "source {} fps {}/{} has a zero term",
-                source.id.0, source.fps.num, source.fps.den
-            ));
-        }
-    }
-    let mut ids: Vec<u64> = project.sources.iter().map(|s| s.id.0).collect();
-    for kind in [TrackKind::Video, TrackKind::Audio] {
-        let track = project.track(kind);
-        for clip in &track.clips {
-            ids.push(clip.id.0);
-            let Some(source) = project.source(clip.source) else {
-                return Err(format!(
-                    "clip {} references missing source {}",
-                    clip.id.0, clip.source.0
-                ));
-            };
-            if clip.source_in >= clip.source_out {
-                return Err(format!(
-                    "clip {} window {}..{} is empty or inverted",
-                    clip.id.0, clip.source_in, clip.source_out
-                ));
-            }
-            if clip.source_out > source.duration {
-                return Err(format!(
-                    "clip {} window end {} exceeds source duration {}",
-                    clip.id.0, clip.source_out, source.duration
-                ));
-            }
-            if clip
-                .position
-                .checked_add(clip.source_out - clip.source_in)
-                .is_none()
-            {
-                return Err(format!("clip {} timeline end overflows u64", clip.id.0));
-            }
-        }
-        // No overlaps within a track: sort by position, check neighbors.
-        let mut spans: Vec<(u64, u64, u64)> = track
-            .clips
-            .iter()
-            .map(|c| (c.position, c.timeline_end(), c.id.0))
-            .collect();
-        spans.sort_unstable();
-        for pair in spans.windows(2) {
-            if pair[1].0 < pair[0].1 {
-                return Err(format!(
-                    "{kind:?} clips {} and {} overlap: [{}, {}) vs [{}, {})",
-                    pair[0].2, pair[1].2, pair[0].0, pair[0].1, pair[1].0, pair[1].1
-                ));
-            }
-        }
-    }
-    ids.sort_unstable();
-    if ids.windows(2).any(|w| w[0] == w[1]) {
-        return Err("duplicate entity id".to_string());
-    }
-    if ids.last().is_some_and(|&max| max >= project.next_id) {
-        return Err(format!(
-            "id {} >= next_id {}; allocator lost monotonicity",
-            ids.last().unwrap(),
-            project.next_id
-        ));
-    }
-    if let Some(selected) = model.selection() {
-        if project.find_clip(selected).is_none() {
-            return Err(format!("selection points at missing clip {}", selected.0));
-        }
-    }
+    model.validate().map_err(|e| e.to_string())?;
     if model.revision() < prev_revision {
         return Err(format!(
             "revision went backwards: {} -> {}",
@@ -883,8 +818,9 @@ fn run_long_sequence() -> Result<usize, String> {
         ));
     }
     // Settle any leftover interleaved-undo residue first so "final" is
-    // well-defined, then: full undo walks back to the default project (the
-    // id allocator alone survives); full redo restores the exact final JSON.
+    // well-defined, then: full undo walks back to the default project —
+    // except `next_id`, which is pinned monotonic across undo (see the
+    // `Project::next_id` doc) — and full redo restores the exact final JSON.
     while model.can_redo() {
         model.apply(VideoCommand::Redo);
     }
@@ -1495,7 +1431,7 @@ fn gate_serialization_round_trip() {
 fn gate_restore_from_parts() {
     // The load half of persistence: a model rebuilt from decoded project +
     // playhead/selection must carry the exact state, satisfy invariants,
-    // clear a dangling selection, and accept further edits with fresh
+    // reject a dangling selection, and accept further edits with fresh
     // history and monotonic id allocation.
     let mut model = VideoModel::new();
     for command in [
@@ -1508,7 +1444,8 @@ fn gate_restore_from_parts() {
     }
     let json = model.project().to_json().expect("serialize");
     let decoded = Project::from_json(&json).expect("deserialize");
-    let mut restored = VideoModel::from_parts(decoded.clone(), model.playhead(), model.selection());
+    let mut restored = VideoModel::from_parts(decoded.clone(), model.playhead(), model.selection())
+        .expect("valid persisted state must restore");
     assert_eq!(restored.project(), model.project());
     assert_eq!(restored.playhead(), 700);
     assert_eq!(restored.selection(), Some(ClipId(2)));
@@ -1519,7 +1456,63 @@ fn gate_restore_from_parts() {
         restored.project().find_clip(ClipId(3)).is_some(),
         "id allocation resumes past restored ids"
     );
-    // A persisted selection that no longer resolves is cleared on restore.
-    let dangling = VideoModel::from_parts(decoded, 0, Some(ClipId(99)));
-    assert_eq!(dangling.selection(), None);
+    // A persisted selection that does not resolve is invalid input: the
+    // constructor rejects instead of silently repairing it.
+    match VideoModel::from_parts(decoded, 0, Some(ClipId(99))) {
+        Err(ValidationError::DanglingSelection { clip: ClipId(99) }) => {}
+        other => panic!("expected DanglingSelection, got {other:?}"),
+    }
+}
+
+#[test]
+fn gate_from_parts_rejects_invalid_state() {
+    // Tester repro: a hand-edited bundle carrying a zero fps term must be
+    // rejected by the shared validation path, not silently accepted.
+    let corrupted = Project {
+        sources: vec![Source {
+            id: SourceId(1),
+            path: "a.mp4".to_string(),
+            duration: 1000,
+            fps: Fps { num: 0, den: 1 },
+        }],
+        next_id: 2,
+        ..Project::default()
+    };
+    match VideoModel::from_parts(corrupted, 0, None) {
+        Err(ValidationError::ZeroFpsTerm {
+            source: SourceId(1),
+            num: 0,
+            den: 1,
+        }) => {}
+        other => panic!("expected ZeroFpsTerm, got {other:?}"),
+    }
+}
+
+#[test]
+fn full_undo_preserves_monotonic_next_id() {
+    // Pinned design decision: `next_id` is NOT restored by undo. After full
+    // undo the project is semantically the initial state except the
+    // strictly advanced allocator — stale external ids stay detectable
+    // instead of silently rebinding to post-undo objects.
+    let mut model = VideoModel::new();
+    let initial_next_id = model.project().next_id;
+    for command in [source("a.mp4", 10_000), vclip(1, 0, 1000, 0), aclip(1, 0, 1000, 0)] {
+        assert_eq!(model.apply(command), ApplyOutcome::Applied);
+    }
+    while model.can_undo() {
+        model.apply(VideoCommand::Undo);
+    }
+    assert!(
+        model.project().next_id > initial_next_id,
+        "next_id must stay advanced after full undo"
+    );
+    let expected = Project {
+        next_id: model.project().next_id,
+        ..Project::default()
+    };
+    assert_eq!(
+        model.project(),
+        &expected,
+        "everything except next_id must equal the initial state"
+    );
 }

--- a/crates/video-model/src/gate.rs
+++ b/crates/video-model/src/gate.rs
@@ -1,0 +1,1525 @@
+//! Video model release gate (stint 0523): a table-driven command matrix, a
+//! long deterministic stress sequence, and seeded randomized command fuzzing
+//! over the pure [`VideoModel`] state machine — with per-command invariant
+//! checks and a machine-readable qualification artifact.
+//!
+//! Compiled only under `cfg(test)`: the gate is test infrastructure, never
+//! product code. Mirrors the editor gate (`src/editor/gate.rs` in the host
+//! crate) and the sibling `plexi-daw-model` gate in structure, seeds,
+//! minimizer, and artifact schema shape.
+#![cfg(test)]
+
+use std::path::Path;
+use std::time::Instant;
+
+use crate::commands::{ApplyOutcome, VideoCommand};
+use crate::history::MAX_GROUPS;
+use crate::model::{ClipId, CutEntry, Fps, Project, SourceId, TrackKind, VideoModel};
+
+/// Environment variable that pins `gate_randomized_commands` to one seed.
+pub const GATE_SEED_ENV: &str = "PLEXI_VIDEO_GATE_SEED";
+
+const DEFAULT_SEEDS: [u64; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+/// Kept modest (vs the editor's 2000): snapshot history makes state clones
+/// the dominant cost, and a sibling agent shares this machine's memory.
+const RANDOM_COMMANDS_PER_SEED: usize = 1500;
+/// Past this many clips the fuzzer biases hard toward shrinking commands.
+const FUZZ_CLIP_SOFT_CAP: usize = 200;
+
+// ─── Case table ──────────────────────────────────────────────────────────────
+
+/// Expected outcome kind of one gate step (`Rejected` matches any reason).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Expect {
+    Applied,
+    Rejected,
+    NoOp,
+}
+
+fn outcome_kind(outcome: &ApplyOutcome) -> Expect {
+    match outcome {
+        ApplyOutcome::Applied => Expect::Applied,
+        ApplyOutcome::Rejected(_) => Expect::Rejected,
+        ApplyOutcome::NoOp => Expect::NoOp,
+    }
+}
+
+/// One step of a gate case: the command and the outcome it must produce.
+#[derive(Debug)]
+pub struct GateStep {
+    pub command: VideoCommand,
+    pub expect: Expect,
+}
+
+/// One named gate case: a step sequence applied to a fresh [`VideoModel`]
+/// and a final-state check. Ids in the steps are deterministic: the model's
+/// allocator starts at 1, so the Nth allocating command yields id N.
+pub struct GateCase {
+    pub name: &'static str,
+    pub steps: Vec<GateStep>,
+    pub check: fn(&VideoModel) -> Result<(), String>,
+}
+
+fn a(command: VideoCommand) -> GateStep {
+    GateStep {
+        command,
+        expect: Expect::Applied,
+    }
+}
+
+fn r(command: VideoCommand) -> GateStep {
+    GateStep {
+        command,
+        expect: Expect::Rejected,
+    }
+}
+
+fn n(command: VideoCommand) -> GateStep {
+    GateStep {
+        command,
+        expect: Expect::NoOp,
+    }
+}
+
+const FPS_30: Fps = Fps { num: 30, den: 1 };
+
+fn source(path: &str, duration: u64) -> VideoCommand {
+    VideoCommand::AddSource {
+        path: path.to_string(),
+        duration,
+        fps: FPS_30,
+    }
+}
+
+fn vclip(src: u64, source_in: u64, source_out: u64, position: u64) -> VideoCommand {
+    VideoCommand::AddClip {
+        track: TrackKind::Video,
+        source: SourceId(src),
+        source_in,
+        source_out,
+        position,
+    }
+}
+
+fn aclip(src: u64, source_in: u64, source_out: u64, position: u64) -> VideoCommand {
+    VideoCommand::AddClip {
+        track: TrackKind::Audio,
+        source: SourceId(src),
+        source_in,
+        source_out,
+        position,
+    }
+}
+
+fn sel(id: u64) -> VideoCommand {
+    VideoCommand::Select {
+        clip: Some(ClipId(id)),
+    }
+}
+
+/// Fetches a clip by id or fails the check with a named error.
+fn clip_by_id(model: &VideoModel, id: u64) -> Result<&crate::model::Clip, String> {
+    let (track, index) = model
+        .project()
+        .find_clip(ClipId(id))
+        .ok_or_else(|| format!("expected clip {id} to exist"))?;
+    Ok(&model.project().track(track).clips[index])
+}
+
+/// The release-gate matrix: every case is small, named, and independently
+/// replayable through a fresh [`VideoModel`].
+#[must_use]
+pub fn gate_cases() -> Vec<GateCase> {
+    vec![
+        GateCase {
+            name: "add_source_and_clip",
+            steps: vec![a(source("a.mp4", 10_000)), a(vclip(1, 0, 1000, 0))],
+            check: |m| {
+                let c = clip_by_id(m, 2)?;
+                if c.length() != 1000 || c.position != 0 || m.undo_depth() != 2 {
+                    return Err(format!("unexpected clip {c:?} / depth {}", m.undo_depth()));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "fps_invalid_rejected",
+            steps: vec![
+                r(VideoCommand::AddSource {
+                    path: "z.mp4".to_string(),
+                    duration: 1000,
+                    fps: Fps { num: 0, den: 1 },
+                }),
+                r(VideoCommand::AddSource {
+                    path: "z.mp4".to_string(),
+                    duration: 1000,
+                    fps: Fps { num: 30, den: 0 },
+                }),
+            ],
+            check: |m| {
+                if !m.project().sources.is_empty() || m.undo_depth() != 0 || m.revision() != 0 {
+                    return Err("invalid fps must leave state untouched".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "add_overlap_rejected_adjacent_ok",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                r(vclip(1, 0, 1000, 500)),
+                // Touching end-to-start is not an overlap.
+                a(vclip(1, 0, 1000, 1000)),
+            ],
+            check: |m| {
+                if m.project().video.clips.len() != 2 || m.undo_depth() != 3 {
+                    return Err("overlap must reject; adjacency must apply".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "tracks_do_not_cross_check_overlap",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(aclip(1, 0, 1000, 0)),
+            ],
+            check: |m| {
+                let p = m.project();
+                if p.video.clips.len() != 1 || p.audio.clips.len() != 1 {
+                    return Err("same span on different tracks must coexist".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "add_clip_window_rejected",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                r(vclip(1, 1000, 1000, 0)),
+                r(vclip(1, 2000, 1000, 0)),
+                r(vclip(1, 0, 20_000, 0)),
+                r(vclip(9, 0, 1000, 0)),
+            ],
+            check: |m| {
+                if m.project().clip_count() != 0 || m.undo_depth() != 1 {
+                    return Err("bad windows must leave state untouched".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "add_clip_position_overflow_rejected",
+            steps: vec![a(source("a.mp4", 10_000)), r(vclip(1, 0, 1000, u64::MAX))],
+            check: |m| {
+                if m.project().clip_count() != 0 {
+                    return Err("overflowing clip must be rejected".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "move_clip_and_overlap",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(vclip(1, 0, 1000, 2000)),
+                a(VideoCommand::MoveClip {
+                    clip: ClipId(2),
+                    position: 5000,
+                }),
+                n(VideoCommand::MoveClip {
+                    clip: ClipId(2),
+                    position: 5000,
+                }),
+                r(VideoCommand::MoveClip {
+                    clip: ClipId(3),
+                    position: 4500,
+                }),
+            ],
+            check: |m| {
+                if clip_by_id(m, 2)?.position != 5000 || clip_by_id(m, 3)?.position != 2000 {
+                    return Err("move must land; overlapping move must reject".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "trim_in_shifts_position",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 200, 1000, 5000)),
+                // In point moves right by 200 → position shifts right by 200.
+                a(VideoCommand::TrimIn {
+                    clip: ClipId(2),
+                    source_in: 400,
+                }),
+                // In point moves left by 300 → position shifts left by 300.
+                a(VideoCommand::TrimIn {
+                    clip: ClipId(2),
+                    source_in: 100,
+                }),
+                n(VideoCommand::TrimIn {
+                    clip: ClipId(2),
+                    source_in: 100,
+                }),
+            ],
+            check: |m| {
+                let c = clip_by_id(m, 2)?;
+                if c.source_in != 100 || c.source_out != 1000 || c.position != 4900 {
+                    return Err(format!(
+                        "TrimIn must keep content timeline-aligned; got {c:?}"
+                    ));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "trim_in_underflow_rejected",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 200, 1000, 0)),
+                // Widening left would move the position before tick 0.
+                r(VideoCommand::TrimIn {
+                    clip: ClipId(2),
+                    source_in: 100,
+                }),
+            ],
+            check: |m| {
+                let c = clip_by_id(m, 2)?;
+                if c.source_in != 200 || c.position != 0 {
+                    return Err("rejected trim must leave the clip untouched".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "trim_in_boundary_and_overlap_rejected",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(vclip(1, 500, 1500, 1000)),
+                // in == out is empty.
+                r(VideoCommand::TrimIn {
+                    clip: ClipId(3),
+                    source_in: 1500,
+                }),
+                // Widening left by 500 would cover [500, 2000) over clip 2.
+                r(VideoCommand::TrimIn {
+                    clip: ClipId(3),
+                    source_in: 0,
+                }),
+                r(VideoCommand::TrimIn {
+                    clip: ClipId(99),
+                    source_in: 0,
+                }),
+            ],
+            check: |m| {
+                let c = clip_by_id(m, 3)?;
+                if c.source_in != 500 || c.position != 1000 {
+                    return Err("boundary trims must reject in place".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "trim_out_moves_end",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(vclip(1, 0, 1000, 2000)),
+                a(VideoCommand::TrimOut {
+                    clip: ClipId(2),
+                    source_out: 1500,
+                }),
+                // Beyond the source duration.
+                r(VideoCommand::TrimOut {
+                    clip: ClipId(2),
+                    source_out: 20_000,
+                }),
+                // out == in is empty.
+                r(VideoCommand::TrimOut {
+                    clip: ClipId(2),
+                    source_out: 0,
+                }),
+                // Extending to 2500 ticks would cover clip 3 at 2000.
+                r(VideoCommand::TrimOut {
+                    clip: ClipId(2),
+                    source_out: 2500,
+                }),
+            ],
+            check: |m| {
+                let c = clip_by_id(m, 2)?;
+                if c.source_out != 1500 || c.position != 0 {
+                    return Err("TrimOut must move only the end".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "split_fresh_ids_and_adjacency",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 3000)),
+                a(VideoCommand::SplitAt {
+                    clip: ClipId(2),
+                    time: 3400,
+                }),
+            ],
+            check: |m| {
+                if m.project().find_clip(ClipId(2)).is_some() {
+                    return Err("split must retire the original id".to_string());
+                }
+                let left = clip_by_id(m, 3)?;
+                let right = clip_by_id(m, 4)?;
+                if left.position != 3000 || left.source_in != 0 || left.source_out != 400 {
+                    return Err(format!("bad left half {left:?}"));
+                }
+                if right.position != 3400 || right.source_in != 400 || right.source_out != 1000 {
+                    return Err(format!("bad right half {right:?}"));
+                }
+                if left.timeline_end() != right.position {
+                    return Err("halves must stay adjacent".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "split_at_edge_rejected",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 3000)),
+                r(VideoCommand::SplitAt {
+                    clip: ClipId(2),
+                    time: 3000,
+                }),
+                r(VideoCommand::SplitAt {
+                    clip: ClipId(2),
+                    time: 4000,
+                }),
+                r(VideoCommand::SplitAt {
+                    clip: ClipId(99),
+                    time: 3500,
+                }),
+            ],
+            check: |m| {
+                if m.project().video.clips.len() != 1 || m.undo_depth() != 2 {
+                    return Err("edge splits must reject in place".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "selection_follows_split",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(sel(2)),
+                a(VideoCommand::SplitAt {
+                    clip: ClipId(2),
+                    time: 500,
+                }),
+            ],
+            check: |m| {
+                if m.selection() != Some(ClipId(3)) {
+                    return Err(format!(
+                        "selection must move to the left half, got {:?}",
+                        m.selection()
+                    ));
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "selection_cleared_on_remove",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(sel(2)),
+                a(VideoCommand::RemoveClip { clip: ClipId(2) }),
+                n(VideoCommand::Select { clip: None }),
+            ],
+            check: |m| {
+                if m.selection().is_some() {
+                    return Err("removing the selected clip must clear selection".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "select_missing_rejected",
+            steps: vec![r(sel(99))],
+            check: |m| {
+                if m.selection().is_some() || m.revision() != 0 {
+                    return Err("selecting a missing clip must reject".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "ripple_delete_shifts_later_same_track",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(vclip(1, 0, 1000, 1000)),
+                a(vclip(1, 0, 1000, 3000)),
+                a(aclip(1, 0, 1000, 1500)),
+                a(VideoCommand::RippleDelete { clip: ClipId(3) }),
+            ],
+            check: |m| {
+                if clip_by_id(m, 2)?.position != 0 {
+                    return Err("earlier clip must not move".to_string());
+                }
+                if clip_by_id(m, 4)?.position != 2000 {
+                    return Err("later same-track clip must shift left by 1000".to_string());
+                }
+                if clip_by_id(m, 5)?.position != 1500 {
+                    return Err("other track must be untouched".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "ripple_delete_single_undo_group",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(vclip(1, 0, 1000, 2000)),
+                a(VideoCommand::RippleDelete { clip: ClipId(2) }),
+                a(VideoCommand::Undo),
+            ],
+            check: |m| {
+                // One undo restores both the removed clip and the shifts.
+                if clip_by_id(m, 2)?.position != 0 || clip_by_id(m, 3)?.position != 2000 {
+                    return Err("one undo must restore the whole ripple".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "remove_leaves_gap",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(vclip(1, 0, 1000, 1000)),
+                a(vclip(1, 0, 1000, 3000)),
+                a(VideoCommand::RemoveClip { clip: ClipId(3) }),
+            ],
+            check: |m| {
+                if clip_by_id(m, 2)?.position != 0 || clip_by_id(m, 4)?.position != 3000 {
+                    return Err("plain remove must not shift neighbors".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "playhead_selection_not_undoable",
+            steps: vec![
+                a(VideoCommand::SetPlayhead { position: 500 }),
+                n(VideoCommand::SetPlayhead { position: 500 }),
+                n(VideoCommand::Undo),
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(sel(2)),
+                a(VideoCommand::SetPlayhead { position: 700 }),
+                // Undo pops the clip add; the playhead stays, and the now
+                // dangling selection is cleared rather than restored.
+                a(VideoCommand::Undo),
+            ],
+            check: |m| {
+                if m.playhead() != 700 {
+                    return Err("undo must not touch the playhead".to_string());
+                }
+                if m.selection().is_some() || m.project().clip_count() != 0 {
+                    return Err("undoing the add must clear the dangling selection".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "remove_source_cascades_and_clears_selection",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(aclip(1, 0, 1000, 0)),
+                a(sel(2)),
+                a(VideoCommand::RemoveSource { source: SourceId(1) }),
+                r(VideoCommand::RemoveSource { source: SourceId(1) }),
+            ],
+            check: |m| {
+                let p = m.project();
+                if !p.sources.is_empty() || p.clip_count() != 0 || m.selection().is_some() {
+                    return Err("cascade must remove both clips and the selection".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "remove_source_cascade_single_undo_group",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(aclip(1, 0, 1000, 0)),
+                a(VideoCommand::RemoveSource { source: SourceId(1) }),
+                a(VideoCommand::Undo),
+            ],
+            check: |m| {
+                let p = m.project();
+                if p.sources.len() != 1 || p.clip_count() != 2 {
+                    return Err("one undo must restore the source and both clips".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "cut_list_derivation",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(source("b.mp4", 5_000)),
+                a(vclip(1, 0, 2000, 0)),
+                a(vclip(2, 1000, 3000, 2000)),
+                a(vclip(1, 5000, 6000, 5000)),
+                // Trim the first clip's head: gap opens at [0, 500).
+                a(VideoCommand::TrimIn {
+                    clip: ClipId(3),
+                    source_in: 500,
+                }),
+                // Split the b.mp4 clip at its midpoint → ids 6 (left) + 7.
+                a(VideoCommand::SplitAt {
+                    clip: ClipId(4),
+                    time: 3000,
+                }),
+                // Ripple out the left half: id 7 and id 5 shift left 1000.
+                a(VideoCommand::RippleDelete { clip: ClipId(6) }),
+            ],
+            check: |m| {
+                let expected = vec![
+                    CutEntry {
+                        source_path: "a.mp4".to_string(),
+                        source_in: 500,
+                        source_out: 2000,
+                        position: 500,
+                    },
+                    CutEntry {
+                        source_path: "b.mp4".to_string(),
+                        source_in: 2000,
+                        source_out: 3000,
+                        position: 2000,
+                    },
+                    CutEntry {
+                        source_path: "a.mp4".to_string(),
+                        source_in: 5000,
+                        source_out: 6000,
+                        position: 4000,
+                    },
+                ];
+                let got = m.project().cut_list(TrackKind::Video);
+                if got != expected {
+                    return Err(format!("cut list mismatch:\nexpected {expected:#?}\ngot {got:#?}"));
+                }
+                if !m.project().cut_list(TrackKind::Audio).is_empty() {
+                    return Err("audio cut list must be empty".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "undo_redo_round_trip",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(VideoCommand::Undo),
+                a(VideoCommand::Redo),
+            ],
+            check: |m| {
+                if m.project().clip_count() != 1 || m.undo_depth() != 2 || m.can_redo() {
+                    return Err("undo+redo must restore the clip".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "redo_invalidated_by_new_edit",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(VideoCommand::Undo),
+                a(source("b.mp4", 5_000)),
+            ],
+            check: |m| {
+                if m.can_redo() || m.project().sources.len() != 1 {
+                    return Err("new edit after undo must clear redo".to_string());
+                }
+                if m.project().sources[0].path != "b.mp4" {
+                    return Err("surviving source must be the new one".to_string());
+                }
+                Ok(())
+            },
+        },
+        GateCase {
+            name: "undo_to_empty",
+            steps: vec![
+                a(source("a.mp4", 10_000)),
+                a(vclip(1, 0, 1000, 0)),
+                a(VideoCommand::Undo),
+                a(VideoCommand::Undo),
+                n(VideoCommand::Undo),
+            ],
+            check: |m| {
+                let p = m.project();
+                if !p.sources.is_empty() || p.clip_count() != 0 || m.undo_depth() != 0 {
+                    return Err("full undo must restore the empty project".to_string());
+                }
+                if !m.can_redo() {
+                    return Err("redo must be available after full undo".to_string());
+                }
+                Ok(())
+            },
+        },
+    ]
+}
+
+// ─── Invariants ──────────────────────────────────────────────────────────────
+
+/// Read-only invariants that must hold after every applied command.
+/// `prev_revision` is the revision observed before the command.
+pub fn check_invariants(model: &VideoModel, prev_revision: u64) -> Result<(), String> {
+    let project = model.project();
+    for source in &project.sources {
+        if source.fps.num == 0 || source.fps.den == 0 {
+            return Err(format!(
+                "source {} fps {}/{} has a zero term",
+                source.id.0, source.fps.num, source.fps.den
+            ));
+        }
+    }
+    let mut ids: Vec<u64> = project.sources.iter().map(|s| s.id.0).collect();
+    for kind in [TrackKind::Video, TrackKind::Audio] {
+        let track = project.track(kind);
+        for clip in &track.clips {
+            ids.push(clip.id.0);
+            let Some(source) = project.source(clip.source) else {
+                return Err(format!(
+                    "clip {} references missing source {}",
+                    clip.id.0, clip.source.0
+                ));
+            };
+            if clip.source_in >= clip.source_out {
+                return Err(format!(
+                    "clip {} window {}..{} is empty or inverted",
+                    clip.id.0, clip.source_in, clip.source_out
+                ));
+            }
+            if clip.source_out > source.duration {
+                return Err(format!(
+                    "clip {} window end {} exceeds source duration {}",
+                    clip.id.0, clip.source_out, source.duration
+                ));
+            }
+            if clip
+                .position
+                .checked_add(clip.source_out - clip.source_in)
+                .is_none()
+            {
+                return Err(format!("clip {} timeline end overflows u64", clip.id.0));
+            }
+        }
+        // No overlaps within a track: sort by position, check neighbors.
+        let mut spans: Vec<(u64, u64, u64)> = track
+            .clips
+            .iter()
+            .map(|c| (c.position, c.timeline_end(), c.id.0))
+            .collect();
+        spans.sort_unstable();
+        for pair in spans.windows(2) {
+            if pair[1].0 < pair[0].1 {
+                return Err(format!(
+                    "{kind:?} clips {} and {} overlap: [{}, {}) vs [{}, {})",
+                    pair[0].2, pair[1].2, pair[0].0, pair[0].1, pair[1].0, pair[1].1
+                ));
+            }
+        }
+    }
+    ids.sort_unstable();
+    if ids.windows(2).any(|w| w[0] == w[1]) {
+        return Err("duplicate entity id".to_string());
+    }
+    if ids.last().is_some_and(|&max| max >= project.next_id) {
+        return Err(format!(
+            "id {} >= next_id {}; allocator lost monotonicity",
+            ids.last().unwrap(),
+            project.next_id
+        ));
+    }
+    if let Some(selected) = model.selection() {
+        if project.find_clip(selected).is_none() {
+            return Err(format!("selection points at missing clip {}", selected.0));
+        }
+    }
+    if model.revision() < prev_revision {
+        return Err(format!(
+            "revision went backwards: {} -> {}",
+            prev_revision,
+            model.revision()
+        ));
+    }
+    if model.can_undo() != (model.undo_depth() > 0) {
+        return Err(format!(
+            "undo_depth {} inconsistent with can_undo {}",
+            model.undo_depth(),
+            model.can_undo()
+        ));
+    }
+    Ok(())
+}
+
+/// History round-trip invariant: when undo is available, Undo then Redo must
+/// restore the exact serialized project. Playhead and selection are
+/// deliberately outside the compare — they are not part of history.
+pub fn check_history_round_trip(model: &mut VideoModel) -> Result<(), String> {
+    if !model.can_undo() {
+        return Ok(());
+    }
+    let before = model.project().to_json()?;
+    model.apply(VideoCommand::Undo);
+    model.apply(VideoCommand::Redo);
+    let after = model.project().to_json()?;
+    if before != after {
+        return Err(format!(
+            "undo/redo round trip did not restore the project:\nbefore: {before}\nafter: {after}"
+        ));
+    }
+    Ok(())
+}
+
+// ─── Case runner ─────────────────────────────────────────────────────────────
+
+/// Final-state summary recorded in the qualification artifact.
+#[derive(Debug, serde::Serialize)]
+pub struct GateFinalState {
+    pub revision: u64,
+    pub undo_depth: usize,
+    pub can_redo: bool,
+}
+
+fn run_case(case: &GateCase) -> Result<GateFinalState, String> {
+    let mut model = VideoModel::new();
+    let mut prev_revision = model.revision();
+    for (index, step) in case.steps.iter().enumerate() {
+        let outcome = model.apply(step.command.clone());
+        if outcome_kind(&outcome) != step.expect {
+            return Err(format!(
+                "step[{index}] {:?}: expected {:?}, got {outcome:?}",
+                step.command, step.expect
+            ));
+        }
+        check_invariants(&model, prev_revision)
+            .map_err(|e| format!("step[{index}] {:?}: {e}", step.command))?;
+        prev_revision = model.revision();
+    }
+    (case.check)(&model)?;
+    check_history_round_trip(&mut model)?;
+    Ok(GateFinalState {
+        revision: model.revision(),
+        undo_depth: model.undo_depth(),
+        can_redo: model.can_redo(),
+    })
+}
+
+// ─── Deterministic long sequence ─────────────────────────────────────────────
+
+const LONG_SEQUENCE_REPS: usize = 10;
+/// Guard band under [`MAX_GROUPS`]: the full-undo-to-empty assertion is only
+/// valid while no undo group was ever evicted.
+const MAX_OBSERVED_DEPTH: usize = MAX_GROUPS - 20;
+
+fn run_long_sequence() -> Result<usize, String> {
+    let mut model = VideoModel::new();
+    let mut prev_revision = model.revision();
+    let mut applied = 0usize;
+    let mut max_depth = 0usize;
+    let cases = gate_cases();
+    for rep in 0..LONG_SEQUENCE_REPS {
+        for case in &cases {
+            for step in &case.steps {
+                // Outcomes differ in the shared model (ids drift); only the
+                // invariants and history behavior are under test here.
+                model.apply(step.command.clone());
+                applied += 1;
+                check_invariants(&model, prev_revision)
+                    .map_err(|e| format!("rep {rep} case {} @{applied}: {e}", case.name))?;
+                prev_revision = model.revision();
+                max_depth = max_depth.max(model.undo_depth());
+                // Interleaved undo/redo passes keep the history exercised
+                // (and pruned: an edit after an undo drops the redone group).
+                if applied % 5 == 0 {
+                    model.apply(VideoCommand::Undo);
+                    check_invariants(&model, prev_revision)
+                        .map_err(|e| format!("interleaved undo @{applied}: {e}"))?;
+                    prev_revision = model.revision();
+                }
+                if applied % 13 == 0 {
+                    model.apply(VideoCommand::Redo);
+                    check_invariants(&model, prev_revision)
+                        .map_err(|e| format!("interleaved redo @{applied}: {e}"))?;
+                    prev_revision = model.revision();
+                }
+                if applied % 97 == 0 {
+                    check_history_round_trip(&mut model)
+                        .map_err(|e| format!("round trip @{applied}: {e}"))?;
+                }
+            }
+        }
+    }
+    if applied < 1000 {
+        return Err(format!(
+            "long sequence too short ({applied} commands) to qualify as a stress pass"
+        ));
+    }
+    if max_depth >= MAX_OBSERVED_DEPTH {
+        return Err(format!(
+            "undo depth reached {max_depth}; retention cap invalidates full-undo assertion"
+        ));
+    }
+    // Settle any leftover interleaved-undo residue first so "final" is
+    // well-defined, then: full undo walks back to the default project (the
+    // id allocator alone survives); full redo restores the exact final JSON.
+    while model.can_redo() {
+        model.apply(VideoCommand::Redo);
+    }
+    let final_json = model.project().to_json()?;
+    let mut guard = 0usize;
+    while model.can_undo() {
+        model.apply(VideoCommand::Undo);
+        guard += 1;
+        if guard > 100_000 {
+            return Err("full undo did not terminate".to_string());
+        }
+    }
+    let empty = Project {
+        next_id: model.project().next_id,
+        ..Project::default()
+    };
+    if model.project() != &empty {
+        return Err(format!(
+            "full undo did not restore the default project; residue: {:?}",
+            model.project()
+        ));
+    }
+    while model.can_redo() {
+        model.apply(VideoCommand::Redo);
+    }
+    if model.project().to_json()? != final_json {
+        return Err("full redo did not restore the final project".to_string());
+    }
+    Ok(applied)
+}
+
+// ─── Deterministic PRNG + randomized commands ────────────────────────────────
+
+/// SplitMix64: tiny, deterministic, dependency-free PRNG.
+pub struct SplitMix64(u64);
+
+impl SplitMix64 {
+    #[must_use]
+    pub fn new(seed: u64) -> Self {
+        Self(seed)
+    }
+
+    pub fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform value in `0..n` (`n > 0`).
+    pub fn below(&mut self, n: u64) -> u64 {
+        self.next_u64() % n
+    }
+}
+
+/// Existing id, or (1-in-8, and always when empty) a deliberately bogus one.
+fn pick_id(rng: &mut SplitMix64, ids: &[u64]) -> u64 {
+    if ids.is_empty() || rng.below(8) == 0 {
+        1_000_000 + rng.below(1000)
+    } else {
+        ids[rng.below(ids.len() as u64) as usize]
+    }
+}
+
+fn source_ids(project: &Project) -> Vec<u64> {
+    project.sources.iter().map(|s| s.id.0).collect()
+}
+
+fn clip_ids(project: &Project) -> Vec<u64> {
+    project
+        .video
+        .clips
+        .iter()
+        .chain(project.audio.clips.iter())
+        .map(|c| c.id.0)
+        .collect()
+}
+
+fn random_track(rng: &mut SplitMix64) -> TrackKind {
+    if rng.below(2) == 0 {
+        TrackKind::Video
+    } else {
+        TrackKind::Audio
+    }
+}
+
+/// Fps values are valid most of the time; zero terms keep rejection hot.
+fn random_fps(rng: &mut SplitMix64) -> Fps {
+    match rng.below(12) {
+        0 => Fps { num: 0, den: 1 },
+        1 => Fps { num: 30, den: 0 },
+        2 => Fps {
+            num: 30_000,
+            den: 1001,
+        },
+        _ => Fps {
+            num: 24 + rng.below(40) as u32,
+            den: 1,
+        },
+    }
+}
+
+/// Positions mix ordinary grid values with near-overflow extremes.
+fn random_position(rng: &mut SplitMix64) -> u64 {
+    if rng.below(16) == 0 {
+        u64::MAX - rng.below(2000)
+    } else {
+        rng.below(64) * 500
+    }
+}
+
+/// Windows include empty, inverted, and beyond-duration shapes.
+fn random_window(rng: &mut SplitMix64) -> (u64, u64) {
+    let source_in = rng.below(8) * 500;
+    let source_out = match rng.below(8) {
+        0 => source_in,
+        1 => source_in.saturating_sub(500),
+        2 => 1_000_000,
+        _ => source_in + (1 + rng.below(6)) * 500,
+    };
+    (source_in, source_out)
+}
+
+/// Weighted random command generator over the full [`VideoCommand`] surface,
+/// including deliberately invalid ids, geometry, and fps values.
+pub fn random_command(rng: &mut SplitMix64, model: &VideoModel) -> VideoCommand {
+    let project = model.project();
+    let sources = source_ids(project);
+    let clips = clip_ids(project);
+    // Memory discipline: past the soft cap, bias hard toward shrinking
+    // commands so fuzz state (and its history snapshots) stays bounded.
+    if clips.len() > FUZZ_CLIP_SOFT_CAP {
+        return match rng.below(10) {
+            0..=3 => VideoCommand::RemoveClip {
+                clip: ClipId(pick_id(rng, &clips)),
+            },
+            4..=5 => VideoCommand::RippleDelete {
+                clip: ClipId(pick_id(rng, &clips)),
+            },
+            6..=7 => VideoCommand::Undo,
+            8 => VideoCommand::RemoveSource {
+                source: SourceId(pick_id(rng, &sources)),
+            },
+            _ => VideoCommand::RemoveClip {
+                clip: ClipId(pick_id(rng, &clips)),
+            },
+        };
+    }
+    match rng.below(100) {
+        0..=11 => VideoCommand::AddSource {
+            path: format!("media/{}.mp4", rng.below(50)),
+            duration: rng.below(20) * 1000,
+            fps: random_fps(rng),
+        },
+        12..=14 => VideoCommand::RemoveSource {
+            source: SourceId(pick_id(rng, &sources)),
+        },
+        15..=39 => {
+            let (source_in, source_out) = random_window(rng);
+            VideoCommand::AddClip {
+                track: random_track(rng),
+                source: SourceId(pick_id(rng, &sources)),
+                source_in,
+                source_out,
+                position: random_position(rng),
+            }
+        }
+        40..=45 => VideoCommand::RemoveClip {
+            clip: ClipId(pick_id(rng, &clips)),
+        },
+        46..=50 => VideoCommand::RippleDelete {
+            clip: ClipId(pick_id(rng, &clips)),
+        },
+        51..=57 => VideoCommand::MoveClip {
+            clip: ClipId(pick_id(rng, &clips)),
+            position: random_position(rng),
+        },
+        58..=64 => VideoCommand::TrimIn {
+            clip: ClipId(pick_id(rng, &clips)),
+            source_in: rng.below(10) * 500,
+        },
+        65..=71 => VideoCommand::TrimOut {
+            clip: ClipId(pick_id(rng, &clips)),
+            source_out: rng.below(12) * 500,
+        },
+        72..=77 => VideoCommand::SplitAt {
+            clip: ClipId(pick_id(rng, &clips)),
+            time: rng.below(40) * 250,
+        },
+        78..=80 => VideoCommand::SetPlayhead {
+            position: random_position(rng),
+        },
+        81..=84 => VideoCommand::Select {
+            clip: if rng.below(4) == 0 {
+                None
+            } else {
+                Some(ClipId(pick_id(rng, &clips)))
+            },
+        },
+        85..=92 => VideoCommand::Undo,
+        _ => VideoCommand::Redo,
+    }
+}
+
+/// Replays `commands` on a fresh model with per-command invariant checks
+/// plus the final history round trip — the same predicates the seed run
+/// applies, so any original failure mode reproduces during minimization.
+/// Returns the failing command index and message, if any.
+fn replay(commands: &[VideoCommand]) -> Result<(), (usize, String)> {
+    let mut model = VideoModel::new();
+    let mut prev_revision = model.revision();
+    for (index, command) in commands.iter().enumerate() {
+        model.apply(command.clone());
+        if let Err(e) = check_invariants(&model, prev_revision) {
+            return Err((index, e));
+        }
+        prev_revision = model.revision();
+    }
+    check_history_round_trip(&mut model)
+        .map_err(|e| (commands.len().saturating_sub(1), e))
+}
+
+/// Greedy sequence minimization: repeatedly drop commands while the failure
+/// still reproduces. Bounded passes keep worst-case cost predictable.
+fn minimize(mut commands: Vec<VideoCommand>) -> (Vec<VideoCommand>, String) {
+    let mut message = match replay(&commands) {
+        Err((index, message)) => {
+            commands.truncate(index + 1);
+            message
+        }
+        Ok(()) => return (commands, "failure did not reproduce on replay".to_string()),
+    };
+    for _pass in 0..6 {
+        let mut removed_any = false;
+        let mut i = commands.len();
+        while i > 0 {
+            i -= 1;
+            let mut candidate = commands.clone();
+            candidate.remove(i);
+            if let Err((_, m)) = replay(&candidate) {
+                commands = candidate;
+                message = m;
+                removed_any = true;
+            }
+        }
+        if !removed_any {
+            break;
+        }
+    }
+    (commands, message)
+}
+
+#[derive(serde::Serialize)]
+struct ReplayBundle {
+    seed: u64,
+    command_count: usize,
+    invariant_message: String,
+    minimized_commands: Vec<VideoCommand>,
+}
+
+/// A rejected or no-op command must leave the model observationally
+/// untouched. Sampled (not per-command) because it serializes the project.
+fn frozen_state(model: &VideoModel) -> Result<String, String> {
+    Ok(format!(
+        "{}|{}|{:?}|{}|{}",
+        model.project().to_json()?,
+        model.playhead(),
+        model.selection(),
+        model.revision(),
+        model.undo_depth()
+    ))
+}
+
+/// Runs one randomized seed. On invariant failure, minimizes the failing
+/// sequence and writes a replay bundle; returns the failure message.
+fn run_random_seed(seed: u64, command_count: usize) -> Result<(), String> {
+    let mut rng = SplitMix64::new(seed);
+    let mut model = VideoModel::new();
+    let mut prev_revision = model.revision();
+    let mut applied: Vec<VideoCommand> = Vec::with_capacity(command_count);
+    let mut failure: Option<String> = None;
+    for index in 0..command_count {
+        let command = random_command(&mut rng, &model);
+        // Sampled no-mutation check for Rejected/NoOp outcomes.
+        let watch = index % 16 == 0;
+        let before = if watch {
+            match frozen_state(&model) {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    failure = Some(e);
+                    break;
+                }
+            }
+        } else {
+            None
+        };
+        applied.push(command.clone());
+        let outcome = model.apply(command);
+        if let (Some(before), ApplyOutcome::Rejected(_) | ApplyOutcome::NoOp) = (before, &outcome)
+        {
+            match frozen_state(&model) {
+                Ok(after) if after != before => {
+                    failure = Some(format!("{outcome:?} outcome mutated state"));
+                    break;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    failure = Some(e);
+                    break;
+                }
+            }
+        }
+        if let Err(e) = check_invariants(&model, prev_revision) {
+            failure = Some(e);
+            break;
+        }
+        prev_revision = model.revision();
+        if (index + 1) % 250 == 0 {
+            if let Err(e) = check_history_round_trip(&mut model) {
+                failure = Some(format!("round trip @{index}: {e}"));
+                break;
+            }
+        }
+    }
+    if failure.is_none() {
+        if let Err(e) = check_history_round_trip(&mut model) {
+            failure = Some(e);
+        }
+    }
+    let Some(original_message) = failure else {
+        return Ok(());
+    };
+    let (minimized, message) = minimize(applied);
+    let bundle = ReplayBundle {
+        seed,
+        command_count: minimized.len(),
+        invariant_message: message.clone(),
+        minimized_commands: minimized,
+    };
+    let bundle_path = std::env::temp_dir().join(format!("plexi-video-gate-failure-{seed}.json"));
+    match serde_json::to_vec_pretty(&bundle)
+        .map_err(|e| e.to_string())
+        .and_then(|json| std::fs::write(&bundle_path, json).map_err(|e| e.to_string()))
+    {
+        Ok(()) => {}
+        Err(e) => log::error!(
+            "video_gate: failed to write replay bundle {}: {e}",
+            bundle_path.display()
+        ),
+    }
+    Err(format!(
+        "seed {seed} invariant failure: {original_message} (minimized: {message}). \
+         Replay bundle: {}. Reproduce with {GATE_SEED_ENV}={seed}",
+        bundle_path.display()
+    ))
+}
+
+fn seeds_under_test() -> Vec<u64> {
+    match std::env::var(GATE_SEED_ENV) {
+        Ok(raw) => {
+            let seed: u64 = raw
+                .parse()
+                .unwrap_or_else(|e| panic!("{GATE_SEED_ENV}={raw:?} is not a u64: {e}"));
+            vec![seed]
+        }
+        Err(_) => DEFAULT_SEEDS.to_vec(),
+    }
+}
+
+// ─── Qualification summary + artifact ────────────────────────────────────────
+
+#[derive(serde::Serialize)]
+pub struct GateCaseResult {
+    pub name: String,
+    pub passed: bool,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub final_state: Option<GateFinalState>,
+}
+
+#[derive(serde::Serialize)]
+pub struct GateRandomizedResult {
+    pub seed: u64,
+    pub commands: usize,
+    pub passed: bool,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+pub struct GateLongSequenceResult {
+    pub passed: bool,
+    pub commands: usize,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+pub struct GateTotals {
+    pub sections: usize,
+    pub passed: usize,
+    pub failed: usize,
+    pub duration_ms: u64,
+}
+
+#[derive(serde::Serialize)]
+pub struct GateSummary {
+    pub schema_version: u32,
+    pub cases: Vec<GateCaseResult>,
+    pub long_sequence: GateLongSequenceResult,
+    pub randomized: Vec<GateRandomizedResult>,
+    pub totals: GateTotals,
+}
+
+/// Runs the whole core gate (matrix + long sequence + default seeds), writes
+/// `video-gate-core.json` into `out_dir`, and returns the summary.
+pub fn run_core_qualification(out_dir: &Path) -> GateSummary {
+    let seeds = seeds_under_test();
+    let cases = gate_cases();
+    log::info!(
+        "video_gate: core qualification started cases={} seeds={}",
+        cases.len(),
+        seeds.len()
+    );
+    let start = Instant::now();
+
+    let case_results: Vec<GateCaseResult> = cases
+        .iter()
+        .map(|case| {
+            let t = Instant::now();
+            let result = run_case(case);
+            GateCaseResult {
+                name: case.name.to_string(),
+                passed: result.is_ok(),
+                duration_ms: t.elapsed().as_millis() as u64,
+                error: result.as_ref().err().cloned(),
+                final_state: result.ok(),
+            }
+        })
+        .collect();
+
+    let t = Instant::now();
+    let long_result = run_long_sequence();
+    let long_sequence = GateLongSequenceResult {
+        passed: long_result.is_ok(),
+        commands: *long_result.as_ref().unwrap_or(&0),
+        duration_ms: t.elapsed().as_millis() as u64,
+        error: long_result.err(),
+    };
+
+    let randomized: Vec<GateRandomizedResult> = seeds
+        .iter()
+        .map(|&seed| {
+            let t = Instant::now();
+            let result = run_random_seed(seed, RANDOM_COMMANDS_PER_SEED);
+            GateRandomizedResult {
+                seed,
+                commands: RANDOM_COMMANDS_PER_SEED,
+                passed: result.is_ok(),
+                duration_ms: t.elapsed().as_millis() as u64,
+                error: result.err(),
+            }
+        })
+        .collect();
+
+    let sections = case_results.len() + 1 + randomized.len();
+    let failed = case_results.iter().filter(|c| !c.passed).count()
+        + usize::from(!long_sequence.passed)
+        + randomized.iter().filter(|r| !r.passed).count();
+    let summary = GateSummary {
+        schema_version: 1,
+        cases: case_results,
+        long_sequence,
+        randomized,
+        totals: GateTotals {
+            sections,
+            passed: sections - failed,
+            failed,
+            duration_ms: start.elapsed().as_millis() as u64,
+        },
+    };
+
+    if let Err(e) = std::fs::create_dir_all(out_dir) {
+        log::error!("video_gate: failed to create {}: {e}", out_dir.display());
+    } else {
+        let artifact = out_dir.join("video-gate-core.json");
+        match serde_json::to_vec_pretty(&summary)
+            .map_err(|e| e.to_string())
+            .and_then(|json| std::fs::write(&artifact, json).map_err(|e| e.to_string()))
+        {
+            Ok(()) => log::info!("video_gate: wrote artifact {}", artifact.display()),
+            Err(e) => log::error!(
+                "video_gate: failed to write artifact {}: {e}",
+                artifact.display()
+            ),
+        }
+    }
+
+    log::info!(
+        "video_gate: core qualification finished passed={} failed={} duration_ms={}",
+        summary.totals.passed,
+        summary.totals.failed,
+        summary.totals.duration_ms
+    );
+    println!(
+        "video_gate: core qualification finished passed={} failed={} duration_ms={}",
+        summary.totals.passed, summary.totals.failed, summary.totals.duration_ms
+    );
+    summary
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn gate_core_matrix() {
+    for case in gate_cases() {
+        if let Err(e) = run_case(&case) {
+            panic!(
+                "video gate case {:?} failed ({} steps): {e}",
+                case.name,
+                case.steps.len()
+            );
+        }
+    }
+}
+
+#[test]
+fn gate_deterministic_long_sequence() {
+    let applied = run_long_sequence().unwrap_or_else(|e| panic!("long sequence failed: {e}"));
+    assert!(applied >= 1000, "sequence must span thousands of commands");
+}
+
+#[test]
+fn gate_randomized_commands() {
+    // Seeds run sequentially, each on a fresh model: bounded memory.
+    for seed in seeds_under_test() {
+        if let Err(e) = run_random_seed(seed, RANDOM_COMMANDS_PER_SEED) {
+            panic!("{e}");
+        }
+    }
+}
+
+#[test]
+fn gate_core_qualification_artifact() {
+    let out_dir = std::env::temp_dir().join("plexi-video-gate");
+    let summary = run_core_qualification(&out_dir);
+    assert_eq!(
+        summary.totals.failed,
+        0,
+        "core qualification reported failures; see {}",
+        out_dir.join("video-gate-core.json").display()
+    );
+    assert!(out_dir.join("video-gate-core.json").is_file());
+}
+
+#[test]
+fn gate_minimizer_shrinks_reproducible_failures() {
+    // Sanity for the minimizer itself: a healthy sequence has no failure to
+    // reproduce, so the greedy pass must return it unchanged and say so.
+    let commands = vec![source("a.mp4", 1000), VideoCommand::Undo];
+    let (kept, message) = minimize(commands.clone());
+    assert_eq!(kept, commands, "healthy sequences must come back unchanged");
+    assert!(message.contains("did not reproduce"));
+}
+
+#[test]
+fn gate_serialization_round_trip() {
+    // Nontrivial project built through commands only, then
+    // serialize → deserialize → serialize must be byte-identical.
+    let mut model = VideoModel::new();
+    for command in [
+        source("a.mp4", 10_000),
+        VideoCommand::AddSource {
+            path: "b.mp4".to_string(),
+            duration: 5_000,
+            fps: Fps {
+                num: 30_000,
+                den: 1001,
+            },
+        },
+        vclip(1, 0, 2000, 0),
+        vclip(2, 1000, 3000, 2000),
+        aclip(1, 0, 4000, 0),
+        VideoCommand::TrimIn {
+            clip: ClipId(3),
+            source_in: 500,
+        },
+        VideoCommand::SplitAt {
+            clip: ClipId(4),
+            time: 3000,
+        },
+    ] {
+        assert_eq!(model.apply(command), ApplyOutcome::Applied);
+    }
+    let json1 = model.project().to_json().expect("serialize");
+    let restored = Project::from_json(&json1).expect("deserialize");
+    assert_eq!(&restored, model.project(), "semantic equality after round trip");
+    let json2 = restored.to_json().expect("re-serialize");
+    assert_eq!(json1, json2, "round trip must be byte-identical");
+}
+
+#[test]
+fn gate_restore_from_parts() {
+    // The load half of persistence: a model rebuilt from decoded project +
+    // playhead/selection must carry the exact state, satisfy invariants,
+    // clear a dangling selection, and accept further edits with fresh
+    // history and monotonic id allocation.
+    let mut model = VideoModel::new();
+    for command in [
+        source("a.mp4", 10_000),
+        vclip(1, 0, 1000, 0),
+        sel(2),
+        VideoCommand::SetPlayhead { position: 700 },
+    ] {
+        assert_eq!(model.apply(command), ApplyOutcome::Applied);
+    }
+    let json = model.project().to_json().expect("serialize");
+    let decoded = Project::from_json(&json).expect("deserialize");
+    let mut restored = VideoModel::from_parts(decoded.clone(), model.playhead(), model.selection());
+    assert_eq!(restored.project(), model.project());
+    assert_eq!(restored.playhead(), 700);
+    assert_eq!(restored.selection(), Some(ClipId(2)));
+    assert_eq!(restored.undo_depth(), 0, "undo never spans sessions");
+    check_invariants(&restored, 0).expect("restored model must satisfy invariants");
+    assert_eq!(restored.apply(vclip(1, 0, 1000, 2000)), ApplyOutcome::Applied);
+    assert!(
+        restored.project().find_clip(ClipId(3)).is_some(),
+        "id allocation resumes past restored ids"
+    );
+    // A persisted selection that no longer resolves is cleared on restore.
+    let dangling = VideoModel::from_parts(decoded, 0, Some(ClipId(99)));
+    assert_eq!(dangling.selection(), None);
+}

--- a/crates/video-model/src/history.rs
+++ b/crates/video-model/src/history.rs
@@ -1,0 +1,63 @@
+//! Snapshot-based grouped undo/redo.
+//!
+//! Mirrors `plexi-daw-model`'s history minus coalescing: the video model
+//! has no continuous controls, so every applied edit is one undo group.
+//! Each group stores a full clone of the project data (never playhead or
+//! selection).
+
+use crate::model::Project;
+
+/// Maximum retained undo groups; the oldest group is dropped beyond this.
+pub const MAX_GROUPS: usize = 500;
+
+/// Undo/redo stacks of project snapshots. Each entry is the project state
+/// *before* one user-visible undo step; recording clears the redo stack.
+#[derive(Debug, Clone, Default)]
+pub struct SnapshotHistory {
+    undo_stack: Vec<Project>,
+    redo_stack: Vec<Project>,
+}
+
+impl SnapshotHistory {
+    /// Records the pre-edit snapshot of one applied edit. Any record
+    /// invalidates the redo stack.
+    pub fn record(&mut self, snapshot: Project) {
+        self.redo_stack.clear();
+        self.undo_stack.push(snapshot);
+        if self.undo_stack.len() > MAX_GROUPS {
+            self.undo_stack.remove(0);
+        }
+    }
+
+    /// Pops the top undo snapshot, pushing `current` onto the redo stack.
+    /// `None` when there is nothing to undo.
+    pub fn undo(&mut self, current: &Project) -> Option<Project> {
+        let snapshot = self.undo_stack.pop()?;
+        self.redo_stack.push(current.clone());
+        Some(snapshot)
+    }
+
+    /// Pops the top redo snapshot, pushing `current` onto the undo stack.
+    /// `None` when there is nothing to redo.
+    pub fn redo(&mut self, current: &Project) -> Option<Project> {
+        let snapshot = self.redo_stack.pop()?;
+        self.undo_stack.push(current.clone());
+        Some(snapshot)
+    }
+
+    #[must_use]
+    pub fn can_undo(&self) -> bool {
+        !self.undo_stack.is_empty()
+    }
+
+    #[must_use]
+    pub fn can_redo(&self) -> bool {
+        !self.redo_stack.is_empty()
+    }
+
+    /// Number of undoable groups.
+    #[must_use]
+    pub fn undo_depth(&self) -> usize {
+        self.undo_stack.len()
+    }
+}

--- a/crates/video-model/src/lib.rs
+++ b/crates/video-model/src/lib.rs
@@ -1,0 +1,23 @@
+//! Pure video-editor edit model (stint 0523): commands in, state out.
+//!
+//! Zero egui, zero host types, zero I/O. The model owns project data
+//! (sources plus exactly two fixed tracks — video and audio), a playhead
+//! and selection, snapshot-based undo/redo, and a monotonic revision
+//! counter. The export substrate is [`Project::cut_list`]. Unit conversion
+//! to frames is the downstream engine's concern.
+//!
+//! Sibling crate: `plexi-daw-model` (stint 0514) shares the same module
+//! shape and conventions.
+
+pub mod commands;
+pub mod history;
+pub mod model;
+
+mod gate;
+
+pub use commands::{ApplyOutcome, VideoCommand};
+pub use history::{SnapshotHistory, MAX_GROUPS};
+pub use model::{
+    Clip, ClipId, CutEntry, Fps, Project, Source, SourceId, Track, TrackKind, VideoModel,
+    TICKS_PER_SECOND,
+};

--- a/crates/video-model/src/lib.rs
+++ b/crates/video-model/src/lib.rs
@@ -18,6 +18,6 @@ mod gate;
 pub use commands::{ApplyOutcome, VideoCommand};
 pub use history::{SnapshotHistory, MAX_GROUPS};
 pub use model::{
-    Clip, ClipId, CutEntry, Fps, Project, Source, SourceId, Track, TrackKind, VideoModel,
-    TICKS_PER_SECOND,
+    Clip, ClipId, CutEntry, Fps, Project, Source, SourceId, Track, TrackKind, ValidationError,
+    VideoModel, TICKS_PER_SECOND,
 };

--- a/crates/video-model/src/model.rs
+++ b/crates/video-model/src/model.rs
@@ -1,0 +1,671 @@
+//! Video-editor project state and the pure `apply` state machine.
+//!
+//! [`Project`] is the serialized project data (sources, the two fixed
+//! tracks, id counter). [`VideoModel`] wraps it with the playhead,
+//! selection, revision counter, and snapshot history — none of which belong
+//! in the serialized project or in undo snapshots.
+
+use serde::{Deserialize, Serialize};
+
+use crate::commands::{ApplyOutcome, VideoCommand};
+use crate::history::SnapshotHistory;
+
+/// Timeline resolution: all video-model times are `u64` ticks at this rate
+/// (a millisecond timeline). Conversion to frames is the downstream
+/// engine's concern.
+pub const TICKS_PER_SECOND: u64 = 1000;
+
+// ─── Ids ─────────────────────────────────────────────────────────────────────
+
+/// Newtype ids allocated by [`Project::next_id`]; never reused, even across
+/// undo (the counter survives snapshot restores).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct ClipId(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct SourceId(pub u64);
+
+// ─── Project data ────────────────────────────────────────────────────────────
+
+/// v1 has exactly two fixed tracks; this addresses them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TrackKind {
+    Video,
+    Audio,
+}
+
+/// Exact rational frame rate (e.g. 30000/1001). Both terms are > 0.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Fps {
+    pub num: u32,
+    pub den: u32,
+}
+
+/// A media source. `duration` is in ticks.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Source {
+    pub id: SourceId,
+    pub path: String,
+    pub duration: u64,
+    pub fps: Fps,
+}
+
+/// A clip on the timeline. Timeline length is `source_out - source_in`
+/// (no retime in v1); `source_in < source_out <= source.duration`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Clip {
+    pub id: ClipId,
+    pub source: SourceId,
+    pub source_in: u64,
+    pub source_out: u64,
+    /// Timeline start, in ticks.
+    pub position: u64,
+}
+
+impl Clip {
+    /// Timeline (and source-window) length; invariants keep `in < out`.
+    #[must_use]
+    pub fn length(&self) -> u64 {
+        self.source_out.saturating_sub(self.source_in)
+    }
+
+    /// Exclusive timeline end; invariants keep this overflow-free.
+    #[must_use]
+    pub fn timeline_end(&self) -> u64 {
+        self.position.saturating_add(self.length())
+    }
+}
+
+/// One fixed track. v1 has exactly two ([`Project::video`],
+/// [`Project::audio`]) — a struct field each, never a growable list.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Track {
+    pub clips: Vec<Clip>,
+}
+
+/// One entry of the export cut list — the substrate for `media.export`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CutEntry {
+    pub source_path: String,
+    pub source_in: u64,
+    pub source_out: u64,
+    pub position: u64,
+}
+
+/// Serialized project data — exactly what undo snapshots clone and what
+/// [`Project::to_json`] emits. Playhead, selection, revision, and history
+/// live on [`VideoModel`], outside this struct.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Project {
+    pub sources: Vec<Source>,
+    pub video: Track,
+    pub audio: Track,
+    /// Monotonic id allocator; part of serialized state, preserved across
+    /// undo/redo so ids are never reused.
+    pub next_id: u64,
+}
+
+impl Default for Project {
+    fn default() -> Self {
+        Self {
+            sources: Vec::new(),
+            video: Track::default(),
+            audio: Track::default(),
+            next_id: 1,
+        }
+    }
+}
+
+impl Project {
+    /// Pretty JSON of the project data. Errors name the failure.
+    pub fn to_json(&self) -> Result<String, String> {
+        serde_json::to_string_pretty(self)
+            .map_err(|e| format!("video project serialization failed: {e}"))
+    }
+
+    pub fn from_json(json: &str) -> Result<Self, String> {
+        serde_json::from_str(json)
+            .map_err(|e| format!("video project deserialization failed: {e}"))
+    }
+
+    #[must_use]
+    pub fn track(&self, kind: TrackKind) -> &Track {
+        match kind {
+            TrackKind::Video => &self.video,
+            TrackKind::Audio => &self.audio,
+        }
+    }
+
+    fn track_mut(&mut self, kind: TrackKind) -> &mut Track {
+        match kind {
+            TrackKind::Video => &mut self.video,
+            TrackKind::Audio => &mut self.audio,
+        }
+    }
+
+    #[must_use]
+    pub fn source(&self, id: SourceId) -> Option<&Source> {
+        self.sources.iter().find(|s| s.id == id)
+    }
+
+    /// Locates a clip as `(track, clip index)`.
+    #[must_use]
+    pub fn find_clip(&self, id: ClipId) -> Option<(TrackKind, usize)> {
+        for kind in [TrackKind::Video, TrackKind::Audio] {
+            if let Some(index) = self.track(kind).clips.iter().position(|c| c.id == id) {
+                return Some((kind, index));
+            }
+        }
+        None
+    }
+
+    /// Total clips across both tracks.
+    #[must_use]
+    pub fn clip_count(&self) -> usize {
+        self.video.clips.len() + self.audio.clips.len()
+    }
+
+    /// The export cut list for one track: every clip resolved to its source
+    /// path and window, sorted by timeline position. Pure derivation — the
+    /// substrate for `media.export`.
+    #[must_use]
+    pub fn cut_list(&self, track: TrackKind) -> Vec<CutEntry> {
+        let mut entries: Vec<CutEntry> = self
+            .track(track)
+            .clips
+            .iter()
+            .filter_map(|clip| match self.source(clip.source) {
+                Some(source) => Some(CutEntry {
+                    source_path: source.path.clone(),
+                    source_in: clip.source_in,
+                    source_out: clip.source_out,
+                    position: clip.position,
+                }),
+                None => {
+                    // Unreachable while invariants hold; never silently
+                    // fabricate an entry for a dangling reference.
+                    log::error!(
+                        "cut_list: clip {} references missing source {}",
+                        clip.id.0,
+                        clip.source.0
+                    );
+                    None
+                }
+            })
+            .collect();
+        entries.sort_by_key(|e| e.position);
+        entries
+    }
+
+    fn alloc_id(&mut self) -> u64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+
+    /// Returns the exclusive timeline end of `[position, position+length)`
+    /// after checking overflow and overlap against every clip on `kind`
+    /// other than `exclude`.
+    fn check_placement(
+        &self,
+        what: &str,
+        kind: TrackKind,
+        position: u64,
+        length: u64,
+        exclude: Option<ClipId>,
+    ) -> Result<u64, String> {
+        let end = position.checked_add(length).ok_or_else(|| {
+            format!("{what}: position {position} + length {length} overflows u64")
+        })?;
+        for clip in &self.track(kind).clips {
+            if Some(clip.id) == exclude {
+                continue;
+            }
+            if position < clip.timeline_end() && clip.position < end {
+                return Err(format!(
+                    "{what}: [{position}, {end}) overlaps clip {} at [{}, {})",
+                    clip.id.0,
+                    clip.position,
+                    clip.timeline_end()
+                ));
+            }
+        }
+        Ok(end)
+    }
+}
+
+// ─── Model ───────────────────────────────────────────────────────────────────
+
+/// The video edit model: project data plus playhead, selection, revision,
+/// and history. Commands in ([`VideoCommand`]), state out — no I/O, no
+/// rendering.
+#[derive(Debug, Clone, Default)]
+pub struct VideoModel {
+    project: Project,
+    /// Not undoable, never snapshotted; changes bump the revision.
+    playhead: u64,
+    /// Not undoable, never snapshotted. Always points at an existing clip
+    /// (restores that would dangle it clear it instead).
+    selection: Option<ClipId>,
+    /// Monotonic change counter, bumped on every `Applied` outcome
+    /// (including undo/redo and playhead/selection changes). Starts at 0.
+    revision: u64,
+    history: SnapshotHistory,
+}
+
+impl VideoModel {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Restores a model from decoded state — the load half of persistence
+    /// ([`Project::from_json`] plus the caller-persisted playhead and
+    /// selection). A selection that no longer resolves to a clip is cleared
+    /// (same rule as undo restores). History starts empty and the revision
+    /// at 0: undo never spans sessions, and the revision counts changes
+    /// within one session only.
+    #[must_use]
+    pub fn from_parts(project: Project, playhead: u64, selection: Option<ClipId>) -> Self {
+        let mut model = Self {
+            project,
+            playhead,
+            selection,
+            revision: 0,
+            history: SnapshotHistory::default(),
+        };
+        model.prune_dangling_selection();
+        model
+    }
+
+    #[must_use]
+    pub fn project(&self) -> &Project {
+        &self.project
+    }
+
+    #[must_use]
+    pub fn playhead(&self) -> u64 {
+        self.playhead
+    }
+
+    #[must_use]
+    pub fn selection(&self) -> Option<ClipId> {
+        self.selection
+    }
+
+    #[must_use]
+    pub fn revision(&self) -> u64 {
+        self.revision
+    }
+
+    #[must_use]
+    pub fn can_undo(&self) -> bool {
+        self.history.can_undo()
+    }
+
+    #[must_use]
+    pub fn can_redo(&self) -> bool {
+        self.history.can_redo()
+    }
+
+    #[must_use]
+    pub fn undo_depth(&self) -> usize {
+        self.history.undo_depth()
+    }
+
+    /// Applies one command. See [`ApplyOutcome`] for the contract; on
+    /// `Rejected` the model is untouched.
+    pub fn apply(&mut self, cmd: VideoCommand) -> ApplyOutcome {
+        match cmd {
+            VideoCommand::AddSource { path, duration, fps } => {
+                self.add_source(path, duration, fps)
+            }
+            VideoCommand::RemoveSource { source } => self.remove_source(source),
+            VideoCommand::AddClip {
+                track,
+                source,
+                source_in,
+                source_out,
+                position,
+            } => self.add_clip(track, source, source_in, source_out, position),
+            VideoCommand::RemoveClip { clip } => self.remove_clip(clip),
+            VideoCommand::RippleDelete { clip } => self.ripple_delete(clip),
+            VideoCommand::MoveClip { clip, position } => self.move_clip(clip, position),
+            VideoCommand::TrimIn { clip, source_in } => self.trim_in(clip, source_in),
+            VideoCommand::TrimOut { clip, source_out } => self.trim_out(clip, source_out),
+            VideoCommand::SplitAt { clip, time } => self.split_at(clip, time),
+            VideoCommand::SetPlayhead { position } => self.set_playhead(position),
+            VideoCommand::Select { clip } => self.select(clip),
+            VideoCommand::Undo => self.undo(),
+            VideoCommand::Redo => self.redo(),
+        }
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────────
+
+    /// Records the pre-edit snapshot for one undoable edit.
+    fn record(&mut self) {
+        self.history.record(self.project.clone());
+    }
+
+    fn applied(&mut self) -> ApplyOutcome {
+        self.revision += 1;
+        ApplyOutcome::Applied
+    }
+
+    /// Clears the selection when it no longer points at an existing clip.
+    fn prune_dangling_selection(&mut self) {
+        if let Some(id) = self.selection {
+            if self.project.find_clip(id).is_none() {
+                self.selection = None;
+            }
+        }
+    }
+
+    fn add_source(&mut self, path: String, duration: u64, fps: Fps) -> ApplyOutcome {
+        if fps.num == 0 || fps.den == 0 {
+            return ApplyOutcome::Rejected(format!(
+                "AddSource: fps {}/{} must have both terms > 0",
+                fps.num, fps.den
+            ));
+        }
+        self.record();
+        let id = SourceId(self.project.alloc_id());
+        self.project.sources.push(Source {
+            id,
+            path,
+            duration,
+            fps,
+        });
+        self.applied()
+    }
+
+    /// Removes the source and every clip referencing it on both tracks —
+    /// one undo group behind a single pre-edit snapshot.
+    fn remove_source(&mut self, source: SourceId) -> ApplyOutcome {
+        let Some(index) = self.project.sources.iter().position(|s| s.id == source) else {
+            return ApplyOutcome::Rejected(format!("RemoveSource: no source {}", source.0));
+        };
+        self.record();
+        self.project.sources.remove(index);
+        self.project.video.clips.retain(|c| c.source != source);
+        self.project.audio.clips.retain(|c| c.source != source);
+        self.prune_dangling_selection();
+        self.applied()
+    }
+
+    /// Validates one source window: `source_in < source_out <= duration`.
+    fn check_window(
+        what: &str,
+        source: &Source,
+        source_in: u64,
+        source_out: u64,
+    ) -> Result<(), ApplyOutcome> {
+        if source_in >= source_out {
+            return Err(ApplyOutcome::Rejected(format!(
+                "{what}: source_in {source_in} must be < source_out {source_out}"
+            )));
+        }
+        if source_out > source.duration {
+            return Err(ApplyOutcome::Rejected(format!(
+                "{what}: source_out {source_out} exceeds source {} duration {}",
+                source.id.0, source.duration
+            )));
+        }
+        Ok(())
+    }
+
+    fn add_clip(
+        &mut self,
+        track: TrackKind,
+        source: SourceId,
+        source_in: u64,
+        source_out: u64,
+        position: u64,
+    ) -> ApplyOutcome {
+        let Some(src) = self.project.source(source) else {
+            return ApplyOutcome::Rejected(format!("AddClip: no source {}", source.0));
+        };
+        if let Err(rejected) = Self::check_window("AddClip", src, source_in, source_out) {
+            return rejected;
+        }
+        if let Err(e) =
+            self.project
+                .check_placement("AddClip", track, position, source_out - source_in, None)
+        {
+            return ApplyOutcome::Rejected(e);
+        }
+        self.record();
+        let id = ClipId(self.project.alloc_id());
+        self.project.track_mut(track).clips.push(Clip {
+            id,
+            source,
+            source_in,
+            source_out,
+            position,
+        });
+        self.applied()
+    }
+
+    fn remove_clip(&mut self, clip: ClipId) -> ApplyOutcome {
+        let Some((track, index)) = self.project.find_clip(clip) else {
+            return ApplyOutcome::Rejected(format!("RemoveClip: no clip {}", clip.0));
+        };
+        self.record();
+        self.project.track_mut(track).clips.remove(index);
+        self.prune_dangling_selection();
+        self.applied()
+    }
+
+    fn ripple_delete(&mut self, clip: ClipId) -> ApplyOutcome {
+        let Some((track, index)) = self.project.find_clip(clip) else {
+            return ApplyOutcome::Rejected(format!("RippleDelete: no clip {}", clip.0));
+        };
+        let removed = self.project.track(track).clips[index].clone();
+        let length = removed.length();
+        // Defensive pre-check: with no overlaps, every later clip starts at
+        // or after the removed clip's end, so the shift can never
+        // underflow. Reject loudly instead of wrapping if that ever breaks.
+        for later in &self.project.track(track).clips {
+            if later.id != removed.id
+                && later.position > removed.position
+                && later.position.checked_sub(length).is_none()
+            {
+                return ApplyOutcome::Rejected(format!(
+                    "RippleDelete: shifting clip {} by {length} would underflow",
+                    later.id.0
+                ));
+            }
+        }
+        self.record();
+        let clips = &mut self.project.track_mut(track).clips;
+        clips.remove(index);
+        for later in clips.iter_mut() {
+            if later.position > removed.position {
+                later.position -= length;
+            }
+        }
+        self.prune_dangling_selection();
+        self.applied()
+    }
+
+    fn move_clip(&mut self, clip: ClipId, position: u64) -> ApplyOutcome {
+        let Some((track, index)) = self.project.find_clip(clip) else {
+            return ApplyOutcome::Rejected(format!("MoveClip: no clip {}", clip.0));
+        };
+        let current = self.project.track(track).clips[index].clone();
+        if current.position == position {
+            return ApplyOutcome::NoOp;
+        }
+        if let Err(e) = self.project.check_placement(
+            "MoveClip",
+            track,
+            position,
+            current.length(),
+            Some(clip),
+        ) {
+            return ApplyOutcome::Rejected(e);
+        }
+        self.record();
+        self.project.track_mut(track).clips[index].position = position;
+        self.applied()
+    }
+
+    fn trim_in(&mut self, clip: ClipId, source_in: u64) -> ApplyOutcome {
+        let Some((track, index)) = self.project.find_clip(clip) else {
+            return ApplyOutcome::Rejected(format!("TrimIn: no clip {}", clip.0));
+        };
+        let current = self.project.track(track).clips[index].clone();
+        if source_in == current.source_in {
+            return ApplyOutcome::NoOp;
+        }
+        if source_in >= current.source_out {
+            return ApplyOutcome::Rejected(format!(
+                "TrimIn: source_in {source_in} must be < source_out {}",
+                current.source_out
+            ));
+        }
+        // Content stays timeline-aligned: the position shifts by the same
+        // delta as the in point.
+        let new_position = if source_in >= current.source_in {
+            current.position.checked_add(source_in - current.source_in)
+        } else {
+            current.position.checked_sub(current.source_in - source_in)
+        };
+        let Some(new_position) = new_position else {
+            return ApplyOutcome::Rejected(format!(
+                "TrimIn: shifting position {} by the in-point delta under/overflows",
+                current.position
+            ));
+        };
+        let new_length = current.source_out - source_in;
+        if let Err(e) = self.project.check_placement(
+            "TrimIn",
+            track,
+            new_position,
+            new_length,
+            Some(clip),
+        ) {
+            return ApplyOutcome::Rejected(e);
+        }
+        self.record();
+        let target = &mut self.project.track_mut(track).clips[index];
+        target.source_in = source_in;
+        target.position = new_position;
+        self.applied()
+    }
+
+    fn trim_out(&mut self, clip: ClipId, source_out: u64) -> ApplyOutcome {
+        let Some((track, index)) = self.project.find_clip(clip) else {
+            return ApplyOutcome::Rejected(format!("TrimOut: no clip {}", clip.0));
+        };
+        let current = self.project.track(track).clips[index].clone();
+        if source_out == current.source_out {
+            return ApplyOutcome::NoOp;
+        }
+        let Some(src) = self.project.source(current.source) else {
+            return ApplyOutcome::Rejected(format!(
+                "TrimOut: clip {} references missing source {}",
+                clip.0, current.source.0
+            ));
+        };
+        if let Err(rejected) = Self::check_window("TrimOut", src, current.source_in, source_out) {
+            return rejected;
+        }
+        if let Err(e) = self.project.check_placement(
+            "TrimOut",
+            track,
+            current.position,
+            source_out - current.source_in,
+            Some(clip),
+        ) {
+            return ApplyOutcome::Rejected(e);
+        }
+        self.record();
+        self.project.track_mut(track).clips[index].source_out = source_out;
+        self.applied()
+    }
+
+    fn split_at(&mut self, clip: ClipId, time: u64) -> ApplyOutcome {
+        let Some((track, index)) = self.project.find_clip(clip) else {
+            return ApplyOutcome::Rejected(format!("SplitAt: no clip {}", clip.0));
+        };
+        let current = self.project.track(track).clips[index].clone();
+        let end = current.timeline_end();
+        if time <= current.position || time >= end {
+            return ApplyOutcome::Rejected(format!(
+                "SplitAt: time {time} is not strictly inside [{}, {end})",
+                current.position
+            ));
+        }
+        let offset = time - current.position;
+        self.record();
+        // Both halves get fresh ids: ids are never aliased across edits.
+        let left_id = ClipId(self.project.alloc_id());
+        let right_id = ClipId(self.project.alloc_id());
+        let left = Clip {
+            id: left_id,
+            source: current.source,
+            source_in: current.source_in,
+            source_out: current.source_in + offset,
+            position: current.position,
+        };
+        let right = Clip {
+            id: right_id,
+            source: current.source,
+            source_in: current.source_in + offset,
+            source_out: current.source_out,
+            position: time,
+        };
+        let clips = &mut self.project.track_mut(track).clips;
+        clips[index] = left;
+        clips.insert(index + 1, right);
+        if self.selection == Some(clip) {
+            self.selection = Some(left_id);
+        }
+        self.applied()
+    }
+
+    /// Playhead and selection bump the revision but never touch history.
+    fn set_playhead(&mut self, position: u64) -> ApplyOutcome {
+        if self.playhead == position {
+            return ApplyOutcome::NoOp;
+        }
+        self.playhead = position;
+        self.applied()
+    }
+
+    fn select(&mut self, clip: Option<ClipId>) -> ApplyOutcome {
+        if let Some(id) = clip {
+            if self.project.find_clip(id).is_none() {
+                return ApplyOutcome::Rejected(format!("Select: no clip {}", id.0));
+            }
+        }
+        if self.selection == clip {
+            return ApplyOutcome::NoOp;
+        }
+        self.selection = clip;
+        self.applied()
+    }
+
+    fn undo(&mut self) -> ApplyOutcome {
+        let Some(mut snapshot) = self.history.undo(&self.project) else {
+            return ApplyOutcome::NoOp;
+        };
+        // The id allocator is monotonic across undo: ids are never reused.
+        snapshot.next_id = self.project.next_id;
+        self.project = snapshot;
+        self.prune_dangling_selection();
+        self.applied()
+    }
+
+    fn redo(&mut self) -> ApplyOutcome {
+        let Some(mut snapshot) = self.history.redo(&self.project) else {
+            return ApplyOutcome::NoOp;
+        };
+        snapshot.next_id = self.project.next_id;
+        self.project = snapshot;
+        self.prune_dangling_selection();
+        self.applied()
+    }
+}

--- a/crates/video-model/src/model.rs
+++ b/crates/video-model/src/model.rs
@@ -15,6 +15,85 @@ use crate::history::SnapshotHistory;
 /// engine's concern.
 pub const TICKS_PER_SECOND: u64 = 1000;
 
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/// One state-validity violation, typed per violation class.
+///
+/// This is the single validation path for persisted or foreign state:
+/// [`VideoModel::from_parts`] (bundle loading) and the release gate's
+/// invariant checks both run [`Project::validate`] /
+/// [`VideoModel::validate`] — the same rules everywhere, never a second
+/// hand-rolled checker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationError {
+    ZeroFpsTerm { source: SourceId, num: u32, den: u32 },
+    MissingClipSource { clip: ClipId, source: SourceId },
+    EmptyClipWindow { clip: ClipId, source_in: u64, source_out: u64 },
+    ClipWindowExceedsSource { clip: ClipId, source_out: u64, duration: u64 },
+    ClipTimelineOverflow { clip: ClipId },
+    OverlappingClips { track: TrackKind, first: ClipId, second: ClipId },
+    DuplicateId { id: u64 },
+    IdNotBelowNextId { id: u64, next_id: u64 },
+    DanglingSelection { clip: ClipId },
+}
+
+impl std::fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ZeroFpsTerm { source, num, den } => write!(
+                f,
+                "source {} fps {num}/{den} has a zero term",
+                source.0
+            ),
+            Self::MissingClipSource { clip, source } => write!(
+                f,
+                "clip {} references missing source {}",
+                clip.0, source.0
+            ),
+            Self::EmptyClipWindow {
+                clip,
+                source_in,
+                source_out,
+            } => write!(
+                f,
+                "clip {} window {source_in}..{source_out} is empty or inverted",
+                clip.0
+            ),
+            Self::ClipWindowExceedsSource {
+                clip,
+                source_out,
+                duration,
+            } => write!(
+                f,
+                "clip {} window end {source_out} exceeds source duration {duration}",
+                clip.0
+            ),
+            Self::ClipTimelineOverflow { clip } => {
+                write!(f, "clip {} timeline end overflows u64", clip.0)
+            }
+            Self::OverlappingClips {
+                track,
+                first,
+                second,
+            } => write!(
+                f,
+                "{track:?} clips {} and {} overlap on the timeline",
+                first.0, second.0
+            ),
+            Self::DuplicateId { id } => write!(f, "duplicate entity id {id}"),
+            Self::IdNotBelowNextId { id, next_id } => write!(
+                f,
+                "id {id} >= next_id {next_id}; allocator lost monotonicity"
+            ),
+            Self::DanglingSelection { clip } => {
+                write!(f, "selection points at missing clip {}", clip.0)
+            }
+        }
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
 // ─── Ids ─────────────────────────────────────────────────────────────────────
 
 /// Newtype ids allocated by [`Project::next_id`]; never reused, even across
@@ -100,8 +179,14 @@ pub struct Project {
     pub sources: Vec<Source>,
     pub video: Track,
     pub audio: Track,
-    /// Monotonic id allocator; part of serialized state, preserved across
-    /// undo/redo so ids are never reused.
+    /// Monotonic id allocator; part of serialized state, deliberately NOT
+    /// restored by undo/redo. Restoring it would let a post-undo edit mint
+    /// an id aliasing one already handed to external holders (assistant
+    /// tools, UI) from the undone branch — a stale reference would silently
+    /// rebind to a new object instead of failing as dangling. Monotonic ids
+    /// keep staleness detectable, and `next_id` stays a deterministic
+    /// function of the applied command history, so bundle serialization
+    /// stays deterministic.
     pub next_id: u64,
 }
 
@@ -197,6 +282,86 @@ impl Project {
         entries
     }
 
+    /// Full state-validity check over the project data: per-track overlap
+    /// freedom, source references, window and overflow geometry, fps
+    /// terms, id uniqueness and allocator monotonicity. The single shared
+    /// path for bundle loading ([`VideoModel::from_parts`]) and the
+    /// release gate's invariants.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        for source in &self.sources {
+            if source.fps.num == 0 || source.fps.den == 0 {
+                return Err(ValidationError::ZeroFpsTerm {
+                    source: source.id,
+                    num: source.fps.num,
+                    den: source.fps.den,
+                });
+            }
+        }
+        let mut ids: Vec<u64> = self.sources.iter().map(|s| s.id.0).collect();
+        for kind in [TrackKind::Video, TrackKind::Audio] {
+            let track = self.track(kind);
+            for clip in &track.clips {
+                ids.push(clip.id.0);
+                let Some(source) = self.source(clip.source) else {
+                    return Err(ValidationError::MissingClipSource {
+                        clip: clip.id,
+                        source: clip.source,
+                    });
+                };
+                if clip.source_in >= clip.source_out {
+                    return Err(ValidationError::EmptyClipWindow {
+                        clip: clip.id,
+                        source_in: clip.source_in,
+                        source_out: clip.source_out,
+                    });
+                }
+                if clip.source_out > source.duration {
+                    return Err(ValidationError::ClipWindowExceedsSource {
+                        clip: clip.id,
+                        source_out: clip.source_out,
+                        duration: source.duration,
+                    });
+                }
+                if clip
+                    .position
+                    .checked_add(clip.source_out - clip.source_in)
+                    .is_none()
+                {
+                    return Err(ValidationError::ClipTimelineOverflow { clip: clip.id });
+                }
+            }
+            // No overlaps within a track: sort by position, check neighbors.
+            let mut spans: Vec<(u64, u64, u64)> = track
+                .clips
+                .iter()
+                .map(|c| (c.position, c.timeline_end(), c.id.0))
+                .collect();
+            spans.sort_unstable();
+            for pair in spans.windows(2) {
+                if pair[1].0 < pair[0].1 {
+                    return Err(ValidationError::OverlappingClips {
+                        track: kind,
+                        first: ClipId(pair[0].2),
+                        second: ClipId(pair[1].2),
+                    });
+                }
+            }
+        }
+        ids.sort_unstable();
+        if let Some(pair) = ids.windows(2).find(|w| w[0] == w[1]) {
+            return Err(ValidationError::DuplicateId { id: pair[0] });
+        }
+        if let Some(&max) = ids.last() {
+            if max >= self.next_id {
+                return Err(ValidationError::IdNotBelowNextId {
+                    id: max,
+                    next_id: self.next_id,
+                });
+            }
+        }
+        Ok(())
+    }
+
     fn alloc_id(&mut self) -> u64 {
         let id = self.next_id;
         self.next_id += 1;
@@ -261,21 +426,42 @@ impl VideoModel {
 
     /// Restores a model from decoded state — the load half of persistence
     /// ([`Project::from_json`] plus the caller-persisted playhead and
-    /// selection). A selection that no longer resolves to a clip is cleared
-    /// (same rule as undo restores). History starts empty and the revision
-    /// at 0: undo never spans sessions, and the revision counts changes
-    /// within one session only.
-    #[must_use]
-    pub fn from_parts(project: Project, playhead: u64, selection: Option<ClipId>) -> Self {
-        let mut model = Self {
+    /// selection). Rejects invariant-violating state (corrupted or
+    /// hand-edited bundles) through the shared [`Project::validate`] path;
+    /// a persisted selection that does not resolve to a clip is likewise
+    /// rejected ([`ValidationError::DanglingSelection`]) — the constructor
+    /// never repairs invalid input (silent pruning is reserved for live
+    /// transitions like undo, where the model itself made the clip
+    /// disappear). History starts empty and the revision at 0: undo never
+    /// spans sessions, and the revision counts changes within one session
+    /// only.
+    pub fn from_parts(
+        project: Project,
+        playhead: u64,
+        selection: Option<ClipId>,
+    ) -> Result<Self, ValidationError> {
+        let model = Self {
             project,
             playhead,
             selection,
             revision: 0,
             history: SnapshotHistory::default(),
         };
-        model.prune_dangling_selection();
-        model
+        model.validate()?;
+        Ok(model)
+    }
+
+    /// Full state-validity check over project data plus the selection —
+    /// the same rules [`from_parts`](Self::from_parts) enforces on load
+    /// and the release gate re-checks after every command.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        self.project.validate()?;
+        if let Some(selected) = self.selection {
+            if self.project.find_clip(selected).is_none() {
+                return Err(ValidationError::DanglingSelection { clip: selected });
+            }
+        }
+        Ok(())
     }
 
     #[must_use]


### PR DESCRIPTION
## Summary

Implements stints 0514 and 0523. No linked GitHub issue — stint is authoritative.

Two sibling pure workspace crates modeled on the notes editor's `Document` (`src/editor/gate.rs` pattern): pure state machines, zero egui/host dependency, no I/O. Commands in, state out — every mutation is a named command so the assistant tool surface (0517) and the UI (0516) drive the identical model.

**`crates/daw-model` — `plexi-daw-model` (stint 0514)**
- Tracks (audio + MIDI), clips (position/length/source ref/trim offset in u64 ticks, `TICKS_PER_BEAT = 960`), per-track mixer (volume/pan/mute/solo, finite + clamped), transport (play/stop/seek/loop — revision-bumping but not undoable), tempo.
- `DawCommand`: SetTempo, AddTrack, RemoveTrack, RenameTrack, AddSource, RemoveSource (cascades clips, one undo group), AddClip, RemoveClip, MoveClip, ResizeClip, SetTrackVolume, SetTrackPan, SetTrackMute, SetTrackSolo, Play, Stop, Seek, SetLoop, Undo, Redo.
- Consecutive volume/pan sets on the same track coalesce into one undo group.

**`crates/video-model` — `plexi-video-model` (stint 0523)**
- Source refs (path, duration, rational `Fps {num, den}`), fixed two tracks (video + audio, struct fields — the v1 contract), clips (source in/out + timeline position, `TICKS_PER_SECOND = 1000`), playhead/selection (not undoable), strict no-overlap invariant per track.
- `VideoCommand`: AddSource, RemoveSource, AddClip, RemoveClip, RippleDelete, MoveClip, TrimIn (timeline-aligned position shift), TrimOut, SplitAt (fresh ids for both halves), SetPlayhead, Select, Undo, Redo.
- `Project::cut_list(TrackKind) -> Vec<CutEntry>` — the pure export substrate feeding `media.export` (0520), gate-tested against an exact expected list after trim + split + ripple delete.

**Shared architecture (both crates)**
- `apply(cmd) -> ApplyOutcome {Applied, Rejected(String), NoOp}`; Rejected/NoOp leave state, revision, and history untouched.
- Snapshot-based undo/redo capped at 500 groups; monotonic `revision`; ids allocated from a serialized `next_id` and never reused (survives undo/redo).
- Deterministic JSON serialization (`to_json`/`from_json`, Vec-only state) with byte-identical round-trip gate; `from_parts` restore path for decoded projects.
- `#[cfg(test)]` gate mirroring `src/editor/gate.rs`: named `GateCase` tables (29 DAW / 26 video), per-command `check_invariants`, history round trip, deterministic long sequence (>1000 commands, full-undo/full-redo assertions), 8-seed SplitMix64 fuzzer (1500 commands/seed, bounded state, invalid ids/geometry/NaN included) with greedy minimizer + replay bundles, qualification artifacts (`daw-gate-core.json` / `video-gate-core.json`), seed pins `PLEXI_DAW_GATE_SEED` / `PLEXI_VIDEO_GATE_SEED`.

Left deliberately unshared: each crate carries its own test-only PRNG/minimizer copy (like the editor gate). Extracting a shared gate-kit crate is a consolidation candidate once a third model crate exists.

## Done When — 0514
- Pure Rust crate: tracks (audio + MIDI), clips (position, length, source ref, trim offsets), mixer (per-track volume/pan/mute/solo), transport (play/stop/position/loop), tempo/BPM. ✔ (zero egui/host deps — only serde, serde_json, log)
- Command-applied edits with undo/redo history, monotonic revisions, `check_invariants()` (clip bounds, no orphaned source refs, mixer ranges, history consistency). ✔
- Named `GateCase` table + seeded randomized fuzzer with replayable seeds mirroring `gate_cases()` / `DEFAULT_SEEDS`. ✔
- Deterministic serialization of the full model. ✔

## Done When — 0523
- Model: source refs (path + duration + fps), timeline clips (source in/out, timeline position), one video + one audio track, playhead/selection. ✔
- Commands: add clip, split at time, trim in/out, ripple delete, move; undo/redo with monotonic revisions. ✔
- `check_invariants()` (no overlaps, in<out, positions valid, history consistency), `GateCase` table, seeded fuzzer with replayable seeds. ✔
- Deterministic serialization. ✔
- Export cut list derivation. ✔

## Test Evidence

- `env -u PLEXI_* cargo test -p plexi-daw-model -p plexi-video-model`: **14 passed, 0 failed** (`test result: ok. 7 passed; 0 failed` per crate, plus empty doc-test sections) — verified independently by the orchestrator after sub-agent implementation.
- `cargo build -p plexi-daw-model -p plexi-video-model`: clean, zero warnings.
- Codex review vs alpha: 2 runs; run 1 finding (no restore path from decoded JSON) fixed via `from_parts` + gate tests; run 2 clean.
- Diff touches only `crates/`, the workspace `members` line, and `Cargo.lock` — the `plexi` binary does not reference the new crates, so the full bin suite is unaffected (pre-existing alpha failure `send_to_app_pane_injects_text_through_focused_render_input` is tracked separately as task 0537, unrelated).
- Conclusion: install skippable for behavior (nothing user-visible in the installed host); tester round owns any live validation per babysitter flow.
