### PR TITLE
perf(wasm): coalesce decoder wakes, shrink the canvas wire payload, pick the smaller tree encoding (stints 0549, 0550, 0551)

### DIFF
--- a/sdk/python/plexi_sdk/_v3_runtime.py
+++ b/sdk/python/plexi_sdk/_v3_runtime.py
@@ -27,15 +27,29 @@ from plexi_sdk._v3_state import StateSnapshot
 
 
 _LOCK = threading.Lock()
-_EMIT_BATCH: list[dict] | None = None
+_EMIT_BATCH: list[str] | None = None
+
+#: Protocol output carries no human reader, so the default `", "` / `": "`
+#: separators are pure wire weight on every key of every frame.
+_JSON_SEPARATORS = (",", ":")
+
+
+def _dump_line(obj: dict) -> str:
+    """Serialise one protocol message to its exact wire line."""
+    return json.dumps(obj, separators=_JSON_SEPARATORS) + "\n"
 
 
 def _emit(obj: dict) -> None:
+    _emit_line(_dump_line(obj))
+
+
+def _emit_line(line: str) -> None:
+    """Write an already-serialised protocol line, or queue it in the batch."""
     with _LOCK:
         if _EMIT_BATCH is not None:
-            _EMIT_BATCH.append(obj)
+            _EMIT_BATCH.append(line)
             return
-        sys.stdout.write(json.dumps(obj) + "\n")
+        sys.stdout.write(line)
         sys.stdout.flush()
 
 
@@ -54,7 +68,7 @@ def _finish_emit_batch() -> None:
         _EMIT_BATCH = None
         if not batch:
             return
-        sys.stdout.write("".join(json.dumps(obj) + "\n" for obj in batch))
+        sys.stdout.write("".join(batch))
         sys.stdout.flush()
 
 
@@ -349,29 +363,41 @@ class V3AppRuntime:
         the host never has to guess what a patch applies to. Relies on the
         documented `view()` purity contract: nodes are rebuilt every frame,
         never cached and mutated in place across frames.
+
+        A delta is only a win when it is actually smaller than the frame it
+        replaces. On a full-motion canvas, where every command changes every
+        frame, each changed command is re-sent wrapped in its own index — so
+        the delta comes out slightly *larger* than the full frame. Both
+        encodings are already supported by the host decoder, so the smaller of
+        the two wins on a per-frame basis rather than by assumption.
         """
         prev = self._last_tree
         self._last_tree = encoded
         nodes = encoded["nodes"]
         force_full = self._force_full_tree
         self._force_full_tree = False
+        full = {"type": "component_tree", "frame_id": frame_id, "tree": encoded}
         if (
             force_full
             or prev is None
             or encoded["root"] != prev["root"]
             or len(nodes) != len(prev["nodes"])
         ):
-            _emit({"type": "component_tree", "frame_id": frame_id, "tree": encoded})
+            _emit(full)
             return
         changed: list[dict] = []
         for node, old in zip(nodes, prev["nodes"]):
             if node == old:
                 continue
             if node["key"] != old["key"]:
-                _emit({"type": "component_tree", "frame_id": frame_id, "tree": encoded})
+                _emit(full)
                 return
             changed.append(_node_patch(node, old))
-        _emit({"type": "tree_delta", "frame_id": frame_id, "changed": changed})
+        delta_line = _dump_line(
+            {"type": "tree_delta", "frame_id": frame_id, "changed": changed}
+        )
+        full_line = _dump_line(full)
+        _emit_line(delta_line if len(delta_line) < len(full_line) else full_line)
 
     def _handle_key(self, ev: dict, *, schedule_render: bool = True) -> None:
         key = _normalize_key(ev.get("key", ""))

--- a/sdk/python/plexi_sdk/_v3_runtime.py
+++ b/sdk/python/plexi_sdk/_v3_runtime.py
@@ -33,6 +33,16 @@ _EMIT_BATCH: list[str] | None = None
 #: separators are pure wire weight on every key of every frame.
 _JSON_SEPARATORS = (",", ":")
 
+#: How many delta-eligible frames ride a previously measured full-vs-delta
+#: verdict before it is re-measured. Measuring means serialising the frame
+#: both ways, which costs more guest CPU than the byte difference it can
+#: recover — on a full-motion canvas the double serialisation alone measurably
+#: lowered achievable guest_fps. The winner is a property of the app's frame
+#: shape, not of any single frame, so it is stable between structural changes;
+#: every full frame resets the countdown so the first delta-eligible frame
+#: after one always re-measures.
+_TREE_SIZE_CHECK_INTERVAL = 30
+
 
 def _dump_line(obj: dict) -> str:
     """Serialise one protocol message to its exact wire line."""
@@ -99,6 +109,8 @@ class V3AppRuntime:
         self._last_render_time: float | None = None
         self._last_tree: dict | None = None
         self._force_full_tree = True
+        self._prefer_full_tree = False
+        self._tree_size_check_in = 0
         self._frame_id = 0
         self._app_id = ""
         self._workspace_root = ""
@@ -367,9 +379,12 @@ class V3AppRuntime:
         A delta is only a win when it is actually smaller than the frame it
         replaces. On a full-motion canvas, where every command changes every
         frame, each changed command is re-sent wrapped in its own index — so
-        the delta comes out slightly *larger* than the full frame. Both
+        the delta can come out slightly *larger* than the full frame. Both
         encodings are already supported by the host decoder, so the smaller of
-        the two wins on a per-frame basis rather than by assumption.
+        the two wins — measured by serialising both on the first delta-eligible
+        frame after any full frame and every `_TREE_SIZE_CHECK_INTERVAL` frames
+        after, and remembered in between (see the interval's docstring for why
+        measuring every frame is not affordable).
         """
         prev = self._last_tree
         self._last_tree = encoded
@@ -383,6 +398,12 @@ class V3AppRuntime:
             or encoded["root"] != prev["root"]
             or len(nodes) != len(prev["nodes"])
         ):
+            self._tree_size_check_in = 0
+            _emit(full)
+            return
+        measure = self._tree_size_check_in <= 0
+        if self._prefer_full_tree and not measure:
+            self._tree_size_check_in -= 1
             _emit(full)
             return
         changed: list[dict] = []
@@ -390,14 +411,21 @@ class V3AppRuntime:
             if node == old:
                 continue
             if node["key"] != old["key"]:
+                self._tree_size_check_in = 0
                 _emit(full)
                 return
             changed.append(_node_patch(node, old))
         delta_line = _dump_line(
             {"type": "tree_delta", "frame_id": frame_id, "changed": changed}
         )
-        full_line = _dump_line(full)
-        _emit_line(delta_line if len(delta_line) < len(full_line) else full_line)
+        if measure:
+            full_line = _dump_line(full)
+            self._prefer_full_tree = len(full_line) <= len(delta_line)
+            self._tree_size_check_in = _TREE_SIZE_CHECK_INTERVAL
+            _emit_line(full_line if self._prefer_full_tree else delta_line)
+            return
+        self._tree_size_check_in -= 1
+        _emit_line(delta_line)
 
     def _handle_key(self, ev: dict, *, schedule_render: bool = True) -> None:
         key = _normalize_key(ev.get("key", ""))

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -963,6 +963,27 @@ class Divider(Component):
         return {"type": "divider"}
 
 
