### PR TITLE
feat(ui): ActionModal keyboard-first defaults + modal density + open-note palette (stints 0542, 0543)

### DIFF
--- a/src/app/app_trait.rs
+++ b/src/app/app_trait.rs
@@ -314,6 +314,14 @@ pub trait App: Send {
     /// the new name into the note's frontmatter `title`.
     fn on_pane_renamed(&mut self, _name: &str) {}
 
+    /// The note this app currently has open, if any. The command palette
+    /// lists notes that are open in a pane, so it asks every builtin app
+    /// rather than scanning the notes dir. Apps that are not note editors —
+    /// and TextEditorApp on an ordinary file — return `None`.
+    fn open_note_path(&self) -> Option<&std::path::Path> {
+        None
+    }
+
     /// Read-only, app-owned semantic details appended to `plexi pane state`.
     /// Production state is authoritative; callers may only serialize it.
     fn semantic_state(&self) -> Option<serde_json::Value> {

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -322,6 +322,11 @@ pub(crate) struct ContextCloseState {
     pub context_id: u64,
     pub context_name: String,
     pub items: Vec<ContextCloseItem>,
+    /// True when a Portal tile in the active window targets this context —
+    /// exactly `dissolve_portal`'s precondition. False for a top-level
+    /// context, where dissolving early-returns and does nothing, so the
+    /// confirm modal must not offer the action at all.
+    pub can_dissolve: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -1199,10 +1204,17 @@ impl PlexiApp {
             }
         }
 
+        let can_dissolve = self.context_has_portal(context_id);
+        log::info!(
+            "context_close: prompt ctx={context_id} name={context_name:?} panes={} can_dissolve={can_dissolve}",
+            items.len(),
+        );
+
         ContextCloseState {
             context_id,
             context_name,
             items,
+            can_dissolve,
         }
     }
 
@@ -1219,6 +1231,55 @@ impl PlexiApp {
     /// source of truth, focus stack follows it deterministically each frame.
     pub(crate) fn sync_command_palette_focus(&mut self) {
         self.reconcile_focus_layer(FocusKind::CommandPalette, self.show_command_palette);
+    }
+
+    /// Every note currently open in an editor pane, across all windows, newest
+    /// modification first. This is the command palette's note corpus — the
+    /// palette is a switcher for what is already open, while the Cmd+O picker
+    /// stays the browse-everything surface that scans inbox and workspace.
+    ///
+    /// The same note open in two panes yields one entry.
+    pub(crate) fn open_note_entries(&self) -> Vec<crate::notes::NotePickerEntry> {
+        let notes_base = crate::config::config_dir().join("notes");
+        let inbox_dir = notes_base.join("inbox");
+
+        let mut seen = std::collections::HashSet::new();
+        let mut paths: Vec<PathBuf> = Vec::new();
+        for win in &self.windows {
+            let mut pane_entries: Vec<_> = win.panes.iter().collect();
+            // Pane id order keeps the pre-sort deterministic when two notes
+            // share an mtime.
+            pane_entries.sort_by_key(|(id, _)| *id);
+            for (_, pane) in pane_entries {
+                let Some(app) = pane.as_app() else { continue };
+                let crate::host::pane::AppRuntime::Builtin(builtin) = &app.runtime else {
+                    continue;
+                };
+                let Some(path) = builtin.open_note_path() else {
+                    continue;
+                };
+                let identity = crate::app::text_editor_app::note_path_identity(path);
+                if seen.insert(identity) {
+                    paths.push(path.to_path_buf());
+                }
+            }
+        }
+
+        // Preserve the picker's newest-first ordering. One stat per open note,
+        // not a directory walk.
+        let mut with_mtime: Vec<(Option<std::time::SystemTime>, PathBuf)> = paths
+            .into_iter()
+            .map(|p| (std::fs::metadata(&p).and_then(|m| m.modified()).ok(), p))
+            .collect();
+        with_mtime.sort_by(|a, b| b.0.cmp(&a.0));
+
+        with_mtime
+            .into_iter()
+            .filter_map(|(_, path)| {
+                let inbox = path.parent() == Some(inbox_dir.as_path());
+                crate::notes::NotePickerEntry::load(&path, inbox)
+            })
+            .collect()
     }
 
     /// Navigate to a pane by id, updating both `focused_pane` on its window and

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -34,9 +34,9 @@ pub(crate) mod ui_mailbox;
 pub mod video_player_app;
 
 #[cfg(test)]
-pub(crate) use focus::FocusLogOutcome;
+pub(crate) use focus::{ContextCloseItem, FocusLogOutcome};
 pub(crate) use focus::{
-    ContextCloseItem, ContextCloseState, FocusKind, FocusSegmentReason, PendingRawWasmLaunch,
+    ContextCloseState, FocusKind, FocusSegmentReason, PendingRawWasmLaunch,
     FOCUS_HEARTBEAT_INTERVAL,
 };
 pub(crate) use notification_image::NotificationImageState;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -36,7 +36,7 @@ pub mod video_player_app;
 #[cfg(test)]
 pub(crate) use focus::FocusLogOutcome;
 pub(crate) use focus::{
-    ContextCloseState, FocusKind, FocusSegmentReason, PendingRawWasmLaunch,
+    ContextCloseItem, ContextCloseState, FocusKind, FocusSegmentReason, PendingRawWasmLaunch,
     FOCUS_HEARTBEAT_INTERVAL,
 };
 pub(crate) use notification_image::NotificationImageState;
@@ -4164,43 +4164,12 @@ impl eframe::App for PlexiApp {
                             "palette: opened, focused workspace = {:?}",
                             self.palette_workspace_root
                         );
-                        // Load notes once at open-time, same pattern as palette_workspace_root.
-                        let notes_base = crate::config::config_dir().join("notes");
-                        let scan_md = |dir: &std::path::Path| -> Vec<std::path::PathBuf> {
-                            let mut with_mtime: Vec<(std::time::SystemTime, std::path::PathBuf)> =
-                                std::fs::read_dir(dir)
-                                    .into_iter()
-                                    .flatten()
-                                    .filter_map(|e| e.ok())
-                                    .filter(|e| e.path().extension().map_or(false, |x| x == "md"))
-                                    .filter_map(|e| {
-                                        let mtime = e.metadata().and_then(|m| m.modified()).ok()?;
-                                        Some((mtime, e.path()))
-                                    })
-                                    .collect();
-                            with_mtime.sort_by(|a, b| b.0.cmp(&a.0));
-                            with_mtime.into_iter().map(|(_, p)| p).collect()
-                        };
-                        let mut palette_notes: Vec<crate::notes::NotePickerEntry> =
-                            scan_md(&notes_base.join("inbox"))
-                                .iter()
-                                .filter_map(|p| crate::notes::NotePickerEntry::load(p, true))
-                                .collect();
-                        let workspace_slug = self
-                            .palette_workspace_root
-                            .as_ref()
-                            .and_then(|p| p.file_name().map(|n| n.to_os_string()))
-                            .map(|n| n.to_string_lossy().into_owned());
-                        let notes_dir = match workspace_slug {
-                            Some(ref slug) => notes_base.join(slug),
-                            None => notes_base,
-                        };
-                        palette_notes.extend(
-                            scan_md(&notes_dir)
-                                .iter()
-                                .filter_map(|p| crate::notes::NotePickerEntry::load(p, false)),
-                        );
-                        log::info!("palette: loaded {} notes", palette_notes.len());
+                        // The palette is a switcher for what you are working
+                        // on, so it lists only notes open in an editor pane —
+                        // never the whole notes dir. Cmd+O's picker remains
+                        // the browse-everything surface. No disk scan here.
+                        let palette_notes = self.open_note_entries();
+                        log::info!("palette: loaded {} open note(s)", palette_notes.len());
                         self.palette_notes = palette_notes;
                         // Resolve user commands once at open-time (re-read each open
                         // → hot reload). Mirrors `plexi run` precedence exactly.

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -2332,3 +2332,42 @@ fn set_context_root_ipc_targets_caller_context() {
         "active context root must be untouched"
     );
 }
+
+/// Dissolve is only reachable for a context that hangs off a Portal tile.
+/// `dissolve_portal` early-returns without one, so the close-confirm modal
+/// must not offer the action for a top-level context (stint 0542).
+#[test]
+fn context_close_offers_dissolve_only_for_portal_backed_context() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let top_level_id = app.router.active().context_id;
+    assert!(
+        !app.build_context_close_state(top_level_id).can_dissolve,
+        "a top-level context has no parent portal — Dissolve would do nothing"
+    );
+
+    // Give the active window a Portal tile pointing at a child context.
+    let child_ctx_id = top_level_id + 1_000;
+    let portal_pane_id = app.host.alloc_pane_id();
+    let win = &mut app.windows[app.active_window];
+    win.panes.insert(
+        portal_pane_id,
+        crate::host::pane::Pane::Portal(Box::new(crate::host::pane::PortalPane {
+            pane_id: portal_pane_id,
+            target_context_id: child_ctx_id,
+            context_state: None,
+            hidden: false,
+        })),
+    );
+
+    assert!(
+        app.build_context_close_state(child_ctx_id).can_dissolve,
+        "a context reached through a Portal tile must offer Dissolve"
+    );
+    assert!(
+        !app.build_context_close_state(child_ctx_id + 1).can_dissolve,
+        "an unrelated context id must not inherit the portal's dissolvability"
+    );
+}

