### PR TITLE
fix(text-editor): persist font size across restart; caret lands at note end (stints 0540, 0544)

### DIFF
--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -160,10 +160,15 @@ impl TextEditorApp {
         log::info!("notes_editor: mode selected {} for {:?}", mode.describe(), path);
         let highlighter = mode.language().and_then(SyntaxHighlighter::new);
         let md_cache = mode.is_markdown().then(MarkdownLayoutCache::default);
+        let mut doc = Document::new(&content);
+        let mut view = ViewState::default();
+        if is_note {
+            position_caret_at_end(&mut doc, &mut view);
+        }
         Self {
             path,
-            doc: Document::new(&content),
-            view: ViewState::default(),
+            doc,
+            view,
             note_header,
             note_title,
             is_note,
@@ -787,6 +792,18 @@ fn detect_mode(path: &Path, is_note: bool) -> EditorMode {
 /// Split a note document into its raw frontmatter block (kept out of the
 /// editable buffer), the body, and the display title. Non-note files and
 /// notes without a frontmatter block pass through unchanged.
+/// Continue-writing is the dominant intent for reopening a note (especially
+/// one started in the Quick Note editor): land the caret at the end of the
+/// document with the viewport anchored to the tail, rather than offset 0.
+fn position_caret_at_end(doc: &mut Document, view: &mut ViewState) {
+    let line_count = doc.buffer().line_count();
+    doc.apply(EditorCommand::Move {
+        movement: crate::editor::commands::Movement::DocEnd,
+        extend: false,
+    });
+    view.scroll_to_line(doc.cursor().line, line_count);
+}
+
 fn split_note(is_note: bool, raw: String) -> (Option<String>, String, String) {
     if !is_note {
         return (None, raw, String::new());
@@ -1453,10 +1470,17 @@ impl App for TextEditorApp {
     }
 
     fn serialize_state(&self) -> Option<serde_json::Value> {
-        Some(serde_json::json!({ "path": self.path.to_string_lossy() }))
+        Some(serde_json::json!({
+            "path": self.path.to_string_lossy(),
+            "font_size": self.font_size,
+        }))
     }
 
     fn restore_state(&mut self, state: &serde_json::Value) {
+        if let Some(size) = state.get("font_size").and_then(|v| v.as_f64()) {
+            self.font_size = (size as f32).clamp(FONT_SIZE_MIN, FONT_SIZE_MAX);
+            log::info!("notes_editor: font_size restored -> {}", self.font_size);
+        }
         if let Some(p) = state.get("path").and_then(|v| v.as_str()) {
             let new_path = PathBuf::from(p);
             if note_path_identity(&new_path) != note_path_identity(&self.path) {
@@ -1485,6 +1509,9 @@ impl App for TextEditorApp {
                 self.path = new_path;
                 self.doc = Document::new(&content);
                 self.view = ViewState::default();
+                if self.is_note {
+                    position_caret_at_end(&mut self.doc, &mut self.view);
+                }
                 self.note_header = note_header;
                 self.note_title = note_title;
                 self.load_error = load_error;
@@ -2676,5 +2703,56 @@ mod tests {
     #[test]
     fn slugify_empty_falls_back_to_note() {
         assert_eq!(slugify_title("---"), "note");
+    }
+
+    #[test]
+    fn font_size_survives_serialize_restore_cycle() {
+        let dir = unique_temp_dir("notes-font-size-persist");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("note.md");
+        std::fs::write(&path, "hello").unwrap();
+
+        let mut app = TextEditorApp::new(path.clone());
+        app.adjust_font_size(FONT_SIZE_MAX);
+        assert_eq!(app.font_size, FONT_SIZE_MAX);
+        let state = crate::app::app_trait::App::serialize_state(&app).unwrap();
+        assert_eq!(state["font_size"], FONT_SIZE_MAX as f64);
+
+        let mut restored = TextEditorApp::new(path.clone());
+        assert_eq!(restored.font_size, FONT_SIZE_DEFAULT);
+        crate::app::app_trait::App::restore_state(&mut restored, &state);
+        assert_eq!(restored.font_size, FONT_SIZE_MAX);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn font_size_restore_clamps_out_of_range_value() {
+        let dir = unique_temp_dir("notes-font-size-clamp");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("note.md");
+        std::fs::write(&path, "hello").unwrap();
+
+        let mut app = TextEditorApp::new(path);
+        let state = serde_json::json!({ "font_size": FONT_SIZE_MAX + 100.0 });
+        crate::app::app_trait::App::restore_state(&mut app, &state);
+        assert_eq!(app.font_size, FONT_SIZE_MAX);
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn font_size_restore_missing_key_keeps_default() {
+        let dir = unique_temp_dir("notes-font-size-missing");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("note.md");
+        std::fs::write(&path, "hello").unwrap();
+
+        let mut app = TextEditorApp::new(path.clone());
+        let state = serde_json::json!({ "path": path.to_string_lossy() });
+        crate::app::app_trait::App::restore_state(&mut app, &state);
+        assert_eq!(app.font_size, FONT_SIZE_DEFAULT);
+
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -527,6 +527,55 @@ mod tests {
     }
 
     #[test]
+    fn notes_picker_open_selected_lands_caret_at_document_end() {
+        let ctx = egui::Context::default();
+        let frame_tick = crate::platform::logging::FrameTick::default();
+        let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+        let profile = std::env::temp_dir().join(format!(
+            "plexi-notes-picker-caret-end-{}",
+            std::process::id()
+        ));
+        let notes_dir = profile.join("notes");
+        std::fs::create_dir_all(&notes_dir).expect("create notes dir");
+        let _guard = crate::config::set_test_profile_dir(profile.clone());
+        let note_path = notes_dir.join("note.md");
+        let note_body = "first line\nsecond line\nthird line";
+        std::fs::write(&note_path, note_body).expect("seed note");
+        let other_path = notes_dir.join("other.md");
+        std::fs::write(&other_path, "unrelated").expect("seed other note");
+
+        let (_existing_tile, _existing_pane) = app.add_test_pane();
+        let (focused_tile, focused_pane) = app.add_test_pane();
+        replace_with_text_editor(&mut app, focused_pane, other_path);
+
+        app.windows[0].focused_pane = Some(focused_tile);
+        app.notes_picker_entries = vec![picker_entry(note_path.clone(), "note")];
+        app.notes_picker_selected = 0;
+        app.push_focus_layer(FocusKind::NotesPicker);
+
+        app.notes_picker_open_selected();
+
+        let semantic = app.windows[0]
+            .panes
+            .get(&focused_pane)
+            .and_then(|pane| pane.as_app())
+            .and_then(|pane| pane.runtime.semantic_details())
+            .expect("focused text editor semantic state");
+        assert_eq!(
+            semantic["caret"].as_u64(),
+            Some(note_body.len() as u64),
+            "caret should land at doc end, not offset 0"
+        );
+        assert!(
+            semantic["scroll"]["y"].as_f64().unwrap_or(0.0) > 0.0,
+            "viewport should scroll to anchor the tail, not stay pinned at the top"
+        );
+
+        let _ = std::fs::remove_dir_all(&profile);
+    }
+
+    #[test]
     fn notes_picker_refuses_to_delete_open_text_editor_note() {
         let ctx = egui::Context::default();
         let frame_tick = crate::platform::logging::FrameTick::default();


### PR DESCRIPTION
## Summary
- stint 0540: `TextEditorApp::serialize_state`/`restore_state` now round-trip `font_size` (clamped to `FONT_SIZE_MIN..MAX`, defaults when absent) so Cmd+=/Cmd+- adjustments survive a host restart.
- stint 0544: note-open paths (fresh construction and the notes-picker reused-pane path-switch) position the caret at document end with the viewport anchored to the tail, so reopening a note continues writing instead of landing at offset 0. Non-note opens (file browser, code files) are unaffected — `is_note` is false for those paths.

## Test plan
- [x] `cargo build` — passes
- [x] `env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID cargo test --bin plexi` — 1817 passed, 0 failed, 2 ignored (one pre-existing unrelated failure, `testing::harness_tests::send_to_app_pane_injects_text_through_focused_render_input`, confirmed failing on alpha HEAD before this branch and excluded via `--skip` for this run)
- New regression tests: `font_size_survives_serialize_restore_cycle`, `font_size_restore_clamps_out_of_range_value`, `font_size_restore_missing_key_keeps_default` (text_editor_app.rs), `notes_picker_open_selected_lands_caret_at_document_end` (notes_picker.rs)