### PR TITLE
RPC response files: rpc/ subdir, atomic writes, unified poller; ephemeral profile reaper; swallowed-send logging (stints 0536+0534+0535)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Read the relevant PRM first. Use `stint next` for the next claimable task. Stint
 
 ## Logging
 
-Log file: `~/.plexi-<channel>/plexi.log`. Rotates at 10 MB. Level set in `config.toml`.
+Log file: `~/.plexi-<channel>/plexi.log`. Rotation is date-based, not size-based: on startup, a log last modified on a prior day is renamed to `plexi-<YYYY-MM-DD>.log` and dated archives older than `[log] retention_days` (default 30) are pruned — see `rotate_and_prune` in `src/platform/logging.rs`. Level set in `config.toml`.
 
 Every new feature must be instrumented. No new capability, command, or user-visible behavior ships without at least one `info`-level trace.
 

--- a/justfile
+++ b/justfile
@@ -349,6 +349,13 @@ channel-clean channel:
 channel-clean-merged:
     bash scripts/channel-clean-merged.sh
 
+# Reap ephemeral ~/.plexi-* profiles (16-hex hashes, ad-hoc test names) idle
+# for 7+ days. Never touches alpha/beta/main/pr-*/rc-*/src.
+#   just channel-clean-ephemeral --dry-run      — list what would be reaped
+#   just channel-clean-ephemeral --age-days 30  — raise the idle threshold
+channel-clean-ephemeral *args:
+    bash scripts/channel-clean-ephemeral.sh {{args}}
+
 # Remove target/ from worktrees whose branch is already merged to alpha.
 # Safe: never touches active branches.
 clean-stale-targets:

--- a/scripts/channel-clean-ephemeral.sh
+++ b/scripts/channel-clean-ephemeral.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Usage: scripts/channel-clean-ephemeral.sh [--dry-run] [--age-days N]
+# Reaps ephemeral ~/.plexi-* profiles: 16-hex-hash channels (minted by external
+# drive-host tooling via PLEXI_CHANNEL=<hex>) and ad-hoc test leftovers
+# (baseline-*, stint*, *test*). Only dirs untouched for N days (default 7) are
+# reaped, via channel-clean.sh so bins/bundles/completions go too.
+# Never touches the real channels: main (~/.plexi), alpha, beta, pr-*, rc-*, src.
+# Periodic-run candidate: a launchd job in ~/dotfiles/launchd (not created here).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+dry_run=0
+age_days=7
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) dry_run=1; shift ;;
+        --age-days) age_days="${2:?--age-days needs a value}"; shift 2 ;;
+        *) echo "error: unknown argument '$1' (expected --dry-run or --age-days N)"; exit 1 ;;
+    esac
+done
+[[ "$age_days" =~ ^[0-9]+$ ]] || { echo "error: --age-days must be a number, got '$age_days'"; exit 1; }
+
+now=$(date +%s)
+min_age_secs=$(( age_days * 86400 ))
+total_kb=0
+reaped=0
+
+for profile in "$HOME"/.plexi-*/; do
+    [[ -d "$profile" ]] || continue
+    channel=$(basename "$profile" | sed 's/^\.plexi-//')
+
+    # Hard protect list: real channels are never ephemeral, whatever else matches.
+    case "$channel" in
+        alpha|beta|main|src|pr-*|rc-*) continue ;;
+    esac
+
+    # Reap only known-ephemeral shapes: 16-hex hashes and ad-hoc test names.
+    if [[ ! "$channel" =~ ^[0-9a-f]{16}$ ]]; then
+        case "$channel" in
+            baseline-*|stint*|*test*) ;;
+            *) continue ;;
+        esac
+    fi
+
+    # Age by the newest mtime in the profile's top two levels, not the dir
+    # itself: writing plexi.log does not bump the directory mtime, and an
+    # active channel must never look idle.
+    mtime=$(find "$profile" -maxdepth 2 -exec stat -f %m {} + 2>/dev/null | sort -rn | head -1)
+    [[ -n "$mtime" ]] || mtime=$(stat -f %m "$profile")
+    age_secs=$(( now - mtime ))
+    if (( age_secs < min_age_secs )); then
+        echo "Skipping $channel (modified $(( age_secs / 86400 ))d ago, threshold ${age_days}d)"
+        continue
+    fi
+
+    kb=$(du -sk "$profile" | cut -f1)
+    total_kb=$(( total_kb + kb ))
+    reaped=$(( reaped + 1 ))
+    if (( dry_run )); then
+        echo "Would reap $channel ($(( kb / 1024 )) MB, idle $(( age_secs / 86400 ))d)"
+    else
+        echo "Reaping $channel ($(( kb / 1024 )) MB, idle $(( age_secs / 86400 ))d)"
+        "$SCRIPT_DIR/channel-clean.sh" "$channel"
+    fi
+done
+
+if (( reaped == 0 )); then
+    echo "Nothing to reap"
+elif (( dry_run )); then
+    echo "Dry run: $reaped profile(s), $(( total_kb / 1024 )) MB reclaimable"
+else
+    echo "Reaped $reaped profile(s), reclaimed $(( total_kb / 1024 )) MB"
+fi

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -1396,12 +1396,8 @@ impl PlexiApp {
                 }
                 if let Some(rf) = &response_file {
                     let content = value.as_deref().unwrap_or("");
-                    let tmp = format!("{rf}.tmp");
-                    match std::fs::write(&tmp, content).and_then(|_| std::fs::rename(&tmp, rf)) {
-                        Ok(_) => log::info!("notify:action: wrote {:?} to {:?}", content, rf),
-                        Err(e) => {
-                            log::warn!("notify:action: failed to write response file {:?}: {e}", rf)
-                        }
+                    if crate::rpc::write_response(rf, content.as_bytes()) {
+                        log::info!("notify:action: wrote {:?} to {:?}", content, rf);
                     }
                 }
                 // Search all windows for the sender pane — it may not be in the

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -7,18 +7,7 @@ use super::PlexiApp;
 
 const MAX_SLOT_CONTENT_SIZE: usize = 10 * 1024 * 1024;
 
-fn write_json_response(response_file: &str, value: serde_json::Value) {
-    match serde_json::to_string(&value) {
-        Ok(json) => {
-            if let Err(e) = std::fs::write(response_file, json) {
-                log::error!("pane_ipc: could not write response file {response_file:?}: {e}");
-            }
-        }
-        Err(e) => {
-            log::error!("pane_ipc: could not serialize response for {response_file:?}: {e}");
-        }
-    }
-}
+use crate::rpc::{write_json_response, write_response};
 
 fn slot_error(response_file: &str, message: impl Into<String>) {
     write_json_response(
@@ -38,16 +27,6 @@ fn slot_read_error(response_file: &str, message: impl Into<String>) {
             "error": message.into(),
         }),
     );
-}
-
-fn write_bytes_response_atomic(response_file: &str, bytes: &[u8]) {
-    let temp_file = format!("{response_file}.tmp");
-    if let Err(e) = std::fs::write(&temp_file, bytes) {
-        log::error!("pane_ipc: could not write temp response file {temp_file:?}: {e}");
-    } else if let Err(e) = std::fs::rename(&temp_file, response_file) {
-        log::error!("pane_ipc: could not rename temp response file to {response_file:?}: {e}");
-        let _ = std::fs::remove_file(&temp_file);
-    }
 }
 
 fn validate_slot_name(slot_name: &str) -> Result<(), String> {
@@ -296,9 +275,7 @@ impl PlexiApp {
                     }
                 }
                 let json_str = serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string());
-                if let Err(e) = std::fs::write(response_file, &json_str) {
-                    log::error!("pane_ipc: list_panes: could not write response file {response_file:?}: {e}");
-                }
+                write_response(response_file, json_str.as_bytes());
             }
             crate::app_protocol::AppRequest::ListContexts { response_file } => {
                 log::info!(
@@ -323,13 +300,7 @@ impl PlexiApp {
                     })
                     .collect();
                 let json_str = serde_json::to_string(&entries).unwrap_or_else(|_| "[]".to_string());
-                let temp_file = format!("{}.tmp", response_file);
-                if let Err(e) = std::fs::write(&temp_file, &json_str) {
-                    log::error!("pane_ipc: list_contexts: could not write temp response file {temp_file:?}: {e}");
-                } else if let Err(e) = std::fs::rename(&temp_file, &response_file) {
-                    log::error!("pane_ipc: list_contexts: could not rename temp response file to {response_file:?}: {e}");
-                    let _ = std::fs::remove_file(&temp_file);
-                }
+                write_response(response_file, json_str.as_bytes());
             }
             crate::app_protocol::AppRequest::GetPaneInfo {
                 pane_id,
@@ -396,12 +367,7 @@ impl PlexiApp {
                         };
                         let json_str =
                             serde_json::to_string(&info).unwrap_or_else(|_| "{}".to_string());
-                        if let Err(e) = std::fs::write(response_file, &json_str) {
-                            log::error!(
-                                "pane_ipc: get_pane_info: could not write response file {:?}: {e}",
-                                response_file
-                            );
-                        }
+                        write_response(response_file, json_str.as_bytes());
                         found = true;
                         break 'outer;
                     }
@@ -409,9 +375,7 @@ impl PlexiApp {
                 if !found {
                     log::warn!("pane_ipc: get_pane_info: pane_id={pane_id} not found");
                     let json_str = format!("{{\"error\":\"pane {pane_id} not found\"}}");
-                    if let Err(e) = std::fs::write(response_file, &json_str) {
-                        log::error!("pane_ipc: get_pane_info: could not write error response: {e}");
-                    }
+                    write_response(response_file, json_str.as_bytes());
                 }
             }
             crate::app_protocol::AppRequest::GetPreviousPaneInfo {
@@ -490,13 +454,7 @@ impl PlexiApp {
                         format!("{{\"error\":\"not enough pane history (requested step {steps}, found {hits} valid entries)\"}}")
                     }
                 };
-                let temp_file = format!("{}.tmp", response_file);
-                if let Err(e) = std::fs::write(&temp_file, &json_str) {
-                    log::error!("pane_ipc: get_previous_pane_info: could not write temp response file {temp_file:?}: {e}");
-                } else if let Err(e) = std::fs::rename(&temp_file, &response_file) {
-                    log::error!("pane_ipc: get_previous_pane_info: could not rename temp response file to {:?}: {e}", response_file);
-                    let _ = std::fs::remove_file(&temp_file);
-                }
+                write_response(response_file, json_str.as_bytes());
             }
             crate::app_protocol::AppRequest::SlotWrite {
                 pane_id,
@@ -653,7 +611,9 @@ impl PlexiApp {
                     return;
                 };
                 match std::fs::read(&path) {
-                    Ok(bytes) => write_bytes_response_atomic(response_file, &bytes),
+                    Ok(bytes) => {
+                        write_response(response_file, &bytes);
+                    }
                     Err(e) => {
                         slot_read_error(
                             response_file,
@@ -1002,9 +962,7 @@ impl PlexiApp {
                                                     )
                                                 }
                                             };
-                                            if let Err(e) = std::fs::write(rf, &json) {
-                                                log::error!("pane_ipc: spawn_pane: could not write response file: {e}");
-                                            }
+                                            write_response(rf, json.as_bytes());
                                         }
                                         return;
                                     }
@@ -1050,11 +1008,7 @@ impl PlexiApp {
                                         format!("{{\"error\":{}}}", serde_json::json!(msg))
                                     }
                                 };
