### PR TITLE
feat(assistant): one instance + conversation per context (stint 0538)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1148,6 +1148,7 @@ impl PlexiApp {
                                 app_cwd.clone(),
                                 broker,
                                 &crate::config::config_dir(),
+                                saved_win.context_id,
                             ));
                         }
                         if pane_entry.is_none() && app_type == "assistant" {

--- a/src/app/tests/navigation_tests.rs
+++ b/src/app/tests/navigation_tests.rs
@@ -729,3 +729,151 @@ fn split_mirror_bypasses_on_launch_dedup() {
         "mirror-split of a focus_existing app must spawn a second instance, not dedup"
     );
 }
+
+// ── Assistant: one instance + conversation per context (stint 0538) ─────────
+
+/// Count assistant panes across every window (top-level panes only — an
+/// assistant used as an overlay still sits in `win.panes`).
+fn assistant_pane_count(app: &PlexiApp) -> usize {
+    app.windows
+        .iter()
+        .flat_map(|w| w.panes.values())
+        .filter(|p| p.as_app().is_some_and(|a| a.manifest_id == "assistant"))
+        .count()
+}
+
+/// A second open in the SAME window focuses the existing assistant instead of
+/// spawning a duplicate.
+#[test]
+fn assistant_open_focuses_existing_in_same_window() {
+    // Alpha-tier channel so the assistant feature gate passes.
+    let _channel = crate::config::set_test_channel("pr-0538");
+    let mut h = HostHarness::new();
+    let _pane_a = h.add_test_pane(); // window 0, context 1
+    let (assistant_tile, assistant_pane) = h.app.add_app_pane_in_window(0, "assistant");
+
+    h.app.open_assistant_pane();
+
+    assert_eq!(
+        assistant_pane_count(&h.app),
+        1,
+        "reopening in the same window must focus, never spawn a second assistant"
+    );
+    assert_eq!(h.app.active_window, 0);
+    assert_eq!(
+        h.app.windows[0].focused_pane,
+        Some(assistant_tile),
+        "the existing assistant pane must be focused"
+    );
+    assert_eq!(
+        h.app
+            .find_app_pane_by_type("assistant", Some(h.app.windows[0].context_id))
+            .map(|(p, _)| p),
+        Some(assistant_pane)
+    );
+}
+
+/// Assistant open in window A of context X; opening from window B of the SAME
+/// context focuses the instance in window A cross-window — no second instance.
+#[test]
+fn assistant_open_focuses_existing_across_windows_of_same_context() {
+    let _channel = crate::config::set_test_channel("pr-0538");
+    let mut h = HostHarness::new();
+    let _pane_a = h.add_test_pane(); // window 0, context 1
+    let (assistant_tile, assistant_pane) = h.app.add_app_pane_in_window(0, "assistant");
+
+    // Window B of the SAME context 1, caller side.
+    h.app.windows.push(empty_window(1, 2));
+    let _other = h.app.add_app_pane_in_window(1, "test");
+    h.app.active_window = 1;
+
+    h.app.open_assistant_pane();
+
+    assert_eq!(
+        assistant_pane_count(&h.app),
+        1,
+        "an instance in another window of the same context must satisfy the open"
+    );
+    assert_eq!(
+        h.app.active_window, 0,
+        "focus must jump to the window holding the existing instance"
+    );
+    assert_eq!(h.app.windows[0].focused_pane, Some(assistant_tile));
+    assert_eq!(
+        h.app
+            .find_app_pane_by_type("assistant", Some(1))
+            .map(|(p, _)| p),
+        Some(assistant_pane)
+    );
+}
+
+/// Assistant open in context X; opening from a window of context Y spawns a
+/// SECOND distinct instance, and each context's store persists its own
+/// conversation pointer.
+#[test]
+fn assistant_open_spawns_second_instance_in_other_context() {
+    let _channel = crate::config::set_test_channel("pr-0538");
+    // Pin the workspace root to this repo checkout by planting the channel
+    // marker dir the workspace resolver walks up to. The channel is unique to
+    // this test and the dir is git-ignored (`.plexi-pr-*/`); nothing here may
+    // ever touch $HOME.
+    let cwd = std::env::current_dir().expect("cwd");
+    let marker = cwd.join(".plexi-pr-0538");
+    std::fs::create_dir_all(&marker).expect("create channel marker dir");
+    struct Cleanup(std::path::PathBuf);
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+    let _cleanup = Cleanup(marker);
+    let workspace_root =
+        crate::config::active_workspace_root().expect("marker dir must make cwd a workspace root");
+    assert_eq!(workspace_root, cwd, "workspace root must resolve to the repo checkout");
+
+    let mut h = HostHarness::new();
+    let (pane_a_tile, _pane_a) = h.app.add_test_pane(); // window 0, context 1
+    h.app.windows[0].focused_pane = Some(pane_a_tile);
+
+    // First open spawns in context 1.
+    h.app.open_assistant_pane();
+    assert_eq!(assistant_pane_count(&h.app), 1);
+
+    // A window of context 2, caller side.
+    h.app.windows.push(empty_window(2, 2));
+    let (pane_b_tile, _pane_b) = h.app.add_app_pane_in_window(1, "test");
+    h.app.router.push(context_b(2));
+    h.app.jump_to_context(1, 2, None);
+    h.app.windows[1].focused_pane = Some(pane_b_tile);
+
+    // Opening from context 2 must NOT focus context 1's instance — it spawns
+    // a second one in the current window.
+    h.app.open_assistant_pane();
+    assert_eq!(
+        assistant_pane_count(&h.app),
+        2,
+        "a different context must get its own assistant instance"
+    );
+    assert_eq!(h.app.active_window, 1, "no cross-context jump on spawn");
+    assert!(
+        h.app.windows[1]
+            .panes
+            .values()
+            .any(|p| p.as_app().is_some_and(|a| a.manifest_id == "assistant")),
+        "the second instance must live in the caller's window"
+    );
+
+    // Each context persisted its own conversation pointer in the store.
+    let store_ctx1 = crate::assistant::store::AssistantStore::new(&workspace_root, 1);
+    let store_ctx2 = crate::assistant::store::AssistantStore::new(&workspace_root, 2);
+    let conv1 = store_ctx1
+        .active_conversation()
+        .expect("context 1 persisted a conversation");
+    let conv2 = store_ctx2
+        .active_conversation()
+        .expect("context 2 persisted a conversation");
+    assert_ne!(
+        conv1, conv2,
+        "each context must persist (and resume) its own conversation"
+    );
+}

