### PR TITLE
test(daw): 4-tier release gate — fuzz, harness, scenes, installed host (stint 0519)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4048,6 +4048,8 @@ dependencies = [
  "objc2-core-media",
  "objc2-core-video",
  "objc2-foundation 0.3.2",
+ "plexi-daw-engine",
+ "plexi-daw-model",
  "pollster",
  "pulldown-cmark",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,11 @@ objc2-core-foundation = { version = "0.3", features = [
 
 [dev-dependencies]
 tempfile = "3"
+# DAW release gate (stint 0519): the host test build drives the pure-model
+# fuzzer (via the `gate` feature) and the offline render engine, so
+# `cargo test --bin plexi` covers every tier. Neither ships in the host binary.
+plexi-daw-model = { path = "crates/daw-model", features = ["gate"] }
+plexi-daw-engine = { path = "crates/daw-engine" }
 
 [patch.crates-io]
 # Vendored because accesskit_consumer 0.38 still panics when a root-change

--- a/crates/daw-model/Cargo.toml
+++ b/crates/daw-model/Cargo.toml
@@ -8,3 +8,9 @@ publish = false
 log = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[features]
+# Compiles the release gate (matrix + long sequence + seeded fuzzer) as a
+# public API so the host binary can drive it under `cargo test --bin plexi`.
+# Off in the shipped WASM app build; on only for the host's dev-dependency.
+gate = []

--- a/crates/daw-model/src/gate.rs
+++ b/crates/daw-model/src/gate.rs
@@ -3,10 +3,12 @@
 //! the pure [`DawModel`] state machine — with per-command invariant checks
 //! and a machine-readable qualification artifact.
 //!
-//! Compiled only under `cfg(test)`: the gate is test infrastructure, never
-//! product code. Mirrors the editor gate (`src/editor/gate.rs` in the host
-//! crate) in structure, seeds, minimizer, and artifact schema shape.
-#![cfg(test)]
+//! Test infrastructure, never product code: compiled for this crate's own
+//! `cargo test` and — via the `gate` feature — into the host binary as a
+//! dev-dependency, so `cargo test --bin plexi` drives the identical fuzzer
+//! (`src/testing/daw_gate.rs`). Absent from the shipped WASM app build.
+//! Mirrors the editor gate (`src/editor/gate.rs` in the host crate) in
+//! structure, seeds, minimizer, and artifact schema shape.
 
 use std::path::Path;
 use std::time::Instant;
@@ -14,9 +16,12 @@ use std::time::Instant;
 use crate::commands::{ApplyOutcome, DawCommand};
 use crate::history::MAX_GROUPS;
 use crate::model::{
-    ClipId, DawModel, Project, SourceId, TrackId, TrackKind, Transport, ValidationError,
-    TEMPO_MIN, TICKS_PER_BEAT, VOLUME_MAX,
+    ClipId, DawModel, Project, SourceId, TrackId, TrackKind, TEMPO_MIN, TICKS_PER_BEAT, VOLUME_MAX,
 };
+// Referenced only by this module's own `#[cfg(test)]` entry points; the host's
+// `gate`-feature build reaches the drivers, not the from-parts assertions.
+#[cfg(test)]
+use crate::model::{Transport, ValidationError};
 
 /// Environment variable that pins `gate_randomized_commands` to one seed.
 pub const GATE_SEED_ENV: &str = "PLEXI_DAW_GATE_SEED";
@@ -24,7 +29,7 @@ pub const GATE_SEED_ENV: &str = "PLEXI_DAW_GATE_SEED";
 const DEFAULT_SEEDS: [u64; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
 /// Kept modest (vs the editor's 2000): snapshot history makes state clones
 /// the dominant cost, and a sibling agent shares this machine's memory.
-const RANDOM_COMMANDS_PER_SEED: usize = 1500;
+pub const RANDOM_COMMANDS_PER_SEED: usize = 1500;
 /// Past this many clips the fuzzer biases hard toward shrinking commands.
 const FUZZ_CLIP_SOFT_CAP: usize = 200;
 
@@ -774,7 +779,7 @@ pub struct GateFinalState {
     pub can_redo: bool,
 }
 
-fn run_case(case: &GateCase) -> Result<GateFinalState, String> {
+pub fn run_case(case: &GateCase) -> Result<GateFinalState, String> {
     let mut model = DawModel::new();
     let mut prev_revision = model.revision();
     for (index, step) in case.steps.iter().enumerate() {
@@ -1159,7 +1164,7 @@ fn frozen_state(model: &DawModel) -> Result<String, String> {
 
 /// Runs one randomized seed. On invariant failure, minimizes the failing
 /// sequence and writes a replay bundle; returns the failure message.
-fn run_random_seed(seed: u64, command_count: usize) -> Result<(), String> {
+pub fn run_random_seed(seed: u64, command_count: usize) -> Result<(), String> {
     let mut rng = SplitMix64::new(seed);
     let mut model = DawModel::new();
     let mut prev_revision = model.revision();
@@ -1241,7 +1246,7 @@ fn run_random_seed(seed: u64, command_count: usize) -> Result<(), String> {
     ))
 }
 
-fn seeds_under_test() -> Vec<u64> {
+pub fn seeds_under_test() -> Vec<u64> {
     match std::env::var(GATE_SEED_ENV) {
         Ok(raw) => {
             let seed: u64 = raw

--- a/crates/daw-model/src/lib.rs
+++ b/crates/daw-model/src/lib.rs
@@ -12,7 +12,12 @@ pub mod commands;
 pub mod history;
 pub mod model;
 
-mod gate;
+// The release gate is test infrastructure: compiled for this crate's own
+// `cargo test`, and for the host binary via the `gate` feature (a host
+// dev-dependency), so `cargo test --bin plexi` drives the same fuzzer. It is
+// absent from the shipped WASM app build, which enables neither.
+#[cfg(any(test, feature = "gate"))]
+pub mod gate;
 
 pub use commands::{ApplyOutcome, DawCommand};
 pub use history::{CoalesceKey, SnapshotHistory, MAX_GROUPS};

--- a/justfile
+++ b/justfile
@@ -492,6 +492,11 @@ scene-live FILE channel out="/tmp/plexi-scenes-live":
 editor-gate channel:
     bash scripts/editor-gate.sh {{channel}}
 
+# Installed-host DAW release gate: core model qualification + every DAW scene
+# against a channel, reports + artifacts + summary.json (stint 0519).
+daw-gate channel:
+    bash scripts/daw-gate.sh {{channel}}
+
 # Run one agent-drives-agent app-authoring E2E session from a prompt fixture.
 # Provisions an isolated session and leaves a capture dir under benchmarks/app-authoring/sessions.
 #   just e2e-session tools/e2e_authoring/fixtures/counter.toml            — live (needs channel + display)

--- a/scripts/daw-gate.sh
+++ b/scripts/daw-gate.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Installed-host DAW release gate (stint 0519). The DAW analog of
+# `scripts/editor-gate.sh`, reusing the same named cases across every tier.
+#
+# Flow:
+#   1. Core qualification (matrix + long sequence + seeded fuzz over the pure
+#      model) — writes the daw-gate-core.json artifact; the gate fails outright
+#      without it.
+#   2. Boot ONE hermetic host for the channel (`host start --ephemeral`: no
+#      workspace restore, no workspace save) and leave an info-level start
+#      marker in the channel's plexi.log via `plexi host log`.
+#   3. Run every DAW scene (tests/scenes/daw-*.toml) against that host in
+#      attach mode (PLEXI_SCENE_ATTACH=1), collecting SceneReport JSONs and
+#      failure bundles per scene, plus a best-effort bounded host screenshot
+#      per scene (`plexi host screenshot` can stall — a hang or failure only
+#      logs a warning and never affects the gate result).
+#   4. Leave a finish marker with pass/fail counts in the channel log, stop
+#      the host, tail the channel's plexi.log, and write summary.json.
+#
+# Exits nonzero when the core qualification, the host boot, or any scene
+# fails. Screenshots and log markers are evidence, not gate conditions.
+#
+# Usage: daw-gate.sh <channel> [out_dir]
+set -uo pipefail
+
+channel="${1:?usage: daw-gate.sh <channel> [out_dir]}"
+out_dir="${2:-/tmp/plexi-daw-gate/$channel}"
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+scene_dir="$repo_root/tests/scenes"
+
+if [[ "$channel" == "main" ]]; then
+    plexi_bin="plexi"
+    profile_dir="$HOME/.plexi"
+else
+    plexi_bin="plexi-$channel"
+    profile_dir="$HOME/.plexi-$channel"
+fi
+
+mkdir -p "$out_dir"
+
+# Run a command with a hard wall-clock bound (portable: macOS ships no
+# `timeout`). Returns 124 on timeout, the command's exit code otherwise.
+run_bounded() {
+    local seconds="$1"
+    shift
+    "$@" &
+    local pid=$!
+    (
+        sleep "$seconds"
+        kill "$pid" 2>/dev/null
+    ) &
+    local watchdog=$!
+    local code=0
+    wait "$pid" 2>/dev/null || code=$?
+    kill "$watchdog" 2>/dev/null
+    wait "$watchdog" 2>/dev/null
+    if [[ $code -ge 128 ]]; then
+        return 124
+    fi
+    return "$code"
+}
+
+# Host log marker: the installed run's start/finish summary must reach the
+# channel's plexi.log, whose logger the host process owns. Bounded and
+# warn-only: a marker failure never changes the gate result.
+host_marker() {
+    if ! run_bounded 10 "$plexi_bin" host log --source daw_gate "$1" \
+        >> "$out_dir/host-markers.log" 2>&1; then
+        echo "daw-gate: warning: host log marker failed: $1" >&2
+    fi
+}
+
+gate_host_started=""
+cleanup_gate_host() {
+    if [[ -n "$gate_host_started" ]]; then
+        "$plexi_bin" host stop >/dev/null 2>&1 || true
+        gate_host_started=""
+    fi
+}
+trap cleanup_gate_host EXIT INT TERM HUP
+
+scenes=()
+for scene in "$scene_dir"/daw-*.toml; do
+    [[ -f "$scene" ]] && scenes+=("$scene")
+done
+if [[ ${#scenes[@]} -eq 0 ]]; then
+    echo "daw-gate: no DAW scenes found in $scene_dir" >&2
+    exit 1
+fi
+
+echo "daw-gate: started channel=$channel scenes=${#scenes[@]} out=$out_dir"
+
+# Core qualification first: run it fresh so the artifact always matches this
+# working tree, and fail the gate outright when it fails.
+core_artifact="${TMPDIR:-/tmp}/plexi-daw-gate/daw-gate-core.json"
+rm -f "$core_artifact"
+echo "daw-gate: running core qualification (cargo test daw_gate core artifact)"
+if ! (cd "$repo_root" && env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID \
+    -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID \
+    cargo test --bin plexi daw_gate::daw_gate_core_qualification_artifact \
+    > "$out_dir/core-qualification.log" 2>&1); then
+    echo "daw-gate: CORE QUALIFICATION FAILED (see $out_dir/core-qualification.log)" >&2
+    exit 1
+fi
+if [[ ! -f "$core_artifact" ]]; then
+    echo "daw-gate: core qualification did not produce $core_artifact" >&2
+    exit 1
+fi
+cp "$core_artifact" "$out_dir/daw-gate-core.json"
+echo "daw-gate: collected core artifact daw-gate-core.json"
+
+# One hermetic host for the whole gate: --ephemeral means the channel's saved
+# session is neither restored nor overwritten. The started flag is set before
+# the attempt: a host that spawns but fails readiness still exists, and the
+# EXIT trap must stop it rather than orphan it (stopping a never-started host
+# is a bounded no-op).
+gate_host_started=1
+if ! "$plexi_bin" host start --ephemeral --pane "cwd=$repo_root" \
+    > "$out_dir/host-start.log" 2>&1; then
+    echo "daw-gate: HOST START FAILED (see $out_dir/host-start.log)" >&2
+    exit 1
+fi
+host_marker "gate started channel=$channel scenes=${#scenes[@]}"
+
+failures=0
+scene_entries=""
+for scene in "${scenes[@]}"; do
+    name="$(basename "$scene" .toml)"
+    scene_out="$out_dir/scenes/$name"
+    mkdir -p "$scene_out"
+    echo "daw-gate: running scene $name"
+    if PLEXI_SCENE_ATTACH=1 bash "$repo_root/scripts/run-live-scene.sh" \
+        "$scene" "$channel" "$scene_out" > "$scene_out/run.log" 2>&1; then
+        passed=true
+    else
+        passed=false
+        failures=$((failures + 1))
+        echo "daw-gate: SCENE FAILED $name (see $scene_out/run.log)" >&2
+    fi
+    # Best-effort pixel evidence. `plexi host screenshot` can silently stall
+    # (pre-existing host bug, tracked separately) — bound it hard and never
+    # let it affect the gate result.
+    if ! run_bounded 20 "$plexi_bin" host screenshot \
+        --output "$scene_out/host-after.png" \
+        > "$scene_out/screenshot.log" 2>&1; then
+        echo "daw-gate: warning: screenshot after scene $name failed or timed out (best-effort, gate unaffected)" \
+            | tee -a "$scene_out/screenshot.log" >&2
+    fi
+    [[ -n "$scene_entries" ]] && scene_entries+=","
+    scene_entries+=$'\n    '"{\"name\": \"$name\", \"passed\": $passed, \"report\": \"scenes/$name/$name.json\"}"
+done
+
+total=${#scenes[@]}
+passed_count=$((total - failures))
+host_marker "gate finished channel=$channel passed=$passed_count failed=$failures"
+cleanup_gate_host
+
+# Channel log tail for post-mortems (includes the markers above).
+channel_log="$profile_dir/plexi.log"
+if [[ -f "$channel_log" ]]; then
+    tail -n 500 "$channel_log" > "$out_dir/log-tail.txt"
+else
+    echo "daw-gate: channel log $channel_log not found" > "$out_dir/log-tail.txt"
+fi
+
+cat > "$out_dir/summary.json" <<SUMMARY
+{
+  "channel": "$channel",
+  "scenes": [$scene_entries
+  ],
+  "totals": {"scenes": $total, "passed": $passed_count, "failed": $failures}
+}
+SUMMARY
+
+echo "daw-gate: finished channel=$channel passed=$passed_count failed=$failures summary=$out_dir/summary.json"
+if [[ $failures -gt 0 ]]; then
+    exit 1
+fi

--- a/scripts/daw-gate.sh
+++ b/scripts/daw-gate.sh
@@ -80,14 +80,29 @@ cleanup_gate_host() {
 }
 trap cleanup_gate_host EXIT INT TERM HUP
 
+# Attach-eligible scene set. Only scenes that can run against a live installed
+# host belong here: raw-WASM review is pre-approved by the live runner
+# (`plexi app trust`), and the file picker is scripted through the host's
+# PLEXI_PICKER_SCRIPT (set below) — never an in-scene `picker_script`, which is
+# headless-only. daw-timeline drives transport/edit via named keys;
+# daw-gate-bundle is the attach counterpart of the headless daw-bundle scene.
+attach_scenes=(daw-timeline daw-gate-bundle)
 scenes=()
-for scene in "$scene_dir"/daw-*.toml; do
-    [[ -f "$scene" ]] && scenes+=("$scene")
+for name in "${attach_scenes[@]}"; do
+    scene="$scene_dir/$name.toml"
+    if [[ ! -f "$scene" ]]; then
+        echo "daw-gate: missing attach scene $scene" >&2
+        exit 1
+    fi
+    # Category guard (stint 0519): an in-scene picker_script is honored only by
+    # the in-process suite backend; the live runner rejects it. Such a scene is
+    # not attach-eligible and must never silently enter the installed-host gate.
+    if grep -Eq '^[[:space:]]*picker_script' "$scene"; then
+        echo "daw-gate: scene $name declares picker_script (headless-only) and is not attach-eligible; script the picker via PLEXI_PICKER_SCRIPT at host start instead" >&2
+        exit 1
+    fi
+    scenes+=("$scene")
 done
-if [[ ${#scenes[@]} -eq 0 ]]; then
-    echo "daw-gate: no DAW scenes found in $scene_dir" >&2
-    exit 1
-fi
 
 echo "daw-gate: started channel=$channel scenes=${#scenes[@]} out=$out_dir"
 
@@ -109,6 +124,21 @@ if [[ ! -f "$core_artifact" ]]; then
 fi
 cp "$core_artifact" "$out_dir/daw-gate-core.json"
 echo "daw-gate: collected core artifact daw-gate-core.json"
+
+# Script the host's file picker for daw-gate-bundle's save-as / open / export
+# (F2/F3/F5). The live host reads PLEXI_PICKER_SCRIPT per pane at launch, so it
+# must be exported before `host start`; each pick grants write to the concrete
+# path it returns. daw-timeline never opens a picker, so its unused queue is
+# harmless.
+picker_script="$out_dir/picker-script.json"
+cat > "$picker_script" <<PICKER
+[
+  {"paths": ["$out_dir/song"]},
+  {"paths": ["$out_dir/song"]},
+  {"paths": ["$out_dir/mixdown.wav"]}
+]
+PICKER
+export PLEXI_PICKER_SCRIPT="$picker_script"
 
 # One hermetic host for the whole gate: --ephemeral means the channel's saved
 # session is neither restored nor overwritten. The started flag is set before

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -512,6 +512,21 @@ pub enum AppCmd {
         #[arg(trailing_var_arg = true, allow_hyphen_values = true, conflicts_with_all = ["mcp", "cli"])]
         extra_args: Vec<String>,
     },
+    /// Pre-approve a raw `.wasm` component's host imports without a prompt.
+    ///
+    /// The non-interactive form of the review `plexi app open <file.wasm>`
+    /// runs at a TTY: it persists Green grants for every host interface the
+    /// component imports, scoped to the wasm's parent directory — the same
+    /// store and scope an installed host checks at open time. Meant for
+    /// automation (release gates, scene runners) pre-approving a vetted,
+    /// repo-committed fixture so an installed host opens it without a human at
+    /// a terminal. It never opens a pane; production interactive review is
+    /// unchanged.
+    Trust {
+        /// Path to the `.wasm` component to trust.
+        #[arg(value_hint = ValueHint::FilePath)]
+        path: String,
+    },
     /// Install an app from a local path, a remote source, or a pack file.
     ///
     /// Local path: `plexi app install ./my-app` — copies the app dir into Plexi's store.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -611,8 +611,8 @@ pub use marketplace::{app_browse_cli, app_publish_cli, app_search_cli};
 pub use notes::{notes_list_cli, notes_open_cli};
 pub use notify::notify_cli;
 pub use open::{
-    mcp_pane_title, open_cli, open_cli_by_name, open_mcp_by_name, pane_new_cli, parse_prefix,
-    OpenPrefix,
+    app_trust_cli, mcp_pane_title, open_cli, open_cli_by_name, open_mcp_by_name, pane_new_cli,
+    parse_prefix, OpenPrefix,
 };
 pub use pane::{
     pane_capture_cli, pane_click_cli, pane_click_node_cli, pane_close_cli, pane_drag_cli,

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -442,6 +442,75 @@ fn review_raw_wasm_open(path: &Path) -> Result<(), String> {
     review_raw_wasm_open_with_reader(path, is_tty, &mut stdin)
 }
 
+/// Non-interactive raw-WASM pre-approval (`plexi app trust`): persist Green
+/// grants for every host interface the component imports, plus `fs.pick`
+/// (a runtime picker gate, not an import), scoped to the wasm's parent dir —
+/// the same store, app id, and scope the interactive review and the host use.
+/// Never opens a pane. Idempotent. Grants only what the component declares, so
+/// a caller vouches for a specific vetted file, not a blanket allow.
+fn trust_raw_wasm_open(path: &Path) -> Result<(), String> {
+    let app_id = raw_wasm_app_id(path);
+    let workspace_root = raw_wasm_workspace_root(path);
+    let required_grants =
+        crate::host::wasm_app::WasmApp::inspect_required_grants(path).map_err(|e| {
+            format!(
+                "could not inspect WASM imports for '{}': {e}",
+                path.display()
+            )
+        })?;
+    let config_dir = crate::config::config_dir();
+    let mut store = crate::app::permissions::PermissionStore::load_or_default(&config_dir);
+    let mut granted: Vec<String> = required_grants.capability_ids();
+    // `fs.pick` gates the file picker at runtime rather than being a component
+    // import, so it never appears in the inspected grants; a fixture that
+    // drives the picker still needs it pre-approved.
+    granted.push("fs.pick".to_string());
+    for capability_id in &granted {
+        store.set_wasm(
+            &app_id,
+            &workspace_root,
+            capability_id,
+            crate::app::permissions::PermissionState::Green,
+        );
+    }
+    store.save();
+    log::info!(
+        "open:cli: app trust granted app={} path={} workspace={} grants={:?}",
+        app_id,
+        path.display(),
+        workspace_root.display(),
+        granted
+    );
+    Ok(())
+}
+
+/// `plexi app trust <file.wasm>` — see [`AppCmd::Trust`](crate::cli::args::AppCmd).
+pub fn app_trust_cli(path: &str) -> i32 {
+    let raw = std::path::Path::new(path);
+    let resolved = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        std::env::current_dir().unwrap_or_default().join(raw)
+    };
+    if resolved.extension().and_then(|e| e.to_str()) != Some("wasm") || !resolved.is_file() {
+        eprintln!(
+            "error: `plexi app trust` expects a path to a .wasm component file; got {}",
+            resolved.display()
+        );
+        return 1;
+    }
+    match trust_raw_wasm_open(&resolved) {
+        Ok(()) => {
+            println!("trusted raw WASM imports for {}", resolved.display());
+            0
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            1
+        }
+    }
+}
+
 /// Thin wrapper preserving the existing `plexi app open` call site.
 pub fn open_cli(
     type_id: &str,
@@ -739,6 +808,39 @@ mod open_cli_tests {
                 store.get_wasm(app_id, workspace_root, &capability_id),
                 Some(crate::app::permissions::PermissionState::Green),
                 "{capability_id} should be remembered"
+            );
+        }
+    }
+
+    #[test]
+    fn app_trust_persists_grants_without_tty() {
+        // `plexi app trust` is the automation path: no reader, no TTY, yet it
+        // must persist Green grants for every imported interface plus `fs.pick`
+        // at the wasm's parent-dir scope — exactly what an installed host
+        // checks, so a raw wasm scene opens without review.
+        let _guard = ENV_LOCK.lock().unwrap();
+        let config_dir = tempfile::tempdir().expect("temp config dir");
+        let _profile_guard = crate::config::set_test_profile_dir(config_dir.path().to_path_buf());
+        let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/wasm-fixtures/sysmon.wasm");
+        let app_id = fixture
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("wasm");
+        let workspace_root = fixture.parent().expect("fixture parent");
+
+        super::trust_raw_wasm_open(&fixture).expect("trust should persist grants");
+
+        let store = crate::app::permissions::PermissionStore::load_or_default(config_dir.path());
+        let mut expected = crate::host::wasm_app::WasmApp::inspect_required_grants(&fixture)
+            .expect("inspect fixture grants")
+            .capability_ids();
+        expected.push("fs.pick".to_string());
+        for capability_id in expected {
+            assert_eq!(
+                store.get_wasm(app_id, workspace_root, &capability_id),
+                Some(crate::app::permissions::PermissionState::Green),
+                "{capability_id} should be trusted"
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -518,6 +518,10 @@ fn main() -> eframe::Result {
                                 std::process::exit(cli::app_uninstall(&id, yes))
                             }
                             AppCmd::List => std::process::exit(cli::app_list()),
+                            AppCmd::Trust { path } => {
+                                log::info!("app_trust:cli: path={path}");
+                                std::process::exit(cli::app_trust_cli(&path));
+                            }
                             AppCmd::Render {
                                 app,
                                 size,

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -1261,6 +1261,16 @@ impl LiveBackend {
                     }
                     OpenSpec::Builtin { id, .. } => id.clone(),
                 };
+                // A live wasm open shells `plexi app open`, whose raw-WASM
+                // review would block on a human at a TTY. Pre-approve through
+                // the real channel binary first (`plexi app trust`), which
+                // persists the fixture's import grants into the channel profile
+                // the attached host reads — the scene-runner test process is
+                // walled off from real profiles, so it cannot do this itself.
+                if let OpenSpec::Wasm { path, .. } = open {
+                    let resolved = resolve(path).display().to_string();
+                    self.command(&["app".to_string(), "trust".to_string(), resolved], false)?;
+                }
                 let mut args = vec!["app".to_string(), "open".to_string(), target];
                 match open {
                     OpenSpec::Process {
@@ -2079,6 +2089,13 @@ fn resolve(path: &str) -> PathBuf {
     }
 }
 
+/// Seeds the in-process test profile's `PermissionStore` with Green grants for
+/// a headless scene fixture's raw-WASM imports so the scene never stalls on an
+/// unanswerable capability review. Headless only: the in-process host and this
+/// call share the same (test-isolated) profile. The live backend cannot use
+/// this — a `#[cfg(test)]` binary is walled off from real channel profiles
+/// (`assert_test_profile_is_isolated`) — so it pre-approves through the real
+/// channel binary with `plexi app trust` instead.
 fn preapprove_wasm_scene_grants(wasm_path: &Path) -> Result<(), String> {
     let app_id = wasm_path
         .file_stem()

--- a/src/testing/TESTING.md
+++ b/src/testing/TESTING.md
@@ -187,6 +187,37 @@ Randomized failures are replayable: the panic names a seed and writes a
 minimized replay bundle to `$TMPDIR/plexi-editor-gate-failure-<seed>.json`;
 rerun exactly that seed with `PLEXI_EDITOR_GATE_SEED=<seed>`.
 
+## DAW Release Gate
+
+Any diff touching `crates/daw-*` or `apps/wasm-poc/daw-engine/` runs the DAW
+release gate before push. The DAW's pure model is a sibling crate, so its gate
+(`gate_cases` in `crates/daw-model/src/gate.rs`, exposed to the host via that
+crate's `gate` feature) is reused across every tier — same shape as the editor
+gate above:
+
+1. **Core matrix + fuzz** — `cargo test --bin plexi daw_gate`. The host bridge
+   (`src/testing/daw_gate.rs`) drives the pure-model matrix, deterministic long
+   sequence, and seeded command fuzzer (per-command `validate` + revision
+   monotonicity + undo consistency, rejected/no-op no-mutation), and asserts
+   offline-mixdown determinism: fixture project → equal PCM hash, block-size
+   independence, byte-identical `.wav` export.
+2. **Harness layer** — `daw_gate_engine_matrix` replays every named case
+   through the real `plexi-daw-engine` render path; `daw_gate_pane_drive` drives
+   the committed DAW WASM fixture in-process through named-key input, asserting
+   the semantic tree reacts.
+3. **Scenes headless** — the `daw-*.toml` scenes (`daw-timeline`, `daw-bundle`)
+   run in `scene_suite`; iterate on one with `just scene tests/scenes/<file>`.
+4. **Installed host** — `just daw-gate pr-<N>` re-runs the core qualification,
+   boots one hermetic host, leaves markers via `plexi host log --source
+   daw_gate`, runs every DAW scene in attach mode, and collects everything into
+   `/tmp/plexi-daw-gate/pr-<N>/` (per-scene SceneReports, best-effort host
+   screenshots, the core qualification artifact `daw-gate-core.json`, a channel
+   `log-tail.txt`, and `summary.json`).
+
+Randomized failures are replayable: the panic names a seed and writes a
+minimized replay bundle to `$TMPDIR/plexi-daw-gate-failure-<seed>.json`; rerun
+exactly that seed with `PLEXI_DAW_GATE_SEED=<seed>`.
+
 ## Conventions
 
 - `cargo test --bin plexi` must be green before any push; the justfile exports `RUSTFLAGS="-D warnings"`, so warnings are build failures under `just test`.

--- a/src/testing/TESTING.md
+++ b/src/testing/TESTING.md
@@ -205,14 +205,23 @@ gate above:
    through the real `plexi-daw-engine` render path; `daw_gate_pane_drive` drives
    the committed DAW WASM fixture in-process through named-key input, asserting
    the semantic tree reacts.
-3. **Scenes headless** — the `daw-*.toml` scenes (`daw-timeline`, `daw-bundle`)
-   run in `scene_suite`; iterate on one with `just scene tests/scenes/<file>`.
+3. **Scenes headless** — the suite `daw-*.toml` scenes (`daw-timeline`,
+   `daw-bundle`) run in `scene_suite`; iterate on one with `just scene
+   tests/scenes/<file>`. The live scene runner pre-approves a fixture's
+   raw-WASM imports so an attach run never stalls on capability review:
+   headless seeds the in-process test profile directly, live shells `plexi app
+   trust <wasm>` through the real channel binary (the test process is walled
+   off from real profiles).
 4. **Installed host** — `just daw-gate pr-<N>` re-runs the core qualification,
    boots one hermetic host, leaves markers via `plexi host log --source
-   daw_gate`, runs every DAW scene in attach mode, and collects everything into
-   `/tmp/plexi-daw-gate/pr-<N>/` (per-scene SceneReports, best-effort host
-   screenshots, the core qualification artifact `daw-gate-core.json`, a channel
-   `log-tail.txt`, and `summary.json`).
+   daw_gate`, and runs the attach-eligible scene set (`daw-timeline` plus
+   `daw-gate-bundle`, the attach counterpart of the headless `daw-bundle` whose
+   in-scene `picker_script` is headless-only) against that host. Save/open/
+   export picks come from the host's `PLEXI_PICKER_SCRIPT`, set before `host
+   start`. The gate refuses any selected scene that declares a headless-only
+   feature. Everything lands in `/tmp/plexi-daw-gate/pr-<N>/` (per-scene
+   SceneReports, best-effort host screenshots, the `daw-gate-core.json`
+   artifact, a channel `log-tail.txt`, and `summary.json`).
 
 Randomized failures are replayable: the panic names a seed and writes a
 minimized replay bundle to `$TMPDIR/plexi-daw-gate-failure-<seed>.json`; rerun

--- a/src/testing/daw_gate.rs
+++ b/src/testing/daw_gate.rs
@@ -1,0 +1,385 @@
+//! DAW release gate, host side (stint 0519): the same tiers the notes editor
+//! gate runs (`src/editor/gate.rs`, `src/testing/harness_tests.rs`), cloned
+//! onto the DAW so the whole app is agent-validatable under one command,
+//! `cargo test --bin plexi`.
+//!
+//! The DAW's pure model lives in a sibling crate (`plexi-daw-model`), unlike
+//! the in-binary notes editor, so its release gate — the 0514 `GateCase`
+//! table plus the seeded command fuzzer — is compiled into this host test
+//! build through that crate's `gate` feature (a dev-dependency). The named
+//! cases defined once in `plexi_daw_model::gate::gate_cases()` are the single
+//! source reused across every tier here:
+//!
+//! - Tier 1 (fuzz): the pure-model matrix, deterministic long sequence, and
+//!   seeded randomized fuzzer, with the same minimizer + replay bundles.
+//! - Tier 2 (harness): every named case replayed through the offline render
+//!   engine (`plexi-daw-engine`) — the audio runtime an installed host drives
+//!   — asserting each produces a valid, deterministic mixdown; plus a real
+//!   DAW WASM pane driven through named-key input, asserting its semantic
+//!   tree reacts (the keyboard-complete, node-addressable contract).
+//! - Determinism: a fixture project → offline mixdown → PCM-hash equality,
+//!   block-size independence, and byte-identical `.wav` export.
+//!
+//! Tiers 3 (TOML scenes, `tests/scenes/daw-*.toml`) and 4 (installed host,
+//! `scripts/daw-gate.sh`) drive the same WASM pane out of process.
+
+use std::collections::BTreeMap;
+
+use plexi_daw_engine::{pcm_hash, wav, Engine, EngineConfig, Note, SourceData};
+use plexi_daw_model::gate;
+use plexi_daw_model::{
+    ApplyOutcome, DawCommand, DawModel, Project, Source, SourceId, TrackId, TrackKind,
+    TICKS_PER_BEAT,
+};
+
+use crate::host::wasm_app::{
+    InputEvent, KeyEvent, Modifiers, StateSnapshot, StateStore, UiNodeData, UiTree, WasmApp,
+};
+
+// ─── Tier 1: pure-model fuzz, wired under `cargo test --bin plexi` ────────────
+
+/// The 0514 case matrix, replayed here so a model regression fails the host
+/// gate command — not only `cargo test -p plexi-daw-model`.
+#[test]
+fn daw_gate_core_matrix() {
+    for case in gate::gate_cases() {
+        if let Err(e) = gate::run_case(&case) {
+            panic!("daw gate case {:?} failed: {e}", case.name);
+        }
+    }
+}
+
+/// Seeded randomized command fuzzing over the pure model. A failing seed
+/// minimizes to a replay bundle and prints `PLEXI_DAW_GATE_SEED=<seed>`; the
+/// env var pins the run to one seed for reproduction.
+#[test]
+fn daw_gate_randomized_commands() {
+    for seed in gate::seeds_under_test() {
+        if let Err(e) = gate::run_random_seed(seed, gate::RANDOM_COMMANDS_PER_SEED) {
+            panic!("{e}");
+        }
+    }
+}
+
+/// The full core qualification (matrix + long sequence + default seeds) with
+/// its machine-readable `daw-gate-core.json` artifact — the artifact
+/// `scripts/daw-gate.sh` collects as the installed-host gate's Tier 1 record.
+#[test]
+fn daw_gate_core_qualification_artifact() {
+    let out_dir = std::env::temp_dir().join("plexi-daw-gate");
+    let summary = gate::run_core_qualification(&out_dir);
+    assert_eq!(
+        summary.totals.failed,
+        0,
+        "core qualification reported failures; see {}",
+        out_dir.join("daw-gate-core.json").display()
+    );
+    assert!(out_dir.join("daw-gate-core.json").is_file());
+}
+
+// ─── Tier 2a: harness matrix — same cases through the render engine ───────────
+
+const ENGINE_CONFIG: EngineConfig = EngineConfig {
+    sample_rate: 48_000,
+    channels: 2,
+};
+
+/// Deterministic decoded content for one model source, keyed on its kind — a
+/// short synthesized buffer for audio, one held note for MIDI. The bytes are
+/// fixed, so any nondeterminism a mixdown exposes is the engine's, not the
+/// fixture's.
+fn source_data_for(source: &Source) -> SourceData {
+    match source.kind {
+        TrackKind::Audio => {
+            let samples: Vec<f32> = (0..ENGINE_CONFIG.sample_rate)
+                .map(|i| {
+                    let t = i as f32 / ENGINE_CONFIG.sample_rate as f32;
+                    (t * 220.0 * std::f32::consts::TAU).sin() * 0.25
+                })
+                .collect();
+            SourceData::AudioPcm {
+                sample_rate: ENGINE_CONFIG.sample_rate,
+                channels: 1,
+                samples,
+            }
+        }
+        TrackKind::Midi => SourceData::MidiNotes(vec![Note {
+            key: 69,
+            velocity: 100,
+            start_ticks: 0,
+            length_ticks: source.duration.max(1),
+        }]),
+    }
+}
+
+fn sources_for(project: &Project) -> BTreeMap<SourceId, SourceData> {
+    project
+        .sources
+        .iter()
+        .map(|s| (s.id, source_data_for(s)))
+        .collect()
+}
+
+/// Prepares the engine for `model`'s final state and, when the project is
+/// audible, mixes it down twice — asserting byte-for-byte agreement. Returns
+/// the mixdown PCM hash for projects that render, `None` otherwise.
+fn render_and_hash(model: &DawModel) -> Result<Option<u64>, String> {
+    let project = model.project();
+    let sources = sources_for(project);
+    let engine = Engine::prepare(project, model.transport(), &sources, ENGINE_CONFIG)?;
+    let end = engine.project_end_frame();
+    if end == 0 {
+        return Ok(None);
+    }
+    let first = engine.mixdown(0, end)?;
+    let second = engine.mixdown(0, end)?;
+    if first.samples != second.samples {
+        return Err("two mixdowns of one prepared engine diverged".to_string());
+    }
+    Ok(Some(pcm_hash(&first.samples)))
+}
+
+/// Every named model case, built through commands only, must prepare and
+/// render on the real engine without error and deterministically — the same
+/// cases the pure-model tier fuzzes, now carried into the audio runtime.
+#[test]
+fn daw_gate_engine_matrix() {
+    for case in gate::gate_cases() {
+        let mut model = DawModel::new();
+        for step in &case.steps {
+            model.apply(step.command.clone());
+        }
+        render_and_hash(&model)
+            .unwrap_or_else(|e| panic!("engine matrix case {:?}: {e}", case.name));
+    }
+}
+
+// ─── Tier 2b: real DAW WASM pane driven through named-key input ───────────────
+
+fn daw_fixture() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/wasm-fixtures/daw-engine.wasm")
+}
+
+fn named_key(k: &str) -> InputEvent {
+    InputEvent::Key(KeyEvent {
+        key: k.to_string(),
+        modifiers: Modifiers {
+            ctrl: false,
+            shift: false,
+            alt: false,
+            meta: false,
+        },
+        pressed: true,
+    })
+}
+
+/// Every human-readable label in the tree — text, button, and badge nodes —
+/// so a substring search matches the same content the out-of-process scene's
+/// `tree_contains` finds in the pane's semantic serialization.
+fn tree_text(tree: &UiTree) -> String {
+    tree.nodes
+        .iter()
+        .filter_map(|n| match &n.data {
+            UiNodeData::Text(t) => Some(t.text.clone()),
+            UiNodeData::Button(b) => Some(b.label.clone()),
+            UiNodeData::Badge(b) => Some(b.text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Drives the committed DAW fixture in-process through the real WASM runtime,
+/// asserting the seeded project renders and that each named transport/edit key
+/// moves the semantic tree — the keyboard-complete, node-addressable contract
+/// the out-of-process scenes and installed-host gate also assert. Only named
+/// keys are delivered: the WASM key channel swallows bare printable chars
+/// (they arrive as `Event::Text`), exactly as in `tests/scenes/daw-*.toml`.
+#[test]
+fn daw_gate_pane_drive() -> wasmtime::Result<()> {
+    let mut app =
+        WasmApp::load_ephemeral_run("daw-gate", &daw_fixture(), StateStore::ephemeral())?;
+    app.init(&StateSnapshot { entries: vec![] }, (1280.0, 800.0), &[])?;
+
+    // The seeded demo project renders both tracks, transport, and readout.
+    let seeded = tree_text(&app.view()?);
+    for expected in ["DAW", "Pluck", "Arp", "Play", "bar 1 · beat 1"] {
+        assert!(
+            seeded.contains(expected),
+            "seeded DAW tree missing {expected:?}; tree=\n{seeded}"
+        );
+    }
+
+    // Named-key drives, each asserting the tree reacts. These mirror the
+    // proven `tests/scenes/daw-timeline.toml` steps against the same fixture.
+    for (key, expected) in [
+        ("space", "PLAYING"),
+        ("right", "beat 2"),
+        ("down", "Selected clip"),
+        ("delete", "Selected clip"),
+        ("home", "bar 1 · beat 1"),
+    ] {
+        app.update(&named_key(key))?;
+        let tree = tree_text(&app.view()?);
+        assert!(
+            tree.contains(expected),
+            "after key {key:?} the DAW tree lacks {expected:?}; tree=\n{tree}"
+        );
+    }
+    Ok(())
+}
+
+// ─── Determinism: fixture project → mixdown → hash equality ───────────────────
+
+/// A nontrivial fixture built through commands only: two audio tracks with
+/// clips plus one MIDI track, a set tempo, and mixer moves — enough to
+/// exercise summing, panning, and MIDI synthesis in one render.
+fn determinism_fixture() -> (DawModel, BTreeMap<SourceId, SourceData>) {
+    let beat = TICKS_PER_BEAT;
+    let mut model = DawModel::new();
+    let cmds = [
+        DawCommand::SetTempo { bpm: 128.0 },
+        DawCommand::AddTrack {
+            kind: TrackKind::Audio,
+            name: "Kick".into(),
+        },
+        DawCommand::AddSource {
+            kind: TrackKind::Audio,
+            path: "samples/kick.wav".into(),
+            duration: 2 * beat,
+        },
+        DawCommand::AddClip {
+            track: TrackId(1),
+            source: SourceId(2),
+            position: 0,
+            length: beat,
+            source_offset: 0,
+        },
+        DawCommand::AddClip {
+            track: TrackId(1),
+            source: SourceId(2),
+            position: 2 * beat,
+            length: beat,
+            source_offset: 0,
+        },
+        // Ids are allocated monotonically in apply order: Kick=T1, its
+        // source=S2, its two clips=C3/C4, so this track is T5 and its
+        // source S6.
+        DawCommand::AddTrack {
+            kind: TrackKind::Midi,
+            name: "Lead".into(),
+        },
+        DawCommand::AddSource {
+            kind: TrackKind::Midi,
+            path: "midi/lead.mid".into(),
+            duration: 4 * beat,
+        },
+        DawCommand::AddClip {
+            track: TrackId(5),
+            source: SourceId(6),
+            position: 0,
+            length: 4 * beat,
+            source_offset: 0,
+        },
+        DawCommand::SetTrackVolume {
+            track: TrackId(1),
+            volume: 0.8,
+        },
+        DawCommand::SetTrackPan {
+            track: TrackId(5),
+            pan: -0.5,
+        },
+    ];
+    for cmd in cmds {
+        assert_eq!(
+            model.apply(cmd.clone()),
+            ApplyOutcome::Applied,
+            "determinism fixture command {cmd:?} must apply"
+        );
+    }
+    let sources = sources_for(model.project());
+    (model, sources)
+}
+
+/// Offline mixdown is deterministic: the same model and decoded sources render
+/// to a byte-identical PCM hash across two independently prepared engines.
+#[test]
+fn daw_gate_mixdown_determinism() {
+    let (model, sources) = determinism_fixture();
+    let render = || {
+        let engine = Engine::prepare(model.project(), model.transport(), &sources, ENGINE_CONFIG)
+            .expect("prepare");
+        let end = engine.project_end_frame();
+        assert!(end > 0, "fixture must produce audible frames");
+        engine.mixdown(0, end).expect("mixdown").samples
+    };
+    let a = render();
+    let b = render();
+    assert_eq!(
+        pcm_hash(&a),
+        pcm_hash(&b),
+        "independent mixdowns of one fixture must hash identically"
+    );
+    assert_eq!(a, b, "PCM samples must be byte-identical, not just hash-equal");
+}
+
+/// Block-size independence: rendering the whole span at once equals rendering
+/// it in arbitrary chunks through `render_span` — the property that lets the
+/// RT callback and the offline export share one mixer.
+#[test]
+fn daw_gate_render_is_block_size_independent() {
+    let (model, sources) = determinism_fixture();
+    let engine = Engine::prepare(model.project(), model.transport(), &sources, ENGINE_CONFIG)
+        .expect("prepare");
+    let end = engine.project_end_frame();
+    let channels = ENGINE_CONFIG.channels as usize;
+
+    let mut whole = vec![0.0f32; end as usize * channels];
+    engine.render_span(0, &mut whole);
+
+    for chunk_frames in [1u64, 17, 512, 4096] {
+        let mut chunked = vec![0.0f32; end as usize * channels];
+        let mut start = 0u64;
+        while start < end {
+            let span = chunk_frames.min(end - start);
+            let from = start as usize * channels;
+            let to = from + span as usize * channels;
+            engine.render_span(start, &mut chunked[from..to]);
+            start += span;
+        }
+        assert_eq!(
+            whole, chunked,
+            "render output changed with chunk size {chunk_frames}"
+        );
+    }
+}
+
+/// WAV export is the mixdown substrate: encoding the same samples twice yields
+/// byte-identical files (equal file hash), so an exported `.wav` is
+/// reproducible from a project.
+#[test]
+fn daw_gate_wav_export_is_byte_identical() {
+    let (model, sources) = determinism_fixture();
+    let engine = Engine::prepare(model.project(), model.transport(), &sources, ENGINE_CONFIG)
+        .expect("prepare");
+    let end = engine.project_end_frame();
+    let mix = engine.mixdown(0, end).expect("mixdown");
+    let a = wav::encode_f32(mix.sample_rate, mix.channels, &mix.samples).expect("encode a");
+    let b = wav::encode_f32(mix.sample_rate, mix.channels, &mix.samples).expect("encode b");
+    assert_eq!(a, b, "WAV export must be byte-identical for identical samples");
+    assert_eq!(
+        pcm_hash_bytes(&a),
+        pcm_hash_bytes(&b),
+        "exported .wav file hashes must match"
+    );
+}
+
+/// FNV-1a over raw bytes — a file fingerprint for the export equality check.
+fn pcm_hash_bytes(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        hash ^= u64::from(b);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -555,6 +555,8 @@ impl HostHarness {
 }
 
 #[cfg(test)]
+mod daw_gate;
+#[cfg(test)]
 mod flow_tests;
 #[cfg(test)]
 mod harness_tests;

--- a/tests/scenes/daw-gate-bundle.toml
+++ b/tests/scenes/daw-gate-bundle.toml
@@ -19,9 +19,11 @@ open = { kind = "wasm", path = "tests/wasm-fixtures/daw-engine.wasm", as = "daw"
 [[steps]]
 run_steps = 3
 
-# Seeded demo project renders with both tracks and the bundle controls.
+# Seeded demo project renders with both tracks and the bundle controls. No
+# absolute pane_count: the attached gate host already holds a base terminal
+# pane, so `lifecycle` + `tree_contains` are the portable proof.
 [[steps]]
-assert = { target = "daw", pane_count = 1, lifecycle = "running", tree_contains = "DAW" }
+assert = { target = "daw", lifecycle = "running", tree_contains = "DAW" }
 
 [[steps]]
 assert = { target = "daw", tree_contains = "Pluck" }

--- a/tests/scenes/daw-gate-bundle.toml
+++ b/tests/scenes/daw-gate-bundle.toml
@@ -1,0 +1,51 @@
+# DAW project bundle save / open / export — installed-host (attach) variant of
+# daw-bundle.toml, for the Tier 4 gate (scripts/daw-gate.sh, stint 0519).
+#
+# The difference from daw-bundle.toml is the picker: an in-scene `picker_script`
+# is headless-only (the in-process suite backend), and the live runner rejects
+# it. Against a real host the picker is scripted by launching the host with
+# PLEXI_PICKER_SCRIPT — which the gate script sets before `host start` with the
+# same three outcomes (save-as bundle dir, open bundle dir, export .wav). So
+# this scene carries no picker_script and is `suite = false`: it is driven only
+# in attach mode by the gate, never by `scene_suite`. Raw-WASM review is
+# pre-approved by the live runner via `plexi app trust`. Every op is a function
+# key (the WASM key channel delivers only named keys in scenes).
+size = [1280.0, 800.0]
+suite = false
+
+[[steps]]
+open = { kind = "wasm", path = "tests/wasm-fixtures/daw-engine.wasm", as = "daw" }
+
+[[steps]]
+run_steps = 3
+
+# Seeded demo project renders with both tracks and the bundle controls.
+[[steps]]
+assert = { target = "daw", pane_count = 1, lifecycle = "running", tree_contains = "DAW" }
+
+[[steps]]
+assert = { target = "daw", tree_contains = "Pluck" }
+
+[[steps]]
+assert = { target = "daw", tree_contains = "Save" }
+
+[[steps]]
+assert = { target = "daw", tree_contains = "Export" }
+
+# F2: save-as writes project.json into the host-scripted bundle dir.
+[[steps]]
+expect = { target = "daw", after_key = "f2", tree_contains = "saved bundle to", timeout_s = 8.0 }
+
+# F3: reopen the bundle from disk — the demo project survives the round trip.
+[[steps]]
+expect = { target = "daw", after_key = "f3", tree_contains = "opened bundle", timeout_s = 8.0 }
+
+[[steps]]
+assert = { target = "daw", tree_contains = "Pluck" }
+
+[[steps]]
+assert = { target = "daw", tree_contains = "Arp" }
+
+# F5: export the offline mixdown to the host-scripted .wav destination.
+[[steps]]
+expect = { target = "daw", after_key = "f5", tree_contains = "exporting", timeout_s = 8.0 }

--- a/tests/scenes/daw-timeline.toml
+++ b/tests/scenes/daw-timeline.toml
@@ -26,8 +26,12 @@ run_steps = 3
 
 # Seeded project + all three surfaces render: transport bar, mixer strips, and
 # the timeline canvas with both tracks.
+# No absolute `pane_count`: this scene also runs in the installed-host gate
+# (scripts/daw-gate.sh) in attach mode, where the host already holds a base
+# terminal pane, so the count is not 1. `lifecycle` + `tree_contains` prove the
+# DAW pane opened and rendered either way.
 [[steps]]
-assert = { target = "daw", pane_count = 1, lifecycle = "running", tree_contains = "DAW" }
+assert = { target = "daw", lifecycle = "running", tree_contains = "DAW" }
 
 [[steps]]
 assert = { target = "daw", tree_contains = "Pluck" }

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -372,6 +372,7 @@ Manage your Plexi apps — open, install, list, scaffold, and inspect
 | Subcommand | Description |
 |---|---|
 | `open` | Open an app or tool in a new pane |
+| `trust` | Pre-approve a raw `.wasm` component's host imports without a prompt |
 | `install` | Install an app from a local path, a remote source, or a pack file |
 | `uninstall` | Remove an installed app by id |
 | `list` | Show all installed apps with their versions |
@@ -411,6 +412,16 @@ Default placement is a sibling split to the right — the calling pane is never 
 | `--window` | flag | no | New window |
 | `--from` | string | no | Open the new pane relative to this pane ID. Defaults to the calling pane (PLEXI_PANE_ID env), falling back to the focused pane |
 | `<extra_args>` | string (repeatable) | no | Extra arguments passed through to the app (only valid with an app id) |
+
+### `plexi app trust`
+
+Pre-approve a raw `.wasm` component's host imports without a prompt.
+
+The non-interactive form of the review `plexi app open <file.wasm>` runs at a TTY: it persists Green grants for every host interface the component imports, scoped to the wasm's parent directory — the same store and scope an installed host checks at open time. Meant for automation (release gates, scene runners) pre-approving a vetted, repo-committed fixture so an installed host opens it without a human at a terminal. It never opens a pane; production interactive review is unchanged.
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<path>` | string | yes | Path to the `.wasm` component to trust |
 
 ### `plexi app install`
 


### PR DESCRIPTION
Stint 0519 — the DAW 4-tier release gate (fuzz, harness, scenes, installed host), the last stint of the run.

## What it does
Clones the notes editor's release-gate architecture onto the DAW so the whole app is agent-validatable under one command, `cargo test --bin plexi`. The named cases live once in `plexi_daw_model::gate::gate_cases()` and are reused across every tier:
- Fuzz: the pure-model matrix, deterministic long sequence, and seeded command fuzzer (exposed to the host via a dev-only `gate` cargo feature), with minimized replay bundles.
- Harness: every named case replayed through the real render engine, plus the committed DAW WASM fixture driven in-process through named-key input asserting the semantic tree.
- Determinism: fixture project to offline mixdown, equal PCM hash, block-size independence, byte-identical `.wav`.
- Scenes + installed host: hermetic suite scenes plus `scripts/daw-gate.sh` (`just daw-gate <channel>`) driving the attach-eligible scenes against a real host.

## Tier 4 fix (post-review)
The hermetic scenes assumed in-process affordances the installed host does not grant, so the attach gate blocked where the in-process tiers passed. Fixes:
- A non-interactive `plexi app trust <wasm>` command pre-approves a fixture's raw-WASM imports; the live scene backend calls it through the real channel binary before `app open`.
- An attach-tuned bundle scene plus `PLEXI_PICKER_SCRIPT` for save/open/export; dropped a headless-only `pane_count` assert.
- The gate refuses any selected scene declaring a headless-only picker in attach mode.

## Verification
`just daw-gate pr-2481` against the installed build exits 0 (2/2 scenes). `cargo test --bin plexi testing::daw_gate` is green. The `gate` feature is dev-only and ships in neither the host binary nor the WASM app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N99pCDHfMQjCHcKk9DiBfM
