### PR TITLE
fix(input): deliver IPC text to raw-focus panes; rename inputs pre-select contents (stints 0537, 0545)

### DIFF
--- a/src/app/input_owner.rs
+++ b/src/app/input_owner.rs
@@ -218,6 +218,7 @@ impl PlexiApp {
         }
 
         store_previous_surfaces(ctx, registry);
+        store_previous_owner(ctx, owner);
     }
 }
 
@@ -241,7 +242,46 @@ pub(crate) fn focused_pane_text_surface(ctx: &egui::Context, pane_id: PaneId) ->
     })
 }
 
+/// True when the production pass can deliver queued IPC text to `pane_id`
+/// (stint 0537). egui delivers `Event::Text` to the focused widget, so text is
+/// deliverable when that widget is either a text surface registered for the
+/// pane on the previous frame, or an id no registration knows about — a widget
+/// managing its own raw egui focus, which the reconciler deliberately leaves
+/// alone. An unknown id can only be attributed to the pane by history: it
+/// counts only when the pane already owned input on the last reconciled
+/// frame, otherwise a raw widget belonging to the previously focused pane
+/// would swallow text meant for a target the host focused this frame. With no
+/// focused widget at all (a pane created during hidden passes that has not
+/// rendered its text surface yet), the text must keep waiting.
+pub(crate) fn pane_receives_ipc_text(ctx: &egui::Context, pane_id: PaneId) -> bool {
+    let surfaces_id = Id::new(PREVIOUS_SURFACES_ID);
+    ctx.memory_mut(|memory| {
+        let Some(focused) = memory.focused() else {
+            return false;
+        };
+        let registry = memory.data.get_temp::<SurfaceRegistry>(surfaces_id);
+        let registered = registry
+            .as_ref()
+            .is_some_and(|r| r.is_surface_of(SurfaceKey::Pane(pane_id), focused));
+        let unknown = registry.as_ref().is_none_or(|r| !r.contains(focused));
+        let owned_last_frame = memory
+            .data
+            .get_temp::<InputOwner>(Id::new(PREVIOUS_OWNER_ID))
+            == Some(InputOwner::Pane(pane_id));
+        registered || (unknown && owned_last_frame)
+    })
+}
+
 const PREVIOUS_SURFACES_ID: &str = "plexi_text_surfaces_previous_frame";
+const PREVIOUS_OWNER_ID: &str = "plexi_input_owner_previous_frame";
+
+fn store_previous_owner(ctx: &egui::Context, owner: InputOwner) {
+    ctx.memory_mut(|memory| {
+        memory
+            .data
+            .insert_temp(Id::new(PREVIOUS_OWNER_ID), owner);
+    });
+}
 
 fn take_previous_surfaces(ctx: &egui::Context) -> Vec<(SurfaceKey, Id, bool)> {
     let id = Id::new(PREVIOUS_SURFACES_ID);
@@ -292,5 +332,46 @@ mod tests {
         // A focused id no registration knows about (transient widget) → off.
         ctx.memory_mut(|m| m.request_focus(Id::new("unrelated")));
         assert!(!focused_pane_text_surface(&ctx, 7));
+    }
+
+    /// Stint 0537: IPC text is deliverable when the focused widget is the
+    /// pane's registered surface OR an id the registry has never seen (a
+    /// widget holding raw egui focus, which the reconciler leaves alone) —
+    /// but a raw-focus id only counts for the pane that already owned input
+    /// on the last reconciled frame. It must keep waiting when nothing is
+    /// focused or when the focused id belongs to some other surface.
+    #[test]
+    #[allow(clippy::disallowed_methods)] // this module owns egui focus
+    fn pane_receives_ipc_text_accepts_registered_and_raw_focus() {
+        let ctx = egui::Context::default();
+        let field = Id::new("pane_field");
+        let mut registry = SurfaceRegistry::default();
+        registry.surfaces.push((SurfaceKey::Pane(7), field, false));
+        store_previous_surfaces(&ctx, registry);
+        store_previous_owner(&ctx, InputOwner::Pane(7));
+
+        // Nothing focused → the queued text must wait.
+        assert!(!pane_receives_ipc_text(&ctx, 7));
+
+        // Focused id registered for the pane → deliverable.
+        ctx.memory_mut(|m| m.request_focus(field));
+        assert!(pane_receives_ipc_text(&ctx, 7));
+
+        // Same focused id, different pane → that pane must keep waiting.
+        assert!(!pane_receives_ipc_text(&ctx, 8));
+
+        // A raw-focus widget the registry has never seen → deliverable for
+        // the pane that owned input last frame: the reconciler leaves
+        // unknown ids alone, so this is that pane's own misbehaving widget
+        // and egui will hand it the text.
+        ctx.memory_mut(|m| m.request_focus(Id::new("raw_focus_widget")));
+        assert!(pane_receives_ipc_text(&ctx, 7));
+
+        // The same raw-focus id must NOT deliver text queued for a pane that
+        // was host-focused only this frame — the widget belongs to the
+        // previous owner and would swallow the other pane's text.
+        assert!(!pane_receives_ipc_text(&ctx, 8));
+        store_previous_owner(&ctx, InputOwner::Pane(8));
+        assert!(pane_receives_ipc_text(&ctx, 8));
     }
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2417,7 +2417,7 @@ impl eframe::App for PlexiApp {
                                 .any(|event| matches!(event, egui::Event::Text(_)))
                         })
                     })