--- a/src/assistant/harness.rs
+++ b/src/assistant/harness.rs
@@ -559,7 +559,7 @@ impl AssistantHarness {
             skills: Mutex::new(probes),
             agent_id: Mutex::new("default".to_string()),
         });
-        let mut app = AssistantApp::new(workspace.clone(), broker.clone(), &profile);
+        let mut app = AssistantApp::new(workspace.clone(), broker.clone(), &profile, 1);
         if let Some((agent_id, _, _)) = route {
             app.model.active_agent_id = agent_id.to_string();
         }

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -538,15 +538,22 @@ struct PendingSubscribe {
 
 impl AssistantApp {
     /// Open the Assistant for a workspace: resume the persisted active
-    /// conversation, or create a fresh one. `profile_dir` is the channel
-    /// config dir — grants load from `<profile_dir>/grants.toml` and audit
-    /// events append to `<profile_dir>/audit.jsonl`.
-    pub fn new(workspace_root: PathBuf, broker: Arc<dyn AiBroker>, profile_dir: &Path) -> Self {
+    /// conversation of `context_id` (the host context this pane lives in),
+    /// or create a fresh one. `profile_dir` is the channel config dir —
+    /// grants load from `<profile_dir>/grants.toml` and audit events append
+    /// to `<profile_dir>/audit.jsonl`.
+    pub fn new(
+        workspace_root: PathBuf,
+        broker: Arc<dyn AiBroker>,
+        profile_dir: &Path,
+        context_id: u64,
+    ) -> Self {
         Self::new_with_timeline(
             workspace_root,
             broker,
             profile_dir,
             crate::host::app_timeline::global(),
+            context_id,
         )
     }
 
@@ -556,8 +563,9 @@ impl AssistantApp {
         broker: Arc<dyn AiBroker>,
         profile_dir: &Path,
         timeline: Arc<Mutex<AppTimeline>>,
+        context_id: u64,
     ) -> Self {
-        let store = AssistantStore::new(&workspace_root);
+        let store = AssistantStore::new(&workspace_root, context_id);
         let mut model = match store.active_conversation() {
             Some(id) => {
                 let turns = store.load_turns(&id);
@@ -3532,7 +3540,7 @@ mod tests {
 
     /// Assistant whose grants + audit live in the (temp) workspace dir.
     fn test_app(ws: &Path) -> AssistantApp {
-        AssistantApp::new(ws.to_path_buf(), MockBroker::ok("echo: ok"), ws)
+        AssistantApp::new(ws.to_path_buf(), MockBroker::ok("echo: ok"), ws, 1)
     }
 
     fn wait_for_turn(app: &mut AssistantApp) {
@@ -3558,7 +3566,7 @@ mod tests {
     fn app_build_prompt_missed_by_general_matcher_still_gets_sdk_context_and_raised_cap() {
         let ws = tempfile::tempdir().unwrap();
         let broker = Arc::new(CapturingBroker::default());
-        let mut app = AssistantApp::new(ws.path().to_path_buf(), broker.clone(), ws.path());
+        let mut app = AssistantApp::new(ws.path().to_path_buf(), broker.clone(), ws.path(), 1);
 
         app.model.composer = "Build me a tiny counter app with plus and minus buttons".to_string();
         let effects = app.model.submit();
@@ -3644,7 +3652,7 @@ enabled = ["allowed.tool"]
         )
         .unwrap();
         let broker = Arc::new(CapturingBroker::default());
-        let mut app = AssistantApp::new(ws.path().to_path_buf(), broker.clone(), ws.path());
+        let mut app = AssistantApp::new(ws.path().to_path_buf(), broker.clone(), ws.path(), 1);
         register_echo_provider(
             9199,
             &["allowed.tool", "denied.tool"],
@@ -4646,7 +4654,7 @@ enabled = ["allowed.tool"]
     }
 
     fn test_app_with_timeline(ws: &Path, timeline: Arc<Mutex<AppTimeline>>) -> AssistantApp {
-        AssistantApp::new_with_timeline(ws.to_path_buf(), MockBroker::ok("echo: ok"), ws, timeline)
+        AssistantApp::new_with_timeline(ws.to_path_buf(), MockBroker::ok("echo: ok"), ws, timeline, 1)
     }
 
     fn emit_move(
@@ -4932,6 +4940,7 @@ enabled = ["allowed.tool"]
                 dispatched: AtomicUsize::new(0),
             }),
             ws.path(),
+            1,
         );
 
         // Turn 1 starts and parks in the broker.
@@ -5224,13 +5233,13 @@ enabled = ["allowed.tool"]
     #[test]
     fn rename_persists_session_name() {
         let ws = tempfile::tempdir().unwrap();
-        let mut app = AssistantApp::new(ws.path().to_path_buf(), MockBroker::ok("ok"), ws.path());
+        let mut app = AssistantApp::new(ws.path().to_path_buf(), MockBroker::ok("ok"), ws.path(), 1);
         assert_eq!(app.model.session_name, None);
         app.on_pane_renamed("My Session");
         assert_eq!(app.model.session_name.as_deref(), Some("My Session"));
         // Reopen: name persists.
         drop(app);
-        let reopened = AssistantApp::new(ws.path().to_path_buf(), MockBroker::ok("ok"), ws.path());
+        let reopened = AssistantApp::new(ws.path().to_path_buf(), MockBroker::ok("ok"), ws.path(), 1);
         assert_eq!(reopened.model.session_name.as_deref(), Some("My Session"));
     }
 
@@ -5252,7 +5261,7 @@ enabled = ["allowed.tool"]
     #[test]
     fn error_turn_appends_error_row() {
         let ws = tempfile::tempdir().unwrap();
-        let mut app = AssistantApp::new(ws.path().to_path_buf(), MockBroker::error(), ws.path());
+        let mut app = AssistantApp::new(ws.path().to_path_buf(), MockBroker::error(), ws.path(), 1);
         app.model.composer = "trigger error".to_string();
         let effects = app.model.submit();
         app.execute_effects(effects);
@@ -5563,7 +5572,7 @@ enabled = ["allowed.tool"]
         )
         .unwrap();
         let broker = Arc::new(CapturingBroker::default());
-        let mut app = AssistantApp::new(ws.path().to_path_buf(), broker.clone(), ws.path());
+        let mut app = AssistantApp::new(ws.path().to_path_buf(), broker.clone(), ws.path(), 1);
         app.model.composer = "/release /Users/ian/project".to_string();
         let effects = app.model.submit();
         assert!(matches!(

--- a/src/assistant/store.rs
+++ b/src/assistant/store.rs
@@ -4,9 +4,19 @@
 //!
 //! ```text
 //! <workspace>/<workspace_channel_dir>/assistant/
-//!   state.toml                     — active_conversation = "<id>"
+//!   state.toml                     — show_thoughts (global UI pref) plus
+//!                                    [contexts.<context_id>] tables, each with
+//!                                    active_conversation = "<id>" and the
+//!                                    per-context session/agent/effort/in-flight
+//!                                    state
 //!   conversations/<id>.jsonl       — one serialized `Turn` per line
 //! ```
+//!
+//! Conversation state is keyed per host *context* (`Window.context_id`): each
+//! context owns its own active conversation pointer, while transcripts on disk
+//! are shared workspace-wide. A conversation claims its owning context the
+//! first time a context activates it (`ConversationHistory::context_id`);
+//! untagged legacy conversations stay visible to every context until claimed.
 //!
 //! JSON lines with tolerant line-by-line reads (a corrupt line is logged and
 //! skipped, never fatal). Each save rewrites the whole transcript: turns can
@@ -21,12 +31,21 @@ use crate::plexi_ai::broker::ReasoningEffort;
 
 #[derive(Default, serde::Serialize, serde::Deserialize)]
 struct StateToml {
+    /// `/thoughts` toggle: show reasoning sections in the transcript.
+    /// Global UI preference — shared by every context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    show_thoughts: Option<bool>,
+    /// Per-context conversation state, keyed by `context_id` rendered as a
+    /// string (TOML table keys are strings).
+    #[serde(default)]
+    contexts: std::collections::BTreeMap<String, ContextStateToml>,
+}
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+struct ContextStateToml {
     active_conversation: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     session_name: Option<String>,
-    /// `/thoughts` toggle: show reasoning sections in the transcript.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    show_thoughts: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     active_agent_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -63,6 +82,10 @@ pub struct CompactionMetadata {
 pub struct ConversationHistory {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// The context that owns this conversation. `None` = untagged legacy
+    /// conversation, visible to every context until one activates (claims) it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<u64>,
     #[serde(default)]
     pub updated_at: String,
     #[serde(default)]
@@ -73,19 +96,27 @@ pub struct ConversationHistory {
     pub interruptions: Vec<String>,
 }
 
-/// Handle to the on-disk Assistant store for one workspace.
+/// Handle to the on-disk Assistant store for one workspace, scoped to one
+/// host context: conversation-pointer state reads and writes go to this
+/// context's entry in `state.toml`.
 pub struct AssistantStore {
     dir: PathBuf,
+    context_id: u64,
 }
 
 impl AssistantStore {
-    /// Store rooted in the workspace's channel dir.
-    pub fn new(workspace_root: &Path) -> Self {
+    /// Store rooted in the workspace's channel dir, scoped to `context_id`.
+    pub fn new(workspace_root: &Path, context_id: u64) -> Self {
         Self {
             dir: workspace_root
                 .join(crate::config::workspace_channel_dir())
                 .join("assistant"),
+            context_id,
         }
+    }
+
+    fn context_key(&self) -> String {
+        self.context_id.to_string()
     }
 
     fn state_path(&self) -> PathBuf {
@@ -153,13 +184,21 @@ impl AssistantStore {
         Self::atomic_write(&self.state_path(), raw.as_bytes())
     }
 
-    /// The persisted active conversation id, if any.
-    pub fn active_conversation(&self) -> Option<String> {
-        Some(self.read_state()?.active_conversation)
+    /// Read this store's context entry, if any.
+    fn read_context_state(&self) -> Option<ContextStateToml> {
+        self.read_state()?.contexts.remove(&self.context_key())
     }
 
-    /// Persist `id` as the active conversation, along with an optional
-    /// session name. Other persisted preferences are preserved.
+    /// The persisted active conversation id for this context, if any.
+    pub fn active_conversation(&self) -> Option<String> {
+        Some(self.read_context_state()?.active_conversation)
+    }
+
+    /// Persist `id` as this context's active conversation, along with an
+    /// optional session name. Other persisted preferences (and other
+    /// contexts' entries) are preserved. The conversation's history is
+    /// stamped with this context id — claim-on-activate: an untagged legacy
+    /// conversation becomes owned by the context that activates it.
     pub fn set_active_conversation(
         &self,
         id: &str,
@@ -168,28 +207,30 @@ impl AssistantStore {
         effort_override: Option<ReasoningEffort>,
     ) -> Result<(), String> {
         let mut state = self.read_state().unwrap_or_default();
-        state.active_conversation = id.to_string();
-        state.session_name = session_name.map(str::to_string);
-        state.active_agent_id = Some(active_agent_id.to_string());
-        state.effort_override = effort_override;
+        let entry = state.contexts.entry(self.context_key()).or_default();
+        entry.active_conversation = id.to_string();
+        entry.session_name = session_name.map(str::to_string);
+        entry.active_agent_id = Some(active_agent_id.to_string());
+        entry.effort_override = effort_override;
         self.write_state(&state)?;
         let mut history = self.load_history(id)?;
         history.name = session_name.map(str::to_string);
+        history.context_id = Some(self.context_id);
         history.updated_at = crate::host::event_log::now_timestamp();
         self.write_history(id, &history)
     }
 
-    /// The persisted session name for the active conversation, if any.
+    /// The persisted session name for this context's active conversation.
     pub fn active_session_name(&self) -> Option<String> {
-        self.read_state()?.session_name
+        self.read_context_state()?.session_name
     }
 
     pub fn active_agent_id(&self) -> Option<String> {
-        self.read_state()?.active_agent_id
+        self.read_context_state()?.active_agent_id
     }
 
     pub fn effort_override(&self) -> Option<ReasoningEffort> {
-        self.read_state()?.effort_override
+        self.read_context_state()?.effort_override
     }
 
     /// The persisted `/thoughts` toggle. Default: hidden.
@@ -208,14 +249,22 @@ impl AssistantStore {
 
     pub fn set_turn_in_flight(&self, in_flight: bool) -> Result<(), String> {
         let mut state = self.read_state().unwrap_or_default();
-        state.turn_in_flight = in_flight;
+        state
+            .contexts
+            .entry(self.context_key())
+            .or_default()
+            .turn_in_flight = in_flight;
         self.write_state(&state)
     }
 
-    /// Clear a persisted in-flight marker and record that restart interrupted it.
+    /// Clear this context's persisted in-flight marker and record that
+    /// restart interrupted it.
     pub fn recover_interrupted_turn(&self, conversation_id: &str) -> Result<bool, String> {
         let mut state = self.read_state().unwrap_or_default();
-        if !state.turn_in_flight || state.active_conversation != conversation_id {
+        let Some(entry) = state.contexts.get_mut(&self.context_key()) else {
+            return Ok(false);
+        };
+        if !entry.turn_in_flight || entry.active_conversation != conversation_id {
             return Ok(false);
         }
         let mut history = self.load_history(conversation_id)?;
@@ -223,7 +272,7 @@ impl AssistantStore {
             .interruptions
             .push(crate::host::event_log::now_timestamp());
         self.write_history(conversation_id, &history)?;
-        state.turn_in_flight = false;
+        entry.turn_in_flight = false;
         self.write_state(&state)?;
         Ok(true)
     }
@@ -274,6 +323,9 @@ impl AssistantStore {
         turns
     }
 
+    /// List conversations visible to this context: those claimed by this
+    /// context plus untagged legacy ones (visible everywhere until a context
+    /// activates them). The `active` marker is this context's pointer.
     pub fn list_conversations(&self) -> Result<Vec<ConversationSummary>, String> {
         let active = self.active_conversation();
         let dir = self.dir.join("conversations");
@@ -299,6 +351,12 @@ impl AssistantStore {
                 .map(|turn| turn.text.chars().take(60).collect())
                 .unwrap_or_else(|| "Untitled conversation".to_string());
             let history = self.load_history(id)?;
+            if history
+                .context_id
+                .is_some_and(|owner| owner != self.context_id)
+            {
+                continue;
+            }
             items.push(ConversationSummary {
                 id: id.to_string(),
                 title: history.name.unwrap_or(title),
@@ -440,7 +498,7 @@ mod tests {
     #[test]
     fn round_trip_resumes_the_same_conversation() {
         let ws = tempfile::tempdir().unwrap();
-        let store = AssistantStore::new(ws.path());
+        let store = AssistantStore::new(ws.path(), 1);
         assert_eq!(store.active_conversation(), None);
 
         let id = "conv-test-1";
@@ -458,7 +516,7 @@ mod tests {
             .unwrap();
 
         // A fresh store handle (same workspace) resumes the same state.
-        let reopened = AssistantStore::new(ws.path());
+        let reopened = AssistantStore::new(ws.path(), 1);
         assert_eq!(reopened.active_conversation().as_deref(), Some(id));
         let turns = reopened.load_turns(id);
         assert_eq!(turns.len(), 2);
@@ -479,7 +537,7 @@ mod tests {
     #[test]
     fn store_path_is_channel_aware() {
         let ws = tempfile::tempdir().unwrap();
-        let store = AssistantStore::new(ws.path());
+        let store = AssistantStore::new(ws.path(), 1);
         store
             .set_active_conversation("c1", None, "default", None)
             .unwrap();
@@ -494,7 +552,7 @@ mod tests {
     #[test]
     fn show_thoughts_round_trips_and_survives_conversation_switch() {
         let ws = tempfile::tempdir().unwrap();
-        let store = AssistantStore::new(ws.path());
+        let store = AssistantStore::new(ws.path(), 1);
         assert!(!store.show_thoughts(), "default is hidden");
 
         store.set_show_thoughts(true).unwrap();
@@ -516,7 +574,7 @@ mod tests {
     #[test]
     fn missing_conversation_loads_empty_and_corrupt_lines_are_skipped() {
         let ws = tempfile::tempdir().unwrap();
-        let store = AssistantStore::new(ws.path());
+        let store = AssistantStore::new(ws.path(), 1);
         assert!(store.load_turns("nope").is_empty());
 
         let id = "conv-corrupt";
@@ -548,7 +606,7 @@ mod tests {
     #[test]
     fn lists_multiple_conversations_with_active_marker() {
         let ws = tempfile::tempdir().unwrap();
-        let store = AssistantStore::new(ws.path());
+        let store = AssistantStore::new(ws.path(), 1);
         store
             .write_turns("older", &[Turn::now(TurnRole::User, "first topic")])
             .unwrap();
@@ -572,7 +630,7 @@ mod tests {
     #[test]
     fn checkpoint_preserves_raw_turns_and_history_metadata() {
         let ws = tempfile::tempdir().unwrap();
-        let store = AssistantStore::new(ws.path());
+        let store = AssistantStore::new(ws.path(), 1);
         let turns = vec![
             Turn::now(TurnRole::User, "one"),
             Turn::now(TurnRole::Assistant, "two"),
@@ -590,9 +648,87 @@ mod tests {
     }
 
     #[test]
+    fn contexts_keep_separate_active_conversation_and_in_flight_state() {
+        let ws = tempfile::tempdir().unwrap();
+        let ctx_a = AssistantStore::new(ws.path(), 1);
+        let ctx_b = AssistantStore::new(ws.path(), 2);
+
+        ctx_a
+            .set_active_conversation("conv-a", Some("alpha"), "default", None)
+            .unwrap();
+        ctx_b
+            .set_active_conversation("conv-b", None, "default", None)
+            .unwrap();
+        ctx_a.set_turn_in_flight(true).unwrap();
+
+        // Each context's pointer is independent.
+        assert_eq!(ctx_a.active_conversation().as_deref(), Some("conv-a"));
+        assert_eq!(ctx_b.active_conversation().as_deref(), Some("conv-b"));
+        assert_eq!(ctx_a.active_session_name().as_deref(), Some("alpha"));
+        assert_eq!(ctx_b.active_session_name(), None);
+
+        // Context A's in-flight marker never bleeds into context B.
+        assert!(ctx_a.recover_interrupted_turn("conv-a").unwrap());
+        assert!(!ctx_b.recover_interrupted_turn("conv-b").unwrap());
+
+        // A reopened store per context resumes its own conversation id.
+        let reopened_a = AssistantStore::new(ws.path(), 1);
+        let reopened_b = AssistantStore::new(ws.path(), 2);
+        assert_eq!(reopened_a.active_conversation().as_deref(), Some("conv-a"));
+        assert_eq!(reopened_b.active_conversation().as_deref(), Some("conv-b"));
+    }
+
+    #[test]
+    fn list_conversations_scopes_by_context_and_claims_legacy_on_activate() {
+        let ws = tempfile::tempdir().unwrap();
+        let ctx_a = AssistantStore::new(ws.path(), 1);
+        let ctx_b = AssistantStore::new(ws.path(), 2);
+
+        // `claimed-b` is activated (claimed) by context B; `legacy` only has a
+        // transcript, no history tag — visible everywhere until claimed.
+        ctx_b
+            .write_turns("claimed-b", &[Turn::now(TurnRole::User, "b topic")])
+            .unwrap();
+        ctx_b
+            .set_active_conversation("claimed-b", None, "default", None)
+            .unwrap();
+        ctx_a
+            .write_turns("legacy", &[Turn::now(TurnRole::User, "old topic")])
+            .unwrap();
+
+        let a_list = ctx_a.list_conversations().unwrap();
+        assert!(
+            a_list.iter().all(|item| item.id != "claimed-b"),
+            "context A must not list a conversation claimed by context B"
+        );
+        assert!(a_list.iter().any(|item| item.id == "legacy"));
+        let b_list = ctx_b.list_conversations().unwrap();
+        assert!(b_list.iter().any(|item| item.id == "claimed-b"));
+        assert!(
+            b_list.iter().any(|item| item.id == "legacy"),
+            "untagged legacy conversations are visible to every context"
+        );
+
+        // Context A activates the legacy conversation → claimed by A, gone
+        // from context B's list.
+        ctx_a
+            .set_active_conversation("legacy", None, "default", None)
+            .unwrap();
+        let a_list = ctx_a.list_conversations().unwrap();
+        assert!(a_list
+            .iter()
+            .any(|item| item.id == "legacy" && item.active));
+        let b_list = ctx_b.list_conversations().unwrap();
+        assert!(
+            b_list.iter().all(|item| item.id != "legacy"),
+            "a claimed conversation disappears from other contexts' lists"
+        );
+    }
+
+    #[test]
     fn export_contains_transcript_and_audit_material() {
         let ws = tempfile::tempdir().unwrap();
-        let store = AssistantStore::new(ws.path());
+        let store = AssistantStore::new(ws.path(), 1);
         let turns = vec![Turn::now(TurnRole::User, "hello")];
         let path = store
             .export_conversation("conv", &turns, "{\"kind\":\"tool_call\"}\n")

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -137,11 +137,13 @@ pub(crate) fn restore_assistant_pane(
     workspace_root: PathBuf,
     broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker>,
     profile_dir: &std::path::Path,
+    context_id: u64,
 ) -> Pane {
     let app = Box::new(crate::assistant::AssistantApp::new(
         workspace_root.clone(),
         broker,
         profile_dir,
+        context_id,
     ));
     let runtime_id = app.type_id().to_string();
     let name = app.display_name();
@@ -1093,7 +1095,6 @@ impl PlexiApp {
             return None;
         };
         let ctx_id = self.windows[win_idx].context_id;
-        let win_id = self.windows[win_idx].window_id;
         log::info!(
             "on_launch[{scope}]: '{id}' already open at slot {slot} in context {ctx_id} (overlay_depth={overlay_depth}) — focusing instead of spawning"
         );
@@ -1104,8 +1105,19 @@ impl PlexiApp {
                  (relaunch arg delivery to a running instance is future work)"
             );
         }
-        // Pop any overlays covering the instance so a relaunch reveals it, then
-        // unhide (it may have been hidden rather than overlaid) and focus.
+        self.reveal_and_focus_instance(win_idx, slot, overlay_depth);
+        Some(slot)
+    }
+
+    /// Reveal a located app instance and focus it: pop any overlays covering
+    /// it, unhide it (it may have been hidden rather than overlaid), and jump
+    /// to its window via the sanctioned
+    /// [`jump_to_context`](Self::jump_to_context) path — never by mutating
+    /// `active_window`/`router.active` directly. Popping overlays closes every
+    /// app overlay stacked above the instance, exactly as pressing Esc that
+    /// many times would.
+    fn reveal_and_focus_instance(&mut self, win_idx: usize, slot: PaneId, overlay_depth: usize) {
+        let win_id = self.windows[win_idx].window_id;
         for _ in 0..overlay_depth {
             super::layout::restore_overlay_replacement(&mut self.windows[win_idx].panes, slot);
         }
@@ -1113,7 +1125,6 @@ impl PlexiApp {
             pane.set_hidden(false);
         }
         self.jump_to_context(win_idx, win_id, Some(slot));
-        Some(slot)
     }
 
     /// Launch an installed app by id in the focused pane.
@@ -1198,17 +1209,9 @@ impl PlexiApp {
                 crate::release::log_feature_blocked(crate::release::ReleaseFeature::Assistant);
                 return Err("assistant is not enabled on this release channel".to_string());
             }
-            let predicted = self.host.next_pane_id();
-            self.open_assistant_pane_with_hint(layout.as_deref().unwrap_or("overlay"));
-            let pane_id = self.windows[self.active_window]
-                .panes
-                .iter()
-                .find_map(|(pane_id, pane)| {
-                    pane.as_app()
-                        .filter(|app| app.runtime.type_id() == "assistant")
-                        .map(|_| *pane_id)
-                })
-                .unwrap_or(predicted);
+            let pane_id = self
+                .open_assistant_pane_with_hint(layout.as_deref().unwrap_or("overlay"))
+                .ok_or_else(|| "assistant is not enabled on this release channel".to_string())?;
             log::info!(
                 "launch_app_by_id_with_layout: 'assistant' resolved as builtin pane_id={pane_id}"
             );
@@ -1509,52 +1512,44 @@ impl PlexiApp {
     /// Open (or focus) the host Assistant pane (Phase 1 of
     /// `docs/assistant-host-app.md`, reachable via Cmd+Ctrl+A and the
     /// Cmd+P palette). Opens as an overlay — it overtakes the focused pane
-    /// like every other app launch. One Assistant pane per window: if one
-    /// already exists it is focused and unhidden instead of spawning a
-    /// duplicate. Conversation state is workspace-scoped on disk, so
-    /// close-then-reopen resumes the same conversation.
+    /// like every other app launch. One Assistant pane per *context*: if one
+    /// already exists in any window of the caller's context it is revealed
+    /// and focused (cross-window) instead of spawning a duplicate.
+    /// Conversation state is persisted per context on disk, so
+    /// close-then-reopen resumes that context's conversation.
     ///
     /// Builtin exception to the manifest `[launch] on_launch` policy (#0336):
     /// the Assistant is a host builtin with its own entry point and is never
-    /// routed through `launch_app_by_id_with_layout`, so the generic resolver
-    /// does not see it. Its dedup is per *window* (not per context) and is kept
-    /// hardcoded here rather than expressed as `focus_existing_in_context`,
-    /// which would change the granularity from window to context.
+    /// routed through the registry resolver, so its dedup — matching
+    /// `focus_existing_in_context` semantics — is kept hardcoded here.
     pub(crate) fn open_assistant_pane(&mut self) {
         self.open_assistant_pane_with_hint("overlay");
     }
 
-    fn open_assistant_pane_with_hint(&mut self, hint: &str) {
+    /// Returns the pane id of the focused-or-spawned Assistant, or `None`
+    /// when the feature gate blocks the open.
+    fn open_assistant_pane_with_hint(&mut self, hint: &str) -> Option<PaneId> {
         if !crate::release::feature_enabled(crate::release::ReleaseFeature::Assistant) {
             crate::release::log_feature_blocked(crate::release::ReleaseFeature::Assistant);
-            return;
+            return None;
         }
-        let active = self.active_window;
-        // Focus an existing Assistant pane instead of opening a second one.
-        let existing = self.windows[active].panes.iter().find_map(|(id, pane)| {
-            pane.as_app()
-                .filter(|a| a.runtime.type_id() == "assistant")
-                .map(|_| *id)
-        });
-        if let Some(pane_id) = existing {
-            let win = &mut self.windows[active];
-            if let Some(pane) = win.panes.get_mut(&pane_id) {
-                pane.set_hidden(false);
-            }
-            let tile_id = win.tree.tiles.iter().find_map(|(tid, tile)| {
-                matches!(tile, egui_tiles::Tile::Pane(pid) if *pid == pane_id).then_some(*tid)
-            });
-            if let Some(tile_id) = tile_id {
-                win.focused_pane = Some(tile_id);
-            }
-            log::info!("assistant: focused existing pane {pane_id}");
-            return;
+        let caller_context_id = self.windows[self.active_window].context_id;
+        // Focus an existing Assistant pane anywhere in this context instead
+        // of opening a second one.
+        if let Some((win_idx, slot, overlay_depth)) =
+            self.locate_app_instance("assistant", Some(caller_context_id))
+        {
+            log::info!(
+                "assistant: focusing existing instance at pane {slot} in context {caller_context_id}"
+            );
+            self.reveal_and_focus_instance(win_idx, slot, overlay_depth);
+            return Some(slot);
         }
 
         let workspace_root = crate::config::active_workspace_root()
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
         log::info!(
-            "assistant: opening pane for workspace {}",
+            "assistant: opening pane for workspace {} in context {caller_context_id}",
             workspace_root.display()
         );
         let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> = std::sync::Arc::new(
@@ -1564,9 +1559,12 @@ impl PlexiApp {
             workspace_root.clone(),
             broker,
             &crate::config::config_dir(),
+            caller_context_id,
         ));
         let perms = crate::app::permissions::AppPermissions::builtin();
+        let predicted = self.host.next_pane_id();
         self.open_builtin_app_pane(app, perms, workspace_root, None, Some(hint), None);
+        Some(predicted)
     }
 
     /// Create a new scratch note in `notes/inbox/` and open it in a text-editor

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -181,10 +181,14 @@ impl HostHarness {
         let pane_id = self.next_pane_id;
         self.next_pane_id += 1;
         let workspace_root = self._workspace_dir.path().to_path_buf();
+        // The pane is inserted into windows[0] below — scope the store to
+        // that window's context.
+        let context_id = self.app.windows[0].context_id;
         let assistant = crate::assistant::AssistantApp::new(
             workspace_root.clone(),
             Arc::new(InertBroker),
             &crate::config::config_dir(),
+            context_id,
         );
         let app_pane = AppPane {
             pip_status: None,

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -70,6 +70,7 @@ fn assistant_harness_factory(
         workspace_root.to_path_buf(),
         broker,
         workspace_root,
+        1,
     ))
 }
 
@@ -459,10 +460,18 @@ impl PlexiUiHarness {
     pub fn open_assistant(&mut self, workspace_root: std::path::PathBuf) {
         let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
             std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
+        // Scope the store to the active window's context — same as the
+        // production open path.
+        let context_id =
+            self.with_app_mut(|app| app.windows[app.active_window].context_id);
         // Grants/audit also stay inside the temp workspace, never the real
         // channel profile dir.
-        let assistant =
-            crate::assistant::AssistantApp::new(workspace_root.clone(), broker, &workspace_root);
+        let assistant = crate::assistant::AssistantApp::new(
+            workspace_root.clone(),
+            broker,
+            &workspace_root,
+            context_id,
+        );
         self.open_assistant_built(assistant, workspace_root);
     }
 
@@ -1426,7 +1435,7 @@ mod tests {
         let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
             std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
         let mut assistant =
-            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path());
+            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path(), 1);
         assistant.model.turns = vec![
             Turn {
                 role: TurnRole::User,
@@ -1499,7 +1508,7 @@ mod tests {
         let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
             std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
         let mut assistant =
-            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path());
+            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path(), 1);
         assistant.model.turns = vec![Turn {
             role: TurnRole::User,
             text: "build me a tictactoe app".to_string(),
@@ -1530,7 +1539,7 @@ mod tests {
         let broker2: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
             std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
         let mut assistant2 =
-            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker2, ws.path());
+            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker2, ws.path(), 1);
         assistant2.model.streaming.in_flight = true;
         assistant2.model.streaming.partial_answer =
             "The SDK uses state.get() from plexi_sdk. Let me fix all the issues.".to_string();
@@ -1562,7 +1571,7 @@ mod tests {
         let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
             std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
         let mut assistant =
-            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path());
+            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path(), 1);
 
         let mut write_tool = Turn::tool("host.files.write", ToolStatus::Succeeded);
         write_tool.input_summary = Some("path: main.py".to_string());
@@ -1633,7 +1642,7 @@ mod tests {
         let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
             std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
         let mut assistant =
-            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path());
+            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path(), 1);
         assistant.model.turns = vec![
             Turn {
                 role: TurnRole::User,
@@ -1753,7 +1762,7 @@ mod tests {
         let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
             std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
         let mut assistant =
-            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path());
+            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path(), 1);
         assistant
             .model
             .permission_requested("csv.write_range", r#"{"range": "A1:B2"}"#);
@@ -1798,7 +1807,7 @@ mod tests {
         let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
             std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
         let mut assistant =
-            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path());
+            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path(), 1);
         let turn = |role, text: &str| crate::assistant::model::Turn {
             role,
             text: text.to_string(),


### PR DESCRIPTION
## Stint

Stint **0538** — "assistant: one instance + conversation per context (focus-or-spawn on open)". No linked GitHub issue; the stint task is the ticket. Supersedes the cross-window dedup / store-clobber decision left open in stint 0440.

## What changed

- **Focus-or-spawn per context** (`src/pane_ops/create.rs`): `open_assistant_pane_with_hint` now searches every window of the caller's context via `locate_app_instance("assistant", Some(context_id))`. Existing instance → overlays popped, unhidden, focused cross-window through the sanctioned `jump_to_context` path (shared `reveal_and_focus_instance` helper extracted from `resolve_on_launch_policy` — no `active_window`/`router.active` steering). No instance → spawn in the current window with the context id passed explicitly to `AssistantApp::new`.
- **Per-context conversation state** (`src/assistant/store.rs`): `state.toml` now holds a `[contexts.<id>]` table per context carrying `active_conversation`, `session_name`, `active_agent_id`, `effort_override`, `turn_in_flight`. `show_thoughts` stays a global UI pref. `AssistantStore`/`AssistantApp` take an explicit `context_id`.
- **Conversation ownership**: `ConversationHistory` gains `context_id`; a conversation is claimed by the context that activates it. `/resume` lists this context's conversations plus untagged legacy ones (visible everywhere until claimed). With one instance per context and per-context pointers, the concurrent same-transcript writers from 0440 no longer exist.
- **Restore path** (`src/app/mod.rs`): workspace restore passes `saved_win.context_id` into `restore_assistant_pane`.

**Legacy state note:** the old global `active_conversation` pointer in `state.toml` is intentionally dropped — no compat shim per repo policy. On first launch after upgrade each context opens a fresh conversation once; no transcript is lost, `/resume` lists and reclaims prior conversations.

## Test evidence (attempt 1)

- cargo test: **1834 passed, 0 failed, 3 ignored** — full bin suite, env-stripped (`env -u PLEXI_CHANNEL ... cargo test --bin plexi`); narrow filters first: assistant 191 passed, store 31 passed, on_launch 9 passed
- New regression tests: `assistant_open_focuses_existing_in_same_window`, `assistant_open_focuses_existing_across_windows_of_same_context`, `assistant_open_spawns_second_instance_in_other_context` (src/app/tests/navigation_tests.rs); per-context store round-trip + list-filter tests (src/assistant/store.rs)
- AI diff review: Codex (pre-push, base alpha). 1 finding — "migrate legacy top-level active_conversation" — rejected by design (repo policy: no backwards-compat shims; see legacy state note)
- Conclusion: **binary install required** — host-runtime assistant lifecycle (cross-window focus, spawn, restore) is only fully observable in an installed build

## Tester instructions (Tier 2 — `just pr-install <this PR#>`, run `plexi-pr-<N>`)

1. In context A, open the assistant (Cmd+Ctrl+A or palette). A pane spawns.
2. Open it again from the same window → the existing pane is focused, **no second instance**.
3. Create a second window in context A, open the assistant from there → focus jumps to the existing instance's window, still one instance.
4. Send a message so the conversation persists.
5. Switch to context B, open the assistant → a **distinct second instance** spawns with a **fresh conversation** (not context A's thread).
6. Send a message in B; restart the host → each context's assistant resumes its **own** conversation.
7. `/resume` in context B must not list the conversation claimed by context A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)