### PR TITLE
docs(wasm): performance section from the balls frame-path audit (stint 0541)

### DIFF
--- a/docs/wasm-runtime.md
+++ b/docs/wasm-runtime.md
@@ -54,6 +54,24 @@ The host renders the WIT `ui-tree` through egui. Typed UI actions are delivered 
 
 The runtime is sandboxed. Components have isolated linear memory and only the host interfaces that Plexi links. Python apps run through the CPython-in-WASM adapter (`src/host/wasm_python.rs`, stint 0285) and are sandboxed by this same component boundary — there is no remaining native-subprocess Python runtime (`src/process_app/` was deleted).
 
+## Performance
+
+The reference workload is `apps/balls` — a continuous-cadence canvas app that moves every drawing command every frame, which is the worst realistic case for the render transport. Measured on alpha (2026-07-24), it holds its declared 60 fps: `guest_fps` ≈ 59.9 with a ~13 ms guest round-trip and ~0.05 ms of host time per pane paint. The frame path is guest-bound, not host-bound.
+
+**How to measure.** Never guess at frame cost. The CPython-WASM adapter logs a sampled `CPython-WASM perf` line per app to the channel log (see the Logging section of the root `CLAUDE.md`), carrying `paint_fps`, `guest_fps`, `avg_host_ms`, `avg_roundtrip_ms`, per-stage decode/render times, and `stdout_kib`. Native WASM surface panes are paced and measured separately by `FrameClock` / `FrameTelemetry` in `src/host/wasm_frame.rs`. Read those numbers before changing anything; the two paths are independent and only the Python one carries today's apps.
+
+**Reading the numbers.** `guest_fps` is the app's real cadence — the only number that answers "is it smooth". `avg_host_ms` is what the pane costs the host per paint. `avg_roundtrip_ms` is the guest's total budget per frame and must stay under the declared interval (16.7 ms at 60 fps). `paint_fps` counts host repaints, which legitimately exceeds `guest_fps`: the scheduler's admission deadline and the decoder's frame-arrival wake are independent repaint sources.
+
+**Peak-performance SDK usage**, with balls as the exemplar:
+
+- **Declare a rate you can sustain, and pace from the host.** Call `SetSchedulerMode("continuous", fps=N)` once in `init()` and let the host own cadence — fixed-deadline admission, a headroom window, and a bounded in-flight pipeline. Never implement an FPS loop, a sleep, or a frame counter in the guest. A steady lower rate reads smoother than a jittery higher one; if `guest_fps` sits below the declared rate, lower the declaration rather than shipping the jitter.
+- **Integrate against the event's own `elapsed`, not the nominal tick.** Take `dt` from `RenderFrame.elapsed` and clamp it (balls uses a max-`dt` cap) so a stall or a tab-back cannot tunnel objects through walls. Physics must be dt-correct, not tick-count-correct.
+- **Keep `view()` pure and cheap.** `view()` runs every frame and should only read simulation state into nodes. Do the simulation in `update()`; never mutate state, allocate caches, or do I/O inside `view()`.
+- **Spend the frame budget on the command list, because it is the transport.** Every canvas command is JSON-encoded and written to stdout each frame, so the command count — not the pixel area — sets the cost. Balls draws a shadow, a body, and a highlight per ball, and its per-frame payload scales linearly with ball count. Bound the object count (balls caps at a fixed maximum) rather than letting the payload grow without limit.
+- **Prefer a stable tree shape.** The runtime emits a positional `tree_delta` instead of a full frame while the tree keeps the same root and shape. Structural churn every frame — a changing node count, a rebuilt root — forces a full re-serialize. Note that a delta is only a win when part of the frame is static: for a canvas where every command changes, the delta is the same size as a full frame or slightly larger.
+
+Both games under `apps/` declare 60 fps. Stint 0446 locked breakout to a lower rate as an explicit interim measure until 0438 (diffed tree updates) landed; 0438 is done, so 60 is the correct current declaration, not a reverted lock.
+
 ## Security Model
 
 Every app pane — Rust WASM component or Python app — runs inside its own `wasmtime::Store` with isolated linear memory. A component can only reach the host interfaces Plexi links for its world (`plexi-app`, `plexi-gpu-app`, `plexi-audio-app`, `plexi-full-app`); this is link-time gating, not a runtime policy check. Python apps run through the CPython-in-WASM adapter (`src/host/wasm_python.rs`, stint 0285) inside the same component boundary — there is no separate native-subprocess Python runtime.


### PR DESCRIPTION
Closes stint 0541 (wasm: performance audit with balls as the golden exemplar).

No linked GitHub issue — stint 0541 is the ticket.

## What this is

Stint 0541 is an **audit**. This PR lands only the audit's documentation deliverable: a `## Performance` section in `docs/wasm-runtime.md` recording how to measure the WASM frame path and what peak-performance SDK usage looks like, with `apps/balls` as the cited exemplar.

The measurements did **not** indict a steady-state regression in the frame path, so no tuning code is forced into this PR. Findings that need design decisions were filed as follow-up stints instead.

## What was measured

Source: the sampled `CPython-WASM perf` telemetry already emitted by `src/host/wasm_python.rs`, read from the alpha channel log, plus a direct per-stage profile of the balls guest frame (physics, draw, tree encode, delta patch, `json.dumps`).

- balls on alpha today holds its declared rate: `guest_fps` ~59.9/60, `avg_roundtrip_ms` ~13 (budget 16.7), `avg_host_ms` ~0.05. The frame path is guest-bound, not host-bound.
- Observed dips are **event-correlated, not steady-state**: round-trip stalls of 277 ms to 6.5 s line up with context dissolve, `workspace_save`, and registry rescan + config reload on the UI thread.
- Host paints ~75x/sec for a 60 fps app, because the scheduler's admission deadline and the decoder's frame-arrival wake are independent repaint sources.
- The positional `tree_delta` is not a win for an animation canvas where every command changes — payload is equal to or slightly larger than a full frame.
- Canvas coordinates serialize at full float precision (16 significant digits) — a large share of the per-frame payload.

## Anomaly resolved

Stint 0446 said breakout was locked to a sustainable fixed fps, yet `apps/breakout/breakout.py` has `TARGET_FPS = 60` on alpha. 0446 scoped that lock explicitly as an interim measure until 0438 (diffed tree updates) landed. 0438 is done, so 60 is the correct current declaration — the stint description did not drift and nothing was wrongly reverted. Recorded in the new docs section.

## Test evidence

- Diff classification: **docs-only** (one `.md` file, no code). Per `src/testing/TESTING.md`, docs-only diffs require no test evidence.
- No host logic, host UI, or app code touched — no harness test or render screenshot applies.
- Conclusion: **install skippable** — nothing in this diff can affect a built binary. `just pr-install` is not required to validate it.