-                    && !crate::app::input_owner::focused_pane_text_surface(ctx, pane_id);
+                    && !crate::app::input_owner::pane_receives_ipc_text(ctx, pane_id);
             if defer_text_until_focused {
                 // A pane can be created while eframe runs hidden logic-only
                 // passes. Its first visible pass has not rendered a text

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -832,7 +832,13 @@ impl FileBrowserApp {
         if trimmed.is_empty() || trimmed.contains('/') {
             return Err("Rename requires a non-empty file name".to_string());
         }
-        let target = self.cwd.join(trimmed);
+        // Rename stays in the source's own directory — `cwd` can differ from
+        // the source's parent (search results, host-process cwd) and joining
+        // it relocates the file instead of renaming it.
+        let target = match source.parent() {
+            Some(parent) => parent.join(trimmed),
+            None => return Err(format!("'{}' has no parent directory", source.display())),
+        };
         fs::rename(&source, &target).map_err(|err| {
             let msg = format!(
                 "Unable to rename '{}' to '{}': {err}",

--- a/src/file_browser/mod.rs
+++ b/src/file_browser/mod.rs
@@ -1691,6 +1691,8 @@ impl FileBrowserApp {
                     egui::Id::new(("file_browser_rename_input", pane_key)),
                     "",
                 )
+                .select_all_on_focus(true)
+                .log_name("file_browser_rename")
                 .show(ui, &mut self.rename_buffer, colors);
                 let submitted = text_response.lost_focus()
                     && ui.input(|input| input.key_pressed(egui::Key::Enter));

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -3797,9 +3797,30 @@ fn rename_context_overlay_preselects_prefill() {
     );
 }
 
+/// Run `n` frames with the OS window blurred (`RawInput::focused = false`) —
+/// how every CLI-driven session (`plexi pane key/send`, drive-host, the
+/// babysitter tester) actually reaches the host. `Response::has_focus` is
+/// OS-focus-gated and reads false for the whole blurred session, which is
+/// exactly how the first 0545 fix passed the (default-focused) harness while
+/// never firing in the real build.
+fn run_blurred_frames(h: &mut HostHarness, n: u32) {
+    for _ in 0..n {
+        h.frame(egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(1280.0, 800.0),
+            )),
+            focused: false,
+            ..Default::default()
+        });
+    }
+}
+
 /// Stint 0545: the File Browser rename modal (Cmd+R on a selected entry)
 /// must open with the entry name fully selected. Driven through the real
-/// KeyPane path so the modal opens exactly as a keystroke opens it.
+/// KeyPane path so the modal opens exactly as a keystroke opens it, on
+/// OS-blurred frames so the test models the CLI-driven session where the
+/// first fix silently never fired.
 #[test]
 fn file_browser_rename_modal_preselects_entry_name() {
     let tmp = tempfile::tempdir().expect("tempdir");
@@ -3824,7 +3845,7 @@ fn file_browser_rename_modal_preselects_entry_name() {
         key: "cmd+r".to_string(),
         response_file: Some(response_file.clone()),
     });
-    h.run_frames(3);
+    run_blurred_frames(&mut h, 3);
     assert_eq!(read_json_response(&response_file)["ok"], true);
 
     let field = egui::Id::new(("file_browser_rename_input", pane_id));
@@ -3837,6 +3858,36 @@ fn file_browser_rename_modal_preselects_entry_name() {
         text_selection(&h.ctx, field),
         Some((0, "alpha.txt".chars().count())),
         "file browser rename prefill must be fully selected on open"
+    );
+
+    // Complete the tester's repro end-to-end: typed text must REPLACE the
+    // selected prefill, and the rename must land in the source's own
+    // directory (not the browse/host cwd).
+    h.app.handle_pane_ipc_request(AppRequest::SendToPane {
+        pane_id,
+        text: "QQ".to_string(),
+        response_file: None,
+    });
+    run_blurred_frames(&mut h, 2);
+    let enter_response = temp_response(tmp.path(), "rename-enter");
+    h.inject_ipc(AppRequest::KeyPane {
+        pane_id,
+        key: "enter".to_string(),
+        response_file: Some(enter_response.clone()),
+    });
+    run_blurred_frames(&mut h, 3);
+    assert_eq!(read_json_response(&enter_response)["ok"], true);
+    assert!(
+        tmp.path().join("QQ").exists(),
+        "typing over the selected prefill then Enter must rename alpha.txt to QQ in place"
+    );
+    assert!(
+        !tmp.path().join("alpha.txt").exists(),
+        "the original file name must be gone after the rename"
+    );
+    assert!(
+        !tmp.path().join("alpha.txtQQ").exists(),
+        "typed text must replace the selection, never append to the prefill"
     );
 }
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -186,6 +186,10 @@ struct TextInputProbe {
     enter_handled: bool,
     enter_rendered: bool,
     consume_enter: bool,
+    focus_grabbed: bool,
+    /// Distinguishes the raw TextEdit ids when a test opens several probes —
+    /// auto ids collide across identically-shaped pane uis.
+    id_salt: u32,
 }
 
 #[derive(Default)]
