### PR TITLE
fix(cli/agent): move agent-state hook script to a channel-neutral path

### DIFF
--- a/src/cli/agent.rs
+++ b/src/cli/agent.rs
@@ -366,7 +366,11 @@ pub fn agent_hook_install_cli(claude_code: bool, codex: bool, pi: bool) -> i32 {
 
     // Hooks are global but execute inside panes from every release channel.
     // The bare shim honors the pane's PLEXI_SOCKET, while a channel-suffixed
-    // binary would report to whichever channel last installed hooks.
+    // binary would report to whichever channel last installed hooks. The
+    // script itself lives under the channel-neutral shared dir for the same
+    // reason: every channel writes byte-identical content there, so the path
+    // patched into the agent's global config survives uninstalling whichever
+    // channel happened to run install last.
     let script_path = match write_agent_state_script("plexi") {
         Ok(path) => path,
         Err(e) => {
@@ -412,7 +416,7 @@ pub fn agent_hook_uninstall_cli(claude_code: bool, codex: bool, pi: bool) -> i32
 }
 
 fn write_agent_state_script(binary: &str) -> Result<PathBuf, String> {
-    let hooks_dir = crate::config::config_dir().join("hooks");
+    let hooks_dir = crate::config::shared_dir().join("hooks");
     std::fs::create_dir_all(&hooks_dir)
         .map_err(|e| format!("could not create hooks dir {}: {e}", hooks_dir.display()))?;
     let script_path = hooks_dir.join(PLEXI_AGENT_STATE_SCRIPT);
@@ -535,13 +539,7 @@ fn install_claude_code_hooks(script_str: &str) -> i32 {
     let settings_path = claude_settings_path();
     let mut settings = read_json_settings(&settings_path);
 
-    if settings.get("hooks").is_none() {
-        settings["hooks"] = serde_json::json!({});
-    }
-
-    for event in CLAUDE_CODE_HOOK_EVENTS {
-        register_json_hook(&mut settings, event, script_str, None);
-    }
+    register_agent_hooks(&mut settings, CLAUDE_CODE_HOOK_EVENTS, script_str, None);
 
     let code = write_json_settings(&settings_path, &settings);
     if code == 0 {
@@ -559,13 +557,12 @@ fn install_codex_hooks(script_str: &str) -> i32 {
     let mut settings = read_json_settings(&hooks_path);
     let command = format!("PLEXI_AGENT_NAME=codex {script_str}");
 
-    if settings.get("hooks").is_none() {
-        settings["hooks"] = serde_json::json!({});
-    }
-
-    for event in CODEX_HOOK_EVENTS {
-        register_json_hook(&mut settings, event, &command, Some("Plexi agent state"));
-    }
+    register_agent_hooks(
+        &mut settings,
+        CODEX_HOOK_EVENTS,
+        &command,
+        Some("Plexi agent state"),
+    );
 
     let code = write_json_settings(&hooks_path, &settings);
     if code == 0 {
@@ -577,6 +574,23 @@ fn install_codex_hooks(script_str: &str) -> i32 {
         println!("Run `/hooks` in Codex once to trust the new hook definitions.");
     }
     code
+}
+
+/// Point every lifecycle event at `command`, dropping any Plexi entry already
+/// there. Re-installing from a second channel therefore rewrites stale
+/// channel-suffixed script paths instead of stacking a duplicate beside them.
+fn register_agent_hooks(
+    settings: &mut serde_json::Value,
+    events: &[&str],
+    command: &str,
+    status_message: Option<&str>,
+) {
+    if settings.get("hooks").is_none() {
+        settings["hooks"] = serde_json::json!({});
+    }
+    for event in events {
+        register_json_hook(settings, event, command, status_message);
+    }
 }
 
 fn register_json_hook(
@@ -929,5 +943,82 @@ mod agent_tests {
     fn channel_neutral_hook_script_uses_the_bare_plexi_shim() {
         let shell = super::agent_state_script("plexi");
         assert!(shell.contains("\"plexi\" \"${ARGS[@]}\""));
+    }
+
+    #[test]
+    fn hook_script_lands_in_the_channel_neutral_shared_dir() {
+        let shared = tempfile::tempdir().unwrap();
+        let profile = tempfile::tempdir().unwrap();
+        let _shared_guard = crate::config::set_test_shared_dir(shared.path().to_path_buf());
+        let _profile_guard = crate::config::set_test_profile_dir(profile.path().to_path_buf());
+
+        let script_path = super::write_agent_state_script("plexi").unwrap();
+
+        assert_eq!(
+            script_path,
+            shared
+                .path()
+                .join("hooks")
+                .join(super::PLEXI_AGENT_STATE_SCRIPT),
+            "hook script must live under the shared dir, not the channel profile dir"
+        );
+        assert!(script_path.is_file());
+        assert!(!profile.path().join("hooks").exists());
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = fs::metadata(&script_path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o755);
+        }
+    }
+
+    #[test]
+    fn shared_dir_is_channel_neutral() {
+        let _channel = crate::config::set_test_channel("pr-999");
+        assert!(crate::config::shared_dir().ends_with(".plexi"));
+    }
+
+    #[test]
+    fn reinstall_rewrites_stale_channel_suffixed_script_paths() {
+        let stale = "/home/u/.plexi-alpha/hooks/claude-code-agent-state.sh";
+        let neutral = "/home/u/.plexi/hooks/claude-code-agent-state.sh";
+
+        let mut settings = serde_json::json!({});
+        super::register_agent_hooks(&mut settings, super::CLAUDE_CODE_HOOK_EVENTS, stale, None);
+        super::register_agent_hooks(&mut settings, super::CLAUDE_CODE_HOOK_EVENTS, neutral, None);
+
+        for event in super::CLAUDE_CODE_HOOK_EVENTS {
+            let entries = settings["hooks"][*event].as_array().unwrap();
+            assert_eq!(
+                entries.len(),
+                1,
+                "{event} kept a stale entry alongside the new one"
+            );
+            assert_eq!(entries[0]["hooks"][0]["command"], neutral);
+        }
+    }
+
+    #[test]
+    fn reinstall_preserves_unrelated_hook_entries() {
+        let mut settings = serde_json::json!({
+            "hooks": {
+                "PreToolUse": [{
+                    "matcher": "",
+                    "hooks": [{"type": "command", "command": "/usr/local/bin/my-own-hook"}]
+                }]
+            }
+        });
+        let neutral = "/home/u/.plexi/hooks/claude-code-agent-state.sh";
+
+        super::register_agent_hooks(&mut settings, super::CLAUDE_CODE_HOOK_EVENTS, neutral, None);
+
+        let entries = settings["hooks"]["PreToolUse"].as_array().unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(
+            entries[0]["hooks"][0]["command"],
+            "/usr/local/bin/my-own-hook"
+        );
+        assert_eq!(entries[1]["hooks"][0]["command"], neutral);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1073,6 +1073,51 @@ pub fn config_dir() -> PathBuf {
         .join(config_dir_name())
 }
 
+/// Channel-neutral state directory, always `~/.plexi` regardless of which
+/// channel's binary is running. For state that is global to the machine rather
+/// than scoped to a release channel — anything a third party reads by absolute
+/// path, where the last channel to write must not own it. Everything else
+/// belongs in `config_dir()`.
+pub fn shared_dir() -> PathBuf {
+    #[cfg(test)]
+    {
+        let override_dir = TEST_SHARED_DIR_OVERRIDE.with(|c| c.borrow().clone());
+        if let Some(dir) = override_dir {
+            return dir;
+        }
+    }
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(SHARED_DIR_NAME)
+}
+
+const SHARED_DIR_NAME: &str = ".plexi";
+
+#[cfg(test)]
+thread_local! {
+    static TEST_SHARED_DIR_OVERRIDE: std::cell::RefCell<Option<std::path::PathBuf>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// RAII guard that clears the per-thread test shared dir override on drop.
+#[cfg(test)]
+pub struct TestSharedDirGuard;
+
+#[cfg(test)]
+impl Drop for TestSharedDirGuard {
+    fn drop(&mut self) {
+        TEST_SHARED_DIR_OVERRIDE.with(|c| *c.borrow_mut() = None);
+    }
+}
+
+/// Redirect `shared_dir()` to an isolated tempdir for the current test thread.
+/// The returned guard must be held for the duration of the test.
+#[cfg(test)]
+pub fn set_test_shared_dir(path: std::path::PathBuf) -> TestSharedDirGuard {
+    TEST_SHARED_DIR_OVERRIDE.with(|c| *c.borrow_mut() = Some(path));
+    TestSharedDirGuard
+}
+
 pub fn workspace_config_path(workspace_root: &Path) -> PathBuf {
     workspace_config_path_for_channel(workspace_root, &workspace_channel_dir())
 }


### PR DESCRIPTION
Closes stint 0556. Fixes #2490.

## Problem

`plexi agent hook install` wrote `claude-code-agent-state.sh` into `config_dir()/hooks/` — a channel-suffixed path. On an alpha build the command patched into the *global* `~/.claude/settings.json` pointed at `~/.plexi-alpha/hooks/...`, so whichever channel ran install last owned the global hook entries, and uninstalling that channel dangled hooks for every other channel.

## Change

- `write_agent_state_script` now writes to a channel-neutral `~/.plexi/hooks/`, which every channel writes byte-identically. This matches the reason the script body already invokes the bare `plexi` shim instead of a suffixed binary — the pane's `PLEXI_SOCKET` does the routing.
- New `config::shared_dir()` for state global to the machine rather than scoped to a release channel. `config_dir()` channel suffixing is untouched.
- Re-install from any channel rewrites stale channel-suffixed entries in place: `register_json_hook` matches Plexi entries by script *filename*, so the old `~/.plexi-alpha/...` entry is replaced rather than duplicated. Extracted the shared install loop into `register_agent_hooks` so that behavior is directly testable.
- Uninstall is unchanged: it removes config entries; the neutral script is inert without them.

Hook script body and state mapping are untouched.

## Tests

`cargo test --bin plexi` — 1859 passed, 0 failed. Four new unit tests in `src/cli/agent.rs`:

- `hook_script_lands_in_the_channel_neutral_shared_dir` — writes through an isolated shared-dir override with a *separate* profile-dir override, asserting the script lands under the shared dir, that the profile dir gets no `hooks/`, and that the 0755 mode survives.
- `shared_dir_is_channel_neutral` — `shared_dir()` still ends in `.plexi` under a `pr-999` channel override.
- `reinstall_rewrites_stale_channel_suffixed_script_paths` — installing a `~/.plexi-alpha/...` path then a `~/.plexi/...` path leaves exactly one entry per lifecycle event, pointing at the neutral path.
- `reinstall_preserves_unrelated_hook_entries` — a user's own non-Plexi hook survives install.

Supporting `set_test_shared_dir` / `TestSharedDirGuard` added alongside the existing profile-dir test override.

## User-visible effect

Ian's `~/.claude/settings.json` currently points at `~/.plexi-alpha/hooks/claude-code-agent-state.sh`. Running `plexi agent hook install --claude-code` from any channel after this lands rewrites those entries to `~/.plexi/hooks/...`, and they stay valid regardless of which channel is installed or removed later.