### PR TITLE
fix: deterministic socket tests, decoded transcript, scope-refusal guidance, shared command output (stints 0555, 0466, 0427, 0380)

### DIFF
--- a/src/assistant/builtin/build-plexi-app.md
+++ b/src/assistant/builtin/build-plexi-app.md
@@ -13,4 +13,8 @@ The complete SDK API reference is appended to this prompt, with the exact constr
 4. Open the app with the host tool host.apps.open (app = the kebab name) as soon as the first check passes. A workspace app hot-reloads in its open pane on every save, so keep iterating with host.files.edit and the user watches it converge. Re-run app check after meaningful changes.
 5. Tell the user the app is open and how to use it.
 
+Before you open the app, re-read your own `main.py` (or run `app check` again) and confirm every interactive widget is wired to a handler that `update()` actually handles. A rendered button with no matching `handler_id` branch is a dead button — the user clicks it and nothing happens. Check the full set, not the one you wrote last.
+
 If a step fails, show the user the exact error and fix it. Do not fall back to a plain terminal script unless the user explicitly asks for one.
+
+A scope refusal is a final answer. `path_out_of_scope` and `command_not_allowed` mean that path or command is outside what you may touch; retrying changes nothing. Never route around one via host.terminals.run, host.terminals.open, or any other tool — the same limit applies there, and the attempt only costs the user a permission prompt they have to deny. State the limitation plainly and offer what you can do inside scope.

--- a/src/assistant/harness.rs
+++ b/src/assistant/harness.rs
@@ -1029,4 +1029,72 @@ mod tests {
             .unwrap_err();
         assert!(error.contains("supports native host tools only"));
     }