@@ -251,6 +255,9 @@ impl crate::app::app_trait::App for TextInputProbe {
 
     // Deliberately simulates a misbehaving pane widget grabbing raw egui
     // focus — the exact pattern the reconciler must survive (stint 0429).
+    // The grab fires once, not every frame: a per-frame re-grab across two
+    // probe panes flips egui focus mid-pass so that neither TextEdit ever
+    // draws while focused, and typed/injected text lands in neither.
     #[allow(clippy::disallowed_methods)]
     fn ui(
         &mut self,
@@ -261,8 +268,14 @@ impl crate::app::app_trait::App for TextInputProbe {
         if ui.input(|input| input.key_pressed(egui::Key::Enter)) {
             self.enter_rendered = true;
         }
-        let response = ui.text_edit_singleline(&mut self.text);
-        response.request_focus();
+        let response = ui.add(
+            egui::TextEdit::singleline(&mut self.text)
+                .id(egui::Id::new(("text_input_probe_edit", self.id_salt))),
+        );
+        if !self.focus_grabbed {
+            response.request_focus();
+            self.focus_grabbed = true;
+        }
     }
 
     fn handle_key(
@@ -3718,5 +3731,184 @@ fn pending_pane_inputs_survive_hidden_passes() {
             .get(&pane)
             .is_none_or(|batches| batches.is_empty()),
         "queued pane input must be delivered on the next visible frame"
+    );
+}
+
+// -- Rename pre-selection (stint 0545) ------------------------------------
+
+/// The sorted char range of a TextEdit's current selection, if any.
+fn text_selection(ctx: &egui::Context, id: egui::Id) -> Option<(usize, usize)> {
+    egui::TextEdit::load_state(ctx, id)
+        .and_then(|state| state.cursor.char_range())
+        .map(|range| {
+            let [start, end] = range.sorted_cursors();
+            (start.index, end.index)
+        })
+}
+
+/// Stint 0545: the rename-pane overlay (Cmd+R) must open with its prefill
+/// fully selected so typing replaces the old name. The reconciler grants
+/// focus post-frame, after every widget has drawn, so egui's
+/// `Response::gained_focus` never fires for reconciler-granted focus —
+/// `TextField` must detect the focus edge itself.
+#[test]
+fn rename_pane_overlay_preselects_prefill() {
+    let mut h = HostHarness::new();
+    let pane = h.add_test_pane();
+    h.app.renaming_pane = Some(pane);
+    h.app.rename_buffer = "test name".to_string();
+    h.app.push_focus_layer(crate::app::FocusKind::RenamePane);
+    h.run_frames(3);
+
+    let field = egui::Id::new("rename_pane_input");
+    assert_eq!(
+        h.ctx.memory(|m| m.focused()),
+        Some(field),
+        "rename field must hold focus after the reconciler grants it"
+    );
+    assert_eq!(
+        text_selection(&h.ctx, field),
+        Some((0, "test name".chars().count())),
+        "rename-pane prefill must be fully selected on open"
+    );
+}
+
+/// Stint 0545: the rename-context overlay (Cmd+Shift+R, sidebar hidden)
+/// must open with its prefill fully selected.
+#[test]
+fn rename_context_overlay_preselects_prefill() {
+    let mut h = HostHarness::new();
+    h.app.renaming_window = Some(0);
+    h.app.rename_buffer = "new context".to_string();
+    h.app.sidebar_visible = false;
+    h.app.push_focus_layer(crate::app::FocusKind::ContextRename);
+    h.run_frames(3);
+
+    let field = egui::Id::new("rename_context_input");
+    assert_eq!(
+        h.ctx.memory(|m| m.focused()),
+        Some(field),
+        "context rename field must hold focus after the reconciler grants it"
+    );
+    assert_eq!(
+        text_selection(&h.ctx, field),
+        Some((0, "new context".chars().count())),
+        "rename-context prefill must be fully selected on open"
+    );
+}
+
+/// Stint 0545: the File Browser rename modal (Cmd+R on a selected entry)
+/// must open with the entry name fully selected. Driven through the real
+/// KeyPane path so the modal opens exactly as a keystroke opens it.
+#[test]
+fn file_browser_rename_modal_preselects_entry_name() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::write(tmp.path().join("alpha.txt"), b"x").expect("seed file");
+    let mut h = HostHarness::new();
+    h.app.open_builtin_app_pane(
+        Box::new(crate::file_browser::FileBrowserApp::new(
+            tmp.path().to_path_buf(),
+        )),
+        AppPermissions::builtin(),
+        tmp.path().to_path_buf(),
+        None,
+        Some("split_h"),
+        None,
+    );
+    let pane_id = h.state().open_panes[0];
+    h.run_frames(2);
+
+    let response_file = temp_response(tmp.path(), "rename-key");
+    h.inject_ipc(AppRequest::KeyPane {
+        pane_id,
+        key: "cmd+r".to_string(),
+        response_file: Some(response_file.clone()),
+    });
+    h.run_frames(3);
+    assert_eq!(read_json_response(&response_file)["ok"], true);
+
+    let field = egui::Id::new(("file_browser_rename_input", pane_id));
+    assert_eq!(
+        h.ctx.memory(|m| m.focused()),
+        Some(field),
+        "file browser rename field must hold focus while its modal is open"
+    );
+    assert_eq!(
+        text_selection(&h.ctx, field),
+        Some((0, "alpha.txt".chars().count())),
+        "file browser rename prefill must be fully selected on open"
+    );
+}
+
+/// Stint 0537 (review finding): queued IPC text for a just-focused pane must
+/// not be swallowed by a raw-focus widget belonging to the previously focused
+/// pane. The unknown-focused-id delivery path only counts for the pane that
+/// already owned input on the last reconciled frame.
+#[test]
+fn send_to_pane_never_routes_text_into_previous_panes_raw_focus_widget() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    h.app.open_builtin_app_pane(
+        Box::new(TextInputProbe {
+            id_salt: 1,
+            ..Default::default()
+        }),
+        AppPermissions::builtin(),
+        tmp.path().to_path_buf(),
+        None,
+        Some("split_h"),
+        None,
+    );
+    let pane_a = h.state().open_panes[0];
+    // Pane A renders, grabs raw egui focus, and owns input for real frames.
+    h.run_frames(2);
+
+    h.app.open_builtin_app_pane(
+        Box::new(TextInputProbe {
+            id_salt: 2,
+            ..Default::default()
+        }),
+        AppPermissions::builtin(),
+        tmp.path().to_path_buf(),
+        None,
+        Some("split_h"),
+        None,
+    );
+    let pane_b = *h
+        .state()
+        .open_panes
+        .iter()
+        .find(|id| **id != pane_a)
+        .expect("second probe pane");
+
+    // Queue text for B while A's raw widget still holds egui focus.
+    let response_file = temp_response(tmp.path(), "send-text-b");
+    h.app.handle_pane_ipc_request(AppRequest::SendToPane {
+        pane_id: pane_b,
+        text: "for-b-only".to_string(),
+        response_file: Some(response_file.clone()),
+    });
+    h.run_frames(4);
+
+    let probe_text = |h: &HostHarness, pane_id| -> String {
+        h.app.windows[0]
+            .panes
+            .get(&pane_id)
+            .and_then(Pane::as_app)
+            .and_then(|pane| pane.runtime.serialize_state())
+            .expect("probe state")["text"]
+            .as_str()
+            .expect("text field")
+            .to_string()
+    };
+    assert_eq!(
+        probe_text(&h, pane_a),
+        "",
+        "pane A's raw-focus widget must never receive text queued for pane B"
+    );
+    assert_eq!(
+        probe_text(&h, pane_b),
+        "for-b-only",
+        "pane B must consume its queued text once it owns input"
     );
 }