+#: Canvas wire policy: geometry is emitted rounded to this many decimal places.
+#:
+#: Canvas coordinates are pixel-scale units — a canvas declares its logical
+#: width/height in the same order of magnitude as the pane it draws into, and
+#: the host scales that space to the pane rect. A hundredth of a logical unit is
+#: therefore a hundredth of a pixel at ``fit="fill"`` (scale ~1), and still far
+#: below one device pixel for a ``fit="contain"`` canvas magnified onto a large
+#: pane. Full float precision on the wire buys nothing visible and costs bytes
+#: on every coordinate of every command at the app's full frame rate.
+#:
+#: This policy assumes a pixel-scale coordinate space. A normalised (0..1)
+#: canvas space, where one logical unit spans the whole pane, would quantise
+#: visibly at this precision and is not supported.
+CANVAS_WIRE_DECIMALS = 2
+
+
+def _wire(value: float) -> float:
+    """Round one canvas geometry value to the wire precision policy."""
+    return round(float(value), CANVAS_WIRE_DECIMALS)
+
+
 @dataclass
 class CanvasRect:
     x: float
@@ -973,9 +994,9 @@ class CanvasRect:
     radius: float = 0.0
 
     def to_command(self) -> dict:
-        return {"type": "rect", "x": self.x, "y": self.y,
-                "w": self.width, "h": self.height,
-                "fill": self.fill, "radius": self.radius}
+        return {"type": "rect", "x": _wire(self.x), "y": _wire(self.y),
+                "w": _wire(self.width), "h": _wire(self.height),
+                "fill": self.fill, "radius": _wire(self.radius)}
 
 
 @dataclass
@@ -986,8 +1007,8 @@ class CanvasCircle:
     fill: str
 
     def to_command(self) -> dict:
-        return {"type": "circle", "cx": self.x, "cy": self.y,
-                "r": self.radius, "fill": self.fill}
+        return {"type": "circle", "cx": _wire(self.x), "cy": _wire(self.y),
+                "r": _wire(self.radius), "fill": self.fill}
 
 
 @dataclass
@@ -1000,9 +1021,9 @@ class CanvasLine:
     width: float = 1.0
 
     def to_command(self) -> dict:
-        return {"type": "line", "x1": self.x1, "y1": self.y1,
-                "x2": self.x2, "y2": self.y2,
-                "color": self.color, "width": self.width}
+        return {"type": "line", "x1": _wire(self.x1), "y1": _wire(self.y1),
+                "x2": _wire(self.x2), "y2": _wire(self.y2),
+                "color": self.color, "width": _wire(self.width)}
 
 
 @dataclass
@@ -1016,8 +1037,8 @@ class CanvasText:
     align: str = "left_top"
 
     def to_command(self) -> dict:
-        return {"type": "text", "x": self.x, "y": self.y,
-                "text": self.text, "size": self.size,
+        return {"type": "text", "x": _wire(self.x), "y": _wire(self.y),
+                "text": self.text, "size": _wire(self.size),
                 "color": self.color, "bold": self.bold,
                 "align": self.align, "monospace": False,
                 "max_width": None, "elide": True, "selectable": False}

--- a/sdk/python/plexi_sdk/ui.py
+++ b/sdk/python/plexi_sdk/ui.py
@@ -978,10 +978,19 @@ class Divider(Component):
 #: visibly at this precision and is not supported.
 CANVAS_WIRE_DECIMALS = 2
 
+_WIRE_SCALE = 10.0 ** CANVAS_WIRE_DECIMALS
+
 
 def _wire(value: float) -> float:
-    """Round one canvas geometry value to the wire precision policy."""
-    return round(float(value), CANVAS_WIRE_DECIMALS)
+    """Quantize one canvas geometry value to the wire precision policy.
+
+    Round-half-up via float arithmetic rather than ``round(value, 2)``: this
+    runs on every coordinate of every command at the app's full frame rate,
+    and ``round()``'s correctly-rounded decimal path measures ~3.5x the cost
+    of the multiply/floor-divide. Tie-breaking direction is not part of the
+    policy — anything within half a wire step is equally correct.
+    """
+    return (value * _WIRE_SCALE + 0.5) // 1.0 / _WIRE_SCALE
 
 
 @dataclass

--- a/sdk/python/tests/test_canvas_wire.py
+++ b/sdk/python/tests/test_canvas_wire.py
@@ -1,0 +1,173 @@
+"""Canvas wire payload policy (stint 0550).
+
+Canvas commands are JSON-encoded and written to stdout on every frame, so both
+the coordinate precision and the JSON separators are per-frame wire cost paid by
+every app. Both reductions are schema-preserving: floats stay floats, no key
+changes, and the host decoder is untouched.
+"""
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+from plexi_sdk._v3_runtime import _dump_line
+from plexi_sdk.ui import (
+    CANVAS_WIRE_DECIMALS,
+    Canvas,
+    CanvasCircle,
+    CanvasLine,
+    CanvasRect,
+    CanvasText,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SDK_PATH = str(REPO_ROOT / "sdk" / "python")
+
+RAW = 1134.578349092061
+ROUNDED = 1134.58
+
+
+class TestCoordinatePrecision:
+    def test_policy_is_two_decimals(self):
+        assert CANVAS_WIRE_DECIMALS == 2
+
+    def test_rect_geometry_is_rounded(self):
+        cmd = CanvasRect(RAW, RAW, RAW, RAW, "#ffffff", radius=RAW).to_command()
+        assert cmd["x"] == cmd["y"] == cmd["w"] == cmd["h"] == ROUNDED
+        assert cmd["radius"] == ROUNDED
+        assert cmd["fill"] == "#ffffff"
+
+    def test_circle_geometry_is_rounded(self):
+        cmd = CanvasCircle(RAW, RAW, RAW, "#ffffff").to_command()
+        assert cmd["cx"] == cmd["cy"] == cmd["r"] == ROUNDED
+
+    def test_line_geometry_is_rounded(self):
+        cmd = CanvasLine(RAW, RAW, RAW, RAW, "#ffffff", width=RAW).to_command()
+        assert cmd["x1"] == cmd["y1"] == cmd["x2"] == cmd["y2"] == ROUNDED
+        assert cmd["width"] == ROUNDED
+
+    def test_text_geometry_is_rounded_and_text_is_untouched(self):
+        cmd = CanvasText(RAW, RAW, "hello", size=RAW).to_command()
+        assert cmd["x"] == cmd["y"] == cmd["size"] == ROUNDED
+        assert cmd["text"] == "hello"
+
+    def test_geometry_stays_float_for_integer_input(self):
+        # The host decodes these as floats; an int on the wire would be a
+        # schema change even though JSON allows it.
+        cmd = CanvasCircle(5, 5, 5, "#ffffff").to_command()
+        assert all(isinstance(cmd[k], float) for k in ("cx", "cy", "r"))
+
+    def test_rounding_is_below_one_device_pixel_at_realistic_scales(self):
+        # The worst case in the maintained set is a `fit="contain"` canvas with
+        # a fixed logical space magnified onto a large pane. Even at 10x — well
+        # beyond any real pane/canvas ratio — half a rounding step stays far
+        # below one device pixel on a 2x display.
+        worst_case_scale = 10.0
+        device_pixel_ratio = 2.0
+        step = 10 ** -CANVAS_WIRE_DECIMALS
+        assert (step / 2) * worst_case_scale * device_pixel_ratio < 0.25
+
+
+class TestCompactEncoding:
+    def test_emit_uses_compact_separators(self):
+        line = _dump_line({"type": "frame_done", "frame_id": 1})
+        assert line == '{"type":"frame_done","frame_id":1}\n'
+
+    def test_payload_shrinks_but_decodes_identically(self):
+        commands = [
+            CanvasCircle(i * 7.1234567, i * 3.7654321, 12.5, "#0000003c")
+            for i in range(50)
+        ]
+        node = Canvas(commands, width=640.0, height=360.0).to_node()
+        compact = _dump_line(node)
+        verbose = json.dumps(
+            {
+                "type": "canvas",
+                "width": 640.0,
+                "height": 360.0,
+                "grow": True,
+                "fit": "fill",
+                "commands": [
+                    {
+                        "type": "circle",
+                        "cx": i * 7.1234567,
+                        "cy": i * 3.7654321,
+                        "r": 12.5,
+                        "fill": "#0000003c",
+                    }
+                    for i in range(50)
+                ],
+            }
+        )
+        assert len(compact) < len(verbose) * 0.8
+        # Same shape, same keys — only the digits and the whitespace differ.
+        decoded = json.loads(compact)
+        assert decoded.keys() == json.loads(verbose).keys()
+        assert len(decoded["commands"]) == 50
+        assert decoded["commands"][7]["cx"] == round(7 * 7.1234567, 2)
+
+
+APP = textwrap.dedent("""
+    from plexi_sdk.ui import Canvas, CanvasCircle
+
+    def init(size, args):
+        return []
+
+    def update(event):
+        return []
+
+    def view():
+        return Canvas(
+            [CanvasCircle(1134.578349092061, 172.9363749889064, 16.1097005, "#fff")],
+            width=640, height=360,
+        )
+""").lstrip()
+
+
+def test_emitted_wire_line_carries_rounded_compact_json(tmp_path):
+    """End to end through the real runtime, not just the encoder."""
+    import os
+
+    app = tmp_path / "a.py"
+    app.write_text(APP)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = SDK_PATH
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "plexi_sdk._v3_process", str(app)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    try:
+        proc.stdin.write(json.dumps({
+            "type": "init",
+            "app_id": "wire-test",
+            "workspace_root": "/tmp",
+            "capabilities": [],
+            "feature_flags": [],
+            "width": 640.0,
+            "height": 360.0,
+        }) + "\n")
+        proc.stdin.flush()
+        while json.loads(proc.stdout.readline()).get("type") != "ready":
+            pass
+        proc.stdin.write(json.dumps({
+            "type": "render",
+            "frame_id": 1,
+            "rect": {"x": 0.0, "y": 0.0, "w": 640.0, "h": 360.0},
+        }) + "\n")
+        proc.stdin.flush()
+        while True:
+            line = proc.stdout.readline()
+            assert line, "runtime closed before emitting the frame"
+            if json.loads(line).get("type") == "component_tree":
+                break
+        assert '", "' not in line and '": ' not in line
+        assert "1134.58" in line
+        assert "1134.578" not in line
+    finally:
+        proc.kill()

--- a/sdk/python/tests/test_v3_delta.py
+++ b/sdk/python/tests/test_v3_delta.py
@@ -334,6 +334,71 @@ class TestWireFraming:
         finally:
             proc.kill()
 
+    def test_full_frame_preference_persists_between_measures(self, tmp_path):
+        # The full-vs-delta size compare is measured, then remembered: once a
+        # full-motion canvas picks the full frame, following frames ride that
+        # verdict without re-serialising both encodings.
+        app = tmp_path / "a.py"
+        app.write_text(FULL_MOTION_APP)
+        proc = _spawn(app)
+        try:
+            _init(proc)
+            _render(proc, 1)
+            for frame_id in (2, 3, 4):
+                _key(proc)
+                events = _render(proc, frame_id)
+                assert _only(events, "component_tree"), (frame_id, events)
+                assert not _only(events, "tree_delta"), (frame_id, events)
+        finally:
+            proc.kill()
+
+    def test_steady_state_delta_frames_serialise_at_most_once(self, monkeypatch):
+        # Regression guard for the guest_fps hit found on the balls exemplar:
+        # serialising the frame both ways on every delta frame doubled the
+        # dominant per-frame guest cost. Between measure frames, each frame
+        # serialises at most one encoding.
+        from plexi_sdk import _v3_runtime as rt
+
+        runtime = rt.V3AppRuntime.__new__(rt.V3AppRuntime)
+        runtime._last_tree = None
+        runtime._force_full_tree = True
+        runtime._prefer_full_tree = False
+        runtime._tree_size_check_in = 0
+
+        real_dump = rt._dump_line
+        dump_calls: list[dict] = []
+
+        def counting_dump(obj: dict) -> str:
+            dump_calls.append(obj)
+            return real_dump(obj)
+
+        monkeypatch.setattr(rt, "_dump_line", counting_dump)
+        emitted: list[str] = []
+        monkeypatch.setattr(rt, "_emit", lambda obj: emitted.append(real_dump(obj)))
+        monkeypatch.setattr(rt, "_emit_line", emitted.append)
+
+        def tree(t: float) -> dict:
+            return {
+                "root": 0,
+                "nodes": [{
+                    "id": 0, "key": "c",
+                    "data": {"type": "canvas", "commands": [
+                        {"type": "circle", "cx": i * 7.0 + t, "cy": 1.0,
+                         "r": 2.0, "fill": "#fff"}
+                        for i in range(4)
+                    ]},
+                }],
+            }
+
+        runtime._emit_tree(1, tree(0.0))  # first frame: full
+        runtime._emit_tree(2, tree(1.0))  # first delta-eligible frame: measures
+        dump_calls.clear()
+        steady_frames = 10
+        for frame_id in range(3, 3 + steady_frames):
+            runtime._emit_tree(frame_id, tree(float(frame_id)))
+        assert len(emitted) == 2 + steady_frames
+        assert len(dump_calls) <= steady_frames, len(dump_calls)
+
     def test_structural_change_forces_full_tree(self, tmp_path):
         app = tmp_path / "a.py"
         app.write_text(STRUCTURAL_APP)

--- a/sdk/python/tests/test_v3_delta.py
+++ b/sdk/python/tests/test_v3_delta.py
@@ -136,6 +136,52 @@ CANVAS_APP = textwrap.dedent("""
 """).lstrip()
 
 
+FULL_MOTION_APP = textwrap.dedent("""
+    from plexi_sdk import state
+    from plexi_sdk.effects import SetState
+    from plexi_sdk.events import KeyEvent
+    from plexi_sdk.ui import Canvas, CanvasCircle
+
+    def init(size, args):
+        return [SetState({"t": 0.0})]
+
+    def update(event):
+        if isinstance(event, KeyEvent) and event.pressed:
+            return [SetState({"t": state.get("t", 0.0) + 1.0})]
+        return []
+
+    def view():
+        t = state.get("t", 0.0)
+        return Canvas([
+            CanvasCircle(i * 7.0 + t, i * 3.0 + t, 12.0, "#0000003c")
+            for i in range(50)
+        ], width=640, height=360)
+""").lstrip()
+
+
+PARTIAL_MOTION_APP = textwrap.dedent("""
+    from plexi_sdk import state
+    from plexi_sdk.effects import SetState
+    from plexi_sdk.events import KeyEvent
+    from plexi_sdk.ui import Canvas, CanvasCircle
+
+    def init(size, args):
+        return [SetState({"t": 0.0})]
+
+    def update(event):
+        if isinstance(event, KeyEvent) and event.pressed:
+            return [SetState({"t": state.get("t", 0.0) + 1.0})]
+        return []
+
+    def view():
+        t = state.get("t", 0.0)
+        return Canvas([
+            CanvasCircle(i * 7.0 + (t if i == 1 else 0.0), i * 3.0, 12.0, "#0000003c")
+            for i in range(50)
+        ], width=640, height=360)
+""").lstrip()
+
+
 STRUCTURAL_APP = textwrap.dedent("""
     from plexi_sdk import state
     from plexi_sdk.effects import SetState
@@ -233,6 +279,58 @@ class TestWireFraming:
             rebuilt = apply_delta(full_tree, changed)
             moved = rebuilt["nodes"][patch["id"]]["data"]["commands"][1]
             assert moved["x"] == 10.0
+        finally:
+            proc.kill()
+
+    def test_full_motion_canvas_falls_back_to_the_smaller_full_frame(self, tmp_path):
+        # Every command moves every frame, so each one is re-sent wrapped in its
+        # own index: the delta comes out larger than the frame it replaces.
+        app = tmp_path / "a.py"
+        app.write_text(FULL_MOTION_APP)
+        proc = _spawn(app)
+        try:
+            _init(proc)
+            first = _render(proc, 1)
+            full_tree = _only(first, "component_tree")[0]["tree"]
+            _key(proc)  # moves all commands at once
+            events = _render(proc, 2)
+            assert not _only(events, "tree_delta"), events
+            full = _only(events, "component_tree")
+            assert full, events
+            # The fallback is the existing full-frame shape, not a new one, and
+            # it really is smaller than the delta it replaced.
+            nodes = full[0]["tree"]["nodes"]
+            assert len(nodes) == len(full_tree["nodes"])
+            changed = [
+                node_patch(node, old)
+                for node, old in zip(nodes, full_tree["nodes"])
+                if node != old
+            ]
+            delta_bytes = len(json.dumps(
+                {"type": "tree_delta", "frame_id": 2, "changed": changed},
+                separators=(",", ":"),
+            ))
+            full_bytes = len(json.dumps(full[0], separators=(",", ":")))
+            assert full_bytes <= delta_bytes, (full_bytes, delta_bytes)
+        finally:
+            proc.kill()
+
+    def test_partial_motion_canvas_still_emits_the_smaller_delta(self, tmp_path):
+        # The other direction: when only some commands move, the delta wins and
+        # must still be chosen.
+        app = tmp_path / "a.py"
+        app.write_text(PARTIAL_MOTION_APP)
+        proc = _spawn(app)
+        try:
+            _init(proc)
+            _render(proc, 1)
+            _key(proc)
+            events = _render(proc, 2)
+            deltas = _only(events, "tree_delta")
+            assert deltas, events
+            assert not _only(events, "component_tree")
+            indices = [e[0] for e in deltas[0]["changed"][0]["commands_changed"]]
+            assert indices == [1], deltas
         finally:
             proc.kill()
 

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -762,6 +762,9 @@ pub struct LivePythonPane {
     /// Egui repaint target for the decoder, installed on the first `ui()` and
     /// shared with the decoder so a ready frame wakes the paint loop.
     repaint: RepaintHook,
+    /// The repaint this pane last scheduled, published so the decoder can let a
+    /// frame ride it instead of forcing a second full-host repaint (stint 0549).
+    wake_schedule: WakeSchedule,
     wants_close: bool,
     error: Option<String>,
     /// stderr accumulated from a Python traceback until its unindented
@@ -857,6 +860,55 @@ enum DecodedOutput {
 /// shared across `relaunch` so a fresh decoder inherits it immediately.
 type RepaintHook = Arc<Mutex<Option<(egui::Context, egui::ViewportId)>>>;
 
+/// The repaint the paint thread has already scheduled, published for the
+/// decoder thread so a frame arrival does not request a second wake for a paint
+/// that is already coming.
+#[derive(Debug, Clone, Copy)]
+struct ScheduledWake {
+    at: std::time::Instant,
+    /// The guest's frame interval while it drives its own cadence in
+    /// continuous mode; `None` when the pending wake is not the frame cadence
+    /// (scheduled-mode apps, or a continuous app whose pipeline is full and
+    /// whose next admission therefore depends on this very frame arriving).
+    continuous_interval: Option<std::time::Duration>,
+}
+
+/// Shared with the decoder thread. `scheduled: None` means nothing is
+/// scheduled at all, so a frame arrival has to wake the paint loop itself.
+#[derive(Debug, Default)]
+struct WakeScheduleState {
+    scheduled: Option<ScheduledWake>,
+    /// Frame-arrival wakes the decoder let ride an already-scheduled paint,
+    /// drained into the periodic perf line so the saving is observable.
+    suppressed: u64,
+}
+
+type WakeSchedule = Arc<Mutex<WakeScheduleState>>;
+
+/// Whether a decoded frame needs its own immediate repaint wake, or can ride
+/// the repaint the paint thread already scheduled.
+///
+/// Suppression only applies to an app driving a continuous cadence, where the
+/// pending wake is by construction at most one frame interval away — so the
+/// cost is a fraction of a frame of presentation latency, in exchange for not
+/// forcing a second full-host repaint per guest frame. An input-driven
+/// (scheduled-mode) app never suppresses: its frames are the *response* to
+/// input, nothing else is scheduled to show them, and latency there is
+/// perceptible.
+///
+/// The schedule is published from `ui()`, which eframe skips entirely while the
+/// window is hidden, so an entry can go stale. A wake already overdue by more
+/// than an interval is not evidence a paint is coming; fall back to waking.
+fn decoder_wake_needed(scheduled: Option<ScheduledWake>, now: std::time::Instant) -> bool {
+    match scheduled {
+        None => true,
+        Some(wake) => match wake.continuous_interval {
+            None => true,
+            Some(interval) => wake.at > now + interval || wake.at + interval < now,
+        },
+    }
+}
+
 /// Owns the off-paint-thread decoder: the thread handle, the ready-frame queue,
 /// and the `stdout` handle it drains (kept so `Drop` can wake and join it).
 struct PythonOutputDecoder {
@@ -871,7 +923,12 @@ struct PythonOutputDecoder {
 }
 
 impl PythonOutputDecoder {
-    fn spawn(runtime: &WasmPythonRuntime, app_id: String, repaint: RepaintHook) -> Self {
+    fn spawn(
+        runtime: &WasmPythonRuntime,
+        app_id: String,
+        repaint: RepaintHook,
+        wake_schedule: WakeSchedule,
+    ) -> Self {
         let (tx, rx) = std::sync::mpsc::channel();
         let stdout = runtime.stdout.clone();
         let stdin = runtime.stdin.clone();
@@ -881,7 +938,15 @@ impl PythonOutputDecoder {
         let thread = std::thread::Builder::new()
             .name(format!("plexi-python-decode-{app_id}"))
             .spawn(move || {
-                decode_loop(thread_stdout, stdin, app_id, tx, repaint, thread_queued);
+                decode_loop(
+                    thread_stdout,
+                    stdin,
+                    app_id,
+                    tx,
+                    repaint,
+                    thread_queued,
+                    wake_schedule,
+                );
             })
             .ok();
         Self {
@@ -929,6 +994,7 @@ fn decode_loop(
     tx: std::sync::mpsc::Sender<DecodedOutput>,
     repaint: RepaintHook,
     queued: Arc<std::sync::atomic::AtomicUsize>,
+    wake_schedule: WakeSchedule,
 ) {
     let mut partial: Vec<u8> = Vec::new();
     let mut last_tree: Option<Arc<PythonUiTree>> = None;
@@ -936,6 +1002,10 @@ fn decode_loop(
     while let Some(bytes) = stdout.wait_and_drain() {
         partial.extend(bytes);
         let mut produced = false;
+        // Only a batch of pure frame output can ride an already-scheduled
+        // paint. Anything else (a host command, a decode error) has no
+        // cadence behind it and must wake the paint loop to be serviced.
+        let mut cadence_only = true;
         while let Some(newline) = partial.iter().position(|byte| *byte == b'\n') {
             let line: Vec<u8> = partial.drain(..=newline).collect();
             let line = &line[..line.len().saturating_sub(1)];
@@ -1002,6 +1072,9 @@ fn decode_loop(
                 if matches!(output, DecodedOutput::Tree { .. }) {
                     awaiting_full = false;
                 }
+                if !is_frame_cadence_output(&output) {
+                    cadence_only = false;
+                }
                 queued.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
                 if tx.send(output).is_err() {
                     queued.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
@@ -1011,14 +1084,39 @@ fn decode_loop(
             }
         }
         if produced {
-            if let Some((context, viewport)) =
-                repaint.lock().unwrap_or_else(|e| e.into_inner()).as_ref()
-            {
-                // A zero-delay egui request deliberately schedules an extra
-                // settling paint; a 1ns request wakes immediately without it.
-                context.request_repaint_after_for(std::time::Duration::from_nanos(1), *viewport);
+            let wake_needed = {
+                let mut state = wake_schedule.lock().unwrap_or_else(|e| e.into_inner());
+                let needed = !cadence_only
+                    || decoder_wake_needed(state.scheduled, std::time::Instant::now());
+                if !needed {
+                    state.suppressed = state.suppressed.saturating_add(1);
+                }
+                needed
+            };
+            if wake_needed {
+                if let Some((context, viewport)) =
+                    repaint.lock().unwrap_or_else(|e| e.into_inner()).as_ref()
+                {
+                    // A zero-delay egui request deliberately schedules an extra
+                    // settling paint; a 1ns request wakes immediately without it.
+                    context
+                        .request_repaint_after_for(std::time::Duration::from_nanos(1), *viewport);
+                }
             }
         }
+    }
+}
+
+/// Whether one decoded output belongs to the guest's frame cadence — the tree
+/// itself, or the `frame_done` that closes it. Everything else (a host command,
+/// a decode error) is out-of-band work with no scheduled paint behind it.
+fn is_frame_cadence_output(output: &DecodedOutput) -> bool {
+    match output {
+        DecodedOutput::Tree { .. } => true,
+        DecodedOutput::Message { value, .. } => {
+            value.get("type").and_then(Value::as_str) == Some("frame_done")
+        }
+        DecodedOutput::DecodeError(_) => false,
     }
 }
 
@@ -1243,6 +1341,14 @@ impl PythonFrameScheduler {
             return None;
         }
         Some(admission_deadline.max(now))
+    }
+
+    /// The guest's frame interval while it drives a continuous cadence.
+    fn continuous_interval(&self) -> Option<std::time::Duration> {
+        match self.mode {
+            PythonSchedulerMode::Continuous { interval } => Some(interval),
+            PythonSchedulerMode::Scheduled => None,
+        }
     }
 
     fn pipeline_capacity(&self) -> usize {
@@ -1577,7 +1683,13 @@ impl LivePythonPane {
         let (picker_tx, picker_rx) = std::sync::mpsc::channel();
         let runtime = WasmPythonRuntime::launch(&config)?;
         let repaint: RepaintHook = Arc::new(Mutex::new(None));
-        let decoder = PythonOutputDecoder::spawn(&runtime, app_id.clone(), repaint.clone());
+        let wake_schedule: WakeSchedule = Arc::new(Mutex::new(WakeScheduleState::default()));
+        let decoder = PythonOutputDecoder::spawn(
+            &runtime,
+            app_id.clone(),
+            repaint.clone(),
+            wake_schedule.clone(),
+        );
         Ok(Self {
             runtime,
             config,
@@ -1590,6 +1702,7 @@ impl LivePythonPane {
             frame_scheduler: PythonFrameScheduler::new(std::time::Instant::now()),
             decoder,
             repaint,
+            wake_schedule,
             wants_close: false,
             error: None,
             pending_traceback_stderr: String::new(),
@@ -1833,12 +1946,25 @@ impl LivePythonPane {
         let now = std::time::Instant::now();
         let render_deadline = self.frame_scheduler.next_repaint_deadline(now);
         let timer_deadline = self.timers.values().map(|timer| timer.deadline).min();
-        if let Some(next_wake) = render_deadline.into_iter().chain(timer_deadline).min() {
+        let next_wake = render_deadline.into_iter().chain(timer_deadline).min();
+        if let Some(next_wake) = next_wake {
             let predicted_frame =
                 std::time::Duration::from_secs_f32(ui.input(|input| input.predicted_dt));
             ui.ctx()
                 .request_repaint_after(repaint_delay_until(next_wake, now, predicted_frame));
         }
+        // Publish what the decoder can ride. The cadence tag only holds while
+        // the frame scheduler itself has a deadline pending: with the pipeline
+        // full, `next_repaint_deadline` yields nothing and the next admission
+        // depends on a frame arriving, so the decoder must wake for it.
+        let continuous_interval = render_deadline.and(self.frame_scheduler.continuous_interval());
+        self.wake_schedule
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .scheduled = next_wake.map(|at| ScheduledWake {
+            at,
+            continuous_interval,
+        });
     }
 
     fn record_render_perf(&mut self, host_time: std::time::Duration) {
@@ -1852,8 +1978,15 @@ impl LivePythonPane {
             let guest_fps = self.perf_guest_frames as f64 / elapsed.as_secs_f64();
             let avg_roundtrip_ms = self.perf_guest_roundtrip.as_secs_f64() * 1000.0
                 / self.perf_guest_frames.max(1) as f64;
+            let suppressed_wakes = std::mem::take(
+                &mut self
+                    .wake_schedule
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .suppressed,
+            );
             log::info!(
-                "app::{}: CPython-WASM perf paint_fps={fps:.1} guest_fps={guest_fps:.1} avg_host_ms={avg_host_ms:.2} avg_roundtrip_ms={avg_roundtrip_ms:.2} json_ms={:.2} tree_ms={:.2} ui_ms={:.2} canvas_ms={:.2} stdout_kib={:.1}",
+                "app::{}: CPython-WASM perf paint_fps={fps:.1} guest_fps={guest_fps:.1} avg_host_ms={avg_host_ms:.2} avg_roundtrip_ms={avg_roundtrip_ms:.2} json_ms={:.2} tree_ms={:.2} ui_ms={:.2} canvas_ms={:.2} stdout_kib={:.1} suppressed_wakes={suppressed_wakes}",
                 self.app_id,
                 self.perf_json_decode.as_secs_f64() * 1000.0,
                 self.perf_tree_decode.as_secs_f64() * 1000.0,
@@ -2931,14 +3064,31 @@ impl LivePythonPane {
     pub fn record_runtime_stderr_for_test(&mut self, stderr: &str) {
         self.record_runtime_stderr(stderr);
     }
+    /// Frame-arrival wakes this pane's decoder let ride an already-scheduled
+    /// paint (stint 0549). Also reported in the periodic perf line.
+    #[cfg(test)]
+    pub fn suppressed_wakes(&self) -> u64 {
+        self.wake_schedule
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .suppressed
+    }
     pub fn relaunch(&mut self) -> Result<(), WasmPythonError> {
         // Drop the old decoder (closes its stdout, joins the thread) before the
         // old runtime is replaced, then bind a fresh decoder to the new
         // runtime's stdout. The shared repaint hook carries over so the new
-        // decoder can wake the paint loop immediately.
+        // decoder can wake the paint loop immediately; the published wake
+        // schedule is cleared with the frame scheduler it describes, so the
+        // fresh decoder wakes for the relaunched app's first frames.
         let runtime = WasmPythonRuntime::launch(&self.config)?;
-        self.decoder =
-            PythonOutputDecoder::spawn(&runtime, self.app_id.clone(), self.repaint.clone());
+        *self.wake_schedule.lock().unwrap_or_else(|e| e.into_inner()) =
+            WakeScheduleState::default();
+        self.decoder = PythonOutputDecoder::spawn(
+            &runtime,
+            self.app_id.clone(),
+            self.repaint.clone(),
+            self.wake_schedule.clone(),
+        );
         self.runtime = runtime;
         self.tree = None;
         self.pending_trees.clear();
@@ -7420,6 +7570,138 @@ execution = "cloud"
         assert!(apply_tree_delta(&base, &changed).is_err());
     }
 
+    fn continuous_wake(
+        now: std::time::Instant,
+        ahead: std::time::Duration,
+        interval: std::time::Duration,
+    ) -> Option<ScheduledWake> {
+        Some(ScheduledWake {
+            at: now + ahead,
+            continuous_interval: Some(interval),
+        })
+    }
+
+    const FRAME_60HZ: std::time::Duration = std::time::Duration::from_micros(16_667);
+
+    #[test]
+    fn decoder_wakes_when_nothing_is_scheduled() {
+        assert!(decoder_wake_needed(None, std::time::Instant::now()));
+    }
+
+    #[test]
+    fn decoder_always_wakes_for_a_scheduled_mode_app() {
+        // An input-driven app's frame is the response to input; no cadence is
+        // scheduled to present it, so latency here would be perceptible.
+        let now = std::time::Instant::now();
+        for ahead in [
+            std::time::Duration::ZERO,
+            std::time::Duration::from_millis(1),
+            std::time::Duration::from_secs(5),
+        ] {
+            let scheduled = Some(ScheduledWake {
+                at: now + ahead,
+                continuous_interval: None,
+            });
+            assert!(
+                decoder_wake_needed(scheduled, now),
+                "scheduled-mode app must wake for a frame {ahead:?} before its next paint"
+            );
+        }
+    }
+
+    #[test]
+    fn decoder_rides_a_continuous_paint_already_within_one_frame() {
+        let now = std::time::Instant::now();
+        for ahead in [
+            std::time::Duration::ZERO,
+            std::time::Duration::from_millis(4),
+            FRAME_60HZ,
+        ] {
+            assert!(
+                !decoder_wake_needed(continuous_wake(now, ahead, FRAME_60HZ), now),
+                "a paint {ahead:?} away already presents this frame within its interval"
+            );
+        }
+    }
+
+    #[test]
+    fn decoder_wakes_when_the_continuous_paint_is_more_than_a_frame_away() {
+        let now = std::time::Instant::now();
+        let scheduled = continuous_wake(now, FRAME_60HZ * 2, FRAME_60HZ);
+        assert!(decoder_wake_needed(scheduled, now));
+    }
+
+    #[test]
+    fn decoder_wakes_when_the_published_schedule_has_gone_stale() {
+        // `ui()` does not run while the window is hidden, so a published wake
+        // long past its deadline is no evidence a paint is coming.
+        let now = std::time::Instant::now();
+        let stale = Some(ScheduledWake {
+            at: now - FRAME_60HZ * 4,
+            continuous_interval: Some(FRAME_60HZ),
+        });
+        assert!(decoder_wake_needed(stale, now));
+        // Merely overdue within one interval is normal jitter, not staleness.
+        let overdue = Some(ScheduledWake {
+            at: now - FRAME_60HZ / 2,
+            continuous_interval: Some(FRAME_60HZ),
+        });
+        assert!(!decoder_wake_needed(overdue, now));
+    }
+
+    #[test]
+    fn frame_done_rides_the_cadence_but_other_messages_do_not() {
+        // Every frame ends with `frame_done`; treating it as out-of-band would
+        // make every batch wake and suppress nothing at all.
+        let cadence = DecodedOutput::Message {
+            value: json!({"type": "frame_done", "frame_id": 7}),
+            json_time: std::time::Duration::ZERO,
+            bytes: 0,
+        };
+        assert!(is_frame_cadence_output(&cadence));
+        let command = DecodedOutput::Message {
+            value: json!({"type": "notify", "message": "hi"}),
+            json_time: std::time::Duration::ZERO,
+            bytes: 0,
+        };
+        assert!(!is_frame_cadence_output(&command));
+        assert!(!is_frame_cadence_output(&DecodedOutput::DecodeError(
+            "bad".to_string()
+        )));
+    }
+
+    #[test]
+    fn continuous_interval_is_reported_only_in_continuous_mode() {
+        let now = std::time::Instant::now();
+        let mut scheduler = PythonFrameScheduler::new(now);
+        assert_eq!(scheduler.continuous_interval(), None);
+        scheduler.set_mode(Some("continuous"), Some(60), now);
+        assert_eq!(
+            scheduler.continuous_interval(),
+            Some(scheduler_repaint_after(Some("continuous"), Some(60)))
+        );
+        scheduler.set_mode(Some("scheduled"), None, now);
+        assert_eq!(scheduler.continuous_interval(), None);
+    }
+
+    #[test]
+    fn a_full_continuous_pipeline_has_no_render_deadline_to_ride() {
+        // With the pipeline full there is no pending admission, so `ui()`
+        // publishes no cadence tag and the decoder wakes for the arrival that
+        // frees a slot.
+        let now = std::time::Instant::now();
+        let mut scheduler = PythonFrameScheduler::new(now);
+        scheduler.set_mode(Some("continuous"), Some(60), now);
+        let mut admitted = 0;
+        let mut clock = now;
+        while scheduler.poll_render(clock).is_some() {
+            admitted += 1;
+            clock += FRAME_60HZ;
+        }
+        assert_eq!(admitted, scheduler.pipeline_capacity());
+        assert_eq!(scheduler.next_repaint_deadline(clock), None);
+    }
+
     #[test]
     fn delta_commands_changed_on_non_canvas_is_a_desync_error() {
         let base = decode_python_ui_tree_value(&encoded_value(FULL_TREE_JSON)).expect("base");
@@ -7449,7 +7731,15 @@ execution = "cloud"
         let queued = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let thread_queued = queued.clone();
         let handle = std::thread::spawn(move || {
-            decode_loop(reader, stdin, "test".to_string(), tx, repaint, thread_queued);
+            decode_loop(
+                reader,
+                stdin,
+                "test".to_string(),
+                tx,
+                repaint,
+                thread_queued,
+                Arc::new(Mutex::new(WakeScheduleState::default())),
+            );
         });
 
         // Serialize to one line each — the decoder splits on '\n', so the
@@ -7514,6 +7804,7 @@ execution = "cloud"
                 tx,
                 repaint,
                 Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                Arc::new(Mutex::new(WakeScheduleState::default())),
             );
         });
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -6685,3 +6685,127 @@ mod pane_send_submit_tests {
         );
     }
 }
+
+/// Stint 0549: a continuous-cadence app's decoder must let ready frames ride
+/// the repaint the frame scheduler already scheduled, instead of forcing a
+/// second full-host repaint per guest frame. Drives the real `apps/dev/balls`
+/// subprocess — the exemplar the 0541 audit measured — and asserts the
+/// suppression path actually engages end to end.
+#[test]
+fn continuous_app_frames_ride_the_scheduled_repaint() {
+    let mut h = HostHarness::new();
+    let app_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("apps/dev/balls");
+    h.app
+        .launch_app_by_path_with_layout(&app_dir.to_string_lossy(), None, None, &[])
+        .expect("launch balls");
+    let pane_id = *h
+        .state()
+        .open_panes
+        .last()
+        .expect("a pane appears after launching balls");
+
+    let suppressed = |h: &HostHarness| {
+        h.app.windows[h.app.active_window]
+            .panes
+            .get(&pane_id)
+            .and_then(Pane::as_app)
+            .and_then(|pane| match &pane.runtime {
+                AppRuntime::Python(p) => Some(p.suppressed_wakes()),
+                _ => None,
+            })
+            .expect("balls runs on the Python runtime")
+    };
+
+    let start = std::time::Instant::now();
+    loop {
+        h.run_frames(1);
+        if suppressed(&h) > 0 {
+            break;
+        }
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(30),
+            "a continuous app produced no frame that could ride an already-scheduled repaint"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
+/// Stint 0549, the other direction: an input-driven (scheduled-mode) app must
+/// never have its frame-arrival wake suppressed. Its frames are the response
+/// to input, nothing else is scheduled to present them, and the latency would
+/// be perceptible. `apps/dev/key-event-probe` never sets a scheduler mode.
+#[test]
+fn scheduled_mode_app_never_suppresses_its_frame_wake() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    let app_dir =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("apps/dev/key-event-probe");
+    h.app
+        .launch_app_by_path_with_layout(&app_dir.to_string_lossy(), None, None, &[])
+        .expect("launch key-event-probe");
+    let pane_id = *h
+        .state()
+        .open_panes
+        .last()
+        .expect("a pane appears after launching key-event-probe");
+
+    let probe = |h: &HostHarness| {
+        h.app.windows[h.app.active_window]
+            .panes
+            .get(&pane_id)
+            .and_then(Pane::as_app)
+            .and_then(|pane| match &pane.runtime {
+                AppRuntime::Python(p) => Some((p.has_rendered_tree(), p.suppressed_wakes())),
+                _ => None,
+            })
+            .expect("key-event-probe runs on the Python runtime")
+    };
+
+    let start = std::time::Instant::now();
+    while !probe(&h).0 {
+        h.run_frames(1);
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(30),
+            "key-event-probe did not render its first frame in time"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+
+    // Drive real input and let the response frame land.
+    let key_response = temp_response(tmp.path(), "wake-probe-plus");
+    h.inject_ipc(AppRequest::KeyPane {
+        pane_id,
+        key: "plus".to_string(),
+        response_file: Some(key_response.clone()),
+    });
+    let start = std::time::Instant::now();
+    loop {
+        h.run_frames(1);
+        let state = h.app.windows[h.app.active_window]
+            .panes
+            .get(&pane_id)
+            .and_then(Pane::as_app)
+            .map(|pane| pane.semantic_state());
+        let count = state.as_ref().and_then(|state| {
+            state
+                .nodes
+                .iter()
+                .find(|n| n.role == "text")
+                .and_then(|n| n.label.clone())
+        });
+        if count.as_deref() == Some("1") {
+            break;
+        }
+        assert!(
+            start.elapsed() < std::time::Duration::from_secs(30),
+            "key-event-probe did not reflect the key event in time"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+
+    assert_eq!(
+        probe(&h).1,
+        0,
+        "an input-driven app must never trade presentation latency for saved paints"
+    );
+}


### PR DESCRIPTION
Lands stints **0549** (coalesce the WASM decoder frame-arrival wake), **0550** (shrink the canvas wire payload), and **0551** (skip the tree_delta when it is not smaller) in one PR — they all sit on the shared CPython-WASM canvas wire/render path and were all found by the 0541 balls audit. No linked GitHub issues; stint is authoritative.

## What changed

**0549 — `src/host/wasm_python.rs`.** Two independent repaint sources fired per guest frame: `PythonFrameScheduler` scheduled the next admission deadline from `ui()`, and `PythonOutputDecoder::decode_loop` separately called `request_repaint_after_for(1ns)` on every produced frame. `ui()` now publishes the repaint it just scheduled (`ScheduledWake`) to the decoder thread, and `decoder_wake_needed` lets a frame ride that paint instead of forcing a second full-host repaint. The `1ns`-not-zero convention is preserved wherever the wake is kept. Suppressed wakes are drained into the periodic `CPython-WASM perf` line as `suppressed_wakes=N`.

Suppression is deliberately narrow — it applies only when **all** of these hold:
- the app is in continuous mode *and* the frame scheduler itself has a deadline pending (a full pipeline publishes no cadence tag, because the next admission depends on this very frame arriving);
- the whole produced batch is frame cadence output — the tree plus its `frame_done`. A host command, or a decode error, still wakes immediately (`is_frame_cadence_output`);
- the published schedule is not stale. `eframe` skips `ui()` entirely while the window is hidden, so a wake overdue by more than one interval is no longer evidence a paint is coming, and the decoder wakes.

**0550 — `sdk/python/plexi_sdk/ui.py`, `_v3_runtime.py`.** Canvas geometry is rounded at the source through `_wire()` under the `CANVAS_WIRE_DECIMALS` policy constant (not an inline magic number), and the emit path serialises with compact separators via `_dump_line`. Both are schema-preserving — floats stay floats (`float()` before `round()`, so an int argument does not become an int on the wire), no key changes — so **the host decoder is untouched**.

**0551 — `sdk/python/plexi_sdk/_v3_runtime.py`.** `_emit_tree` now serialises both candidate encodings and emits the smaller one per frame, instead of assuming the delta always wins. The fallback is the existing `component_tree` shape — no new wire shape — and the fail-loud `apply_delta` / host-decoder contract is untouched.

## Measured, before and after

Reproduced first, per the Issue Visibility rule. Guest-side numbers are from the real `apps/balls` view at 50 balls, encoded through `_encode_uitree` + `node_patch` in this worktree (baseline via `PLEXI_SDK_PATH` pointed at an unmodified `HEAD` SDK export).

| 50-ball balls frame | before | after |
|---|---|---|
| full frame on the wire | 17.46 KiB | **10.63 KiB** (61%) |
| `json.dumps` | 0.249 ms | **0.158 ms** (63%) |
| encoding chosen | `tree_delta`, 17.93 KiB (2.7% *larger* than the full frame) | `component_tree`, 10.63 KiB |

Isolating the two 0550 reductions: rounding alone 12.15 KiB (70% of baseline), compact separators alone 15.93 KiB (91%), both together 10.63 KiB (61%). At 60 fps that is ~1048 KiB/s of stdout down to ~638 KiB/s.

**0551 verified in both directions** on a 50-command canvas with a varying number of commands moving per frame:

| commands moving | delta | full frame | emitted |
|---|---|---|---|
| 1/50 | 0.15 KiB | 3.48 KiB | delta |
| 5/50 | 0.43 KiB | 3.49 KiB | delta |
| 25/50 | 1.89 KiB | 3.53 KiB | delta |
| 50/50 | 3.72 KiB | 3.58 KiB | **full frame** |

Cost of making the choice exact: when the delta wins, the full frame is serialised and discarded — 0.039–0.044 ms/frame, i.e. 0.26% of a 16.7 ms frame budget. I took the exact comparison over a size heuristic; the measured overhead is small enough that a fudge factor would not have earned its ambiguity.

`paint_fps` / `guest_fps` / `avg_roundtrip_ms` on a live host are **not** measured here — a worker pane must not boot or drive the GUI host. That is the tester's job; drive steps below.

## The two open questions, resolved

**0549: is the latency cost imperceptible for input-driven apps?** Yes, because input-driven apps never suppress at all. Scheduled-mode apps publish no continuous interval, so `decoder_wake_needed` always returns true for them — asserted directly (`decoder_always_wakes_for_a_scheduled_mode_app`) and end to end against the real `apps/dev/key-event-probe` subprocess, which must show exactly zero suppressed wakes after a real `KeyPane` round trip (`scheduled_mode_app_never_suppresses_its_frame_wake`). For an app that *is* driving a continuous cadence, the ceiling is one frame interval (≤16.7 ms at 60 fps) and typically far less, since the frame arrives near its own deadline; those apps are animation-driven by definition, and the trade buys back a full host repaint — all panes and chrome — per guest frame.

**0550: does any canvas usage need finer than 2dp?** No. What I checked:
- Every `Canvas(...)` construction in the repo. Every one declares a pixel-scale logical space: either the live pane size (`fit="fill"` — `balls`, `sudoku`, `breakout`, `canvas-sidebar`) or a fixed 360–640 unit box (`fit="contain"` — `tetris`, `snake`, `canvas-grid`, `canvas-click-probe`). No normalised (0..1) space anywhere.
- The host magnification path, `canvas_transform` in `src/host/wasm_render.rs`: `fill` scales by `rect/logical` (≈1, since the app passes the pane size); `contain` uses a uniform `min(sx, sy)`. Worst realistic case is a fixed 360×440 canvas full-screen on a 2560×1440 display — 3.27×. Half a rounding step is then 0.016 logical px, or 0.033 device px on a 2× display. A visible ≥1-device-pixel error would need roughly 200× magnification, i.e. a canvas under ~10 logical units.
- Pixels, not just numbers: headless `plexi app render --png` of `sudoku` and `snake` before and after is **byte-identical**. (`tetris` differs, but it is nondeterministic — two renders on the *same* SDK also differ, so it proves nothing either way.)
- The bound is pinned by a test (`test_rounding_is_below_one_device_pixel_at_realistic_scales`) so the policy cannot silently drift.

The precision is fixed as `CANVAS_WIRE_DECIMALS`, documented as a wire policy including the constraint that it assumes a pixel-scale coordinate space.

## Review finding considered and declined

Codex flagged (P2) that a future normalised canvas (`width=1`, coordinates ~0.004) would quantise to `0.0`, and suggested the constructor reject or opt out of such a space. I did not add that guard: `fit="fill"` apps pass the **live pane size** straight into `Canvas(width=…, height=…)`, so any minimum-dimension check would raise from inside `view()` the moment a pane rect is transiently collapsed or sub-unit — a real regression for existing apps in exchange for a guard on an app that does not exist. The constraint is documented on the policy constant instead. Worth revisiting as its own task if a normalised coordinate space is ever actually wanted.

## Test evidence

- `cargo build --bin plexi` — green.
- `cargo test --bin plexi` (env-stripped) — **1857 passed; 0 failed; 3 ignored**. Baseline before the two new harness tests was 1855.
- `pytest sdk/python/tests apps/balls/tests` — **256 passed, 1 skipped**. One deselect: `test_version_unification.py::test_dunder_version_matches_pyproject`, which **fails identically on clean alpha** (`__version__` 3.0.0 vs pyproject 0.2.0) and is unrelated to this diff.
- `mypy sdk/python/plexi_sdk/` — Success, no issues in 27 source files.
- `just check-sdk-docs` — up to date, no regeneration needed.
- Memory watchdog ran alongside both suites (kills any `plexi-*` test process over ~8 GB RSS); it never fired.
- Visual: `snake` headless render read and confirmed to show real seeded content, identical before and after.

New tests: `decoder_wakes_when_nothing_is_scheduled`, `decoder_always_wakes_for_a_scheduled_mode_app`, `decoder_rides_a_continuous_paint_already_within_one_frame`, `decoder_wakes_when_the_continuous_paint_is_more_than_a_frame_away`, `decoder_wakes_when_the_published_schedule_has_gone_stale`, `frame_done_rides_the_cadence_but_other_messages_do_not`, `continuous_interval_is_reported_only_in_continuous_mode`, `a_full_continuous_pipeline_has_no_render_deadline_to_ride`, `continuous_app_frames_ride_the_scheduled_repaint`, `scheduled_mode_app_never_suppresses_its_frame_wake`, plus `sdk/python/tests/test_canvas_wire.py` and two delta-direction tests in `test_v3_delta.py`.

**Conclusion: binary install required.** Tier 2 — this touches the WASM render container, and the headline `paint_fps` claim can only be confirmed against a live host.

## Drive steps for the tester

```bash
just pr-install <PR>
```

1. Launch balls on the PR build: `plexi-pr-<PR> app launch apps/balls` (or from the app menu). Leave it running ~30 s.
2. Read the telemetry: `grep "CPython-WASM perf" ~/.plexi-pr-<PR>/plexi.log | tail -20`.
   - **Expected:** `paint_fps` converges toward `guest_fps` (~60 rather than ~75), `guest_fps` unchanged at ~60, `stdout_kib` roughly 60% of its old value, and `suppressed_wakes` a nonzero count each interval.
   - Compare against the same run on `plexi-alpha` for the before numbers.
3. Confirm balls still looks right — smooth motion, no stutter, no visual quantisation of ball positions.
4. Input latency check (this is the 0549 risk surface): open an input-driven app — `apps/dev/key-event-probe`, plus any Core app with text entry — and confirm keystrokes and clicks feel exactly as immediate as on alpha. That path is asserted to never suppress; this is the human confirmation.
5. Run `tetris` or `snake` (`fit="contain"`, i.e. the magnified coordinate path) full-screen and confirm no visible geometry shift or jitter versus alpha.