+
+    /// Stint 0427: a scope refusal must end the turn, not redirect it through a
+    /// terminal. `reject_unexpected_calls` makes any `host.terminals.*` call
+    /// after the refusal a test failure, and the guidance the model is given is
+    /// asserted alongside it — the prompt is what keeps a live model on this
+    /// path, so it is part of the regression surface.
+    #[test]
+    fn scope_refusal_is_final_and_never_routes_through_a_terminal() {
+        for guidance in [
+            crate::assistant::DEFAULT_AGENT_PROMPT,
+            &crate::assistant::skills::SkillRegistry::load(
+                std::path::Path::new("/nonexistent-profile"),
+                std::path::Path::new("/nonexistent-workspace"),
+            )
+            .get(crate::assistant::skills::APP_BUILD_SKILL_NAME)
+            .expect("builtin app-build skill")
+            .instructions
+            .clone(),
+        ] {
+            assert!(
+                guidance.contains("path_out_of_scope")
+                    && guidance.contains("command_not_allowed"),
+                "guidance must name both refusal codes: {guidance}"
+            );
+            assert!(
+                guidance.contains("host.terminals.run"),
+                "guidance must name the terminal fallback it forbids: {guidance}"
+            );
+        }
+
+        let mut harness = AssistantHarness::new(&[]);
+        let args = serde_json::json!({"path": "/etc/hosts", "content": "nope"});
+        let trace = harness
+            .run_turn(
+                "write to /etc/hosts",
+                ScriptedTurn {
+                    calls: vec![ScriptedCall::failure(
+                        "host.files.write",
+                        args,
+                        "path_out_of_scope: /etc/hosts is not under a context file root",
+                    )
+                    .with_permission(HarnessPermission::AllowOnce)],
+                    outcome: ScriptedOutcome::Answer(
+                        "/etc/hosts is outside my file scope, so I can't write there.".to_string(),
+                    ),
+                },
+            )
+            .unwrap();
+
+        assert!(
+            !trace.iter().any(|event| matches!(
+                event,
+                OrchestrationEvent::ToolCall { name, .. } | OrchestrationEvent::HostEffect { name, .. }
+                    if name.starts_with("host.terminals.")
+            )),
+            "a scope refusal must not be followed by a terminal call: {trace:?}"
+        );
+        let error = trace
+            .iter()
+            .find_map(|event| match event {
+                OrchestrationEvent::ToolResult {
+                    error: Some(error), ..
+                } => Some(error.clone()),
+                _ => None,
+            })
+            .expect("the refusal must surface as a tool error");
+        assert!(error.starts_with("path_out_of_scope"), "{error}");
+    }
 }

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -1364,10 +1364,21 @@ impl AssistantApp {
     /// Conversation history for the broker: user/assistant turns plus
     /// delivered app events (as user-role context lines).
     fn history_messages(&self) -> Vec<AiMessage> {
+        // Slash-command output is next-turn context, not permanent context.
+        // Keep the transcript row for rendering/audit, but stop injecting it
+        // after the assistant has had one chance to respond to it. This also
+        // prevents repeated `/history` and `/context` calls from growing every
+        // later broker request without bound.
+        let last_assistant = self
+            .model
+            .turns
+            .iter()
+            .rposition(|turn| turn.role == TurnRole::Assistant);
         self.model
             .turns
             .iter()
-            .filter_map(|turn| match turn.role {
+            .enumerate()
+            .filter_map(|(index, turn)| match turn.role {
                 TurnRole::User => Some(AiMessage {
                     role: "user".to_string(),
                     content: turn.text.clone(),
@@ -1383,13 +1394,16 @@ impl AssistantApp {
                 // Shared slash-command output enters as labelled context, not
                 // as something the assistant said — an assistant that cannot
                 // see `/context` cannot help debug its own session (0380).
-                TurnRole::Command => Some(AiMessage {
-                    role: "user".to_string(),
-                    content: format!(
-                        "Output of a slash command the user ran in this session:\n{}",
-                        turn.text
-                    ),
-                }),
+                TurnRole::Command if last_assistant.is_none_or(|at| index > at) => {
+                    Some(AiMessage {
+                        role: "user".to_string(),
+                        content: format!(
+                            "Output of a slash command the user ran in this session:\n{}",
+                            turn.text
+                        ),
+                    })
+                }
+                TurnRole::Command => None,
                 TurnRole::Tool | TurnRole::Error | TurnRole::Local => None,
             })
             .collect()
@@ -3737,6 +3751,32 @@ mod tests {
                 .iter()
                 .any(|m| m.content.contains("Built-in commands")),
             "user-only command output must never reach the model: {history:?}"
+        );
+
+        app.model.turns.push(model::Turn::now(
+            TurnRole::Assistant,
+            "I can see the context output.",
+        ));
+        let after_reply = app.history_messages();
+        assert_eq!(
+            after_reply
+                .iter()
+                .filter(|m| m.content.contains("Assistant context:"))
+                .count(),
+            0,
+            "command output is next-turn context and must not grow every later request"
+        );
+
+        app.model
+            .push_command_output("Assistant context: refreshed");
+        let refreshed = app.history_messages();
+        assert_eq!(
+            refreshed
+                .iter()
+                .filter(|m| m.content.contains("Assistant context:"))
+                .count(),
+            1,
+            "a new command row must be injected exactly once, not duplicated"
         );
     }
 

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -99,7 +99,15 @@ user sees), and validate with host.build.run {\"args\": [\"app\", \"check\", \
 \"<app-dir>\"]} until it passes. Open the app with host.apps.open as soon as the \
 first check passes — workspace apps hot-reload on every file save, so the user \
 watches the app improve live while you keep editing; you do not need to close \
-or reopen it. ";
+or reopen it. \
+A scope refusal is a final answer, not an obstacle to route around. When a tool \
+fails with path_out_of_scope or command_not_allowed, that path or command is \
+outside what you are permitted to touch — the refusal will not change on a \
+retry. Do NOT re-attempt it through host.terminals.run, host.terminals.open, or \
+any other tool: the same limit applies there, the attempt costs the user a \
+permission prompt they must deny, and it reads as working around your own \
+boundaries. Instead, stop, tell the user in plain words what was refused and \
+why, and offer the nearest thing you can do inside scope. ";
 
 /// Host tool names the Assistant injects into its dispatcher snapshot.
 const HOST_TOOL_SUBSCRIBE: &str = "host.events.subscribe";
@@ -305,10 +313,9 @@ mod output_preview_tests {
         let preview = tool_output_preview(output);
         assert_eq!(preview, "stdout: line one\nline two\nstderr: boom");
 
-        // No liftable string fields → pretty-printed JSON, one field per line.
-        let pretty = tool_output_preview(r#"{"ok": true, "count": 3}"#);
-        assert!(pretty.contains("\n"), "must break into lines: {pretty}");
-        assert!(pretty.contains("\"count\": 3"));
+        // No liftable string fields → one decoded `key: value` line per entry.
+        let fallback = tool_output_preview(r#"{"ok": true, "count": 3}"#);
+        assert_eq!(fallback, "count: 3\nok: true");
 
         // Input detail: one key per line, string values unquoted.
         let detail = super::tool_input_detail(r#"{"path": "/tmp/x.py", "sizes": [480, 320]}"#);
@@ -320,11 +327,93 @@ mod output_preview_tests {
         assert!(bounded.chars().count() <= super::TOOL_OUTPUT_PREVIEW_BUDGET + 40);
         assert!(bounded.contains("chars omitted"));
     }
+
+    /// Stint 0466: the three transcript render paths all decode JSON strings at
+    /// every depth. Before the shared helper, `summarize_input` never parsed at
+    /// all, `tool_input_detail` decoded only top-level strings, and
+    /// `tool_output_preview`'s fallback re-escaped everything it printed.
+    #[test]
+    fn every_render_path_decodes_nested_strings() {
+        let nested = r#"{"edits": [{"body": "line one\nline two"}], "note": "he said \"hi\""}"#;
+
+        let summary = super::summarize_input(nested);
+        assert!(
+            !summary.contains("\\n") && !summary.contains("\\\""),
+            "summary must not carry raw escape sequences: {summary}"
+        );
+        assert!(summary.contains("line one line two"), "{summary}");
+        assert!(summary.contains(r#"he said "hi""#), "{summary}");
+
+        let detail = super::tool_input_detail(nested);
+        assert!(
+            !detail.contains("\\n") && !detail.contains("\\\""),
+            "detail must not carry raw escape sequences: {detail}"
+        );
+        assert!(detail.contains("line one\nline two"), "{detail}");
+
+        // Output fallback: no liftable top-level field, so the nested string is
+        // reached only through the recursive renderer.
+        let preview = tool_output_preview(r#"{"result": {"body": "line one\nline two"}}"#);
+        assert!(
+            !preview.contains("\\n"),
+            "output fallback must not re-escape nested strings: {preview}"
+        );
+        assert!(preview.contains("line one\nline two"), "{preview}");
+    }
+}
+
+/// Renders a JSON value as the text a human reads, with every string decoded at
+/// every depth.
+///
+/// `serde_json::Value`'s `Display` re-serialises, so any string it renders comes
+/// back escaped — a nested `"line one\nline two"` reaches the transcript as the
+/// literal characters `\` and `n`. Every assistant render path funnels through
+/// this one helper so decoding never depends on how deep a string happens to sit
+/// (stint 0466).
+fn render_json_value(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(text) => text.clone(),
+        serde_json::Value::Array(items) => {
+            let rendered = items
+                .iter()
+                .map(render_json_value)
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("[{rendered}]")
+        }
+        serde_json::Value::Object(map) => {
+            let rendered = map
+                .iter()
+                .map(|(key, value)| format!("{key}: {}", render_json_value(value)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{{{rendered}}}")
+        }
+        other => other.to_string(),
+    }
+}
+
+/// Renders a JSON object as one decoded `key: value` line per entry. Returns
+/// `None` when the text is not a non-empty JSON object, leaving the caller to
+/// decide its own fallback.
+fn render_json_object_lines(json: &str) -> Option<String> {
+    match serde_json::from_str::<serde_json::Value>(json) {
+        Ok(serde_json::Value::Object(map)) if !map.is_empty() => Some(
+            map.iter()
+                .map(|(key, value)| format!("{key}: {}", render_json_value(value)))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        ),
+        _ => None,
+    }
 }
 
 /// Compact single-line summary of a tool input for sheets and audit lines.
 fn summarize_input(input_json: &str) -> String {
-    let flat: String = input_json.split_whitespace().collect::<Vec<_>>().join(" ");
+    let decoded = serde_json::from_str::<serde_json::Value>(input_json)
+        .map(|value| render_json_value(&value))
+        .unwrap_or_else(|_| input_json.to_string());
+    let flat: String = decoded.split_whitespace().collect::<Vec<_>>().join(" ");
     if flat.chars().count() > 120 {
         let truncated: String = flat.chars().take(117).collect();
         format!("{truncated}…")
@@ -361,13 +450,17 @@ fn tool_output_preview(output_json: &str) -> String {
             }
         }
     }
-    // No liftable string field: pretty-print the JSON so it breaks into
-    // lines instead of one endless run that overflows the pane.
+    // No liftable string field: render one decoded `key: value` line per entry
+    // so it breaks into lines instead of one endless run that overflows the
+    // pane — and so nested strings arrive decoded rather than re-escaped by a
+    // pretty-printer.
     let raw = if sections.is_empty() {
-        parsed
-            .as_ref()
-            .and_then(|value| serde_json::to_string_pretty(value).ok())
-            .unwrap_or_else(|| output_json.to_string())
+        render_json_object_lines(output_json).unwrap_or_else(|| {
+            parsed
+                .as_ref()
+                .map(render_json_value)
+                .unwrap_or_else(|| output_json.to_string())
+        })
     } else {
         sections.join("\n")
     };
@@ -378,17 +471,8 @@ fn tool_output_preview(output_json: &str) -> String {
 /// body — string values keep their real newlines, non-strings print as
 /// compact JSON. Falls back to the raw input when it isn't a JSON object.
 fn tool_input_detail(input_json: &str) -> String {
-    let detail = match serde_json::from_str::<serde_json::Value>(input_json) {
-        Ok(serde_json::Value::Object(map)) if !map.is_empty() => map
-            .iter()
-            .map(|(key, value)| match value {
-                serde_json::Value::String(text) => format!("{key}: {text}"),
-                other => format!("{key}: {other}"),
-            })
-            .collect::<Vec<_>>()
-            .join("\n"),
-        _ => input_json.to_string(),
-    };
+    let detail =
+        render_json_object_lines(input_json).unwrap_or_else(|| input_json.to_string());
     bounded_head_tail_multiline(&detail, TOOL_OUTPUT_PREVIEW_BUDGET)
 }
 
@@ -1296,7 +1380,17 @@ impl AssistantApp {
                     role: "assistant".to_string(),
                     content: turn.text.clone(),
                 }),
-                TurnRole::Tool | TurnRole::Error => None,
+                // Shared slash-command output enters as labelled context, not
+                // as something the assistant said — an assistant that cannot
+                // see `/context` cannot help debug its own session (0380).
+                TurnRole::Command => Some(AiMessage {
+                    role: "user".to_string(),
+                    content: format!(
+                        "Output of a slash command the user ran in this session:\n{}",
+                        turn.text
+                    ),
+                }),
+                TurnRole::Tool | TurnRole::Error | TurnRole::Local => None,
             })
             .collect()
     }
@@ -2242,7 +2336,7 @@ impl AssistantApp {
             .join("\n");
         let effects = self
             .model
-            .push_info(format!("**Assistant agents**\n\n{lines}"));
+            .push_command_output(format!("**Assistant agents**\n\n{lines}"));
         self.execute_effects(effects);
     }
 
@@ -2262,7 +2356,7 @@ impl AssistantApp {
             agent.id,
             agent.source.label()
         );
-        let effects = self.model.push_info(format!(
+        let effects = self.model.push_command_output(format!(
             "Active agent: `{}` ({}).",
             agent.id, agent.display_name
         ));
@@ -2343,7 +2437,7 @@ impl AssistantApp {
         } else {
             format!("{text}\n\n**Shadowed definitions**\n\n{shadow_details}")
         };
-        let effects = self.model.push_info(text);
+        let effects = self.model.push_command_output(text);
         self.execute_effects(effects);
     }
 
@@ -2418,7 +2512,7 @@ impl AssistantApp {
         );
         let effects = self
             .model
-            .push_info(format!("Created agent `{id}` at `{}`.", dir.display()));
+            .push_command_output(format!("Created agent `{id}` at `{}`.", dir.display()));
         self.execute_effects(effects);
     }
 
@@ -2443,7 +2537,7 @@ impl AssistantApp {
         log::info!("assistant: edit agent '{}' at {}", id, path.display());
         let effects = self
             .model
-            .push_info(format!("Edit agent `{id}` at `{}`.", path.display()));
+            .push_command_output(format!("Edit agent `{id}` at `{}`.", path.display()));
         self.execute_effects(effects);
     }
 
@@ -2457,7 +2551,7 @@ impl AssistantApp {
         } else {
             "provider default"
         };
-        let effects = self.model.push_info(format!(
+        let effects = self.model.push_command_output(format!(
             "Reasoning effort: `{}` ({source}).",
             effective.map(ReasoningEffort::label).unwrap_or("auto")
         ));
@@ -2470,7 +2564,7 @@ impl AssistantApp {
             "assistant: session reasoning effort set to {}",
             effort.map(ReasoningEffort::label).unwrap_or("auto")
         );
-        let effects = self.model.push_info(format!(
+        let effects = self.model.push_command_output(format!(
             "Reasoning effort set to `{}` for this session.",
             effort.map(ReasoningEffort::label).unwrap_or("auto")
         ));
@@ -2501,7 +2595,7 @@ impl AssistantApp {
                         .join("\n");
                     format!("**Workspace conversations**\n\n{rows}\n\nUse `/resume <index-or-id>`.")
                 };
-                let effects = self.model.push_info(body);
+                let effects = self.model.push_local_note(body);
                 self.execute_effects(effects);
             }
             Err(e) => {
@@ -2560,7 +2654,7 @@ impl AssistantApp {
         self.model.session_name = session_name;
         self.execute_effects(cancel);
         log::info!("assistant[{id}]: resumed conversation ({turn_count} turn(s))");
-        let effects = self.model.push_info(format!(
+        let effects = self.model.push_local_note(format!(
             "Resumed `{id}` with {turn_count} turn(s). Agent, effort, and thought settings were preserved."
         ));
         self.execute_effects(effects);
@@ -2615,7 +2709,7 @@ impl AssistantApp {
                     history.compactions.len(),
                     history.interruptions.len()
                 );
-                let effects = self.model.push_info(format!(
+                let effects = self.model.push_command_output(format!(
                     "**Conversation history**\n\n{}",
                     if rows.is_empty() {
                         "No history yet.".to_string()
@@ -2679,7 +2773,7 @@ impl AssistantApp {
             "assistant[{id}]: rewound conversation context safety_checkpoint={}",
             checkpoint.id
         );
-        let effects = self.model.push_info(format!(
+        let effects = self.model.push_local_note(format!(
             "Conversation context rewound to `{selector}`. Safety checkpoint: `{}`. Files and apps were untouched.",
             checkpoint.id
         ));
@@ -2693,7 +2787,7 @@ impl AssistantApp {
             self.model.clear_compaction();
             let effects = self
                 .model
-                .push_info("Nothing to compact yet; fewer than seven turns are active.");
+                .push_local_note("Nothing to compact yet; fewer than seven turns are active.");
             self.execute_effects(effects);
             return;
         }
@@ -2745,7 +2839,7 @@ impl AssistantApp {
             "assistant[{id}]: compacted {compacted} turn(s) checkpoint={}",
             checkpoint.id
         );
-        let effects = self.model.push_info(format!(
+        let effects = self.model.push_local_note(format!(
             "Compacted {compacted} turns into checkpoint `{}`.",
             checkpoint.id
         ));
@@ -2788,7 +2882,7 @@ impl AssistantApp {
                     "assistant[{id}]: exported transcript and audit to {}",
                     path.display()
                 );
-                let effects = self.model.push_info(format!(
+                let effects = self.model.push_local_note(format!(
                     "Exported transcript and tool/audit log to `{}`.",
                     path.display()
                 ));
@@ -2810,7 +2904,7 @@ impl AssistantApp {
             self.model.conversation_id,
             settings::model_tier_name(tier)
         );
-        let effects = self.model.push_info(format!(
+        let effects = self.model.push_local_note(format!(
             "Model tier set to `{}` for this session.",
             settings::model_tier_name(tier)
         ));
@@ -2898,7 +2992,7 @@ impl AssistantApp {
             self.settings.permissions.rules.len(),
             self.settings_errors.len()
         );
-        let effects = self.model.push_info(text);
+        let effects = self.model.push_command_output(text);
         self.execute_effects(effects);
     }
 
@@ -2953,7 +3047,7 @@ impl AssistantApp {
                 ));
             }
         }
-        let effects = self.model.push_info(text);
+        let effects = self.model.push_command_output(text);
         self.execute_effects(effects);
     }
 
@@ -2984,7 +3078,7 @@ impl AssistantApp {
             }
             text
         };
-        let effects = self.model.push_info(text);
+        let effects = self.model.push_command_output(text);
         self.execute_effects(effects);
     }
 
@@ -3071,7 +3165,7 @@ impl AssistantApp {
             self.model.turns.len(),
             chars.div_ceil(4)
         );
-        let effects = self.model.push_info(text);
+        let effects = self.model.push_command_output(text);
         self.execute_effects(effects);
     }
 
@@ -3102,7 +3196,7 @@ impl AssistantApp {
             )
         };
         log::info!("assistant: /hooks");
-        let effects = self.model.push_info(text);
+        let effects = self.model.push_command_output(text);
         self.execute_effects(effects);
     }
 
@@ -3140,7 +3234,7 @@ impl AssistantApp {
             }
             out
         };
-        let effects = self.model.push_info(text);
+        let effects = self.model.push_command_output(text);
         self.execute_effects(effects);
     }
 
@@ -3263,7 +3357,7 @@ impl AssistantApp {
         } else {
             format!("Updated {changed} permission(s).")
         };
-        let effects = self.model.push_info(text);
+        let effects = self.model.push_command_output(text);
         self.execute_effects(effects);
     }
 
@@ -3324,7 +3418,7 @@ impl AssistantApp {
                 }
             )
         };
-        let effects = self.model.push_info(text);
+        let effects = self.model.push_command_output(text);
         self.execute_effects(effects);
     }
 
@@ -3353,7 +3447,7 @@ impl AssistantApp {
             }
             out
         };
-        let effects = self.model.push_info(text);
+        let effects = self.model.push_command_output(text);
         self.execute_effects(effects);
     }
 }
@@ -3589,6 +3683,60 @@ mod tests {
             seen[0].max_tool_iterations,
             Some(60),
             "app-build turns must get the raised tool-call cap, not the 30-call default"
+        );
+    }
+
+    /// Stint 0380: `/context` and friends land in the next turn's history as
+    /// labelled command output, while user-only rows (`/help`, `/thoughts`,
+    /// `/export`) never reach the model.
+    #[test]
+    fn shared_slash_command_output_reaches_the_model_and_local_output_does_not() {
+        let ws = tempfile::tempdir().unwrap();
+        let mut app = test_app(ws.path());
+
+        app.model.composer = "/context".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+        app.model.composer = "/help".to_string();
+        let effects = app.model.submit();
+        app.execute_effects(effects);
+
+        assert!(
+            app.model
+                .turns
+                .iter()
+                .any(|t| t.role == TurnRole::Command && t.text.contains("Assistant context:")),
+            "/context output must be a shared command row: {:?}",
+            app.model.turns
+        );
+        assert!(
+            app.model
+                .turns
+                .iter()
+                .any(|t| t.role == TurnRole::Local && t.text.contains("Built-in commands")),
+            "/help output must be a user-only row: {:?}",
+            app.model.turns
+        );
+
+        let history = app.history_messages();
+        let shared = history
+            .iter()
+            .find(|m| m.content.contains("Assistant context:"))
+            .expect("shared command output must reach the model");
+        assert_eq!(
+            shared.role, "user",
+            "command output is context handed to the model, not something it said"
+        );
+        assert!(
+            shared.content.starts_with("Output of a slash command"),
+            "command output must be labelled as such: {}",
+            shared.content
+        );
+        assert!(
+            !history
+                .iter()
+                .any(|m| m.content.contains("Built-in commands")),
+            "user-only command output must never reach the model: {history:?}"
         );
     }
 

--- a/src/assistant/model.rs
+++ b/src/assistant/model.rs
@@ -18,6 +18,13 @@ pub enum TurnRole {
     Error,
     /// An app event delivered through a granted subscription (Phase D3).
     Event,
+    /// Output of a slash command the user ran, shared with the model. It
+    /// enters the next turn's history as clearly-labelled command output so
+    /// the assistant can reason about its own session state (stint 0380).
+    Command,
+    /// Output of a slash command that is the user's business only — cosmetic
+    /// toggles and local artifacts. Rendered, never sent to the model.
+    Local,
 }
 
 /// Final state of a tool-call transcript row. In-flight states (pending,
@@ -697,7 +704,7 @@ impl AssistantModel {
                 self.set_session_name(&cmd.args);
                 if !cmd.args.is_empty() {
                     self.turns.push(Turn::now(
-                        TurnRole::Assistant,
+                        TurnRole::Local,
                         format!("Started conversation '{}'.", cmd.args),
                     ));
                 }
@@ -713,7 +720,7 @@ impl AssistantModel {
             }
             "help" => {
                 self.turns
-                    .push(Turn::now(TurnRole::Assistant, commands::help_text()));
+                    .push(Turn::now(TurnRole::Local, commands::help_text()));
                 vec![AssistantEffect::SessionWrite {
                     conversation_id: self.conversation_id.clone(),
                 }]
@@ -722,7 +729,7 @@ impl AssistantModel {
             "thoughts" => {
                 self.show_thoughts = !self.show_thoughts;
                 self.turns.push(Turn::now(
-                    TurnRole::Assistant,
+                    TurnRole::Local,
                     if self.show_thoughts {
                         "Thoughts are now shown. Run /thoughts again to hide them."
                     } else {
@@ -899,10 +906,22 @@ impl AssistantModel {
         }
     }
 
-    /// Push an informational assistant row (slash-view output). Returns the
-    /// persistence effect.
-    pub fn push_info(&mut self, text: impl Into<String>) -> Vec<AssistantEffect> {
-        self.turns.push(Turn::now(TurnRole::Assistant, text));
+    /// Push slash-command output the model should see. It reaches the next
+    /// turn as labelled command output, not as something the assistant said —
+    /// an assistant that cannot see `/context` cannot help debug its own
+    /// session (stint 0380).
+    pub fn push_command_output(&mut self, text: impl Into<String>) -> Vec<AssistantEffect> {
+        self.turns.push(Turn::now(TurnRole::Command, text));
+        vec![AssistantEffect::SessionWrite {
+            conversation_id: self.conversation_id.clone(),
+        }]
+    }
+
+    /// Push slash-command output that stays with the user: cosmetic toggles,
+    /// local file artifacts, and notes describing context surgery the context
+    /// itself already reflects. Never sent to the model.
+    pub fn push_local_note(&mut self, text: impl Into<String>) -> Vec<AssistantEffect> {
+        self.turns.push(Turn::now(TurnRole::Local, text));
         vec![AssistantEffect::SessionWrite {
             conversation_id: self.conversation_id.clone(),
         }]
@@ -1215,7 +1234,9 @@ mod tests {
         let effects = submitted(&mut m, "/help");
         assert!(m.composer.is_empty());
         assert!(m.streaming.in_flight, "in-flight turn unaffected by /help");
-        assert_eq!(m.turns.last().unwrap().role, TurnRole::Assistant);
+        // `/help` is a static table the model gains nothing from carrying, so
+        // it is a user-only row (stint 0380).
+        assert_eq!(m.turns.last().unwrap().role, TurnRole::Local);
         assert!(m.turns.last().unwrap().text.contains("/clear"));
         assert!(matches!(effects[0], AssistantEffect::SessionWrite { .. }));
     }

--- a/src/assistant/render.rs
+++ b/src/assistant/render.rs
@@ -118,6 +118,8 @@ impl MarkdownTextCache {
             TurnRole::Tool => 2,
             TurnRole::Error => 3,
             TurnRole::Event => 4,
+            TurnRole::Command => 5,
+            TurnRole::Local => 6,
         }
         .hash(&mut hasher);
         hasher.finish()
@@ -557,6 +559,13 @@ impl AssistantRenderer {
                         Self::draw_thoughts_section(ui, colors, thoughts);
                     }
                 }
+                let markdown = text_cache.softened_turn_text(conversation_id, turn_index, turn);
+                Self::assistant_bubble(ui, colors, md_cache, markdown);
+                ui.add_space(style::SPACE_MD);
+            }
+            // Slash-command output reads like an assistant reply either way;
+            // the split is who receives it, not how it looks (stint 0380).
+            TurnRole::Command | TurnRole::Local => {
                 let markdown = text_cache.softened_turn_text(conversation_id, turn_index, turn);
                 Self::assistant_bubble(ui, colors, md_cache, markdown);
                 ui.add_space(style::SPACE_MD);

--- a/src/assistant/skills.rs
+++ b/src/assistant/skills.rs
@@ -436,9 +436,18 @@ mod tests {
             .instructions
             .contains(r#"host.build.run {"args": ["app", "check", "<app-dir>"]}"#));
         assert!(skill.instructions.contains("host.files.write"));
+        // The build flow must never route through a user-visible terminal. The
+        // skill now names `host.terminals.run` only to forbid it after a scope
+        // refusal (stint 0427), so assert the prohibition rather than absence.
         assert!(
-            !skill.instructions.contains("host.terminals.run"),
-            "the build flow must never route through a user-visible terminal"
+            skill
+                .instructions
+                .contains("Never open a terminal pane for your own build work"),
+            "the build flow must still forbid terminals for build work"
+        );
+        assert!(
+            skill.instructions.contains("Never route around one via host.terminals.run"),
+            "a scope refusal must be a final answer, not a cue to use a terminal"
         );
         assert_eq!(
             registry

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -201,6 +201,8 @@ pub mod help;
 pub mod registry;
 pub mod setup;
 pub mod subprocess;
+#[cfg(test)]
+pub mod test_env;
 
 pub mod account;
 pub mod agent;

--- a/src/cli/notify.rs
+++ b/src/cli/notify.rs
@@ -124,18 +124,20 @@ mod notify_tests {
     use serde_json::Value;
     use std::io::{BufRead, BufReader};
     use std::os::unix::net::UnixListener;
-    use std::sync::Mutex;
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use crate::cli::test_env::{socket_env_guard, SocketEnvGuard};
 
-    fn capture_notify_payload<F>(run_cli: F) -> (i32, Value)
+    /// Runs `run_cli` against a throwaway listener with `PLEXI_SOCKET` pointed at
+    /// it. The caller owns the [`SocketEnvGuard`], which both serialises against
+    /// every other socket-mutating CLI test and restores the prior value on drop.
+    fn capture_notify_payload<F>(env: &SocketEnvGuard, run_cli: F) -> (i32, Value)
     where
         F: FnOnce() -> i32,
     {
         let dir = tempfile::tempdir().expect("tempdir");
         let socket_path = dir.path().join("notify.sock");
         let listener = UnixListener::bind(&socket_path).expect("bind notify socket");
-        std::env::set_var("PLEXI_SOCKET", &socket_path);
+        env.set(&socket_path);
 
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
@@ -149,7 +151,6 @@ mod notify_tests {
         });
 
         let code = run_cli();
-        std::env::remove_var("PLEXI_SOCKET");
         let payload = rx
             .recv_timeout(std::time::Duration::from_secs(5))
             .expect("notify listener did not receive a connection within 5s — notify_cli likely failed to connect");
@@ -159,22 +160,22 @@ mod notify_tests {
     /// Without PLEXI_SOCKET set, notify_cli must fail fast (exit 1) rather than panic.
     #[test]
     fn notify_cli_no_socket_returns_one() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        std::env::remove_var("PLEXI_SOCKET");
+        let env = socket_env_guard();
+        env.unset();
         let code = notify_cli("Test title", "Test body", "info", &[], true, 0, None);
         assert_eq!(code, 1);
     }
 
     #[test]
     fn notify_cli_nonblocking_choice_omits_response_file() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let env = socket_env_guard();
         let choices = vec![(
             "talk".to_string(),
             "Talk to Claude".to_string(),
             Some("pane_focus:188".to_string()),
         )];
 
-        let (code, payload) = capture_notify_payload(|| {
+        let (code, payload) = capture_notify_payload(&env, || {
             notify_cli("Ready", "Review tests", "info", &choices, false, 0, None)
         });
 
@@ -193,10 +194,10 @@ mod notify_tests {
     /// and must not leave a response file behind in the profile's rpc/ dir.
     #[test]
     fn notify_cli_timeout_leaves_no_response_file() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let env = socket_env_guard();
         let _channel_guard = crate::config::set_test_channel("notify-test");
         let choices = vec![("talk".to_string(), "Talk".to_string(), None)];
-        let (code, payload) = capture_notify_payload(|| {
+        let (code, payload) = capture_notify_payload(&env, || {
             notify_cli("Ready", "Review tests", "info", &choices, true, 1, None)
         });
         assert_eq!(code, 2, "timeout must exit 2");
@@ -215,11 +216,11 @@ mod notify_tests {
 
     #[test]
     fn notify_cli_blocking_choice_sends_response_file() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let env = socket_env_guard();
         let dir = tempfile::tempdir().expect("tempdir");
         let socket_path = dir.path().join("notify.sock");
         let listener = UnixListener::bind(&socket_path).expect("bind notify socket");
-        std::env::set_var("PLEXI_SOCKET", &socket_path);
+        env.set(&socket_path);
         let _channel_guard = crate::config::set_test_channel("notify-test");
 
         let handle = std::thread::spawn(move || {
@@ -245,7 +246,6 @@ mod notify_tests {
 
         let choices = vec![("talk".to_string(), "Talk to Claude".to_string(), None)];
         let code = notify_cli("Ready", "Review tests", "info", &choices, true, 1, None);
-        std::env::remove_var("PLEXI_SOCKET");
         let payload = handle.join().expect("payload thread");
 
         assert_eq!(code, 0);

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -658,21 +658,22 @@ fn open_app_by_path(
 #[cfg(test)]
 mod open_cli_tests {
     use super::{open_cli, review_raw_wasm_open_with_reader};
+    use crate::cli::test_env::{socket_env_guard, SocketEnvGuard};
     use serde_json::Value;
     use std::io::{BufRead, BufReader, Cursor};
     use std::os::unix::net::UnixListener;
-    use std::sync::Mutex;
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    fn capture_spawn_payload<F>(run_cli: F) -> (i32, Value)
+    /// Runs `run_cli` against a throwaway listener with `PLEXI_SOCKET` pointed at
+    /// it. The caller owns the [`SocketEnvGuard`], which both serialises against
+    /// every other socket-mutating CLI test and restores the prior value on drop.
+    fn capture_spawn_payload<F>(env: &SocketEnvGuard, run_cli: F) -> (i32, Value)
     where
         F: FnOnce() -> i32,
     {
         let dir = tempfile::tempdir().expect("tempdir");
         let socket_path = dir.path().join("open.sock");
         let listener = UnixListener::bind(&socket_path).expect("bind open socket");
-        std::env::set_var("PLEXI_SOCKET", &socket_path);
+        env.set(&socket_path);
 
         let handle = std::thread::spawn(move || {
             let (stream, _) = listener.accept().expect("accept open connection");
@@ -688,7 +689,6 @@ mod open_cli_tests {
         });
 
         let code = run_cli();
-        std::env::remove_var("PLEXI_SOCKET");
         let payload = handle.join().expect("payload thread");
         (code, payload)
     }
@@ -698,8 +698,9 @@ mod open_cli_tests {
         // With no directional flag the CLI must leave `layout` unset so the host
         // applies its placement default (manifest `[launch] placement`, else a
         // sibling split) rather than forcing an overlay takeover (stint 0330).
-        let _guard = ENV_LOCK.lock().unwrap();
-        let (code, payload) = capture_spawn_payload(|| open_cli("balls", &[], None, None, None));
+        let env = socket_env_guard();
+        let (code, payload) =
+            capture_spawn_payload(&env, || open_cli("balls", &[], None, None, None));
 
         assert_eq!(code, 0);
         assert_eq!(payload["type"], "spawn_pane");
@@ -713,9 +714,10 @@ mod open_cli_tests {
 
     #[test]
     fn app_open_explicit_tab_layout_is_preserved() {
-        let _guard = ENV_LOCK.lock().unwrap();
-        let (code, payload) =
-            capture_spawn_payload(|| open_cli("file_browser", &[], Some("tab"), None, None));
+        let env = socket_env_guard();
+        let (code, payload) = capture_spawn_payload(&env, || {
+            open_cli("file_browser", &[], Some("tab"), None, None)
+        });
 
         assert_eq!(code, 0);
         assert_eq!(payload["type"], "spawn_pane");
@@ -725,7 +727,7 @@ mod open_cli_tests {
 
     #[test]
     fn wasm_path_open_forwards_launch_args() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let env = socket_env_guard();
         let config_dir = tempfile::tempdir().expect("temp config dir");
         let _profile_guard = crate::config::set_test_profile_dir(config_dir.path().to_path_buf());
 
@@ -759,7 +761,7 @@ mod open_cli_tests {
         let args = vec!["--sample".to_string(), "96".to_string()];
 
         let (code, payload) =
-            capture_spawn_payload(|| open_cli(&wasm_path_str, &args, None, None, None));
+            capture_spawn_payload(&env, || open_cli(&wasm_path_str, &args, None, None, None));
 
         assert_eq!(code, 0);
         assert_eq!(payload["type"], "spawn_pane");
@@ -769,7 +771,6 @@ mod open_cli_tests {
 
     #[test]
     fn raw_wasm_review_requires_tty_for_unreviewed_imports() {
-        let _guard = ENV_LOCK.lock().unwrap();
         let config_dir = tempfile::tempdir().expect("temp config dir");
         let _profile_guard = crate::config::set_test_profile_dir(config_dir.path().to_path_buf());
         let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -784,7 +785,6 @@ mod open_cli_tests {
 
     #[test]
     fn raw_wasm_review_tty_persists_required_imports() {
-        let _guard = ENV_LOCK.lock().unwrap();
         let config_dir = tempfile::tempdir().expect("temp config dir");
         let _profile_guard = crate::config::set_test_profile_dir(config_dir.path().to_path_buf());
         let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -818,7 +818,6 @@ mod open_cli_tests {
         // must persist Green grants for every imported interface plus `fs.pick`
         // at the wasm's parent-dir scope — exactly what an installed host
         // checks, so a raw wasm scene opens without review.
-        let _guard = ENV_LOCK.lock().unwrap();
         let config_dir = tempfile::tempdir().expect("temp config dir");
         let _profile_guard = crate::config::set_test_profile_dir(config_dir.path().to_path_buf());
         let fixture = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/src/cli/test_env.rs
+++ b/src/cli/test_env.rs
@@ -1,0 +1,117 @@
+//! Shared test-environment guard for CLI tests that mutate process-wide env vars.
+//!
+//! `PLEXI_SOCKET` is process-global, but `cargo test` runs test functions on
+//! parallel threads. Module-local mutexes (one in `open.rs`, one in `notify.rs`)
+//! do not serialise against each other, so a `notify` test could replace or
+//! remove the socket while an `open` test was still connecting — a
+//! nondeterministically red `cargo test --bin plexi` (stint 0555).
+//!
+//! Every test that touches `PLEXI_SOCKET` must acquire [`SocketEnvGuard`]. It is
+//! the single lock for that variable, and it restores the pre-test value on drop
+//! so a panicking assertion cannot leak state into the next test.
+
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+use std::sync::{Mutex, MutexGuard};
+
+/// The one lock serialising `PLEXI_SOCKET` mutation across all CLI test modules.
+static SOCKET_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Exclusive access to the process-wide `PLEXI_SOCKET` variable for one test.
+///
+/// Acquire with [`socket_env_guard`]. The previous value is captured at
+/// acquisition and restored when the guard drops, including on unwind.
+pub struct SocketEnvGuard {
+    previous: Option<OsString>,
+    // Held for the guard's lifetime; released on drop after the value is restored.
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl SocketEnvGuard {
+    /// Point `PLEXI_SOCKET` at `path` for the remainder of this guard's life.
+    pub fn set(&self, path: impl AsRef<Path>) {
+        std::env::set_var("PLEXI_SOCKET", path.as_ref().as_os_str());
+    }
+
+    /// Remove `PLEXI_SOCKET`, simulating a CLI invoked outside a Plexi pane.
+    pub fn unset(&self) {
+        std::env::remove_var("PLEXI_SOCKET");
+    }
+}
+
+impl Drop for SocketEnvGuard {
+    fn drop(&mut self) {
+        match self.previous.as_deref() {
+            Some(value) => restore(value),
+            None => std::env::remove_var("PLEXI_SOCKET"),
+        }
+    }
+}
+
+fn restore(value: &OsStr) {
+    std::env::set_var("PLEXI_SOCKET", value);
+}
+
+/// Acquire the process-wide `PLEXI_SOCKET` test lock.
+///
+/// A poisoned lock is recovered rather than propagated: poisoning means an
+/// earlier test panicked while holding it, and that test's own failure is the
+/// signal — cascading the poison into every other socket test only hides it.
+pub fn socket_env_guard() -> SocketEnvGuard {
+    let lock = SOCKET_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    SocketEnvGuard {
+        previous: std::env::var_os("PLEXI_SOCKET"),
+        _lock: lock,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::socket_env_guard;
+
+    // The lock is not reentrant, so these tests acquire guards sequentially —
+    // never nested — exactly as the CLI test helpers do.
+
+    #[test]
+    fn guard_restores_the_value_it_found_on_drop() {
+        let before = {
+            let env = socket_env_guard();
+            let before = std::env::var_os("PLEXI_SOCKET");
+            env.set("/tmp/plexi-guard-probe.sock");
+            assert_eq!(
+                std::env::var("PLEXI_SOCKET").as_deref(),
+                Ok("/tmp/plexi-guard-probe.sock")
+            );
+            before
+        };
+
+        let env = socket_env_guard();
+        assert_eq!(
+            std::env::var_os("PLEXI_SOCKET"),
+            before,
+            "dropping a guard must restore the value captured at acquisition"
+        );
+        drop(env);
+    }
+
+    #[test]
+    fn guard_restores_after_unset() {
+        let before = {
+            let env = socket_env_guard();
+            let before = std::env::var_os("PLEXI_SOCKET");
+            env.unset();
+            assert!(std::env::var_os("PLEXI_SOCKET").is_none());
+            before
+        };
+
+        let env = socket_env_guard();
+        assert_eq!(
+            std::env::var_os("PLEXI_SOCKET"),
+            before,
+            "an unset inside the guard must not leak past its drop"
+        );
+        drop(env);
+    }
+}

--- a/src/cli/test_env.rs
+++ b/src/cli/test_env.rs
@@ -114,4 +114,24 @@ mod tests {
         );
         drop(env);
     }
+
+    #[test]
+    fn guard_restores_when_a_test_panics() {
+        let mut before = None;
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let env = socket_env_guard();
+            before = Some(std::env::var_os("PLEXI_SOCKET"));
+            env.set("/tmp/plexi-panicking-guard.sock");
+            panic!("probe unwind");
+        }));
+        assert!(result.is_err());
+
+        let env = socket_env_guard();
+        assert_eq!(
+            std::env::var_os("PLEXI_SOCKET"),
+            before.expect("captured under the socket lock"),
+            "unwinding must restore the value captured at acquisition"
+        );
+        drop(env);
+    }
 }

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1426,6 +1426,62 @@ mod tests {
         println!("Screenshot saved to /tmp/plexi_assistant_pane.png");
     }
 
+    /// Visual review for stints 0466/0380: a tool row whose input/output carry
+    /// nested JSON strings must show decoded text (real newlines, real quotes)
+    /// rather than `\n` / `\"` literals, and a shared slash-command row must
+    /// render like an ordinary assistant row.
+    #[test]
+    fn screenshot_assistant_decoded_tool_rows_and_command_output() {
+        use crate::assistant::model::{Turn, TurnRole};
+
+        let ws = tempfile::tempdir().unwrap();
+        let broker: std::sync::Arc<dyn crate::plexi_ai::broker::AiBroker> =
+            std::sync::Arc::new(crate::plexi_ai::broker::LiveAiBroker::new(None));
+        let mut assistant =
+            crate::assistant::AssistantApp::new(ws.path().to_path_buf(), broker, ws.path(), 1);
+        let row = |role: TurnRole, text: &str, at: &str| Turn {
+            role,
+            text: text.to_string(),
+            created_at: at.to_string(),
+            status: None,
+            thoughts: None,
+            detail: None,
+            input_summary: None,
+            output_preview: None,
+        };
+        let mut tool = row(TurnRole::Tool, "host.files.write", "2026-07-27T00:00:02Z");
+        tool.status = Some(crate::assistant::model::ToolStatus::Succeeded);
+        tool.input_summary =
+            Some(r#"{path: notes/log.md, body: line one line two, note: he said "hi"}"#.to_string());
+        tool.output_preview = Some("stdout: wrote 2 lines\nline one\nline two".to_string());
+
+        assistant.model.turns = vec![
+            row(TurnRole::User, "/context", "2026-07-27T00:00:00Z"),
+            row(
+                TurnRole::Command,
+                "Assistant context:\n- Estimated transcript tokens: ~180 (4 turns)\n- Enabled tools: host.files.write, host.build.run",
+                "2026-07-27T00:00:01Z",
+            ),
+            tool,
+            row(
+                TurnRole::Assistant,
+                "Wrote both lines to `notes/log.md`.",
+                "2026-07-27T00:00:03Z",
+            ),
+        ];
+
+        let mut h = PlexiUiHarness::new_sized(1000.0, 720.0);
+        h.step();
+        h.open_assistant_built(assistant, ws.path().to_path_buf());
+        h.run_steps(3);
+        h.save_screenshot("/tmp/plexi_assistant_decoded_rows.png")
+            .expect("render failed");
+        println!(
+            "Screenshot saved to /tmp/plexi_assistant_decoded_rows.png — inspect: \
+             no literal \\n or \\\" anywhere, /context output reads as a normal row."
+        );
+    }
+
     /// Visual regression for stints 0435/0442: a real multi-turn conversation
     /// (short + long messages on both sides) rendered end-to-end through the
     /// actual assistant pane path, screenshotted for human/agent eyeball


### PR DESCRIPTION
Four stints, one batch. No linked GitHub issues; stint tasks are authoritative.

- **stint 0555 — test: serialize PLEXI_SOCKET mutation across CLI modules**
- **stint 0466 — fix: assistant tool-call transcript shows raw escaped strings inconsistently**
- **stint 0427 — Reinforce assistant guidance against PTY fallback when a scoped tool refuses**
- **stint 0380 — assistant should see the output of slash commands the user runs**

## 0555 — one socket guard, not two module-local mutexes

`src/cli/open.rs` and `src/cli/notify.rs` each held their own `ENV_LOCK` around a process-global variable, so they never serialised against each other: a notify test could remove `PLEXI_SOCKET` while an open test was connecting, producing a stale-socket failure and then a mutex-poison cascade. `src/cli/test_env.rs` now owns the single lock. It captures the prior value at acquisition and restores it on drop — including on unwind, so a failing assertion cannot leak state — and recovers a poisoned lock rather than propagating it, since the panicking test is already its own signal.

Tests that do not touch `PLEXI_SOCKET` (`raw_wasm_review_*`, `app_trust_*`) no longer take the lock; their profile-dir override is thread-local.

## 0466 — one recursive decoder, not three partial ones

`serde_json::Value`'s `Display` re-serialises, so any string it renders comes back escaped. The three render paths each handled that differently: `summarize_input` never parsed JSON at all, `tool_input_detail` decoded only top-level strings, and `tool_output_preview`'s no-liftable-field fallback pretty-printed — re-escaping every nested string. `render_json_value` now decodes strings at every depth and all three call it. The output fallback renders decoded `key: value` lines instead of pretty JSON.

## 0427 — a scope refusal is a final answer

Both the system prompt and the builtin `build-plexi-app` skill now say explicitly that `path_out_of_scope` / `command_not_allowed` will not change on retry and must not be routed around via `host.terminals.run` / `host.terminals.open` — state the limitation and offer what is in scope. The skill also requires re-reading the final code (or re-running `app check`) to confirm every interactive widget is wired, after PR #2420 validation found rendered-but-unwired buttons.

Regression test `scope_refusal_is_final_and_never_routes_through_a_terminal` asserts both that the guidance text names the refusal codes and the forbidden tool, and that a turn following a refusal emits no `host.terminals.*` call or host effect.

## 0380 — which slash commands the assistant sees

Slash-command output previously landed as `TurnRole::Assistant`, so it *was* in context but attributed as something the assistant itself said — which is why it reports "I don't see the output of slash commands." Output now splits into two roles: `TurnRole::Command` enters the next turn's history as a user-role message labelled `Output of a slash command the user ran in this session:`, and `TurnRole::Local` is rendered but never sent. Both draw identically; the split is who receives it.

**Shared with the assistant** — session state it needs to reason about itself:

| Command | Rationale |
|---|---|
| `/context` | The whole point of the stint: an assistant that can't see its own context report can't debug it. |
| `/tools`, `/apps`, `/skills` | Defines what it can actually call this turn. |
| `/hooks` | Lifecycle behaviour that changes what happens around its turns. |
| `/settings`, `/config` | Resolved settings govern its own dispatch. |
| `/audit` | Its own recent calls, grants, and denials. |
| `/history` | Turn/checkpoint structure of the conversation it is in. |
| `/agent` (list, inspect, create, edit, switch) | Agent identity is who is answering. |
| `/model`, `/effort` | Tier and reasoning effort are its own operating parameters. |
| `/permissions`, `/revoke` | A grant change silently changes which calls will succeed. |

**User-only** — nothing the model gains from carrying:

| Command | Rationale |
|---|---|
| `/help` | A static command table that would cost tokens every turn. |
| `/thoughts` | Purely cosmetic display toggle. |
| `/clear`, `/new` | Start fresh context; there is nothing to carry into it. |
| `/resume` (list) | Other conversations' titles are noise in this one. |
| `/resume <id>` | The resumed transcript replaces the context; the banner adds nothing. |
| `/rewind`, `/compact` | Describe context surgery the context already reflects. |
| `/export` | A local file artifact for the user, not session state. |

**Test evidence:**
- `cargo test --bin plexi` (env-stripped, memory watchdog attached): **1865 passed, 0 failed, 3 ignored**. Watchdog killed nothing.
- 0555 determinism: the affected `cli::open` / `cli::notify` / `cli::test_env` tests run **30/30 green** under the default parallel runner.
- New tests: `guard_restores_the_value_it_found_on_drop`, `guard_restores_after_unset`, `every_render_path_decodes_nested_strings`, `scope_refusal_is_final_and_never_routes_through_a_terminal`, `shared_slash_command_output_reaches_the_model_and_local_output_does_not`, `screenshot_assistant_decoded_tool_rows_and_command_output`.
- Visual review: rendered the assistant transcript headless with a `/context` command row and a tool row carrying nested JSON — no literal `\n` or `\"`, command row reads as an ordinary row.
- Codex review vs `origin/alpha`: **no actionable correctness issues**.
- Conclusion: binary install required — assistant transcript and prompt behaviour need live confirmation. Validate with `just pr-install <PR>` and run `plexi-pr-<PR>`.