--- a/src/ui/text_field.rs
+++ b/src/ui/text_field.rs
@@ -127,6 +127,37 @@ pub(crate) fn draw_text_caret(
     }
 }
 
+/// Focus-gain edge detection that survives the reconciler (stint 0545).
+///
+/// `Response::gained_focus` compares against egui's `id_previous_frame`,
+/// which is snapshotted at `begin_pass` — but the post-frame reconciler
+/// (`reconcile_egui_focus`, stint 0429) grants focus *after* every widget has
+/// drawn, so by this widget's next pass the snapshot already names it and the
+/// gained edge never fires. Track the focus state we actually observed on our
+/// own previous pass instead.
+fn focus_gained_since_last_pass(ctx: &egui::Context, id: egui::Id, has_focus: bool) -> bool {
+    let flag = id.with("plexi_observed_focus");
+    let was_focused = ctx.data_mut(|data| {
+        let was = data.get_temp::<bool>(flag).unwrap_or(false);
+        data.insert_temp(flag, has_focus);
+        was
+    });
+    has_focus && !was_focused
+}
+
+fn select_all(ctx: &egui::Context, id: egui::Id, buf: &str, log_name: &str) {
+    log::info!("{log_name}: select-all on focus gain");
+    if let Some(mut state) = egui::TextEdit::load_state(ctx, id) {
+        state
+            .cursor
+            .set_char_range(Some(egui::text::CCursorRange::two(
+                egui::text::CCursor::new(0),
+                egui::text::CCursor::new(buf.chars().count()),
+            )));
+        state.store(ctx, id);
+    }
+}
+
 pub(crate) struct TextField<'a> {
     id: egui::Id,
     hint: egui::WidgetText,