--- a/src/app/tests/focus_tests.rs
+++ b/src/app/tests/focus_tests.rs
@@ -622,3 +622,193 @@ fn navigate_to_activates_ancestor_tabs() {
     #[cfg(debug_assertions)]
     app.windows[0].assert_focus_invariants();
 }
+
+// ── Command palette note corpus (stint 0543) ──────────────────────────────
+
+/// Install a text editor pane on `path` in window 0.
+fn open_note_in_editor(app: &mut PlexiApp, path: &std::path::Path) {
+    let (_tile, pane_id) = app.add_test_pane();
+    let app_pane = crate::host::pane::AppPane {
+        pip_status: None,
+        id: pane_id,
+        runtime: crate::host::pane::AppRuntime::Builtin(Box::new(
+            crate::app::text_editor_app::TextEditorApp::new_for_test_note(path.to_path_buf()),
+        )),
+        workspace_root: std::env::temp_dir(),
+        permissions: crate::app::permissions::AppPermissions::builtin(),
+        manifest_id: "text-editor".to_string(),
+        name: "Text Editor".to_string(),
+        pane_group: None,
+        linked_pane_id: None,
+        overlay_replaced: None,
+        hidden: false,
+        agent: None,
+        slots: std::collections::HashMap::new(),
+        semantic_state: Default::default(),
+    };
+    app.windows[0]
+        .panes
+        .insert(pane_id, crate::host::pane::Pane::App(Box::new(app_pane)));
+}
+
+/// Cmd+P lists the notes you have open, not every note on disk. A note
+/// sitting in the notes dir with no pane must not appear, and the same note
+/// open twice must appear once.
+#[test]
+fn open_note_entries_lists_only_notes_open_in_a_pane() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let dir = tempfile::tempdir().expect("notes dir");
+    let opened = dir.path().join("opened.md");
+    let opened_twice = dir.path().join("opened-twice.md");
+    let on_disk_only = dir.path().join("never-opened.md");
+    std::fs::write(&opened, "opened note body").expect("write opened");
+    std::fs::write(&opened_twice, "twice note body").expect("write twice");
+    std::fs::write(&on_disk_only, "unopened body").expect("write unopened");
+
+    assert!(
+        app.open_note_entries().is_empty(),
+        "no editor panes open — the palette's note corpus must be empty"
+    );
+
+    open_note_in_editor(&mut app, &opened);
+    open_note_in_editor(&mut app, &opened_twice);
+    open_note_in_editor(&mut app, &opened_twice);
+
+    let paths: Vec<std::path::PathBuf> = app
+        .open_note_entries()
+        .into_iter()
+        .map(|entry| entry.path)
+        .collect();
+
+    assert_eq!(
+        paths.len(),
+        2,
+        "one entry per open note, deduped across panes: {paths:?}"
+    );
+    assert!(paths.contains(&opened), "open note must be listed: {paths:?}");
+    assert!(
+        paths.contains(&opened_twice),
+        "note open in two panes must be listed once: {paths:?}"
+    );
+    assert!(
+        !paths.contains(&on_disk_only),
+        "a note that is not open must never reach the palette: {paths:?}"
+    );
+}
+
+/// A text editor on an ordinary file is not a note, so it contributes nothing
+/// to the palette's note corpus.
+#[test]
+fn open_note_entries_ignores_non_note_editor_panes() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let dir = tempfile::tempdir().expect("src dir");
+    let source = dir.path().join("main.rs");
+    std::fs::write(&source, "fn main() {}").expect("write source");
+
+    let (_tile, pane_id) = app.add_test_pane();
+    let app_pane = crate::host::pane::AppPane {
+        pip_status: None,
+        id: pane_id,
+        runtime: crate::host::pane::AppRuntime::Builtin(Box::new(
+            crate::app::text_editor_app::TextEditorApp::new(source.clone()),
+        )),
+        workspace_root: std::env::temp_dir(),
+        permissions: crate::app::permissions::AppPermissions::builtin(),
+        manifest_id: "text-editor".to_string(),
+        name: "Text Editor".to_string(),
+        pane_group: None,
+        linked_pane_id: None,
+        overlay_replaced: None,
+        hidden: false,
+        agent: None,
+        slots: std::collections::HashMap::new(),
+        semantic_state: Default::default(),
+    };
+    app.windows[0]
+        .panes
+        .insert(pane_id, crate::host::pane::Pane::App(Box::new(app_pane)));
+
+    assert!(
+        app.open_note_entries().is_empty(),
+        "an editor on a non-note file must not appear in the palette's notes"
+    );
+}
+
+/// The palette's note corpus spans every window, so activating a note that
+/// lives in another window must navigate to that pane, not open a second
+/// editor on the same file (stint 0543).
+#[test]
+fn palette_finds_open_note_editor_in_a_non_active_window() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let dir = tempfile::tempdir().expect("notes dir");
+    let note = dir.path().join("cross-window.md");
+    std::fs::write(&note, "cross window body").expect("write note");
+
+    // Second window, holding the only editor pane for the note.
+    let other_window_idx = app.windows.len();
+    let mut panes = std::collections::HashMap::new();
+    let mut tiles = egui_tiles::Tiles::default();
+    let pane_id = app.host.alloc_pane_id();
+    panes.insert(
+        pane_id,
+        crate::host::pane::Pane::App(Box::new(crate::host::pane::AppPane {
+            pip_status: None,
+            id: pane_id,
+            runtime: crate::host::pane::AppRuntime::Builtin(Box::new(
+                crate::app::text_editor_app::TextEditorApp::new_for_test_note(note.clone()),
+            )),
+            workspace_root: std::env::temp_dir(),
+            permissions: crate::app::permissions::AppPermissions::builtin(),
+            manifest_id: "text-editor".to_string(),
+            name: "Text Editor".to_string(),
+            pane_group: None,
+            linked_pane_id: None,
+            overlay_replaced: None,
+            hidden: false,
+            agent: None,
+            slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
+        })),
+    );
+    let tile = tiles.insert_pane(pane_id);
+    let window_id = app.next_window_id;
+    app.next_window_id += 1;
+    app.windows.push(crate::host::context::Window {
+        name: "second".to_string(),
+        path: std::env::temp_dir(),
+        tree: egui_tiles::Tree::new("second", tile, tiles),
+        panes,
+        focused_pane: Some(tile),
+        zoomed_pane: None,
+        grid_x: 1,
+        grid_y: 0,
+        window_id,
+        context_id: app.router.active().context_id,
+    });
+
+    assert_eq!(
+        app.find_open_text_editor_tile(app.active_window, &note),
+        None,
+        "the note is deliberately not open in the active window"
+    );
+    assert_eq!(
+        app.find_open_text_editor_pane_any_window(&note),
+        Some(pane_id),
+        "the palette must find the editor pane in the other window"
+    );
+
+    assert!(app.pane_navigate(pane_id), "navigation must reach the pane");
+    assert_eq!(
+        app.active_window, other_window_idx,
+        "navigating must move focus to the window that owns the note"
+    );
+}