-                                if let Err(e) = std::fs::write(rf, &json) {
-                                    log::error!(
-                                        "pane_ipc: spawn_pane: could not write response file: {e}"
-                                    );
-                                }
+                                write_response(rf, json.as_bytes());
                             }
                             return;
                         };
@@ -1196,9 +1150,7 @@ impl PlexiApp {
                             )
                         }
                     };
-                    if let Err(e) = std::fs::write(rf, &json) {
-                        log::error!("pane_ipc: spawn_pane: could not write response file: {e}");
-                    }
+                    write_response(rf, json.as_bytes());
                 }
             }
             crate::app_protocol::AppRequest::SendToPane {
@@ -1271,9 +1223,7 @@ impl PlexiApp {
                             serde_json::to_string(msg).unwrap_or_else(|_| format!("\"{msg}\""))
                         ),
                     };
-                    if let Err(e) = std::fs::write(rf, &json) {
-                        log::error!("pane_ipc: send_to_pane: could not write response file: {e}");
-                    }
+                    write_response(rf, json.as_bytes());
                 }
             }
             crate::app_protocol::AppRequest::KeyPane {
@@ -1399,9 +1349,7 @@ impl PlexiApp {
                         Ok(v) => v.to_string(),
                         Err(msg) => serde_json::json!({"error": msg}).to_string(),
                     };
-                    if let Err(e) = std::fs::write(rf, &json) {
-                        log::error!("pane_ipc: key_pane: could not write response file: {e}");
-                    }
+                    write_response(rf, json.as_bytes());
                 }
             }
             crate::app_protocol::AppRequest::DropFile {
@@ -1440,9 +1388,7 @@ impl PlexiApp {
                     Ok(value) => serde_json::json!({"ok": true, "delivery": value}),
                     Err(error) => serde_json::json!({"error": error}),
                 };
-                if let Err(error) = std::fs::write(response_file, json.to_string()) {
-                    log::error!("pane_ipc: drop_file response write failed: {error}");
-                }
+                write_json_response(response_file, json);
                 self.ctx.request_repaint();
             }
             crate::app_protocol::AppRequest::ClickPane {
@@ -1553,9 +1499,7 @@ impl PlexiApp {
                         Ok(v) => v.to_string(),
                         Err(msg) => serde_json::json!({"error": msg}).to_string(),
                     };
-                    if let Err(e) = std::fs::write(rf, &json) {
-                        log::error!("pane_ipc: click_pane: could not write response file: {e}");
-                    }
+                    write_response(rf, json.as_bytes());
                 }
             }
             crate::app_protocol::AppRequest::ClickPaneNode {
@@ -1614,11 +1558,7 @@ impl PlexiApp {
                         Ok(v) => v.to_string(),
                         Err(msg) => serde_json::json!({"error": msg}).to_string(),
                     };
-                    if let Err(e) = std::fs::write(rf, &json) {
-                        log::error!(
-                            "pane_ipc: click_pane_node: could not write response file: {e}"
-                        );
-                    }
+                    write_response(rf, json.as_bytes());
                 }
             }
             crate::app_protocol::AppRequest::CapturePane {
@@ -1700,11 +1640,7 @@ impl PlexiApp {
                     }),
                     Err(msg) => serde_json::json!({"error": msg}).to_string(),
                 };
-                if let Err(e) = std::fs::write(response_file, &json_str) {
-                    log::error!(
-                        "pane_ipc: capture_pane: could not write response file {response_file:?}: {e}"
-                    );
-                }
+                write_response(response_file, json_str.as_bytes());
             }
             crate::app_protocol::AppRequest::Screenshot {
                 pane_id,
@@ -1722,11 +1658,7 @@ impl PlexiApp {
                     let response = serde_json::json!({
                         "error": format!("pane {} not found", pane_id.unwrap_or_default())
                     });
-                    if let Err(e) = std::fs::write(response_file, response.to_string()) {
-                        log::error!(
-                            "pane_ipc: screenshot: could not write response file {response_file:?}: {e}"
-                        );
-                    }
+                    write_json_response(response_file, response);
                 } else {
                     self.pending_screenshots
                         .push(crate::app::screenshot::PendingScreenshot {
@@ -1801,9 +1733,7 @@ impl PlexiApp {
                         }
                     }
                 };
-                if let Err(e) = std::fs::write(response_file, &json_str) {
-                    log::error!("pane_ipc: get_pane_state: could not write response file {response_file:?}: {e}");
-                }
+                write_response(response_file, json_str.as_bytes());
             }
             crate::app_protocol::AppRequest::SendAppAction {
                 pane_id,
@@ -1839,11 +1769,7 @@ impl PlexiApp {
                         Ok(()) => serde_json::json!({"ok": true}).to_string(),
                         Err(msg) => serde_json::json!({"error": msg}).to_string(),
                     };
-                    if let Err(e) = std::fs::write(rf, &json) {
-                        log::error!(
-                            "pane_ipc: send_app_action: could not write response file: {e}"
-                        );
-                    }
+                    write_response(rf, json.as_bytes());
                 }
             }
             crate::app_protocol::AppRequest::SetAgentState {
@@ -1904,13 +1830,7 @@ impl PlexiApp {
                     .filter_map(|pane| pane.agent())
                     .collect();
                 let json_str = serde_json::to_string(&states).unwrap_or_else(|_| "[]".to_string());
-                let temp = format!("{response_file}.tmp");
-                if let Err(e) = std::fs::write(&temp, &json_str) {
-                    log::error!("pane_ipc: get_agent_states: could not write temp file: {e}");
-                } else if let Err(e) = std::fs::rename(&temp, response_file) {
-                    log::error!("pane_ipc: get_agent_states: rename failed: {e}");
-                    let _ = std::fs::remove_file(&temp);
-                }
+                write_response(response_file, json_str.as_bytes());
             }
             crate::app_protocol::AppRequest::Notify {
                 level,
@@ -2126,13 +2046,7 @@ impl PlexiApp {
                             "context_id": new_ctx_id,
                             "windows": windows_info,
                         });
-                        if let Ok(s) = serde_json::to_string(&response) {
-                            if let Err(e) = std::fs::write(&rf, s) {
-                                log::warn!(
-                                    "pane_ipc: create_context failed to write response file {rf}: {e}"
-                                );
-                            }
-                        }
+                        write_json_response(&rf, response);
                     }
                 }
                 self.save_workspace();
@@ -2298,11 +2212,7 @@ impl PlexiApp {
             "running": running.into_iter().collect::<Vec<_>>(),
         })
         .to_string();
-        if let Err(e) = std::fs::write(response_file, &body) {
-            log::error!(
-                "pane_ipc: list_permissions: could not write response file {response_file:?}: {e}"
-            );
-        }
+        write_response(response_file, body.as_bytes());
     }
 
     /// `SetPermission` host handler (stint 0017). Persists the new state to
@@ -2407,11 +2317,7 @@ impl PlexiApp {
             Ok(()) => "{\"ok\":true}".to_string(),
             Err(e) => serde_json::json!({ "error": e }).to_string(),
         };
-        if let Err(e) = std::fs::write(response_file, &body) {
-            log::error!(
-                "pane_ipc: set_permission: could not write response file {response_file:?}: {e}"
-            );
-        }
+        write_response(response_file, body.as_bytes());
         if let Err(e) = outcome {
             log::warn!("pane_ipc: set_permission failed: {e}");
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3497,14 +3497,8 @@ impl eframe::App for PlexiApp {
                     }
                     if let Some(rf) = &response_file {
                         let content = value.as_deref().unwrap_or("");
-                        let tmp = format!("{rf}.tmp");
-                        match std::fs::write(&tmp, content).and_then(|_| std::fs::rename(&tmp, rf))
-                        {
-                            Ok(_) => log::info!("notify:action: wrote {:?} to {:?}", content, rf),
-                            Err(e) => log::warn!(
-                                "notify:action: failed to write response file {:?}: {e}",
-                                rf
-                            ),
+                        if crate::rpc::write_response(rf, content.as_bytes()) {
+                            log::info!("notify:action: wrote {:?} to {:?}", content, rf);
                         }
                     }
                     // Search all windows for the sender pane — it may not be in the

--- a/src/app/screenshot.rs
+++ b/src/app/screenshot.rs
@@ -118,12 +118,7 @@ impl PlexiApp {
                     serde_json::json!({ "error": error })
                 }
             };
-            if let Err(error) = std::fs::write(&request.response_file, response.to_string()) {
-                log::warn!(
-                    "screenshot: could not write response file {}: {error}",
-                    request.response_file
-                );
-            }
+            crate::rpc::write_json_response(&request.response_file, response);
         }
     }
 