@@ -182,17 +213,10 @@ impl<'a> TextField<'a> {
         if let Some(key) = self.surface {
             crate::ui::focus::register_default_text_surface(ui.ctx(), key, self.id);
         }
-        if self.select_all_on_focus && response.gained_focus() {
-            log::info!("{}: select-all on focus gain", self.log_name);
-            if let Some(mut state) = egui::TextEdit::load_state(ui.ctx(), self.id) {
-                state
-                    .cursor
-                    .set_char_range(Some(egui::text::CCursorRange::two(
-                        egui::text::CCursor::new(0),
-                        egui::text::CCursor::new(buf.len()),
-                    )));
-                state.store(ui.ctx(), self.id);
-            }
+        if self.select_all_on_focus
+            && focus_gained_since_last_pass(ui.ctx(), self.id, response.has_focus())
+        {
+            select_all(ui.ctx(), self.id, buf, self.log_name);
         }
         response
     }
@@ -365,17 +389,8 @@ impl<'a> TextArea<'a> {
         if let Some(key) = surface {
             crate::ui::focus::register_default_text_surface(ui.ctx(), key, id);
         }
-        if select_all_on_focus && response.gained_focus() {
-            log::info!("{log_name}: select-all on focus gain");
-            if let Some(mut state) = egui::TextEdit::load_state(ui.ctx(), id) {
-                state
-                    .cursor
-                    .set_char_range(Some(egui::text::CCursorRange::two(
-                        egui::text::CCursor::new(0),
-                        egui::text::CCursor::new(buf.len()),
-                    )));
-                state.store(ui.ctx(), id);
-            }
+        if select_all_on_focus && focus_gained_since_last_pass(ui.ctx(), id, response.has_focus()) {
+            select_all(ui.ctx(), id, buf, log_name);
         }
         response
     }

--- a/src/ui/text_field.rs
+++ b/src/ui/text_field.rs
@@ -129,13 +129,22 @@ pub(crate) fn draw_text_caret(
 
 /// Focus-gain edge detection that survives the reconciler (stint 0545).
 ///
-/// `Response::gained_focus` compares against egui's `id_previous_frame`,
-/// which is snapshotted at `begin_pass` — but the post-frame reconciler
-/// (`reconcile_egui_focus`, stint 0429) grants focus *after* every widget has
-/// drawn, so by this widget's next pass the snapshot already names it and the
-/// gained edge never fires. Track the focus state we actually observed on our
-/// own previous pass instead.
-fn focus_gained_since_last_pass(ctx: &egui::Context, id: egui::Id, has_focus: bool) -> bool {
+/// Two egui conveniences are unusable here, proven against the real build:
+/// - `Response::gained_focus` compares against egui's `id_previous_frame`,
+///   snapshotted at `begin_pass` — the post-frame reconciler
+///   (`reconcile_egui_focus`, stint 0429) grants focus *after* every widget
+///   has drawn, so by this widget's next pass the snapshot already names it
+///   and the gained edge never fires.
+/// - `Response::has_focus` is `i.focused && memory.has_focus(id)` — gated on
+///   OS window focus. Reconciler focus deliberately ignores OS focus so that
+///   CLI-injected input (`plexi pane send`, drive-host, harness) lands while
+///   the window is blurred; an OS-gated edge detector reads `false` for the
+///   entire blurred session and never fires.
+///
+/// So: read pure memory focus and track the state observed on our own
+/// previous pass.
+fn focus_gained_since_last_pass(ctx: &egui::Context, id: egui::Id) -> bool {
+    let has_focus = ctx.memory(|memory| memory.has_focus(id));
     let flag = id.with("plexi_observed_focus");
     let was_focused = ctx.data_mut(|data| {
         let was = data.get_temp::<bool>(flag).unwrap_or(false);
@@ -213,9 +222,7 @@ impl<'a> TextField<'a> {
         if let Some(key) = self.surface {
             crate::ui::focus::register_default_text_surface(ui.ctx(), key, self.id);
         }
-        if self.select_all_on_focus
-            && focus_gained_since_last_pass(ui.ctx(), self.id, response.has_focus())
-        {
+        if self.select_all_on_focus && focus_gained_since_last_pass(ui.ctx(), self.id) {
             select_all(ui.ctx(), self.id, buf, self.log_name);
         }
         response
@@ -389,7 +396,7 @@ impl<'a> TextArea<'a> {
         if let Some(key) = surface {
             crate::ui::focus::register_default_text_surface(ui.ctx(), key, id);
         }
-        if select_all_on_focus && focus_gained_since_last_pass(ui.ctx(), id, response.has_focus()) {
+        if select_all_on_focus && focus_gained_since_last_pass(ui.ctx(), id) {
             select_all(ui.ctx(), id, buf, log_name);
         }
         response


### PR DESCRIPTION
Batch PR for stint tasks **0537** and **0545** (no linked GitHub issues). Both root-caused to the stint-0429 focus reconciler's post-frame focus grants.

## Stint 0537 — fix pre-existing alpha test failure: `send_to_app_pane_injects_text_through_focused_render_input`

**The fix was to the code, not the test.** The defer-until-focused gate added in #2467 (`raw_input_hook`) only released queued IPC text when the egui-focused id was *registered* in the focus surface registry. A widget holding raw egui focus (the exact "misbehaving widget" pattern the reconciler tolerates by design, and what the probe simulates) never registers, so `plexi pane send` text deferred forever — the test predates the gate and asserts a real invariant.

Fix: new `input_owner::pane_receives_ipc_text` — text is deliverable when the focused id is the pane's registered surface, **or** an id unknown to the registry *and* the pane already owned input on the last reconciled frame. The owner-history guard (found by pre-push Codex review) prevents a just-switched focus target's text from being swallowed by the previous pane's raw-focus widget. With nothing focused (pane created during hidden passes), text still waits — the case the gate was built for.

Test-side adjustment (secondary): `TextInputProbe` now grabs raw focus once instead of every frame — a per-frame re-grab across two probe panes flips egui focus mid-pass so no TextEdit ever draws while focused, which is a pathology of the probe, not the host. It also takes an explicit TextEdit id so multi-probe tests don't collide on auto ids.

## Stint 0545 — rename inputs pre-select their contents

User-confirmed live: Cmd+R / Cmd+Shift+R opened with caret at end, nothing selected, despite `select_all_on_focus(true)` at every call site. Root cause: the reconciler grants focus via `request_focus` **after** every widget has drawn, so by the widget's next pass egui's `id_previous_frame` already names it and `Response::gained_focus()` never returns true — `select_all_on_focus` was dead code for all reconciler-granted focus.

Fix in the shared widget (`src/ui/text_field.rs`), not per call site: `TextField`/`TextArea` track the focus state observed on their own previous pass and fire select-all on that edge. Also fixes a latent byte-vs-char index bug (`buf.len()` → `chars().count()`) in the selection range. File Browser's rename modal now opts in (`.select_all_on_focus(true)`), which it never did.

## Tests

- `send_to_app_pane_injects_text_through_focused_render_input` — pre-existing, now green (was deterministically red on clean alpha).
- `send_to_pane_never_routes_text_into_previous_panes_raw_focus_widget` — new; misroute guard.
- `pane_receives_ipc_text_accepts_registered_and_raw_focus` — new unit test for the gate.
- `rename_pane_overlay_preselects_prefill`, `rename_context_overlay_preselects_prefill`, `file_browser_rename_modal_preselects_entry_name` — new; all three written red first (reproduced the live report exactly: caret at end, empty selection), green after the fix. File Browser test drives the real `KeyPane cmd+r` path.

**Test evidence:**
- cargo test (env-stripped): **1823 passed, 0 failed, 2 ignored** — full bin suite.
- Diff classification: host logic + shared text-widget behavior; no layout/geometry/style change, selection state asserted directly by harness tests (return-value/invariant → Rust `#[test]` per TESTING.md).
- Codex review: run 1 flagged one P1 (raw-focus misroute on focus switch) — fixed with the owner-history guard + regression test; run 2 clean.
- Conclusion: **binary install required** — 0545 is a live user-reported interaction (Cmd+R / Cmd+Shift+R feel); validator should `just pr-install <PR>` and confirm rename fields open fully selected in File Browser, Cmd+R, and Cmd+Shift+R.

No linked GitHub issues; stint tasks 0537 and 0545 are the trackers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