--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -954,6 +954,10 @@ impl App for TextEditorApp {
         "text-editor"
     }
 
+    fn open_note_path(&self) -> Option<&Path> {
+        self.is_note.then_some(self.path.as_path())
+    }
+
     fn display_name(&self) -> String {
         self.path
             .file_name()

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -1897,7 +1897,6 @@ impl LiveWasmPane {
             )
             .shortcut(crate::ui::dialog::DialogShortcut::new(
                 &["Enter"],
-                "grant once",
                 egui::Modifiers::NONE,
                 egui::Key::Enter,
             )),
@@ -1908,7 +1907,6 @@ impl LiveWasmPane {
             )
             .shortcut(crate::ui::dialog::DialogShortcut::new(
                 &["Shift", "Enter"],
-                "always allow",
                 egui::Modifiers::SHIFT,
                 egui::Key::Enter,
             )),
@@ -1919,7 +1917,6 @@ impl LiveWasmPane {
             )
             .shortcut(crate::ui::dialog::DialogShortcut::new(
                 &["Esc"],
-                "deny once",
                 egui::Modifiers::NONE,
                 egui::Key::Escape,
             )),
@@ -1930,7 +1927,6 @@ impl LiveWasmPane {
             )
             .shortcut(crate::ui::dialog::DialogShortcut::new(
                 &["Shift", "Esc"],
-                "always deny",
                 egui::Modifiers::SHIFT,
                 egui::Key::Escape,
             )),

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -879,12 +879,10 @@ impl PlexiApp {
             Some(Action::OpenNote(path)) => {
                 self.show_command_palette = false;
                 self.palette_query.clear();
-                let active = self.active_window;
                 let path_str = path.display().to_string();
-                if let Some((existing_tile_id, _)) = self.find_open_text_editor_tile(active, &path)
-                {
-                    log::info!("palette: note already open, focusing pane");
-                    self.set_window_focused_pane(active, existing_tile_id);
+                if let Some(pane_id) = self.find_open_text_editor_pane_any_window(&path) {
+                    log::info!("palette: note already open in pane {pane_id}, navigating");
+                    self.pane_navigate(pane_id);
                 } else {
                     log::info!("palette: opening note {:?} in new pane", path);
                     let _ =
@@ -1220,13 +1218,14 @@ impl PlexiApp {
                         Action::OpenNote(path) => {
                             self.show_command_palette = false;
                             self.palette_query.clear();
-                            let active = self.active_window;
                             let path_str = path.display().to_string();
-                            if let Some((existing_tile_id, _)) =
-                                self.find_open_text_editor_tile(active, &path)
+                            if let Some(pane_id) =
+                                self.find_open_text_editor_pane_any_window(&path)
                             {
-                                log::info!("palette: note already open, focusing pane");
-                                self.set_window_focused_pane(active, existing_tile_id);
+                                log::info!(
+                                    "palette: note already open in pane {pane_id}, navigating"
+                                );
+                                self.pane_navigate(pane_id);
                             } else {
                                 log::info!("palette: opening note {:?} in new pane", path);
                                 let _ = self.launch_app_by_id_with_layout(

--- a/src/overlays/confirmations.rs
+++ b/src/overlays/confirmations.rs
@@ -37,7 +37,6 @@ impl PlexiApp {
             )
             .shortcut(crate::ui::dialog::DialogShortcut::new(
                 &["Enter"],
-                "confirm",
                 egui::Modifiers::NONE,
                 egui::Key::Enter,
             )),
@@ -48,7 +47,6 @@ impl PlexiApp {
             )
             .shortcut(crate::ui::dialog::DialogShortcut::new(
                 &["Esc"],
-                "cancel",
                 egui::Modifiers::NONE,
                 egui::Key::Escape,
             )),
@@ -114,29 +112,34 @@ impl PlexiApp {
         } else {
             format!("Close \"{}\"?", state.context_name)
         };
-        let actions = [
-            crate::ui::dialog::DialogAction::new(
-                "close_all",
-                "Close all",
-                crate::ui::button::ButtonKind::Danger,
-            )
-            .shortcut(crate::ui::dialog::DialogShortcut::new(
-                &["Enter"],
-                "close all",
-                egui::Modifiers::NONE,
-                egui::Key::Enter,
-            )),
-            crate::ui::dialog::DialogAction::new(
-                "dissolve",
-                "Dissolve",
-                crate::ui::button::ButtonKind::Secondary,
-            )
-            .shortcut(crate::ui::dialog::DialogShortcut::new(
-                &["D"],
-                "dissolve",
-                egui::Modifiers::NONE,
-                egui::Key::D,
-            )),
+        let mut actions = vec![crate::ui::dialog::DialogAction::new(
+            "close_all",
+            "Close all",
+            crate::ui::button::ButtonKind::Danger,
+        )
+        .shortcut(crate::ui::dialog::DialogShortcut::new(
+            &["Enter"],
+            egui::Modifiers::NONE,
+            egui::Key::Enter,
+        ))];
+        // Dissolve only exists for a context reached through a Portal tile.
+        // Offering it on a top-level context reads as a broken command: the
+        // key is consumed and `dissolve_portal` early-returns.
+        if state.can_dissolve {
+            actions.push(
+                crate::ui::dialog::DialogAction::new(
+                    "dissolve",
+                    "Dissolve",
+                    crate::ui::button::ButtonKind::Secondary,
+                )
+                .shortcut(crate::ui::dialog::DialogShortcut::new(
+                    &["D"],
+                    egui::Modifiers::NONE,
+                    egui::Key::D,
+                )),
+            );
+        }
+        actions.push(
             crate::ui::dialog::DialogAction::new(
                 "cancel",
                 "Cancel",
@@ -144,11 +147,10 @@ impl PlexiApp {
             )
             .shortcut(crate::ui::dialog::DialogShortcut::new(
                 &["Esc"],
-                "cancel",
                 egui::Modifiers::NONE,
                 egui::Key::Escape,
             )),
-        ];
+        );
         let response =
             crate::ui::dialog::ActionModal::new("ctx_close_confirm_modal", &title, &actions)
                 .width(super::MODAL_WIDTH)
@@ -266,7 +268,6 @@ impl PlexiApp {
             )
             .shortcut(crate::ui::dialog::DialogShortcut::new(
                 &["Enter"],
-                "allow once",
                 egui::Modifiers::NONE,
                 egui::Key::Enter,
             )),
@@ -277,7 +278,6 @@ impl PlexiApp {
             )
             .shortcut(crate::ui::dialog::DialogShortcut::new(
                 &["A"],
-                "always",
                 egui::Modifiers::NONE,
                 egui::Key::A,
             )),
@@ -288,7 +288,6 @@ impl PlexiApp {
             )
             .shortcut(crate::ui::dialog::DialogShortcut::new(
                 &["Esc"],
-                "deny",
                 egui::Modifiers::NONE,
                 egui::Key::Escape,
             )),
@@ -343,7 +342,6 @@ impl PlexiApp {
             )
             .shortcut(crate::ui::dialog::DialogShortcut::new(
                 &["Enter"],
-                "allow",
                 egui::Modifiers::NONE,
                 egui::Key::Enter,
             )),
@@ -354,7 +352,6 @@ impl PlexiApp {
             )
             .shortcut(crate::ui::dialog::DialogShortcut::new(
                 &["Esc"],
-                "deny",
                 egui::Modifiers::NONE,
                 egui::Key::Escape,
             )),

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -54,6 +54,18 @@ impl PlexiApp {
         })
     }
 
+    /// The pane holding `path` in any window, not just the active one. The
+    /// command palette's note corpus spans every window, so activating an
+    /// entry must be able to reach the pane that owns it — searching only the
+    /// active window would open a second editor on an already-open note.
+    pub(crate) fn find_open_text_editor_pane_any_window(
+        &self,
+        path: &std::path::Path,
+    ) -> Option<crate::spatial::tiling::PaneId> {
+        (0..self.windows.len())
+            .find_map(|idx| self.find_open_text_editor_tile(idx, path).map(|(_, pane)| pane))
+    }
+
     /// Indices into `notes_picker_entries` matching the current query, ranked:
     /// title substring, then title fuzzy, then full-text fuzzy. Empty query
     /// returns every entry in stored order (inbox first, then by mtime).

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -1387,6 +1387,17 @@ impl PlexiApp {
         self.reload_config_for_active_context();
     }
 
+    /// True when the active window holds a Portal tile targeting `child_ctx_id`,
+    /// which is precisely what [`Self::dissolve_portal`] needs to do anything.
+    /// Offer Dissolve only when this holds — a top-level context has no parent
+    /// portal, so the action would early-return and visibly do nothing.
+    pub(crate) fn context_has_portal(&self, child_ctx_id: u64) -> bool {
+        self.windows[self.active_window]
+            .panes
+            .values()
+            .any(|pane| pane.portal_target() == Some(child_ctx_id))
+    }
+
     /// Dissolve a portal: remove the context boundary while preserving the child
     /// layout. The active child window is grafted into the Portal tile's exact
     /// position; any remaining child windows are promoted as parent-context windows.

--- a/src/ui/dialog.rs
+++ b/src/ui/dialog.rs
@@ -1,26 +1,22 @@
-use crate::ui::button::{self, ButtonKind};
-use crate::ui::hints::{HintBar, HintGroup};
+use crate::ui::button::ButtonKind;
 use crate::ui::overlay::ModalShell;
+use crate::ui::shortcuts;
 use crate::ui::style;
 use crate::ui::theme::Colors;
 
+/// The keys that trigger an action, and the chips that advertise them. The
+/// action's own label is the only prose — a keyboard-first row carries no
+/// separate hint text.
 pub(crate) struct DialogShortcut<'a> {
     pub(crate) keys: &'a [&'a str],
-    pub(crate) label: &'a str,
     modifiers: egui::Modifiers,
     key: egui::Key,
 }
 
 impl<'a> DialogShortcut<'a> {
-    pub(crate) fn new(
-        keys: &'a [&'a str],
-        label: &'a str,
-        modifiers: egui::Modifiers,
-        key: egui::Key,
-    ) -> Self {
+    pub(crate) fn new(keys: &'a [&'a str], modifiers: egui::Modifiers, key: egui::Key) -> Self {
         Self {
             keys,
-            label,
             modifiers,
             key,
         }
@@ -35,7 +31,6 @@ pub(crate) struct DialogAction<'a> {
     pub(crate) id: &'a str,
     pub(crate) label: &'a str,
     pub(crate) kind: ButtonKind,
-    pub(crate) min_width: f32,
     pub(crate) shortcut: Option<DialogShortcut<'a>>,
 }
 
@@ -45,7 +40,6 @@ impl<'a> DialogAction<'a> {
             id,
             label,
             kind,
-            min_width: 0.0,
             shortcut: None,
         }
     }
@@ -107,35 +101,25 @@ impl<'a> ActionModal<'a> {
         let response = shell.show(ctx, colors, |ui| {
             add_body(ui);
             ui.add_space(style::SPACE_MD);
-            ui.horizontal(|ui| {
-                for action in self.actions {
-                    if button::chrome_button(
-                        ui,
-                        action.label,
-                        action.kind,
-                        colors,
-                        action.min_width,
-                    )
-                    .clicked()
-                    {
-                        selected = Some(action.id);
-                    }
-                    ui.add_space(style::SPACE_SM);
-                }
-            });
 
-            let hints: Vec<HintGroup<'a>> = self
+            // Every label starts past the widest combo so the chip column and
+            // the label column each read as one edge — the modal has a single
+            // left alignment from title through body to actions.
+            let chip_col_w = self
                 .actions
                 .iter()
-                .filter_map(|action| {
+                .map(|action| {
                     action
                         .shortcut
                         .as_ref()
-                        .map(|shortcut| HintGroup::new(shortcut.keys, shortcut.label))
+                        .map_or(0.0, |shortcut| shortcuts::key_combo_width(ui, shortcut.keys))
                 })
-                .collect();
-            if !hints.is_empty() {
-                HintBar::new(&hints).show(ui, colors);
+                .fold(0.0_f32, f32::max);
+
+            for action in self.actions {
+                if action_row(ui, action, chip_col_w, colors).clicked() {
+                    selected = Some(action.id);
+                }
             }
         });
 
@@ -144,4 +128,58 @@ impl<'a> ActionModal<'a> {
             dismissed: response.dismissed,
         }
     }
+}
+
+/// One full-width action row: its shortcut chips are the primary affordance,
+/// the label names what they do, and the whole row is the hit target. Rows
+/// share the modal's left edge, so a modal never mixes left-aligned prose
+/// with centered chrome.
+fn action_row(
+    ui: &mut egui::Ui,
+    action: &DialogAction<'_>,
+    chip_col_w: f32,
+    colors: &Colors,
+) -> egui::Response {
+    let (rect, response) = ui.allocate_exact_size(
+        egui::vec2(ui.available_width(), style::MODAL_ACTION_ROW_H),
+        egui::Sense::click(),
+    );
+    if response.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+        // The fill bleeds into the modal's gutter so the chips can sit flush
+        // with the title and body text. Indenting the chips instead would
+        // reintroduce a second left edge inside the modal.
+        ui.painter().rect_filled(
+            rect.expand2(egui::vec2(style::SPACE_XS, 0.0)),
+            style::RADIUS_SM,
+            colors.bg_hover,
+        );
+    }
+
+    let center_y = rect.center().y;
+    let chip_x = rect.left();
+    if let Some(shortcut) = &action.shortcut {
+        shortcuts::key_combo_painted(ui, chip_x, center_y, shortcut.keys, colors);
+    }
+
+    // Destructive actions stay distinct without a filled button: the label
+    // carries the danger color while the row geometry matches its siblings.
+    let label_color = match action.kind {
+        ButtonKind::Danger => colors.danger,
+        _ => colors.text_primary,
+    };
+    let galley = ui.fonts_mut(|f| {
+        f.layout_no_wrap(
+            action.label.to_string(),
+            crate::ui::theme::font_medium(style::TEXT_CAPTION),
+            label_color,
+        )
+    });
+    let label_pos = egui::Pos2::new(
+        chip_x + chip_col_w + style::KEYCHIP_DESC_GAP,
+        center_y - galley.size().y / 2.0,
+    );
+    crate::ui::snap::galley_snapped(ui.painter(), label_pos, galley, label_color);
+
+    response
 }

--- a/src/ui/shortcuts.rs
+++ b/src/ui/shortcuts.rs
@@ -101,6 +101,64 @@ pub(crate) fn key_combo_list_with_body<R>(
     })
 }
 
+/// Paint one key chip with its left edge at `left`, vertically centered on
+/// `center_y`, without allocating layout space. Returns the chip width.
+/// For painter-driven rows that place their own chips (modal action rows).
+pub(crate) fn key_chip_painted(
+    ui: &egui::Ui,
+    left: f32,
+    center_y: f32,
+    label: &str,
+    colors: &Colors,
+) -> f32 {
+    let fg = shortcut_key_color(colors);
+    let galley = ui.fonts_mut(|f| f.layout_no_wrap(label.to_string(), combo_chip_font(), fg));
+    let text_w = galley.size().x;
+    let chip_h = galley.size().y + style::KEYCHIP_PAD_V * 2.0;
+    let chip_w = (text_w + style::KEYCHIP_PAD_H * 2.0)
+        .max(chip_h)
+        .max(style::KEYCHIP_MIN_W);
+    let rect = egui::Rect::from_min_size(
+        Pos2::new(left, center_y - chip_h / 2.0),
+        Vec2::new(chip_w, chip_h),
+    );
+    let painter = ui.painter();
+    painter.rect_filled(rect, CornerRadius::same(4), colors.bg_active);
+    let text_pos = Pos2::new(
+        rect.center().x - text_w / 2.0,
+        rect.min.y + style::KEYCHIP_PAD_V,
+    );
+    crate::ui::snap::galley_snapped(painter, text_pos, galley, fg);
+    chip_w
+}
+
+/// Paint a whole key combo starting at `left`, centered on `center_y`.
+/// Returns the total painted width. Pairs with [`key_combo_width`], which
+/// measures the same geometry without painting.
+pub(crate) fn key_combo_painted(
+    ui: &egui::Ui,
+    left: f32,
+    center_y: f32,
+    keys: &[&str],
+    colors: &Colors,
+) -> f32 {
+    let mut x = left;
+    for (i, key) in keys.iter().enumerate() {
+        if i > 0 {
+            x += style::KEYCHIP_GAP;
+        }
+        x += key_chip_painted(ui, x, center_y, key, colors);
+    }
+    x - left
+}
+
+/// Rendered width of one combo's chips and their gaps. Callers aligning a
+/// column of combos (modal action rows) measure every combo with this and
+/// lay the labels out past the widest.
+pub(crate) fn key_combo_width(ui: &egui::Ui, keys: &[&str]) -> f32 {
+    key_combo_list_width(ui, &[keys], None)
+}
+
 pub(crate) fn key_combo_list_width(
     ui: &egui::Ui,
     combos: &[&[&str]],

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -86,11 +86,18 @@ pub const TABLE_HEADER_H: f32 = 28.0;
 pub const SCRIM_ALPHA: u8 = 190;
 
 /// Inner padding of a modal frame (horizontal, vertical). Applied via
-/// `egui::Margin::symmetric`. Calibrated against the rename-pane popover
-/// (16/12), the tightest modal in the product: ModalShell carries a title
-/// row so it gets slightly more, but anything past 20/16 read as dead air.
-pub const MODAL_PADDING_H: i8 = 20;
-pub const MODAL_PADDING_V: i8 = 16;
+/// `egui::Margin::symmetric`. Judged by screenshot at ppp 1.0 and 2.0 across
+/// the command palette, the notes picker, and a confirm modal: the frame's
+/// own border and shadow already separate it from the scrim, so the padding
+/// only has to keep text off the edge. Past ~12/10 the gap reads as dead air
+/// rather than as breathing room.
+pub const MODAL_PADDING_H: i8 = 12;
+pub const MODAL_PADDING_V: i8 = 10;
+
+/// Height of one `ActionModal` action row (shortcut chips + label). Sits
+/// between a dense list row and a form button: the chips need breathing room
+/// but a confirm modal's action stack must not read as a menu.
+pub const MODAL_ACTION_ROW_H: f32 = 30.0;
 
 // ── Pane ID overlay ────────────────────────────────────────────────────────
 /// Font size for the ⌘-hold pane ID ghost number (large, centered over pane content).

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1840,6 +1840,153 @@ mod tests {
             .expect("render failed");
     }
 
+    /// Seed a context-close confirm with a realistic pane inventory. When
+    /// `portal_backed`, the active window gets a Portal tile targeting the
+    /// context, which is what unlocks the Dissolve action (stint 0542).
+    fn seed_context_close_confirm(h: &mut PlexiUiHarness, portal_backed: bool) {
+        h.with_app_mut(|app| {
+            let ctx_id = if portal_backed {
+                let child_ctx_id = app.router.active().context_id + 4_000;
+                let portal_pane_id = app.host.alloc_pane_id();
+                let win = &mut app.windows[app.active_window];
+                win.panes.insert(
+                    portal_pane_id,
+                    Pane::Portal(Box::new(PortalPane {
+                        pane_id: portal_pane_id,
+                        target_context_id: child_ctx_id,
+                        context_state: None,
+                        hidden: false,
+                    })),
+                );
+                child_ctx_id
+            } else {
+                app.router.active().context_id
+            };
+            let mut state = app.build_context_close_state(ctx_id);
+            state.context_name = "api-server".to_string();
+            state.items = vec![
+                crate::app::ContextCloseItem {
+                    kind: "Terminal",
+                    name: "cargo watch".to_string(),
+                },
+                crate::app::ContextCloseItem {
+                    kind: "Terminal",
+                    name: "psql plexi_dev".to_string(),
+                },
+                crate::app::ContextCloseItem {
+                    kind: "App",
+                    name: "File Browser".to_string(),
+                },
+            ];
+            app.pending_context_close = Some(state);
+            app.push_focus_layer(crate::app::FocusKind::ContextCloseConfirm);
+        });
+        // Two steps for the egui Area sizing pass.
+        h.run_steps(2);
+    }
+
+    /// ActionModal defaults: shortcut chips lead every action row, all rows
+    /// share the modal's left edge, and the destructive action is distinct
+    /// without a filled button (stint 0542).
+    #[test]
+    fn screenshot_action_modal_context_close_confirm() {
+        let mut h = PlexiUiHarness::new_sized(1168.0, 720.0);
+        add_focused_pane(&mut h);
+        h.step();
+        seed_context_close_confirm(&mut h, true);
+        h.save_screenshot("/tmp/plexi_action_modal_context_close.png")
+            .expect("render failed");
+        assert!(
+            h.with_app(|app| app.pending_context_close.is_some()),
+            "confirm must still be pending — nothing consumed it"
+        );
+        println!("Screenshot saved to /tmp/plexi_action_modal_context_close.png");
+    }
+
+    /// A top-level context has no parent portal, so the modal must render
+    /// exactly two action rows — Dissolve would early-return (stint 0542).
+    #[test]
+    fn screenshot_action_modal_context_close_top_level_has_no_dissolve() {
+        let mut h = PlexiUiHarness::new_sized(1168.0, 720.0);
+        add_focused_pane(&mut h);
+        h.step();
+        seed_context_close_confirm(&mut h, false);
+        h.save_screenshot("/tmp/plexi_action_modal_context_close_top_level.png")
+            .expect("render failed");
+        assert!(
+            h.with_app(|app| app
+                .pending_context_close
+                .as_ref()
+                .is_some_and(|state| !state.can_dissolve)),
+            "a top-level context must not advertise Dissolve"
+        );
+        println!("Screenshot saved to /tmp/plexi_action_modal_context_close_top_level.png");
+    }
+
+    /// Density review surface for the modal padding tokens (stint 0543):
+    /// palette, notes picker, and a confirm modal rendered with realistic
+    /// seeded content at the given `pixels_per_point`.
+    #[test]
+    #[ignore = "density review artifact — run explicitly when tuning MODAL_PADDING_*"]
+    fn screenshot_modal_density_review() {
+        for ppp in [1.0_f32, 2.0] {
+            let tag = if ppp == 1.0 { "1x" } else { "2x" };
+
+            let mut h = PlexiUiHarness::new_sized_ppp(1168.0, 720.0, ppp);
+            add_focused_pane(&mut h);
+            h.step();
+            h.with_app_mut(|app| {
+                app.palette_notes = ["deploy checklist", "sprint 12 retro", "api rate limits"]
+                    .iter()
+                    .map(|title| crate::notes::NotePickerEntry {
+                        path: std::env::temp_dir().join(format!("plexi-density-{title}.md")),
+                        title: (*title).to_string(),
+                        preview: format!("{title} — first body line of the note"),
+                        inbox: false,
+                        search_text: title.to_lowercase(),
+                    })
+                    .collect();
+                app.show_command_palette = true;
+                app.sync_command_palette_focus();
+            });
+            h.run_steps(3);
+            h.save_screenshot(&format!("/tmp/plexi_density_palette_{tag}.png"))
+                .expect("render failed");
+
+            let mut h = PlexiUiHarness::new_sized_ppp(1168.0, 720.0, ppp);
+            add_focused_pane(&mut h);
+            h.step();
+            h.with_app_mut(|app| {
+                app.open_notes_picker();
+                app.notes_picker_entries = [
+                    ("meeting notes 2026-07-24", true),
+                    ("deploy checklist", false),
+                    ("sprint 12 retro", false),
+                ]
+                .iter()
+                .map(|(title, inbox)| crate::notes::NotePickerEntry {
+                    path: std::env::temp_dir().join(format!("plexi-density-{title}.md")),
+                    title: (*title).to_string(),
+                    preview: format!("{title} — first body line of the note"),
+                    inbox: *inbox,
+                    search_text: title.to_lowercase(),
+                })
+                .collect();
+                app.notes_picker_selected = 0;
+            });
+            h.run_steps(3);
+            h.save_screenshot(&format!("/tmp/plexi_density_picker_{tag}.png"))
+                .expect("render failed");
+
+            let mut h = PlexiUiHarness::new_sized_ppp(1168.0, 720.0, ppp);
+            add_focused_pane(&mut h);
+            h.step();
+            seed_context_close_confirm(&mut h, true);
+            h.save_screenshot(&format!("/tmp/plexi_density_confirm_{tag}.png"))
+                .expect("render failed");
+        }
+    }
+
     #[test]
     fn screenshot_command_palette_metadata_lane() {
         let mut h = PlexiUiHarness::new_sized(1168.0, 720.0);


### PR DESCRIPTION
Batch of two stint tasks. No linked GitHub issues — stint is authoritative.

- **stint 0542** — ui: ActionModal defaults redesign — keyboard-first actions, coherent alignment, dissolve gated to subcontexts
- **stint 0543** — ui: halve modal padding (screenshot-judged) + Cmd+P lists only open notes, Cmd+O keeps all

## What changed

**ActionModal defaults (0542).** Actions were a left-aligned button row plus a separately centered shortcut-hint bar — four alignments in one small modal. Now each action is one full-width row led by its shortcut chips, with labels aligned in a column past the widest combo, so title, body, and actions share a single left edge. The whole row is the hit target. Destructive actions are distinct via the danger-colored label instead of a filled button. `DialogShortcut` loses its now-redundant hint label; `DialogAction` loses its unused `min_width`. All call sites inherit the defaults: confirm-close-pane, context-close, event consent, raw WASM review, and the WASM capability modal.

**Dissolve gating (0542).** `dissolve_portal` requires a Portal tile in the active window targeting the context; for a top-level context it early-returned and the button visibly did nothing. `ContextCloseState` now carries `can_dissolve`, computed once at prompt time by the new `context_has_portal`, and the modal only offers the action when it will do something.

**Modal padding (0543).** `MODAL_PADDING_H/V` 20/16 → 12/10, judged by screenshot rather than spec'd — the halving in the task was a starting point. 12/10 keeps the selected-row focus ring off the frame edge where 10/8 crowded it.

**Cmd+P scoping (0543).** The palette's note corpus is the set of notes open in editor panes, not a scan of the notes dir, so opening the palette no longer walks the filesystem. Cmd+O's picker is untouched and remains the browse-everything surface. Notes are collected via a new `App::open_note_path` trait method rather than a downcast, since `as_any_mut` is deliberately `#[cfg(test)]`.

Because that corpus spans every window, activating a palette note entry now resolves the owning pane in **any** window and navigates to it (`pane_navigate`) instead of opening a duplicate editor — caught by the Codex review pass and fixed here.

## Test evidence

- `cargo test --bin plexi` (env-stripped): **1823 passed, 1 failed, 3 ignored**.
- The single failure — `testing::harness_tests::send_to_app_pane_injects_text_through_focused_render_input` — is **pre-existing on clean alpha**. Verified by running it at alpha HEAD `59ea0383` in the untouched repo root: same panic (`target render must consume its queued IPC input exactly once`). Not caused by and not touched by this diff; it needs its own task.
- New regression tests:
  - `context_close_offers_dissolve_only_for_portal_backed_context` — verified falsifiable: forcing `can_dissolve = true` makes it fail with the intended message.
  - `open_note_entries_lists_only_notes_open_in_a_pane` — unopened notes excluded, dedupe across two panes on one note.
  - `open_note_entries_ignores_non_note_editor_panes`
  - `palette_finds_open_note_editor_in_a_non_active_window` — covers the cross-window activation fix.
  - `screenshot_action_modal_context_close_confirm` / `..._top_level_has_no_dissolve` — the second asserts the top-level context does not advertise Dissolve.
  - `screenshot_modal_density_review` (`#[ignore]`) — regenerates the padding-judging artifacts at ppp 1.0 and 2.0.
- Visual review (TESTING.md step, mandatory for 0543): rendered the Cmd+P palette, Cmd+O picker, and the context-close confirm with realistic seeded content at ppp 1.0 and 2.0, plus confirm-close-pane and raw-WASM-review, and read every PNG. Two fixes came out of it — chips were indented 8px from the title (now flush, hover fill bleeds into the gutter instead) and the row height came down 34 → 30. Throwaway PNGs deleted.
- Codex review vs alpha: one P2 finding (cross-window duplicate editor), fixed; second pass clean.

**PR install:** required — `just pr-install <PR>`, then drive `plexi-pr-<PR>`. The harness covers geometry and state, but modal density and the keyboard-first row treatment are pixel judgments, and the Dissolve gate should be exercised live on both a top-level context and a portal-backed subcontext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)