--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -281,36 +281,17 @@ pub fn agent_report_cli(
 /// `plexi agent status` — query agent states for all panes.
 pub fn agent_status_cli(blocked: bool, working: bool, idle: bool) -> i32 {
     log::info!("agent_status:cli: blocked={blocked} working={working} idle={idle}");
-    let tmp_path =
-        std::env::temp_dir().join(format!("plexi-agent-states-{}.json", uuid::Uuid::new_v4()));
-    let tmp_path_str = tmp_path.to_string_lossy().to_string();
+    let response_file = crate::rpc::response_file("plexi-agent-states", "json");
     let code = super::send_to_socket(serde_json::json!({
         "type": "get_agent_states",
-        "response_file": tmp_path_str,
+        "response_file": response_file,
     }));
     if code != 0 {
         return code;
     }
-    // Poll for response (host writes async); check before sleeping to avoid artificial latency
-    let response = (|| {
-        for _ in 0..250 {
-            if let Ok(content) = std::fs::read_to_string(&tmp_path) {
-                if !content.is_empty() {
-                    return Some(content);
-                }
-            }
-            std::thread::sleep(std::time::Duration::from_millis(10));
-        }
-        None
-    })();
-    // Clean up temp file.
-    let _ = std::fs::remove_file(&tmp_path);
-    let content = match response {
-        Some(c) => c,
-        None => {
-            eprintln!("error: timed out waiting for agent states response");
-            return 1;
-        }
+    let content = match super::poll_rpc(&response_file, "agent states") {
+        Ok(content) => content,
+        Err(code) => return code,
     };
     let states: Vec<serde_json::Value> = match serde_json::from_str(&content) {
         Ok(v) => v,

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1747,11 +1747,7 @@ pub fn app_update_cli(id: Option<&str>) -> i32 {
 /// The host delivers a `PlexiEvent::Action { action, args }` to the target app pane.
 /// Returns 0 on success, 1 on error.
 pub fn app_action_cli(pane_id: u64, action: &str, args: &[String]) -> i32 {
-    let id = uuid::Uuid::new_v4();
-    let response_file = crate::config::config_dir()
-        .join(format!("app-action-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("app-action-response", "json");
 
     log::info!(
         "app_action:cli: pane_id={pane_id} action={action:?} args={args:?} response_file={response_file:?}"
@@ -1772,37 +1768,17 @@ pub fn app_action_cli(pane_id: u64, action: &str, args: &[String]) -> i32 {
         return code;
     }
 
-    let response_path = std::path::PathBuf::from(&response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            match std::fs::read_to_string(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                        if v.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
-                            return 0;
-                        }
-                        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
-                            eprintln!("error: {msg}");
-                            return 1;
-                        }
-                    }
-                    return 0;
-                }
-                Err(e) => {
-                    log::warn!("app_action:cli: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            eprintln!("error: timed out waiting for app action response");
+    let content = match super::poll_rpc(&response_file, "app action") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
+            eprintln!("error: {msg}");
             return 1;
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
     }
+    0
 }
 
 #[cfg(test)]

--- a/src/cli/context_cli.rs
+++ b/src/cli/context_cli.rs
@@ -45,19 +45,9 @@ pub fn context_new_cli(
     };
     // Only request a response file when creating a sub-context (--parent set).
     // Top-level context new stays fire-and-forget to preserve existing behaviour.
-    let response_file = if explicit_parent.is_some() {
-        Some(
-            crate::config::config_dir()
-                .join(format!(
-                    "context-new-response-{}.json",
-                    uuid::Uuid::new_v4()
-                ))
-                .to_string_lossy()
-                .into_owned(),
-        )
-    } else {
-        None
-    };
+    let response_file = explicit_parent
+        .is_some()
+        .then(|| crate::rpc::response_file("context-new-response", "json"));
     // Portal split anchor: explicit --from wins; otherwise the caller's own pane
     // (PLEXI_PANE_ID, set in every Plexi terminal). Only meaningful with --parent.
     let anchor_pane = from.or_else(|| {
@@ -107,29 +97,9 @@ pub fn context_new_cli(
     }
     // Poll for response JSON (sub-context only).
     if let Some(rf) = response_file {
-        let path = std::path::PathBuf::from(&rf);
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        loop {
-            if path.exists() {
-                match std::fs::read_to_string(&path) {
-                    Ok(content) => {
-                        let _ = std::fs::remove_file(&path);
-                        println!("{content}");
-                        return 0;
-                    }
-                    Err(e) => {
-                        let _ = std::fs::remove_file(&path);
-                        eprintln!("error: could not read context-new response: {e}");
-                        return 1;
-                    }
-                }
-            }
-            if std::time::Instant::now() >= deadline {
-                let _ = std::fs::remove_file(&path);
-                eprintln!("error: timed out waiting for context-new response");
-                return 1;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(50));
+        match super::poll_rpc(&rf, "context-new") {
+            Ok(content) => println!("{content}"),
+            Err(code) => return code,
         }
     }
     0
@@ -295,11 +265,7 @@ pub fn context_current_cli() -> i32 {
 /// to a response file; this function polls for it and prints it to stdout.
 /// Returns 0 on success, 1 on error.
 pub fn context_list_cli() -> i32 {
-    let id = uuid::Uuid::new_v4();
-    let response_file = crate::config::config_dir()
-        .join(format!("context-list-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("context-list-response", "json");
 
     let payload = serde_json::json!({
         "type": "list_contexts",
@@ -316,29 +282,9 @@ pub fn context_list_cli() -> i32 {
         return code;
     }
 
-    let response_path = std::path::PathBuf::from(&response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            match std::fs::read_to_string(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    return print_json_output(&content);
-                }
-                Err(e) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    log::warn!("context_list:cli: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            let _ = std::fs::remove_file(&response_path);
-            eprintln!("error: timed out waiting for context list response");
-            return 1;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+    match super::poll_rpc(&response_file, "context list") {
+        Ok(content) => print_json_output(&content),
+        Err(code) => code,
     }
 }
 

--- a/src/cli/host.rs
+++ b/src/cli/host.rs
@@ -258,29 +258,6 @@ fn probe_notify_socket(socket_path: &Path) -> RunningState {
     }
 }
 
-/// Poll a response file until it appears or `timeout` elapses. Distinct from
-/// (but structurally identical to) `open.rs`'s `wait_for_response`: this
-/// variant returns the raw content instead of printing it, and takes a
-/// caller-supplied timeout instead of a fixed 5s — `host start` needs a
-/// longer, configurable boot timeout, and `host status`/`host stop` need the
-/// parsed pane count rather than `wait_for_response`'s stdout side effect.
-fn poll_response_file(response_file: &str, timeout: Duration) -> Result<String, String> {
-    let path = PathBuf::from(response_file);
-    let deadline = Instant::now() + timeout;
-    loop {
-        if path.exists() {
-            let content = std::fs::read_to_string(&path)
-                .map_err(|e| format!("could not read response file {path:?}: {e}"))?;
-            let _ = std::fs::remove_file(&path);
-            return Ok(content);
-        }
-        if Instant::now() >= deadline {
-            return Err(format!("timed out after {timeout:?} waiting for {path:?}"));
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-}
-
 /// One-shot readiness/pane-count query: connect to `notify.sock`, send
 /// `AppRequest::ListPanes`, and wait up to 5s for the JSON array response.
 /// `None` means either the socket is not reachable (host not running) or the
@@ -289,17 +266,15 @@ fn poll_response_file(response_file: &str, timeout: Duration) -> Result<String, 
 /// `config::config_dir()`.
 fn query_ready_status(socket_path: &Path, channel: Option<&str>) -> Option<usize> {
     let mut stream = UnixStream::connect(socket_path).ok()?;
-    let response_file = host_config_dir(channel)
-        .join(format!("host-status-{}.json", uuid::Uuid::new_v4()))
-        .to_string_lossy()
-        .into_owned();
+    let response_file =
+        crate::rpc::response_file_in(&host_config_dir(channel), "host-status", "json");
     let request = crate::app_protocol::AppRequest::ListPanes {
         response_file: response_file.clone(),
         context_id: None,
     };
     let line = serde_json::to_string(&request).ok()?;
     stream.write_all(format!("{line}\n").as_bytes()).ok()?;
-    let content = poll_response_file(&response_file, Duration::from_secs(5)).ok()?;
+    let content = crate::rpc::poll_string(&response_file, Some(crate::rpc::DEFAULT_TIMEOUT)).ok()?;
     serde_json::from_str::<Vec<serde_json::Value>>(&content)
         .ok()
         .map(|v| v.len())
@@ -693,11 +668,7 @@ pub fn host_log_cli(source: &str, message: &str) -> i32 {
     let channel = crate::config::build_channel();
     let profile_dir = host_config_dir(channel.as_deref());
     let socket_path = profile_dir.join("notify.sock");
-    let id = uuid::Uuid::new_v4();
-    let response_file = profile_dir
-        .join(format!("host-log-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file_in(&profile_dir, "host-log-response", "json");
     log::info!(
         "host_log:cli: channel={channel:?} source={source} message_chars={}",
         message.chars().count()
@@ -726,18 +697,16 @@ pub fn host_log_cli(source: &str, message: &str) -> i32 {
         return 1;
     }
 
-    let response_path = std::path::PathBuf::from(&response_file);
-    let deadline = Instant::now() + Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            let _ = std::fs::remove_file(&response_path);
-            return 0;
-        }
-        if Instant::now() >= deadline {
+    match crate::rpc::poll_string(&response_file, Some(crate::rpc::DEFAULT_TIMEOUT)) {
+        Ok(_) => 0,
+        Err(crate::rpc::PollError::TimedOut) => {
             eprintln!("error: timed out waiting for host log acknowledgement");
-            return 1;
+            1
         }
-        std::thread::sleep(Duration::from_millis(50));
+        Err(e) => {
+            eprintln!("error: {e}");
+            1
+        }
     }
 }
 
@@ -745,7 +714,6 @@ pub fn host_log_cli(source: &str, message: &str) -> i32 {
 /// live host window (optionally cropped to one pane) through the real
 /// render pipeline. Prints the written PNG path on success.
 pub fn host_screenshot_cli(pane: Option<u64>, output: Option<&str>) -> i32 {
-    let id = uuid::Uuid::new_v4();
     let output_path = match output {
         Some(path) => path.to_string(),
         None => {
@@ -760,10 +728,7 @@ pub fn host_screenshot_cli(pane: Option<u64>, output: Option<&str>) -> i32 {
                 .into_owned()
         }
     };
-    let response_file = crate::config::config_dir()
-        .join(format!("screenshot-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("screenshot-response", "json");
     log::info!("host_screenshot:cli: pane={pane:?} output_path={output_path}");
 
     let code = super::send_to_socket(serde_json::json!({
@@ -778,46 +743,32 @@ pub fn host_screenshot_cli(pane: Option<u64>, output: Option<&str>) -> i32 {
 
     // The capture round-trips through the GPU (request frame -> readback ->
     // next frame's input), so allow a little longer than plain state reads.
-    let response_path = std::path::PathBuf::from(&response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
-    loop {
-        if response_path.exists() {
-            let content = match std::fs::read_to_string(&response_path) {
-                Ok(content) => content,
-                Err(e) => {
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
-                }
-            };
-            let _ = std::fs::remove_file(&response_path);
-            match serde_json::from_str::<serde_json::Value>(&content) {
-                Ok(v) if v.get("error").is_some() => {
-                    eprintln!(
-                        "error: {}",
-                        v["error"].as_str().unwrap_or("screenshot failed")
-                    );
-                    return 1;
-                }
-                Ok(v) => {
-                    println!(
-                        "{} ({}x{})",
-                        v["path"].as_str().unwrap_or(&output_path),
-                        v["width"],
-                        v["height"]
-                    );
-                    return 0;
-                }
-                Err(e) => {
-                    eprintln!("error: malformed screenshot response: {e}");
-                    return 1;
-                }
-            }
+    let content = match super::poll_rpc_with(&response_file, "screenshot", Duration::from_secs(10))
+    {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    match serde_json::from_str::<serde_json::Value>(&content) {
+        Ok(v) if v.get("error").is_some() => {
+            eprintln!(
+                "error: {}",
+                v["error"].as_str().unwrap_or("screenshot failed")
+            );
+            1
         }
-        if std::time::Instant::now() >= deadline {
-            eprintln!("error: timed out waiting for screenshot response");
-            return 1;
+        Ok(v) => {
+            println!(
+                "{} ({}x{})",
+                v["path"].as_str().unwrap_or(&output_path),
+                v["width"],
+                v["height"]
+            );
+            0
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        Err(e) => {
+            eprintln!("error: malformed screenshot response: {e}");
+            1
+        }
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -397,6 +397,32 @@ pub(super) fn command_socket_available() -> bool {
     )
 }
 
+/// Poll an RPC response file with the standard CLI error reporting: timeout
+/// and read failures print `error: ...` to stderr and yield exit code 1.
+/// `label` names the command in the timeout message.
+pub(super) fn poll_rpc(response_file: &str, label: &str) -> Result<String, i32> {
+    poll_rpc_with(response_file, label, crate::rpc::DEFAULT_TIMEOUT)
+}
+
+pub(super) fn poll_rpc_with(
+    response_file: &str,
+    label: &str,
+    timeout: std::time::Duration,
+) -> Result<String, i32> {
+    match crate::rpc::poll_string(response_file, Some(timeout)) {
+        Ok(content) => Ok(content),
+        Err(crate::rpc::PollError::TimedOut) => {
+            eprintln!("error: timed out waiting for {label} response");
+            Err(1)
+        }
+        Err(e) => {
+            log::warn!("{label}:cli: {e}");
+            eprintln!("error: {e}");
+            Err(1)
+        }
+    }
+}
+
 /// Spawn-queue writer gate (stint 0532): outside a Plexi pane, a spawn
 /// request may only be queued when this channel's host is actually accepting
 /// IPC on its notify socket. A file queued into the void fires on some later

--- a/src/cli/notify.rs
+++ b/src/cli/notify.rs
@@ -15,8 +15,6 @@ pub fn notify_cli(
         }
     };
 
-    let id = uuid::Uuid::new_v4();
-
     let options_json: Vec<serde_json::Value> = choices
         .iter()
         .map(|(key, label, host_action)| {
@@ -34,11 +32,7 @@ pub fn notify_cli(
         "choice".to_string()
     };
     let response_file_str = if !choices.is_empty() && wait_for_response {
-        let rf = crate::config::config_dir()
-            .join(format!("notify-response-{id}.txt"))
-            .to_string_lossy()
-            .into_owned();
-        Some(rf)
+        Some(crate::rpc::response_file("notify-response", "txt"))
     } else {
         None
     };
@@ -102,38 +96,24 @@ pub fn notify_cli(
         println!("notification queued");
         return 0;
     };
-    let response_file = std::path::PathBuf::from(response_file);
-    log::info!("notify:cli: polling for response at {:?}", response_file);
+    log::info!("notify:cli: polling for response at {response_file:?}");
 
-    let deadline = if timeout_secs > 0 {
-        Some(std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs))
-    } else {
-        None
-    };
-
-    loop {
-        if response_file.exists() {
-            match std::fs::read_to_string(&response_file) {
-                Ok(key) => {
-                    log::info!("notify:cli: response received {:?}", key.trim());
-                    let _ = std::fs::remove_file(&response_file);
-                    print!("{}", key.trim());
-                    return 0;
-                }
-                Err(e) => {
-                    log::warn!("notify:cli: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
-                }
-            }
+    let timeout = (timeout_secs > 0).then(|| std::time::Duration::from_secs(timeout_secs));
+    match crate::rpc::poll_string(&response_file, timeout) {
+        Ok(key) => {
+            log::info!("notify:cli: response received {:?}", key.trim());
+            print!("{}", key.trim());
+            0
         }
-        if let Some(dl) = deadline {
-            if std::time::Instant::now() >= dl {
-                log::info!("notify:cli: timed out after {timeout_secs}s");
-                return 2;
-            }
+        Err(crate::rpc::PollError::TimedOut) => {
+            log::info!("notify:cli: timed out after {timeout_secs}s");
+            2
         }
-        std::thread::sleep(std::time::Duration::from_millis(100));
+        Err(e) => {
+            log::warn!("notify:cli: {e}");
+            eprintln!("error: {e}");
+            1
+        }
     }
 }
 
@@ -207,6 +187,30 @@ mod notify_tests {
         assert_eq!(payload["options"][0]["value"], "talk");
         assert_eq!(payload["options"][0]["label"], "Talk to Claude");
         assert_eq!(payload["options"][0]["host_action"], "pane_focus:188");
+    }
+
+    /// The stint 0536 leak fix: a blocking choice that times out must exit 2
+    /// and must not leave a response file behind in the profile's rpc/ dir.
+    #[test]
+    fn notify_cli_timeout_leaves_no_response_file() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _channel_guard = crate::config::set_test_channel("notify-test");
+        let choices = vec![("talk".to_string(), "Talk".to_string(), None)];
+        let (code, payload) = capture_notify_payload(|| {
+            notify_cli("Ready", "Review tests", "info", &choices, true, 1, None)
+        });
+        assert_eq!(code, 2, "timeout must exit 2");
+        let rf = payload["response_file"]
+            .as_str()
+            .expect("blocking choice response_file");
+        assert!(
+            rf.contains("/rpc/"),
+            "response file must live in the rpc/ subdir: {rf}"
+        );
+        assert!(
+            !std::path::Path::new(rf).exists(),
+            "timeout must not leave a response file behind"
+        );
     }
 
     #[test]

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -4,46 +4,26 @@ use crate::app::launch_spec::PaneLaunchSpec;
 use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
-/// Poll a response file until it appears (or timeout). Shared by all spawn paths.
-///
-/// `pub(super)` so `host.rs` can reference the same convention. `host.rs`'s
-/// own readiness/status polling uses a bespoke variant (`poll_response_file`)
-/// instead — it needs the raw JSON content and a configurable timeout rather
-/// than this function's fixed 5s timeout and print-to-stdout side effect.
+/// Wait for a spawn response and print the resulting pane id (or the raw
+/// response when the host answered with something else). Shared by all spawn
+/// paths.
 pub(super) fn wait_for_response(response_file: &str) -> i32 {
-    let response_path = std::path::PathBuf::from(response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            match std::fs::read_to_string(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
-                            eprintln!("error: {msg}");
-                            return 1;
-                        }
-                        if let Some(pid) = v.get("pane_id").and_then(|v| v.as_u64()) {
-                            println!("{pid}");
-                            return 0;
-                        }
-                    }
-                    print!("{content}");
-                    return 0;
-                }
-                Err(e) => {
-                    log::warn!("pane_new: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            eprintln!("error: timed out waiting for pane response");
+    let content = match super::poll_rpc(response_file, "pane") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
+            eprintln!("error: {msg}");
             return 1;
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        if let Some(pid) = v.get("pane_id").and_then(|v| v.as_u64()) {
+            println!("{pid}");
+            return 0;
+        }
     }
+    print!("{content}");
+    0
 }
 
 /// Unified pane spawning. All CLI spawn paths funnel through here.
@@ -87,11 +67,7 @@ pub fn pane_new_cli(
 
     // Socket path — inside a Plexi pane
     if super::command_socket_available() {
-        let id = uuid::Uuid::new_v4();
-        let response_file = crate::config::config_dir()
-            .join(format!("spawn-pane-response-{id}.json"))
-            .to_string_lossy()
-            .into_owned();
+        let response_file = crate::rpc::response_file("spawn-pane-response", "json");
         let mut payload = serde_json::json!({
             "type": "spawn_pane",
             "type_id": type_id,
@@ -551,11 +527,7 @@ fn open_app_by_path(
     };
 
     if super::command_socket_available() {
-        let id = uuid::Uuid::new_v4();
-        let response_file = crate::config::config_dir()
-            .join(format!("spawn-pane-response-{id}.json"))
-            .to_string_lossy()
-            .into_owned();
+        let response_file = crate::rpc::response_file("spawn-pane-response", "json");
         let spec = spec.with_response_file(Some(response_file.clone()));
         let payload = serde_json::to_value(spec.to_spawn_pane_request()).unwrap_or_else(|e| {
             log::error!("open_app_by_path: failed to serialize spawn request: {e}");

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -98,81 +98,41 @@ fn resolve_pane_id(pane_id: Option<u64>) -> Result<u64, i32> {
     }
 }
 
-fn response_file(prefix: &str) -> String {
-    let id = uuid::Uuid::new_v4();
-    crate::config::config_dir()
-        .join(format!("{prefix}-{id}.json"))
-        .to_string_lossy()
-        .into_owned()
-}
-
 fn wait_for_response_bytes(response_file: &str, label: &str) -> Result<Vec<u8>, i32> {
-    let response_path = std::path::PathBuf::from(response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            match std::fs::read(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    return Ok(content);
-                }
-                Err(e) => {
-                    log::warn!("{label}:cli: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return Err(1);
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
+    match crate::rpc::poll_bytes(response_file, Some(crate::rpc::DEFAULT_TIMEOUT)) {
+        Ok(content) => Ok(content),
+        Err(crate::rpc::PollError::TimedOut) => {
             eprintln!("error: timed out waiting for {label} response");
-            return Err(1);
+            Err(1)
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        Err(e) => {
+            log::warn!("{label}:cli: {e}");
+            eprintln!("error: {e}");
+            Err(1)
+        }
     }
 }
 
 fn wait_for_slot_read_response(response_file: &str) -> Result<Vec<u8>, i32> {
-    let response_path = std::path::PathBuf::from(response_file);
-    let error_path = std::path::PathBuf::from(format!("{response_file}.err"));
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if error_path.exists() {
-            let content = match std::fs::read(&error_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&error_path);
-                    content
-                }
-                Err(e) => {
-                    log::warn!("pane_slot_read:cli: could not read error response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return Err(1);
-                }
-            };
+    match crate::rpc::poll_slot_reply(response_file, Some(crate::rpc::DEFAULT_TIMEOUT)) {
+        Ok(crate::rpc::SlotReply::Data(content)) => Ok(content),
+        Ok(crate::rpc::SlotReply::Err(content)) => {
             if let Some(err) = response_error(&content) {
                 eprintln!("error: {err}");
-                return Err(1);
+            } else {
+                eprintln!("error: invalid slot read error response");
             }
-            eprintln!("error: invalid slot read error response");
-            return Err(1);
+            Err(1)
         }
-        if response_path.exists() {
-            match std::fs::read(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    return Ok(content);
-                }
-                Err(e) => {
-                    log::warn!("pane_slot_read:cli: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return Err(1);
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
+        Err(crate::rpc::PollError::TimedOut) => {
             eprintln!("error: timed out waiting for pane slot read response");
-            return Err(1);
+            Err(1)
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        Err(e) => {
+            log::warn!("pane_slot_read:cli: {e}");
+            eprintln!("error: {e}");
+            Err(1)
+        }
     }
 }
 
@@ -219,7 +179,7 @@ pub fn pane_slot_write_cli(
             return 1;
         }
     }
-    let response_file = response_file("pane-slot-write-response");
+    let response_file = crate::rpc::response_file("pane-slot-write-response", "json");
     log::info!(
         "pane_slot_write:cli: pane_id={resolved_pane_id} slot={name:?} bytes={} append={append} replace={replace} response_file={response_file:?}",
         bytes.len()
@@ -254,7 +214,7 @@ pub fn pane_slot_read_cli(name: &str, pane_id: Option<u64>) -> i32 {
         Ok(id) => id,
         Err(code) => return code,
     };
-    let response_file = response_file("pane-slot-read-response");
+    let response_file = crate::rpc::response_file("pane-slot-read-response", "json");
     log::info!(
         "pane_slot_read:cli: pane_id={resolved_pane_id} slot={name:?} response_file={response_file:?}"
     );
@@ -285,7 +245,7 @@ pub fn pane_slot_list_cli(pane_id: Option<u64>) -> i32 {
         Ok(id) => id,
         Err(code) => return code,
     };
-    let response_file = response_file("pane-slot-list-response");
+    let response_file = crate::rpc::response_file("pane-slot-list-response", "json");
     log::info!("pane_slot_list:cli: pane_id={resolved_pane_id} response_file={response_file:?}");
     let code = send_to_socket(serde_json::json!({
         "type": "slot_list",
@@ -312,7 +272,7 @@ pub fn pane_slot_delete_cli(name: &str, pane_id: Option<u64>) -> i32 {
         Ok(id) => id,
         Err(code) => return code,
     };
-    let response_file = response_file("pane-slot-delete-response");
+    let response_file = crate::rpc::response_file("pane-slot-delete-response", "json");
     log::info!(
         "pane_slot_delete:cli: pane_id={resolved_pane_id} slot={name:?} response_file={response_file:?}"
     );
@@ -363,11 +323,7 @@ pub fn pane_list_cli(context: Option<u64>, current: bool) -> i32 {
         context
     };
 
-    let id = uuid::Uuid::new_v4();
-    let response_file = crate::config::config_dir()
-        .join(format!("pane-list-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("pane-list-response", "json");
 
     let mut payload = serde_json::json!({
         "type": "list_panes",
@@ -388,27 +344,9 @@ pub fn pane_list_cli(context: Option<u64>, current: bool) -> i32 {
         return code;
     }
 
-    let response_path = std::path::PathBuf::from(&response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            match std::fs::read_to_string(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    return print_json_output(&content);
-                }
-                Err(e) => {
-                    log::warn!("pane_list:cli: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            eprintln!("error: timed out waiting for pane list response");
-            return 1;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+    match super::poll_rpc(&response_file, "pane list") {
+        Ok(content) => print_json_output(&content),
+        Err(code) => code,
     }
 }
 
@@ -452,11 +390,7 @@ pub fn pane_info_cli(previous: Option<u64>) -> i32 {
         }
     };
 
-    let id = uuid::Uuid::new_v4();
-    let response_file = crate::config::config_dir()
-        .join(format!("pane-info-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("pane-info-response", "json");
 
     let payload = if let Some(steps) = previous {
         log::info!(
@@ -501,50 +435,29 @@ pub fn pane_info_cli(previous: Option<u64>) -> i32 {
         return code;
     }
 
-    let response_path = std::path::PathBuf::from(&response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            match std::fs::read_to_string(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                        if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
-                            eprintln!("error: {err}");
-                            return 1;
-                        }
-                        let mut obj = v;
-                        obj["socket"] =
-                            serde_json::Value::String(socket_path.to_string_lossy().into_owned());
-                        let channel =
-                            crate::config::build_channel().unwrap_or_else(|| "main".to_string());
-                        obj["channel"] = serde_json::Value::String(channel);
-                        match serde_json::to_string(&obj) {
-                            Ok(json_str) => {
-                                return print_json_output(&json_str);
-                            }
-                            Err(e) => {
-                                eprintln!("error: could not serialize response: {e}");
-                                return 1;
-                            }
-                        }
-                    } else {
-                        eprintln!("error: invalid JSON from host: {content}");
-                        return 1;
-                    }
-                }
-                Err(e) => {
-                    log::warn!("pane_info:cli: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            eprintln!("error: timed out waiting for pane info response");
+    let content = match super::poll_rpc(&response_file, "pane info") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+        if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
+            eprintln!("error: {err}");
             return 1;
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        let mut obj = v;
+        obj["socket"] = serde_json::Value::String(socket_path.to_string_lossy().into_owned());
+        let channel = crate::config::build_channel().unwrap_or_else(|| "main".to_string());
+        obj["channel"] = serde_json::Value::String(channel);
+        match serde_json::to_string(&obj) {
+            Ok(json_str) => print_json_output(&json_str),
+            Err(e) => {
+                eprintln!("error: could not serialize response: {e}");
+                1
+            }
+        }
+    } else {
+        eprintln!("error: invalid JSON from host: {content}");
+        1
     }
 }
 
@@ -577,11 +490,7 @@ pub fn pane_close_cli(pane_id: u64) -> i32 {
 /// Polls a response file to surface errors (e.g. pane not found) to the caller.
 /// Returns 0 on success, 1 on error.
 pub fn pane_send_cli(pane_id: u64, text: &str) -> i32 {
-    let id = uuid::Uuid::new_v4();
-    let response_file = crate::config::config_dir()
-        .join(format!("send-to-pane-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("send-to-pane-response", "json");
     log::info!(
         "pane_send:cli: pane_id={pane_id} len={} response_file={response_file:?}",
         text.len()
@@ -595,37 +504,17 @@ pub fn pane_send_cli(pane_id: u64, text: &str) -> i32 {
     if code != 0 {
         return code;
     }
-    let response_path = std::path::PathBuf::from(&response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            match std::fs::read_to_string(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                        if v.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
-                            return 0;
-                        }
-                        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
-                            eprintln!("error: {msg}");
-                            return 1;
-                        }
-                    }
-                    return 0;
-                }
-                Err(e) => {
-                    log::warn!("pane_send:cli: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            eprintln!("error: timed out waiting for pane send response");
+    let content = match super::poll_rpc(&response_file, "pane send") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
+            eprintln!("error: {msg}");
             return 1;
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
     }
+    0
 }
 
 /// `plexi pane key <pane_id> <key>`
@@ -633,11 +522,7 @@ pub fn pane_send_cli(pane_id: u64, text: &str) -> i32 {
 /// Sends `key_pane` command to PLEXI_SOCKET. Waits for response.
 /// Returns 0 on success, 1 on error.
 pub fn pane_key_cli(pane_id: u64, key: &str) -> i32 {
-    let id = uuid::Uuid::new_v4();
-    let response_file = crate::config::config_dir()
-        .join(format!("pane-key-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("pane-key-response", "json");
     log::info!(
         "pane_key:cli: pane_id={pane_id} key={key:?} key_chars={} response_file={response_file:?}",
         key.chars().count()
@@ -651,67 +536,44 @@ pub fn pane_key_cli(pane_id: u64, key: &str) -> i32 {
     if code != 0 {
         return code;
     }
-    let response_path = std::path::PathBuf::from(&response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            match std::fs::read_to_string(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                        if v.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
-                            // Native app panes report whether the app's key
-                            // handler consumed the key — surface a miss so
-                            // driving agents don't assume the key acted.
-                            if let Some(d) = v.get("disposition").and_then(|v| v.as_str()) {
-                                match d {
-                                    "consumed" => {}
-                                    // Routed into the focused text surface's real
-                                    // input queue; egui applies it next frame, so
-                                    // consumption is not knowable here — but this
-                                    // is the success path, not a miss.
-                                    "text_input" | "text_input_escape" => eprintln!(
-                                        "note: key routed to the pane's focused text \
-                                         surface (applied next frame)"
-                                    ),
-                                    _ => eprintln!(
-                                        "note: key delivered but not consumed by the app \
-                                         (disposition: {d})"
-                                    ),
-                                }
-                            }
-                            return 0;
-                        }
-                        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
-                            eprintln!("error: {msg}");
-                            return 1;
-                        }
-                    }
-                    return 0;
-                }
-                Err(e) => {
-                    log::warn!("pane_key:cli: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
+    let content = match super::poll_rpc(&response_file, "pane key") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+        if v.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
+            // Native app panes report whether the app's key handler consumed
+            // the key — surface a miss so driving agents don't assume the
+            // key acted.
+            if let Some(d) = v.get("disposition").and_then(|v| v.as_str()) {
+                match d {
+                    "consumed" => {}
+                    // Routed into the focused text surface's real input
+                    // queue; egui applies it next frame, so consumption is
+                    // not knowable here — but this is the success path, not
+                    // a miss.
+                    "text_input" | "text_input_escape" => eprintln!(
+                        "note: key routed to the pane's focused text \
+                         surface (applied next frame)"
+                    ),
+                    _ => eprintln!(
+                        "note: key delivered but not consumed by the app \
+                         (disposition: {d})"
+                    ),
                 }
             }
+            return 0;
         }
-        if std::time::Instant::now() >= deadline {
-            eprintln!("error: timed out waiting for pane key response");
+        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
+            eprintln!("error: {msg}");
             return 1;
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
     }
+    0
 }
 
 pub fn pane_drop_cli(pane_id: u64, path_or_url: &str) -> i32 {
-    let response_file = std::env::temp_dir()
-        .join(format!(
-            "plexi-pane-drop-{}-{pane_id}.json",
-            std::process::id()
-        ))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("pane-drop-response", "json");
     let code = send_to_socket(serde_json::json!({
         "type": "drop_file",
         "pane_id": pane_id,
@@ -721,65 +583,39 @@ pub fn pane_drop_cli(pane_id: u64, path_or_url: &str) -> i32 {
     if code != 0 {
         return code;
     }
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if let Ok(content) = std::fs::read_to_string(&response_file) {
-            let _ = std::fs::remove_file(&response_file);
-            if serde_json::from_str::<serde_json::Value>(&content)
-                .ok()
-                .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(str::to_owned))
-                .is_some_and(|error| {
-                    eprintln!("error: {error}");
-                    true
-                })
-            {
-                return 1;
-            }
-            return print_json_output(&content);
-        }
-        if std::time::Instant::now() >= deadline {
-            eprintln!("error: timed out waiting for pane drop response");
-            return 1;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(20));
+    let content = match super::poll_rpc(&response_file, "pane drop") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if serde_json::from_str::<serde_json::Value>(&content)
+        .ok()
+        .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(str::to_owned))
+        .is_some_and(|error| {
+            eprintln!("error: {error}");
+            true
+        })
+    {
+        return 1;
     }
+    print_json_output(&content)
 }
 
 /// Poll `response_file` for a `click_pane`/`click_pane_node` response,
 /// shared by the pixel and node-targeted `plexi pane click` variants.
 /// Returns 0 on success, 1 on error.
 fn poll_click_response(response_file: &str, log_prefix: &str) -> i32 {
-    let response_path = std::path::PathBuf::from(response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            match std::fs::read_to_string(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                        if v.get("ok").and_then(|v| v.as_bool()).unwrap_or(false) {
-                            return 0;
-                        }
-                        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
-                            eprintln!("error: {msg}");
-                            return 1;
-                        }
-                    }
-                    return 0;
-                }
-                Err(e) => {
-                    log::warn!("{log_prefix}: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            eprintln!("error: timed out waiting for pane click response");
+    let content = match super::poll_rpc(response_file, "pane click") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+        if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
+            log::warn!("{log_prefix}: host reported error: {msg}");
+            eprintln!("error: {msg}");
             return 1;
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
     }
+    0
 }
 
 /// `plexi pane click <pane_id> <x> <y> [--button left]`
@@ -787,11 +623,7 @@ fn poll_click_response(response_file: &str, log_prefix: &str) -> i32 {
 /// Sends `click_pane` command to PLEXI_SOCKET. Waits for response.
 /// Returns 0 on success, 1 on error.
 pub fn pane_click_cli(pane_id: u64, x: f32, y: f32, button: &str) -> i32 {
-    let id = uuid::Uuid::new_v4();
-    let response_file = crate::config::config_dir()
-        .join(format!("pane-click-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("pane-click-response", "json");
     log::info!(
         "pane_click:cli: pane_id={pane_id} x={x} y={y} button={button} response_file={response_file:?}"
     );
@@ -814,11 +646,7 @@ pub fn pane_click_cli(pane_id: u64, x: f32, y: f32, button: &str) -> i32 {
 /// Sends `click_pane_node` command to PLEXI_SOCKET. Waits for response.
 /// Returns 0 on success, 1 on error.
 pub fn pane_click_node_cli(pane_id: u64, node_id: &str, button: &str) -> i32 {
-    let id = uuid::Uuid::new_v4();
-    let response_file = crate::config::config_dir()
-        .join(format!("pane-click-node-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("pane-click-node-response", "json");
     log::info!(
         "pane_click_node:cli: pane_id={pane_id} node_id={node_id} button={button} response_file={response_file:?}"
     );
@@ -863,11 +691,7 @@ pub fn pane_capture_cli(
         },
     };
 
-    let id = uuid::Uuid::new_v4();
-    let response_file = crate::config::config_dir()
-        .join(format!("pane-capture-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("pane-capture-response", "json");
 
     log::info!("pane_capture:cli: pane_id={resolved_pane_id} lines={lines} full_output={full_output} from_cursor={from_cursor:?} response_file={response_file:?}");
 
@@ -886,42 +710,22 @@ pub fn pane_capture_cli(
         return code;
     }
 
-    let response_path = std::path::PathBuf::from(&response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            match std::fs::read_to_string(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    match serde_json::from_str::<serde_json::Value>(&content) {
-                        Ok(v) => {
-                            if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
-                                eprintln!("error: {err}");
-                                return 1;
-                            }
-                            // Print cursor to stderr so callers can capture it without
-                            // polluting the line stream.
-                            if let Some(cursor) = v.get("cursor").and_then(|c| c.as_u64()) {
-                                eprintln!("cursor={cursor}");
-                            }
-                            return print_json_output(&content);
-                        }
-                        Err(_) => return print_json_output(&content),
-                    }
-                }
-                Err(e) => {
-                    log::warn!("pane_capture:cli: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            eprintln!("error: timed out waiting for pane capture response");
+    let content = match super::poll_rpc(&response_file, "pane capture") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+        if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
+            eprintln!("error: {err}");
             return 1;
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Print cursor to stderr so callers can capture it without
+        // polluting the line stream.
+        if let Some(cursor) = v.get("cursor").and_then(|c| c.as_u64()) {
+            eprintln!("cursor={cursor}");
+        }
     }
+    print_json_output(&content)
 }
 
 /// `plexi pane state <id>`
@@ -931,11 +735,7 @@ pub fn pane_capture_cli(
 /// Process apps also retain the compatible `frame` RenderCommand array.
 /// For terminal panes, returns a simple status object. Returns 0 on success, 1 on error.
 pub fn pane_state_cli(pane_id: u64) -> i32 {
-    let id = uuid::Uuid::new_v4();
-    let response_file = crate::config::config_dir()
-        .join(format!("pane-state-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("pane-state-response", "json");
 
     log::info!("pane_state:cli: pane_id={pane_id} response_file={response_file:?}");
 
@@ -948,34 +748,17 @@ pub fn pane_state_cli(pane_id: u64) -> i32 {
         return code;
     }
 
-    let response_path = std::path::PathBuf::from(&response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            match std::fs::read_to_string(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                        if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
-                            eprintln!("error: {err}");
-                            return 1;
-                        }
-                    }
-                    return print_json_output(&content);
-                }
-                Err(e) => {
-                    log::warn!("pane_state:cli: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
-                }
-            }
-        }
-        if std::time::Instant::now() >= deadline {
-            eprintln!("error: timed out waiting for pane state response");
+    let content = match super::poll_rpc(&response_file, "pane state") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+        if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
+            eprintln!("error: {err}");
             return 1;
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
     }
+    print_json_output(&content)
 }
 
 /// `plexi open <type_id> [args...] [--layout=X]`
@@ -1065,11 +848,7 @@ pub(super) fn open_github_ephemeral(
     );
 
     if super::command_socket_available() {
-        let id = uuid::Uuid::new_v4();
-        let response_file = crate::config::config_dir()
-            .join(format!("spawn-pane-response-{id}.json"))
-            .to_string_lossy()
-            .into_owned();
+        let response_file = crate::rpc::response_file("spawn-pane-response", "json");
         let mut payload = serde_json::json!({
             "type": "spawn_pane",
             "type_id": "",
@@ -1091,38 +870,7 @@ pub(super) fn open_github_ephemeral(
         if code != 0 {
             return code;
         }
-        let response_path = std::path::PathBuf::from(&response_file);
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        loop {
-            if response_path.exists() {
-                match std::fs::read_to_string(&response_path) {
-                    Ok(content) => {
-                        let _ = std::fs::remove_file(&response_path);
-                        if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-                            if let Some(msg) = v.get("error").and_then(|v| v.as_str()) {
-                                eprintln!("error: {msg}");
-                                return 1;
-                            }
-                            if let Some(pid) = v.get("pane_id").and_then(|v| v.as_u64()) {
-                                println!("{pid}");
-                                return 0;
-                            }
-                        }
-                        print!("{content}");
-                        return 0;
-                    }
-                    Err(e) => {
-                        eprintln!("error: could not read response file: {e}");
-                        return 1;
-                    }
-                }
-            }
-            if std::time::Instant::now() >= deadline {
-                eprintln!("error: timed out waiting for open response");
-                return 1;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
+        return super::open::wait_for_response(&response_file);
     }
 
     // Fallback: spawn-queue (outside a Plexi pane). Only queue when a host is

--- a/src/cli/workspace.rs
+++ b/src/cli/workspace.rs
@@ -62,11 +62,7 @@ pub fn workspace_init() -> i32 {
 }
 
 pub fn workspace_clean_cli(dry_run: bool) -> i32 {
-    let id = uuid::Uuid::new_v4();
-    let response_file = crate::config::config_dir()
-        .join(format!("workspace-clean-response-{id}.json"))
-        .to_string_lossy()
-        .into_owned();
+    let response_file = crate::rpc::response_file("workspace-clean-response", "json");
     log::info!("workspace_clean:cli: dry_run={dry_run} response_file={response_file:?}");
     let code = super::send_to_socket(serde_json::json!({
         "type": "workspace_clean_slots",
@@ -77,54 +73,36 @@ pub fn workspace_clean_cli(dry_run: bool) -> i32 {
         return code;
     }
 
-    let response_path = std::path::PathBuf::from(&response_file);
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-    loop {
-        if response_path.exists() {
-            let content = match std::fs::read_to_string(&response_path) {
-                Ok(content) => {
-                    let _ = std::fs::remove_file(&response_path);
-                    content
-                }
-                Err(e) => {
-                    log::warn!("workspace_clean:cli: could not read response file: {e}");
-                    eprintln!("error: could not read response file: {e}");
-                    return 1;
-                }
-            };
-            let value = match serde_json::from_str::<serde_json::Value>(&content) {
-                Ok(value) => value,
-                Err(e) => {
-                    eprintln!("error: invalid workspace clean response: {e}");
-                    return 1;
-                }
-            };
-            if let Some(err) = value.get("error").and_then(|v| v.as_str()) {
-                eprintln!("error: {err}");
-                return 1;
-            }
-            let paths = value
-                .get("paths")
-                .and_then(|v| v.as_array())
-                .cloned()
-                .unwrap_or_default();
-            if paths.is_empty() {
-                println!("No stale pane slot files found.");
-                return 0;
-            }
-            for path in paths {
-                if let Some(path) = path.as_str() {
-                    println!("{path}");
-                }
-            }
-            return 0;
-        }
-        if std::time::Instant::now() >= deadline {
-            eprintln!("error: timed out waiting for workspace clean response");
+    let content = match super::poll_rpc(&response_file, "workspace clean") {
+        Ok(content) => content,
+        Err(code) => return code,
+    };
+    let value = match serde_json::from_str::<serde_json::Value>(&content) {
+        Ok(value) => value,
+        Err(e) => {
+            eprintln!("error: invalid workspace clean response: {e}");
             return 1;
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+    };
+    if let Some(err) = value.get("error").and_then(|v| v.as_str()) {
+        eprintln!("error: {err}");
+        return 1;
     }
+    let paths = value
+        .get("paths")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    if paths.is_empty() {
+        println!("No stale pane slot files found.");
+        return 0;
+    }
+    for path in paths {
+        if let Some(path) = path.as_str() {
+            println!("{path}");
+        }
+    }
+    0
 }
 
 // ── plexi secret subcommands (workspace-aware, issue #322) ───────────────────

--- a/src/host/services.rs
+++ b/src/host/services.rs
@@ -54,8 +54,12 @@ impl FileEventSink {
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
             let line = format!("{{\"kind\":\"sink_opened\",\"timestamp\":{now}}}\n");
-            let _ = writer.write_all(line.as_bytes());
-            let _ = writer.flush();
+            if let Err(e) = writer.write_all(line.as_bytes()).and_then(|()| writer.flush()) {
+                log::debug!(
+                    "FileEventSink: startup heartbeat write({}) failed: {e}",
+                    sink.path.display()
+                );
+            }
         }
         sink
     }
@@ -73,7 +77,9 @@ impl EventSink for FileEventSink {
                 if let Err(e) = writer.write_all(line.as_bytes()) {
                     log::warn!("FileEventSink write({}) failed: {e}", self.path.display());
                 }
-                let _ = writer.flush();
+                if let Err(e) = writer.flush() {
+                    log::debug!("FileEventSink flush({}) failed: {e}", self.path.display());
+                }
             }
             Err(e) => log::warn!("FileEventSink serialize failed: {e}"),
         }

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -1178,6 +1178,18 @@ fn load_python_state(config: &PythonLaunchConfig) -> serde_json::Map<String, Val
 }
 
 impl LivePythonPane {
+    /// Send an event to the CPython subprocess. A failed send (broken pipe)
+    /// means the app runtime is dead — say so in the log instead of failing
+    /// silent, so a hung app is diagnosable from plexi.log.
+    fn send_to_runtime(&self, event: &Value) {
+        if let Err(error) = self.runtime.send(event) {
+            log::warn!(
+                "app::{}: send to CPython runtime failed — runtime likely dead: {error}",
+                self.app_id
+            );
+        }
+    }
+
     pub fn launch(config: PythonLaunchConfig) -> Result<Self, WasmPythonError> {
         let app_id = config.app_id.clone();
         let persisted_state = load_python_state(&config);
@@ -1361,17 +1373,15 @@ impl LivePythonPane {
             self.perf_ui_render += render_started.elapsed();
             self.perf_canvas_render += result.canvas_time;
             for action in result.actions {
-                let _ = self
-                    .runtime
-                    .send(&json!({"type": "ui_action", "handler_id": action}));
+                self.send_to_runtime(&json!({"type": "ui_action", "handler_id": action}));
             }
             for (handler_id, value) in result.value_changes {
-                let _ = self.runtime.send(&json!({
+                self.send_to_runtime(&json!({
                     "type": "text_submitted", "id": handler_id, "value": value
                 }));
             }
             for click in result.canvas_clicks {
-                let _ = self.runtime.send(&json!({
+                self.send_to_runtime(&json!({
                     "type": "mouse",
                     "x": click.x,
                     "y": click.y,
@@ -1451,7 +1461,7 @@ impl LivePythonPane {
 
     fn drain_runtime(&mut self) {
         while let Ok((request_id, response)) = self.http_rx.try_recv() {
-            let _ = self.runtime.send(&json!({
+            self.send_to_runtime(&json!({
                 "type": "http_response", "request_id": request_id,
                 "status": response.status, "body": response.body, "error": response.error,
                 "headers": response.response_headers,
@@ -1685,7 +1695,7 @@ impl LivePythonPane {
             Ok(content) => json!({"type": "file_read_result", "content": content}),
             Err(error) => json!({"type": "file_read_result", "error": error}),
         };
-        let _ = self.runtime.send(&response);
+        self.send_to_runtime(&response);
     }
 
     fn handle_file_write(&mut self, message: &Value) {
@@ -1710,7 +1720,7 @@ impl LivePythonPane {
             Ok(()) => json!({"type": "file_write_result"}),
             Err(error) => json!({"type": "file_write_result", "error": error}),
         };
-        let _ = self.runtime.send(&response);
+        self.send_to_runtime(&response);
     }
 
     /// Serve a capability-gated `read_host_log` request (stint 0444). The host
@@ -1756,7 +1766,7 @@ impl LivePythonPane {
             .unwrap_or_default()
             .to_string();
         if !self.has_capability("net.http") {
-            let _ = self.runtime.send(&json!({"type": "http_response", "request_id": request_id, "error": "missing capability net.http"}));
+            self.send_to_runtime(&json!({"type": "http_response", "request_id": request_id, "error": "missing capability net.http"}));
             return;
         }
         let method = message
@@ -1770,7 +1780,7 @@ impl LivePythonPane {
             .unwrap_or_default()
             .to_string();
         if !http_host_allowed(&url, &self.config.allowed_hosts) {
-            let _ = self.runtime.send(&json!({"type": "http_response", "request_id": request_id, "error": "host is not in manifest allowed_hosts"}));
+            self.send_to_runtime(&json!({"type": "http_response", "request_id": request_id, "error": "host is not in manifest allowed_hosts"}));
             return;
         }
         let headers = message
@@ -1810,7 +1820,7 @@ impl LivePythonPane {
             .and_then(Value::as_str)
             .unwrap_or_default();
         let granted = self.has_capability(capability);
-        let _ = self.runtime.send(
+        self.send_to_runtime(
             &json!({"type": "capability_decision", "capability": capability, "granted": granted}),
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ mod plexi_ai;
 mod protocol;
 mod release;
 mod render;
+mod rpc;
 #[cfg(test)]
 mod scenes;
 mod secrets;
@@ -1167,6 +1168,11 @@ fn main() -> eframe::Result {
     if !cli_mode && adopted_root.is_none() {
         println!("Starting Plexi — run 'plexi --help' to see available commands.");
     }
+
+    // One-shot RPC response files this host's clients abandoned (died before
+    // the answer landed) accumulate in the profile's rpc/ dir; sweep them at
+    // boot, mirroring the log rotate-and-prune in `platform::logging::init`.
+    rpc::sweep_stale(&config::config_dir());
 
     let icon = eframe::icon_data::from_png_bytes(include_bytes!("../assets/app-icon.png"))
         .expect("failed to load app icon");

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,0 +1,278 @@
+//! CLI-to-host RPC over one-shot response files.
+//!
+//! The CLI writes a request line to the channel's `notify.sock` carrying a
+//! `response_file` path; the host answers by writing that file; the CLI polls
+//! until the file appears. This module owns every piece of that mechanism:
+//!
+//! - **Path construction** (client side): `response_file` / `response_file_in`
+//!   mint a `<profile>/rpc/<prefix>-<uuid>.<ext>` path and ensure the `rpc/`
+//!   subdir exists — the host may be an older binary that writes without
+//!   creating directories.
+//! - **Polling** (client side): `poll_string` / `poll_bytes` /
+//!   `poll_slot_reply` wait for the file, read it, and delete it — on success
+//!   *and* on timeout, so an answer that lands just after the deadline does
+//!   not orphan a file.
+//! - **Writing** (host side): `write_response` / `write_json_response` write
+//!   atomically (temp file + rename) so a polling client never observes a
+//!   partial response.
+//! - **Sweeping** (host side): `sweep_stale` removes `rpc/` entries older
+//!   than a few minutes at host startup — the backstop for clients that died
+//!   before their response arrived.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Default client-side wait for a host response.
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Entries in `rpc/` older than this are startup-sweep garbage: no live
+/// request/response round trip spans minutes.
+const SWEEP_MAX_AGE: Duration = Duration::from_secs(600);
+
+/// Mint a one-shot response-file path under the active profile's `rpc/`
+/// subdir: `<config_dir>/rpc/<prefix>-<uuid>.<ext>`.
+pub(crate) fn response_file(prefix: &str, ext: &str) -> String {
+    response_file_in(&crate::config::config_dir(), prefix, ext)
+}
+
+/// `response_file` against an explicit profile dir — for callers that target
+/// a channel other than the ambient one (`plexi host status --channel ...`).
+pub(crate) fn response_file_in(profile_dir: &Path, prefix: &str, ext: &str) -> String {
+    let rpc_dir = profile_dir.join("rpc");
+    if let Err(e) = std::fs::create_dir_all(&rpc_dir) {
+        log::warn!("rpc: could not create {rpc_dir:?}: {e}");
+    }
+    rpc_dir
+        .join(format!("{prefix}-{}.{ext}", uuid::Uuid::new_v4()))
+        .to_string_lossy()
+        .into_owned()
+}
+
+pub(crate) enum PollError {
+    /// No response arrived within the timeout.
+    TimedOut,
+    /// The file appeared but could not be read.
+    Unreadable(std::io::Error),
+}
+
+impl std::fmt::Display for PollError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PollError::TimedOut => write!(f, "timed out waiting for response"),
+            PollError::Unreadable(e) => write!(f, "could not read response file: {e}"),
+        }
+    }
+}
+
+/// Poll until `response_file` appears, then read and delete it. `None`
+/// timeout waits forever (`plexi notify --timeout 0`). On timeout the file is
+/// removed best-effort in case the host answered just after the last check.
+pub(crate) fn poll_bytes(
+    response_file: &str,
+    timeout: Option<Duration>,
+) -> Result<Vec<u8>, PollError> {
+    let path = PathBuf::from(response_file);
+    let deadline = timeout.map(|t| std::time::Instant::now() + t);
+    loop {
+        if path.exists() {
+            return take_response(&path);
+        }
+        if deadline.is_some_and(|dl| std::time::Instant::now() >= dl) {
+            let _ = std::fs::remove_file(&path);
+            return Err(PollError::TimedOut);
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// `poll_bytes` decoded as UTF-8 (lossy — responses are host-written JSON).
+pub(crate) fn poll_string(
+    response_file: &str,
+    timeout: Option<Duration>,
+) -> Result<String, PollError> {
+    poll_bytes(response_file, timeout).map(|b| String::from_utf8_lossy(&b).into_owned())
+}
+
+/// A slot-read round trip answers on one of two files: raw payload bytes at
+/// `response_file`, or a JSON error at `<response_file>.err` (payloads are
+/// byte-clean, so errors cannot share the data file).
+pub(crate) enum SlotReply {
+    Data(Vec<u8>),
+    Err(Vec<u8>),
+}
+
+/// Poll for a slot reply on either file; delete both on every exit path.
+pub(crate) fn poll_slot_reply(
+    response_file: &str,
+    timeout: Option<Duration>,
+) -> Result<SlotReply, PollError> {
+    let data_path = PathBuf::from(response_file);
+    let err_path = PathBuf::from(format!("{response_file}.err"));
+    let deadline = timeout.map(|t| std::time::Instant::now() + t);
+    loop {
+        if err_path.exists() {
+            let _ = std::fs::remove_file(&data_path);
+            return take_response(&err_path).map(SlotReply::Err);
+        }
+        if data_path.exists() {
+            let _ = std::fs::remove_file(&err_path);
+            return take_response(&data_path).map(SlotReply::Data);
+        }
+        if deadline.is_some_and(|dl| std::time::Instant::now() >= dl) {
+            let _ = std::fs::remove_file(&data_path);
+            let _ = std::fs::remove_file(&err_path);
+            return Err(PollError::TimedOut);
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn take_response(path: &Path) -> Result<Vec<u8>, PollError> {
+    let content = std::fs::read(path);
+    let _ = std::fs::remove_file(path);
+    content.map_err(PollError::Unreadable)
+}
+
+/// Host-side response write: atomic (temp file + rename) so a polling client
+/// never reads a partial file. Returns whether the write landed; failure is
+/// logged here — the response-file name identifies the request kind.
+pub(crate) fn write_response(response_file: &str, body: &[u8]) -> bool {
+    let temp_file = format!("{response_file}.tmp");
+    if let Err(e) = std::fs::write(&temp_file, body) {
+        log::error!("rpc: could not write temp response file {temp_file:?}: {e}");
+        return false;
+    }
+    if let Err(e) = std::fs::rename(&temp_file, response_file) {
+        log::error!("rpc: could not rename temp response file to {response_file:?}: {e}");
+        let _ = std::fs::remove_file(&temp_file);
+        return false;
+    }
+    true
+}
+
+/// `write_response` for a JSON value.
+pub(crate) fn write_json_response(response_file: &str, value: serde_json::Value) -> bool {
+    match serde_json::to_string(&value) {
+        Ok(json) => write_response(response_file, json.as_bytes()),
+        Err(e) => {
+            log::error!("rpc: could not serialize response for {response_file:?}: {e}");
+            false
+        }
+    }
+}
+
+/// Startup sweep: delete `rpc/` entries older than `SWEEP_MAX_AGE`. Catches
+/// responses the host wrote after their client gave up, and clients that died
+/// mid-request. Best-effort; called once per host boot.
+pub(crate) fn sweep_stale(profile_dir: &Path) {
+    let rpc_dir = profile_dir.join("rpc");
+    let entries = match std::fs::read_dir(&rpc_dir) {
+        Ok(entries) => entries,
+        Err(_) => return, // no rpc dir yet — nothing to sweep
+    };
+    let now = std::time::SystemTime::now();
+    let mut swept = 0u32;
+    for entry in entries.flatten() {
+        let age = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|modified| now.duration_since(modified).ok());
+        if age.is_some_and(|age| age > SWEEP_MAX_AGE) {
+            match std::fs::remove_file(entry.path()) {
+                Ok(()) => swept += 1,
+                Err(e) => log::warn!("rpc: sweep could not remove {:?}: {e}", entry.path()),
+            }
+        }
+    }
+    if swept > 0 {
+        log::info!("rpc: swept {swept} stale response file(s) from {rpc_dir:?}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn poll_reads_and_deletes_on_success() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("x-response-1.json");
+        std::fs::write(&path, b"{\"ok\":true}").expect("plant response");
+        let content = poll_bytes(path.to_str().unwrap(), Some(Duration::from_secs(1)))
+            .unwrap_or_else(|e| panic!("poll failed: {e}"));
+        assert_eq!(content, b"{\"ok\":true}");
+        assert!(!path.exists(), "response file must be deleted on success");
+    }
+
+    /// A response that lands only after the client's deadline is the
+    /// startup sweep's job (`sweep_removes_only_stale_entries`), not the
+    /// poller's — the client process is gone by then.
+    #[test]
+    fn poll_times_out_when_no_response_arrives() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("x-response-2.json");
+        let result = poll_bytes(path.to_str().unwrap(), Some(Duration::from_millis(1)));
+        assert!(matches!(result, Err(PollError::TimedOut)));
+        assert!(!path.exists(), "timeout must not create files");
+    }
+
+    #[test]
+    fn slot_reply_prefers_err_file_and_cleans_both() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("slot-response.json");
+        let err_path = dir.path().join("slot-response.json.err");
+        std::fs::write(&path, b"data").expect("plant data");
+        std::fs::write(&err_path, b"{\"ok\":false}").expect("plant err");
+        let reply = poll_slot_reply(path.to_str().unwrap(), Some(Duration::from_secs(1)))
+            .unwrap_or_else(|e| panic!("poll failed: {e}"));
+        assert!(matches!(reply, SlotReply::Err(bytes) if bytes == b"{\"ok\":false}"));
+        assert!(!path.exists() && !err_path.exists(), "both files cleaned");
+    }
+
+    #[test]
+    fn write_response_is_atomic_and_leaves_no_temp() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("w-response.json");
+        let path_str = path.to_str().unwrap();
+        assert!(write_response(path_str, b"{\"ok\":true}"));
+        assert_eq!(
+            std::fs::read(&path).expect("read back"),
+            b"{\"ok\":true}"
+        );
+        assert!(
+            !Path::new(&format!("{path_str}.tmp")).exists(),
+            "temp file must be renamed away"
+        );
+    }
+
+    #[test]
+    fn sweep_removes_only_stale_entries() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let rpc_dir = dir.path().join("rpc");
+        std::fs::create_dir_all(&rpc_dir).expect("mkdir rpc");
+        let stale = rpc_dir.join("old-response.json");
+        let fresh = rpc_dir.join("new-response.json");
+        std::fs::write(&stale, b"old").expect("plant stale");
+        std::fs::write(&fresh, b"new").expect("plant fresh");
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&stale)
+            .and_then(|f| f.set_modified(std::time::SystemTime::now() - Duration::from_secs(3600)))
+            .expect("age stale file");
+        sweep_stale(dir.path());
+        assert!(!stale.exists(), "stale entry must be swept");
+        assert!(fresh.exists(), "fresh entry must survive");
+    }
+
+    #[test]
+    fn response_file_in_creates_rpc_subdir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = response_file_in(dir.path(), "pane-list-response", "json");
+        assert!(dir.path().join("rpc").is_dir(), "rpc/ must exist");
+        assert!(path.contains("/rpc/pane-list-response-"));
+        assert!(path.ends_with(".json"));
+    }
+}

--- a/src/testing/AGENTS.md
+++ b/src/testing/AGENTS.md
@@ -26,6 +26,7 @@ Test infrastructure for the Plexi host. `HostHarness` (headless egui test harnes
 - **`cargo test --lib` silently misses host tests.** `--lib` only runs the `app_protocol` lib target (~47 tests). Host tests — app_registry, HostHarness, wasm_python, workspace_secrets — live in the binary target. Always use `cargo test --bin plexi`.
 - **`HostHarness::add_test_pane()` inserts a builtin app pane, not a Terminal.** Terminal-count assertions must not assume the initial pane is a Terminal; offset accordingly.
 - **Test constructor sync.** When adding a field to any struct that has a `new_for_test()` constructor, update that constructor in the same commit. Run `cargo test --bin plexi` on the base branch first to distinguish pre-existing failures from regressions.
+- **Never root a harness app at a real machine directory.** A `FileBrowserApp` (or any scanning app) pointed at `std::env::temp_dir()` renders whatever the dev machine's temp dir holds — ~50k entries drove test binaries past 30 GB RSS while CI stayed green on its clean temp. Root harness panes in the harness's own workspace tempdir (`HostHarness::_workspace_dir`, `PlexiUiHarness::workspace`) or a scoped `tempfile::tempdir()`.
 
 ## Style
 

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -122,13 +122,17 @@ impl HostHarness {
         let pane_id = self.next_pane_id;
         self.next_pane_id += 1;
 
+        // Root the file browser in the harness's empty workspace dir — NEVER
+        // the real temp_dir(), which on a dev machine can hold ~50k entries
+        // and balloons any test that renders the pane by gigabytes.
+        let browser_root = self._workspace_dir.path().to_path_buf();
         let app_pane = AppPane {
             pip_status: None,
             id: pane_id,
             runtime: AppRuntime::Builtin(Box::new(crate::file_browser::FileBrowserApp::new(
-                std::env::temp_dir(),
+                browser_root.clone(),
             ))),
-            workspace_root: std::env::temp_dir(),
+            workspace_root: browser_root,
             permissions,
             manifest_id: "test".to_string(),
             name: "Test App".to_string(),

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -491,15 +491,18 @@ mod tests {
     use egui_kittest::kittest::Queryable;
 
     fn add_focused_pane(h: &mut PlexiUiHarness) -> crate::spatial::tiling::PaneId {
+        // Root the file browser in the harness's empty workspace — never the
+        // real temp_dir(), whose ~50k dev-machine entries balloon rendering.
+        let browser_root = h.workspace.path().to_path_buf();
         h.with_app_mut(|app| {
             let pane_id = app.host.alloc_pane_id();
             let app_pane = AppPane {
                 pip_status: None,
                 id: pane_id,
                 runtime: AppRuntime::Builtin(Box::new(crate::file_browser::FileBrowserApp::new(
-                    std::env::temp_dir(),
+                    browser_root.clone(),
                 ))),
-                workspace_root: std::env::temp_dir(),
+                workspace_root: browser_root.clone(),
                 permissions: AppPermissions::builtin(),
                 manifest_id: "test".to_string(),
                 name: "Test App".to_string(),
@@ -747,6 +750,11 @@ mod tests {
     /// sidebar. Zoom the portal so the icon is legible in the PNG.
     #[test]
     fn screenshot_portal_text_editor_icon() {
+        // Never point the harnessed file browser at the real temp_dir(): a dev
+        // machine's temp dir can hold ~50k entries and rendering them balloons
+        // this test past 30 GB RSS. An empty scoped tempdir renders instantly.
+        let editor_root = tempfile::tempdir().expect("tempdir");
+        let editor_path = editor_root.path().to_path_buf();
         let mut h = PlexiUiHarness::new_sized(900.0, 640.0);
         let _base = add_focused_pane(&mut h);
         h.with_app_mut(|app| {
@@ -755,7 +763,7 @@ mod tests {
             // Register the child context so the portal header shows a real name.
             app.router.push(crate::host::context::Context {
                 name: "Notes".to_string(),
-                path: std::env::temp_dir(),
+                path: editor_path.clone(),
                 root: None,
                 description: Some("Editing notes".to_string()),
                 context_id: child_ctx_id,
@@ -770,9 +778,9 @@ mod tests {
                 pip_status: Some(crate::app_protocol::PipStatus::Green),
                 id: editor_pane_id,
                 runtime: AppRuntime::Builtin(Box::new(crate::file_browser::FileBrowserApp::new(
-                    std::env::temp_dir(),
+                    editor_path.clone(),
                 ))),
-                workspace_root: std::env::temp_dir(),
+                workspace_root: editor_path.clone(),
                 permissions: AppPermissions::builtin(),
                 manifest_id: "text-editor".to_string(),
                 name: "note.md".to_string(),
@@ -792,7 +800,7 @@ mod tests {
             app.next_window_id += 1;
             app.windows.push(Window {
                 name: "notes window".to_string(),
-                path: std::env::temp_dir(),
+                path: editor_path.clone(),
                 tree: egui_tiles::Tree::new("notes window", child_tile, child_tiles),
                 panes: child_panes,
                 focused_pane: Some(child_tile),
@@ -1827,15 +1835,16 @@ mod tests {
     fn screenshot_command_palette_metadata_lane() {
         let mut h = PlexiUiHarness::new_sized(1168.0, 720.0);
         let first_pane_id = add_focused_pane(&mut h);
+        let browser_root = h.workspace.path().to_path_buf();
         h.with_app_mut(|app| {
             let second_pane_id = app.host.alloc_pane_id();
             let app_pane = AppPane {
                 pip_status: None,
                 id: second_pane_id,
                 runtime: AppRuntime::Builtin(Box::new(crate::file_browser::FileBrowserApp::new(
-                    std::env::temp_dir(),
+                    browser_root.clone(),
                 ))),
-                workspace_root: std::env::temp_dir(),
+                workspace_root: browser_root.clone(),
                 permissions: AppPermissions::builtin(),
                 manifest_id: "hidden-test".to_string(),
                 name: "Hidden Test App".to_string(),
@@ -2236,6 +2245,7 @@ mod tests {
         let mut h = PlexiUiHarness::new();
         h.step();
 
+        let browser_root = h.workspace.path().to_path_buf();
         h.with_app_mut(|app| {
             let pane_id_a = app.host.alloc_pane_id();
             let pane_id_b = app.host.alloc_pane_id();
@@ -2247,9 +2257,9 @@ mod tests {
                     pip_status: None,
                     id: pane_id,
                     runtime: AppRuntime::Builtin(Box::new(
-                        crate::file_browser::FileBrowserApp::new(std::env::temp_dir()),
+                        crate::file_browser::FileBrowserApp::new(browser_root.clone()),
                     )),
-                    workspace_root: std::env::temp_dir(),
+                    workspace_root: browser_root.clone(),
                     permissions: AppPermissions::builtin(),
                     manifest_id: "test".to_string(),
                     name: name.to_string(),


### PR DESCRIPTION
Bundles the s9 tooling cluster: stints **0536**, **0534**, **0535** (no linked GitHub issues; stint tasks are authoritative).

## 0536 — RPC response-file consolidation (`src/rpc.rs`)
- One-shot CLI↔host response files move from the profile root into **`<profile>/rpc/`** (names/UUID scheme unchanged). The client pre-creates `rpc/`, so an older running host still writes successfully mid-upgrade.
- **One atomic writer** (temp file + rename) replaces ~21 hand-rolled `std::fs::write` response sites (`lifecycle.rs`, `screenshot.rs`, `focus.rs`, `app/mod.rs`); a polling client can never read a partial response.
- **One shared poller** (`rpc::poll_bytes`/`poll_string`/`poll_slot_reply` + `cli::poll_rpc`) replaces the 5 named poller fns and ~10 inline copies. It deletes the response file on success **and** on timeout — fixing the `plexi notify` timeout leak that left 23 orphan files in `~/.plexi-beta`.
- **Startup sweep**: the host removes `rpc/` entries older than 10 minutes at boot (next to the log rotate-and-prune call), catching responses written after a client died. Cleanup is unconditional on both sides — no second cleanup path.
- Net **−131 lines** across the mechanism even counting the new module and its tests.

## 0534 — ephemeral profile reaper
`scripts/channel-clean-ephemeral.sh` + `just channel-clean-ephemeral`: reaps `~/.plexi-<16 hex>` drive-host profiles and ad-hoc leftovers (`baseline-*`, `stint*`, `*test*`) idle ≥7 days (`--age-days`), with `--dry-run`, byte totals, and delegation to `channel-clean.sh` so bins/bundles/completions go too. Activity is judged by the newest mtime under the profile (not the dir mtime, which log writes don't bump). Hard-protected: `alpha`/`beta`/`main`/`pr-*`/`rc-*`/`src`. Dry run on this machine: 5 profiles, 3 MB.

## 0535 — swallowed failures + stale doc
- `FileEventSink` (services.rs): startup-heartbeat write and per-emit flush failures now log instead of `let _ =`.
- `LivePythonPane` (wasm_python.rs): all CPython subprocess sends route through `send_to_runtime()`, which warns with the app id when the pipe is dead — a dead runtime is now one grep away in plexi.log.
- Root `AGENTS.md` Logging section now documents the real **date-based** rotation (`rotate_and_prune`, `[log] retention_days`, default 30) instead of the stale "rotates at 10 MB" claim.

## Also: pre-existing runaway-test fix (found during this run's gate)
`ui_tests::screenshot_portal_text_editor_icon` (and every `HostHarness::add_test_pane` caller) rooted a `FileBrowserApp` at the **real** `std::env::temp_dir()` — ~50k entries on this dev machine ballooned test binaries past 30 GB RSS (reproduced in isolation on the **alpha-HEAD binary**, so pre-existing, merged in d76495ab). Harness panes now root in the harness's own workspace tempdir; trap recorded in `src/testing/AGENTS.md`. Full suite: **30+ min / 35 GB → ~60 s / 843 MB peak**.

## Test evidence
- `cargo test --bin plexi` (env `-u PLEXI_*`, skipping known pre-existing 0537 failure `send_to_app_pane_injects_text_through_focused_render_input`):
  `test result: ok. 1755 passed; 0 failed; 2 ignored; 0 measured; 1 filtered out; finished in 62.36s`
- New tests: `rpc::tests` (poll deletes on success, timeout leaves nothing, slot `.err` protocol, atomic write, sweep, rpc-dir creation) and `notify_cli_timeout_leaves_no_response_file` (end-to-end leak regression: exit 2, `rpc/` path, no file left).
- `just check-cli-docs` ✅ · `just check-docs-coverage` ✅ · `cargo build` ✅ · reaper `--dry-run` exercised against real `~/.plexi-*` state ✅
- Codex review ×2: round 1 findings (reaper mtime activity, timeout-race test masking) fixed; round 2 clean apart from then-unstaged new files.
- Conclusion: **binary install required** — the sweep call and rpc/ relocation deserve a live-host round via `just pr-install <PR>`; validator should run `plexi-pr-<PR>` commands (pane list/state/notify choice) and confirm responses land in `<profile>/rpc/` and vanish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
