### PR TITLE
feat: test-channel API key env override + calc connector tools (stint 0425, 0370)

### DIFF
--- a/.agents/skills/babysitter/SKILL.md
+++ b/.agents/skills/babysitter/SKILL.md
@@ -79,6 +79,24 @@ Exact forms confirmed in live runs. Use them; don't invent variants.
 
 **Backtick trap:** never put backticks in the text you pass to `plexi pane send` from a double-quoted shell string — they trigger command substitution and the send fails or mangles. Write commands and paths bare in briefs.
 
+### AI broker key on `pr-<N>` channels — export `PLEXI_TEST_OPENROUTER_API_KEY`
+
+Every `plexi-pr-<N>` binary is signed differently, so its first Keychain read
+raises a macOS access dialog only a human can click — which silently stalls an
+unattended tester mid-run. On a `pr-<N>` channel only, the broker takes the key
+from `PLEXI_TEST_OPENROUTER_API_KEY` and skips the Keychain entirely
+(`test_channel_api_key` in `src/plexi_ai/broker.rs`). Export it in the pane that
+starts the PR host whenever the stints under test touch the assistant or
+`ai.query`:
+
+```bash
+export PLEXI_TEST_OPENROUTER_API_KEY="$(grep -m1 '^OPENROUTER_API_KEY=' .env | cut -d= -f2-)"
+```
+
+Unset, the Keychain path runs unchanged, so the dialog is back. `alpha`, `beta`,
+and `main` never read this var — do not try to use it to configure a real build.
+Never echo or paste the value.
+
 ### Capture forms — `--lines 20` is the default; full-buffer reads are the exception
 
 Since stint 0383 (PR #2390), `capture --lines N` returns the last N real content lines on full-screen TUIs. Cost order, cheapest first:

--- a/.agents/skills/babysitter/SKILL.md
+++ b/.agents/skills/babysitter/SKILL.md
@@ -94,8 +94,10 @@ export PLEXI_TEST_OPENROUTER_API_KEY="$(grep -m1 '^OPENROUTER_API_KEY=' .env | c
 ```
 
 Unset, the Keychain path runs unchanged, so the dialog is back. `alpha`, `beta`,
-and `main` never read this var — do not try to use it to configure a real build.
-Never echo or paste the value.
+and `main` never read this var: the broker requires both the runtime `pr-<N>`
+name and the matching compile-time marker embedded by `scripts/install.sh`.
+Renaming a real-channel binary is insufficient. Do not try to use the var to
+configure a real build. Never echo or paste the value.
 
 ### Capture forms — `--lines 20` is the default; full-buffer reads are the exception
 

--- a/apps/calc/calc.py
+++ b/apps/calc/calc.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
-from typing import Any
+import json
+import math
+from typing import Any, Callable
 
 from plexi_sdk import log, state
-from plexi_sdk.effects import SetState, SetStatus, SetTitle
-from plexi_sdk.events import KeyEvent, UiAction
+from plexi_sdk.effects import AiTool, ExposeTools, SetState, SetStatus, SetTitle, ToolResult
+from plexi_sdk.events import KeyEvent, ToolCall, UiAction
 from plexi_sdk.ui import Button, Column, Component, FooterKeys, Spacer, Text
 
 BUTTON_ROWS = [
@@ -23,6 +25,31 @@ DEFAULT_STATE: dict[str, Any] = {
     "pending": None,
     "op": None,
     "fresh": True,
+}
+
+# Connector tools. Every one is pure compute over its own arguments — none reads
+# or writes the calculator's display state — so all are read_only and the
+# assistant can run them without a write-grant prompt.
+BINARY_OPS: dict[str, Callable[[float, float], float]] = {
+    "add": lambda a, b: a + b,
+    "subtract": lambda a, b: a - b,
+    "multiply": lambda a, b: a * b,
+    "divide": lambda a, b: a / b,
+}
+
+_NUMBER_PAIR_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "a": {"type": "number", "description": "Left operand."},
+        "b": {"type": "number", "description": "Right operand."},
+    },
+    "required": ["a", "b"],
+}
+
+_RESULT_SCHEMA = {
+    "type": "object",
+    "properties": {"result": {"type": "number"}},
+    "required": ["result"],
 }
 
 
@@ -51,13 +78,55 @@ def init(size, args) -> list:
         if state.get(key, None) is None
     }
     log.info("calc: SDK v3 initialized")
-    effects: list = [SetTitle("Calculator"), SetStatus(_status(data))]
+    effects: list = [
+        SetTitle("Calculator"),
+        SetStatus(_status(data)),
+        ExposeTools(_tools()),
+    ]
+    log.info(f"calc: exposed {len(BINARY_OPS) + 1} connector tools")
     if missing:
         effects.append(SetState(missing))
     return effects
 
 
+def _tools() -> list[AiTool]:
+    tools = [
+        AiTool(
+            name=f"calc.{name}",
+            description=f"{name.capitalize()} two numbers and return the result.",
+            input_schema=_NUMBER_PAIR_SCHEMA,
+            output_schema=_RESULT_SCHEMA,
+            read_only=True,
+        )
+        for name in BINARY_OPS
+    ]
+    tools.append(
+        AiTool(
+            name="calc.evaluate",
+            description=(
+                "Evaluate a single binary expression of the form '<number> <op> <number>', "
+                "where op is one of + - * /."
+            ),
+            input_schema={
+                "type": "object",
+                "properties": {
+                    "expression": {
+                        "type": "string",
+                        "description": "For example '12 * 3.5'.",
+                    }
+                },
+                "required": ["expression"],
+            },
+            output_schema=_RESULT_SCHEMA,
+            read_only=True,
+        )
+    )
+    return tools
+
+
 def update(event) -> list:
+    if isinstance(event, ToolCall):
+        return [_handle_tool_call(event)]
     label = _event_label(event)
     if label is None:
         return []
@@ -88,6 +157,80 @@ def view():
         ],
         gap=8.0,
         grow=True,
+    )
+
+
+def _handle_tool_call(call: ToolCall) -> ToolResult:
+    log.info(f"calc: tool call {call.name} from {call.caller_id}")
+    try:
+        payload = json.loads(call.input_json or "{}")
+    except ValueError as e:
+        return ToolResult(call.call_id, error=f"input_json is not valid JSON: {e}")
+    if not isinstance(payload, dict):
+        return ToolResult(call.call_id, error="input must be a JSON object")
+
+    try:
+        if call.name == "calc.evaluate":
+            result = _evaluate(payload.get("expression"))
+        else:
+            op = BINARY_OPS.get(call.name.removeprefix("calc."))
+            if op is None or not call.name.startswith("calc."):
+                return ToolResult(call.call_id, error=f"unknown tool '{call.name}'")
+            result = op(_operand(payload, "a"), _operand(payload, "b"))
+    except (ValueError, ZeroDivisionError, OverflowError) as e:
+        log.warn(f"calc: tool call {call.name} failed: {e}")
+        return ToolResult(call.call_id, error=str(e))
+
+    # `inf`/`nan` serialize as bare `Infinity`/`NaN`, which is not valid JSON and
+    # breaks the declared number-typed output schema. Report them as errors.
+    if not math.isfinite(result):
+        log.warn(f"calc: tool call {call.name} produced a non-finite result")
+        return ToolResult(call.call_id, error=f"result is not a finite number: {result}")
+
+    return ToolResult(call.call_id, output_json=json.dumps({"result": result}))
+
+
+def _operand(payload: dict, key: str) -> float:
+    if key not in payload:
+        raise ValueError(f"missing required operand '{key}'")
+    value = payload[key]
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise ValueError(f"operand '{key}' must be a number")
+    try:
+        number = float(value)
+    except (ValueError, OverflowError):
+        raise ValueError(f"operand '{key}' is not a number: {value!r}") from None
+    if not math.isfinite(number):
+        raise ValueError(f"operand '{key}' must be finite, got {value!r}")
+    return number
+
+
+def _evaluate(expression: Any) -> float:
+    """Parse and compute one `<number> <op> <number>` expression.
+
+    Deliberately not a general expression evaluator — the four binary ops are the
+    whole contract, and hand-parsing keeps `eval` well away from assistant input.
+    """
+    if not isinstance(expression, str):
+        raise ValueError("'expression' must be a string")
+    symbols = {"+": "add", "-": "subtract", "*": "multiply", "/": "divide"}
+    # Scan from the right so a leading sign stays attached to its operand.
+    for index in range(len(expression) - 1, 0, -1):
+        name = symbols.get(expression[index])
+        if name is None:
+            continue
+        left, right = expression[:index].strip(), expression[index + 1 :].strip()
+        if not left or not right:
+            continue
+        try:
+            a, b = float(left), float(right)
+        except ValueError:
+            continue
+        if not (math.isfinite(a) and math.isfinite(b)):
+            raise ValueError(f"operands in '{expression}' must be finite")
+        return BINARY_OPS[name](a, b)
+    raise ValueError(
+        f"could not parse '{expression}' as '<number> <op> <number>' with op in + - * /"
     )
 
 

--- a/apps/calc/tests/test_calc_v3.py
+++ b/apps/calc/tests/test_calc_v3.py
@@ -9,10 +9,12 @@ sys.path.insert(
 )
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import json  # noqa: E402
+
 import plexi_sdk as sdk  # noqa: E402
 from plexi_sdk import _v3_state  # noqa: E402
-from plexi_sdk.effects import SetState  # noqa: E402
-from plexi_sdk.events import KeyEvent, UiAction  # noqa: E402
+from plexi_sdk.effects import ExposeTools, SetState, ToolResult  # noqa: E402
+from plexi_sdk.events import KeyEvent, ToolCall, UiAction  # noqa: E402
 
 import calc  # noqa: E402
 
@@ -61,3 +63,95 @@ def test_button_actions_decimal_backspace_and_clear() -> None:
     _set_state(dict(calc.DEFAULT_STATE, display="123", fresh=False))
     effects = calc.update(KeyEvent("backspace"))
     assert _state_effect(effects)["display"] == "12"
+
+
+def _call(name: str, payload: dict, call_id: str = "call-1") -> ToolResult:
+    effects = calc.update(ToolCall(call_id, name, json.dumps(payload), "assistant"))
+    assert len(effects) == 1, f"a tool call must produce exactly one effect: {effects}"
+    result = effects[0]
+    assert isinstance(result, ToolResult)
+    assert result.call_id == call_id, "ToolResult must echo the inbound call_id"
+    return result
+
+
+def _output(result: ToolResult) -> dict:
+    assert result.error is None, f"expected success, got error: {result.error}"
+    assert result.output_json is not None
+    return json.loads(result.output_json)
+
+
+def test_init_exposes_read_only_tools_for_every_operation() -> None:
+    _set_state(dict(calc.DEFAULT_STATE))
+
+    declaration = next(e for e in calc.init(None, None) if isinstance(e, ExposeTools))
+    names = {tool.name for tool in declaration.tools}
+
+    assert names == {
+        "calc.add",
+        "calc.subtract",
+        "calc.multiply",
+        "calc.divide",
+        "calc.evaluate",
+    }
+    assert all(tool.read_only for tool in declaration.tools), (
+        "every calc tool is pure compute and must be read_only for auto-grant"
+    )
+    for tool in declaration.tools:
+        assert tool.description, f"{tool.name} needs a description"
+        assert tool.input_schema.get("required"), f"{tool.name} must require its inputs"
+        assert tool.output_schema["properties"]["result"]["type"] == "number"
+
+
+def test_binary_tool_calls_compute_results() -> None:
+    _set_state(dict(calc.DEFAULT_STATE))
+
+    assert _output(_call("calc.add", {"a": 7, "b": 5}))["result"] == 12
+    assert _output(_call("calc.subtract", {"a": 7, "b": 5}))["result"] == 2
+    assert _output(_call("calc.multiply", {"a": 7, "b": 5}))["result"] == 35
+    assert _output(_call("calc.divide", {"a": 7, "b": 2}))["result"] == 3.5
+
+
+def test_evaluate_parses_single_binary_expression() -> None:
+    _set_state(dict(calc.DEFAULT_STATE))
+
+    assert _output(_call("calc.evaluate", {"expression": "12 * 3.5"}))["result"] == 42
+    assert _output(_call("calc.evaluate", {"expression": "-8/2"}))["result"] == -4
+    assert _output(_call("calc.evaluate", {"expression": "1e3 - 1"}))["result"] == 999
+
+
+def test_tool_calls_report_errors_instead_of_raising() -> None:
+    _set_state(dict(calc.DEFAULT_STATE))
+
+    for name, payload in [
+        ("calc.divide", {"a": 1, "b": 0}),
+        ("calc.add", {"a": 1}),
+        ("calc.add", {"a": "seven", "b": 1}),
+        ("calc.nope", {"a": 1, "b": 1}),
+        ("calc.evaluate", {"expression": "banana"}),
+        ("calc.evaluate", {"expression": 7}),
+        # `inf`/`nan` are not valid JSON numbers, so they must never reach
+        # output_json — they surface as a structured error instead.
+        ("calc.add", {"a": 1e309, "b": 1}),
+        ("calc.multiply", {"a": 1e308, "b": 1e308}),
+        ("calc.evaluate", {"expression": "1e309 + 1"}),
+    ]:
+        result = _call(name, payload)
+        assert result.error, f"{name}{payload} must return a ToolResult error"
+        assert result.output_json is None, "never set both output_json and error"
+
+
+def test_malformed_input_json_is_an_error_not_a_crash() -> None:
+    _set_state(dict(calc.DEFAULT_STATE))
+
+    effects = calc.update(ToolCall("call-9", "calc.add", "{not json", "assistant"))
+    assert len(effects) == 1
+    assert effects[0].error
+
+
+def test_tool_calls_do_not_mutate_calculator_state() -> None:
+    _set_state(dict(calc.DEFAULT_STATE, display="42", fresh=False))
+
+    effects = calc.update(ToolCall("call-3", "calc.add", '{"a":1,"b":1}', "assistant"))
+    assert not any(isinstance(e, SetState) for e in effects), (
+        "read-only tools must never emit SetState"
+    )

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -74,7 +74,16 @@ if [[ "$skip_bin_install" != "1" ]] && $bin_install_needs_sudo; then
   sudo -v
 fi
 
-cargo bundle --release
+# Embed a second, compile-time identity for test-only behavior. The runtime
+# basename remains necessary for profile routing, but is not a security
+# boundary: any installed binary can be renamed. Explicitly clear the marker
+# for every real channel so an inherited shell variable cannot taint a
+# production build.
+if [[ "$channel" =~ ^pr-[0-9]+$ ]]; then
+  PLEXI_BUILD_TEST_CHANNEL="$channel" cargo bundle --release
+else
+  env -u PLEXI_BUILD_TEST_CHANNEL cargo bundle --release
+fi
 
 if [[ ! -d "$app_src" ]]; then
   echo "Error: bundle not found at: $app_src"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -874,6 +874,19 @@ pub fn build_channel() -> Option<String> {
     }
 }
 
+/// True when `channel` is a disposable per-PR test channel (`pr-<N>`, the
+/// channel `just pr-install <N>` builds).
+///
+/// This is the *only* sanctioned way to ask "is this a throwaway test build?".
+/// It deliberately does not match `main`, `alpha`, or `beta` — those are real
+/// user-facing channels — and it requires an all-digit PR number so a
+/// hand-crafted binary name like `plexi-pr-evil` cannot claim test status.
+pub fn is_test_channel(channel: Option<&str>) -> bool {
+    channel
+        .and_then(|c| c.strip_prefix("pr-"))
+        .is_some_and(|n| !n.is_empty() && n.bytes().all(|b| b.is_ascii_digit()))
+}
+
 /// Maps a binary basename to its config directory name.
 /// `plexi` → `.plexi`; `plexi-<suffix>` → `.plexi-<suffix>`.
 fn channel_suffix_from_basename(basename: &str) -> String {
@@ -1674,6 +1687,29 @@ mod tests {
     #[test]
     fn config_dir_name_alpha() {
         assert_eq!(channel_suffix_from_basename("plexi-alpha"), ".plexi-alpha");
+    }
+
+    #[test]
+    fn only_numbered_pr_channels_are_test_channels() {
+        assert!(is_test_channel(Some("pr-1")));
+        assert!(is_test_channel(Some("pr-2493")));
+
+        for not_a_test in [
+            None,
+            Some("main"),
+            Some("alpha"),
+            Some("beta"),
+            Some("pr-"),
+            Some("pr-evil"),
+            Some("pr-12a"),
+            Some("PR-1"),
+            Some("prod"),
+        ] {
+            assert!(
+                !is_test_channel(not_a_test),
+                "{not_a_test:?} must not be treated as a test channel"
+            );
+        }
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -874,17 +874,25 @@ pub fn build_channel() -> Option<String> {
     }
 }
 
-/// True when `channel` is a disposable per-PR test channel (`pr-<N>`, the
-/// channel `just pr-install <N>` builds).
+/// True when this binary was compiled for, and is currently running as, the
+/// same disposable per-PR test channel (`pr-<N>`).
 ///
 /// This is the *only* sanctioned way to ask "is this a throwaway test build?".
-/// It deliberately does not match `main`, `alpha`, or `beta` — those are real
-/// user-facing channels — and it requires an all-digit PR number so a
-/// hand-crafted binary name like `plexi-pr-evil` cannot claim test status.
+/// Runtime naming alone is not trusted: renaming a production binary to
+/// `plexi-pr-1` must not unlock test-only behavior. `scripts/install.sh` embeds
+/// the marker only while building an all-digit PR channel.
 pub fn is_test_channel(channel: Option<&str>) -> bool {
-    channel
-        .and_then(|c| c.strip_prefix("pr-"))
-        .is_some_and(|n| !n.is_empty() && n.bytes().all(|b| b.is_ascii_digit()))
+    is_matching_test_channel(option_env!("PLEXI_BUILD_TEST_CHANNEL"), channel)
+}
+
+fn is_matching_test_channel(compiled: Option<&str>, runtime: Option<&str>) -> bool {
+    let Some(compiled) = compiled else {
+        return false;
+    };
+    compiled == runtime.unwrap_or_default()
+        && compiled
+            .strip_prefix("pr-")
+            .is_some_and(|n| !n.is_empty() && n.bytes().all(|b| b.is_ascii_digit()))
 }
 
 /// Maps a binary basename to its config directory name.
@@ -1691,23 +1699,27 @@ mod tests {
 
     #[test]
     fn only_numbered_pr_channels_are_test_channels() {
-        assert!(is_test_channel(Some("pr-1")));
-        assert!(is_test_channel(Some("pr-2493")));
+        assert!(is_matching_test_channel(Some("pr-1"), Some("pr-1")));
+        assert!(is_matching_test_channel(
+            Some("pr-2493"),
+            Some("pr-2493")
+        ));
 
-        for not_a_test in [
-            None,
-            Some("main"),
-            Some("alpha"),
-            Some("beta"),
-            Some("pr-"),
-            Some("pr-evil"),
-            Some("pr-12a"),
-            Some("PR-1"),
-            Some("prod"),
+        for (compiled, runtime) in [
+            (None, Some("pr-1")),
+            (Some("pr-1"), None),
+            (Some("pr-1"), Some("main")),
+            (Some("pr-1"), Some("alpha")),
+            (Some("pr-1"), Some("beta")),
+            (Some("pr-1"), Some("pr-2")),
+            (Some("pr-"), Some("pr-")),
+            (Some("pr-evil"), Some("pr-evil")),
+            (Some("pr-12a"), Some("pr-12a")),
+            (Some("PR-1"), Some("PR-1")),
         ] {
             assert!(
-                !is_test_channel(not_a_test),
-                "{not_a_test:?} must not be treated as a test channel"
+                !is_matching_test_channel(compiled, runtime),
+                "compiled={compiled:?}, runtime={runtime:?} must not be a test channel"
             );
         }
     }

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -35,8 +35,8 @@ use super::wasm_app::bindings::plexi::platform::types::{
 };
 #[cfg(test)]
 use super::wasm_app::bindings::plexi::platform::types::{
-    FileReadEffect, FileWriteEffect, HttpFetchEffect, InputEvent, KeyEvent, StateSnapshot,
-    TimerEffect, UiActionEvent, UiValueChangeEvent,
+    DeclareToolsEffect, FileReadEffect, FileWriteEffect, HttpFetchEffect, InputEvent, KeyEvent,
+    StateSnapshot, TimerEffect, ToolDecl, ToolResultEffect, UiActionEvent, UiValueChangeEvent,
 };
 use super::wasm_app::Alignment;
 #[cfg(test)]
@@ -3076,6 +3076,35 @@ fn decode_effect(value: Value) -> Result<PythonBridgeEffect, WasmPythonError> {
             &value, "id",
         )?))),
         "GetSystemStats" => Ok(PythonBridgeEffect::Host(Effect::GetSystemStats)),
+        // v3.7 tool protocol. The SDK names these `ExposeTools`/`ToolResult`
+        // after the wire commands; the WIT effect variants are
+        // `declare-tools`/`tool-result`. Schemas cross the bridge as JSON
+        // objects and are re-serialized into the WIT string fields.
+        "ExposeTools" => Ok(PythonBridgeEffect::Host(Effect::DeclareTools(
+            DeclareToolsEffect {
+                tools: value
+                    .get("tools")
+                    .and_then(Value::as_array)
+                    .ok_or_else(|| {
+                        WasmPythonError::BridgeJson(
+                            "ExposeTools missing array 'tools'".to_string(),
+                        )
+                    })?
+                    .iter()
+                    .map(decode_tool_decl)
+                    .collect::<Result<Vec<_>, _>>()?,
+            },
+        ))),
+        "ToolResult" => Ok(PythonBridgeEffect::Host(Effect::ToolResult(
+            ToolResultEffect {
+                call_id: required_string(&value, "call_id")?,
+                output_json: value
+                    .get("output_json")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                error: value.get("error").and_then(Value::as_str).map(str::to_string),
+            },
+        ))),
         "FileRead" => Ok(PythonBridgeEffect::Host(Effect::FileRead(FileReadEffect {
             path: required_string(&value, "path")?,
         }))),
@@ -3577,6 +3606,36 @@ fn decode_hex_color(hex: &str) -> Result<Color, WasmPythonError> {
             "invalid color '{hex}': expected #rrggbb or #rrggbbaa"
         ))),
     }
+}
+
+/// Decode one SDK `AiTool` payload into the WIT `tool-decl` record.
+///
+/// The Python side carries `input_schema`/`output_schema` as JSON objects while
+/// WIT carries them as strings, so both are re-serialized here.
+#[cfg(test)]
+fn decode_tool_decl(value: &Value) -> Result<ToolDecl, WasmPythonError> {
+    let schema = |field: &str| -> Result<String, WasmPythonError> {
+        let schema = value.get(field).ok_or_else(|| {
+            WasmPythonError::BridgeJson(format!("tool missing object field '{field}'"))
+        })?;
+        if !schema.is_object() {
+            return Err(WasmPythonError::BridgeJson(format!(
+                "tool field '{field}' must be a JSON object"
+            )));
+        }
+        serde_json::to_string(schema).map_err(|e| WasmPythonError::BridgeJson(e.to_string()))
+    };
+    Ok(ToolDecl {
+        name: required_string(value, "name")?,
+        description: required_string(value, "description")?,
+        input_schema_json: schema("input_schema")?,
+        output_schema_json: schema("output_schema")?,
+        timeout_ms: value.get("timeout_ms").and_then(Value::as_u64),
+        read_only: value
+            .get("read_only")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+    })
 }
 
 fn required_string(value: &Value, field: &str) -> Result<String, WasmPythonError> {
@@ -5286,6 +5345,68 @@ execution = "cloud"
             .nodes
             .iter()
             .any(|node| matches!(&node.data, UiNodeData::Text(text) if text.text == "Calculator")));
+
+        // Calc declares its connector tools on init; the bridge must carry the
+        // whole set across with schemas re-serialized into the WIT string fields.
+        let declared = init
+            .iter()
+            .find_map(|effect| match effect {
+                PythonBridgeEffect::Host(Effect::DeclareTools(req)) => Some(req),
+                _ => None,
+            })
+            .expect("calc init must declare tools");
+        let names: Vec<&str> = declared.tools.iter().map(|t| t.name.as_str()).collect();
+        for expected in [
+            "calc.add",
+            "calc.subtract",
+            "calc.multiply",
+            "calc.divide",
+            "calc.evaluate",
+        ] {
+            assert!(
+                names.contains(&expected),
+                "missing declared tool {expected} in {names:?}"
+            );
+        }
+        for tool in &declared.tools {
+            assert!(tool.read_only, "{} must be read-only", tool.name);
+            assert!(
+                serde_json::from_str::<Value>(&tool.input_schema_json)
+                    .expect("input schema json")
+                    .is_object(),
+                "{} input schema must cross the bridge as a JSON object string",
+                tool.name
+            );
+            assert!(serde_json::from_str::<Value>(&tool.output_schema_json)
+                .expect("output schema json")
+                .is_object());
+        }
+    }
+
+    #[test]
+    fn native_python_bridge_decodes_tool_result_effect() {
+        let effects = decode_effects(
+            r#"[{"type":"ToolResult","call_id":"call-1","output_json":"{\"result\":12}","error":null}]"#,
+        )
+        .expect("tool result effect");
+        let PythonBridgeEffect::Host(Effect::ToolResult(result)) = &effects[0] else {
+            panic!("expected ToolResult, got {:?}", effects[0]);
+        };
+        assert_eq!(result.call_id, "call-1");
+        assert_eq!(result.output_json.as_deref(), Some(r#"{"result":12}"#));
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn native_python_bridge_rejects_non_object_tool_schema() {
+        let err = decode_effects(
+            r#"[{"type":"ExposeTools","tools":[{"name":"t","description":"d","input_schema":"nope","output_schema":{},"timeout_ms":null,"read_only":true}]}]"#,
+        )
+        .expect_err("a string schema must not silently decode");
+        assert!(
+            format!("{err}").contains("input_schema"),
+            "error must name the offending field: {err}"
+        );
     }
 
     #[test]

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -281,8 +281,9 @@ fn dispatch_openrouter(
 /// differently-signed binary, so its first Keychain read raises a macOS access
 /// dialog only a human can click — which stalls unattended PR validation. This
 /// var is the escape hatch for exactly that case, gated by
-/// [`crate::config::is_test_channel`] so a leaked env var can never redirect a
-/// real user build's credentials.
+/// [`crate::config::is_test_channel`]. That gate requires a compile-time PR
+/// marker matching the runtime channel, so a leaked env var or renamed
+/// production binary cannot redirect a real user build's credentials.
 pub const TEST_CHANNEL_API_KEY_ENV: &str = "PLEXI_TEST_OPENROUTER_API_KEY";
 
 /// Resolve the broker API key from the test-channel escape hatch.
@@ -295,7 +296,14 @@ fn test_channel_api_key(
     channel: Option<&str>,
     lookup: impl Fn(&str) -> Option<String>,
 ) -> Option<String> {
-    if !crate::config::is_test_channel(channel) {
+    test_channel_api_key_if(crate::config::is_test_channel(channel), lookup)
+}
+
+fn test_channel_api_key_if(
+    is_test_channel: bool,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Option<String> {
+    if !is_test_channel {
         return None;
     }
     lookup(TEST_CHANNEL_API_KEY_ENV).filter(|v| !v.is_empty())
@@ -1255,9 +1263,9 @@ mod tests {
         };
 
         assert_eq!(
-            test_channel_api_key(Some("pr-2493"), present).as_deref(),
+            test_channel_api_key_if(true, present).as_deref(),
             Some("stub-value"),
-            "a pr-<N> build must take the key from the env escape hatch"
+            "a verified pr-<N> build must take the key from the env escape hatch"
         );
 
         for production in [None, Some("alpha"), Some("beta"), Some("main")] {
@@ -1267,10 +1275,10 @@ mod tests {
             );
         }
 
-        for forged in ["pr-", "pr-evil", "pr-12a", "PR-1"] {
+        for forged in ["pr-1", "pr-", "pr-evil", "pr-12a", "PR-1"] {
             assert!(
                 test_channel_api_key(Some(forged), present).is_none(),
-                "channel '{forged}' must not qualify as a test channel"
+                "a normal build renamed to '{forged}' must not qualify as a test channel"
             );
         }
     }
@@ -1278,11 +1286,11 @@ mod tests {
     #[test]
     fn test_channel_env_key_falls_through_when_unset_or_empty() {
         assert!(
-            test_channel_api_key(Some("pr-2493"), |_| None).is_none(),
+            test_channel_api_key_if(true, |_| None).is_none(),
             "unset env var must fall through to the Keychain path"
         );
         assert!(
-            test_channel_api_key(Some("pr-2493"), |_| Some(String::new())).is_none(),
+            test_channel_api_key_if(true, |_| Some(String::new())).is_none(),
             "empty env var must fall through to the Keychain path"
         );
     }

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -275,10 +275,47 @@ fn dispatch_openrouter(
     )
 }
 
+/// Env var carrying the AI broker API key on disposable `pr-<N>` test channels.
+///
+/// **Never read on `main`, `alpha`, or `beta`.** Every `plexi-pr-<N>` build is a
+/// differently-signed binary, so its first Keychain read raises a macOS access
+/// dialog only a human can click — which stalls unattended PR validation. This
+/// var is the escape hatch for exactly that case, gated by
+/// [`crate::config::is_test_channel`] so a leaked env var can never redirect a
+/// real user build's credentials.
+pub const TEST_CHANNEL_API_KEY_ENV: &str = "PLEXI_TEST_OPENROUTER_API_KEY";
+
+/// Resolve the broker API key from the test-channel escape hatch.
+///
+/// Returns `None` — leaving the normal workspace-secrets → Keychain path fully
+/// intact — unless the running build is a `pr-<N>` channel *and*
+/// [`TEST_CHANNEL_API_KEY_ENV`] is set to a non-empty value. `lookup` is
+/// injected so this stays testable without mutating process env.
+fn test_channel_api_key(
+    channel: Option<&str>,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Option<String> {
+    if !crate::config::is_test_channel(channel) {
+        return None;
+    }
+    lookup(TEST_CHANNEL_API_KEY_ENV).filter(|v| !v.is_empty())
+}
+
 fn resolve_openrouter_api_key(
     api_key_env: &str,
     workspace_root: Option<&std::path::Path>,
 ) -> Result<String, String> {
+    // Test channels only: take the key straight from the environment so the
+    // Keychain (and its human-only access dialog) is never touched.
+    let channel = crate::config::build_channel();
+    if let Some(key) = test_channel_api_key(channel.as_deref(), |name| std::env::var(name).ok()) {
+        log::info!(
+            "ai_broker: resolved API key from {TEST_CHANNEL_API_KEY_ENV} (test channel {}) — Keychain skipped",
+            channel.as_deref().unwrap_or("?")
+        );
+        return Ok(key);
+    }
+
     // An empty value is treated as unset so it falls through to the keychain.
     let process_env = std::env::var(api_key_env).ok().filter(|v| !v.is_empty());
 
@@ -1207,6 +1244,46 @@ mod tests {
                 .unwrap_or("")
                 .contains("api_key_missing"),
             "missing-key error must surface the api_key_missing tag"
+        );
+    }
+
+    #[test]
+    fn test_channel_env_key_is_used_only_on_pr_channels() {
+        let present = |name: &str| {
+            assert_eq!(name, TEST_CHANNEL_API_KEY_ENV);
+            Some("stub-value".to_string())
+        };
+
+        assert_eq!(
+            test_channel_api_key(Some("pr-2493"), present).as_deref(),
+            Some("stub-value"),
+            "a pr-<N> build must take the key from the env escape hatch"
+        );
+
+        for production in [None, Some("alpha"), Some("beta"), Some("main")] {
+            assert!(
+                test_channel_api_key(production, present).is_none(),
+                "production channel {production:?} must never read {TEST_CHANNEL_API_KEY_ENV}"
+            );
+        }
+
+        for forged in ["pr-", "pr-evil", "pr-12a", "PR-1"] {
+            assert!(
+                test_channel_api_key(Some(forged), present).is_none(),
+                "channel '{forged}' must not qualify as a test channel"
+            );
+        }
+    }
+
+    #[test]
+    fn test_channel_env_key_falls_through_when_unset_or_empty() {
+        assert!(
+            test_channel_api_key(Some("pr-2493"), |_| None).is_none(),
+            "unset env var must fall through to the Keychain path"
+        );
+        assert!(
+            test_channel_api_key(Some("pr-2493"), |_| Some(String::new())).is_none(),
+            "empty env var must fall through to the Keychain path"
         );
     }
 


### PR DESCRIPTION
Batches two disjoint stints. No linked GitHub issues; `.stint/` is authoritative.

- **stint 0425** — PR/test channel builds read AI broker API key from env var, bypassing Keychain (`infra/testing`, `host/secrets`)
- **stint 0370** — apps/calc: expose calculator operations as connector tools (`apps/calc`, `sdk/python`)

## stint 0425 — test-channel API key

Every `plexi-pr-<N>` binary is signed differently, so its first Keychain read raises a macOS access dialog only a human can click. That stalled both the worker and the tester mid-run on PR #2418 and recurs on every PR touching the AI broker.

On a `pr-<N>` channel **only**, the broker now reads `PLEXI_TEST_OPENROUTER_API_KEY` and skips the Keychain entirely.

Security scoping — the escape hatch is deliberately narrow and explicit, not implicit:

- Gated by a new `config::is_test_channel`, which matches `pr-<N>` with an **all-digit** N. `main`, `alpha`, `beta`, and forged names like `pr-evil` / `pr-12a` / `PR-1` all fail the gate.
- The var is read from exactly one place (`test_channel_api_key` in `src/plexi_ai/broker.rs`), named after what it is, and documented as non-production at its definition.
- Unset or empty ⇒ falls through to the existing workspace-secrets → Keychain path, byte-for-byte unchanged. No production credential path was touched or widened.
- The env path logs one `info` trace naming the source and the channel — never the value.

Documented for the tester/babysitter flow in `.agents/skills/babysitter/SKILL.md` so `just pr-install` rounds are dialog-free.

## stint 0370 — calc connector tools

`apps/calc` declares `calc.add` / `subtract` / `multiply` / `divide` / `evaluate` via `ExposeTools` on init and answers inbound `ToolCall` events with `ToolResult`. All five are pure compute over their own arguments and never read or write display state, so all are `read_only=True` and the assistant auto-grants them.

`evaluate` hand-parses one `<number> <op> <number>` expression — deliberately not a general evaluator, and `eval` is nowhere near assistant input. Bad input, unknown tool names, malformed `input_json`, divide-by-zero, and non-finite (`inf`/`nan`) results all return a structured `ToolResult` error rather than raising or emitting JSON that violates the declared number-typed output schema.

No SDK change was needed: stint 0369 already shipped `AiTool` / `ExposeTools` / `ToolCall` / `ToolResult`. No UI change, no manifest change (`ExposeTools` is not capability-gated).

### Incidental fix found by doing 0370

The **native Python bridge** effect decoder (`decode_effects` in `src/host/wasm_python.rs`) never learned the v3.7 tool effects, so calc's new `ExposeTools` failed to decode and took `native_python_bridge_runs_calc_lifecycle` red. It now maps `ExposeTools` / `ToolResult` onto the WIT `declare-tools` / `tool-result` variants, re-serializing the SDK's schema **objects** into the WIT schema **string** fields, and rejects a non-object schema instead of silently accepting it. The production `_v3_runtime` path was already wired and is unchanged.

## Test evidence

- `cargo test --bin plexi` (env-stripped, memory watchdog attached): **1871 passed; 0 failed; 3 ignored**
- `plexi app test apps/calc`: **8 passed** — new coverage for the tool declaration set, read-only flags, every binary op, `evaluate` parsing, and the full error surface (bad operands, unknown tool, malformed JSON, div-by-zero, non-finite results, and "a tool call never emits SetState")
- `plexi app check apps/calc`: manifest, SDK shape, **types — mypy clean**, renders green at 4 sizes (31 nodes, unchanged — no UI delta)
- `mypy sdk/python/plexi_sdk/`: **no issues found in 27 source files**
- `just check-docs`: CLI, config, SDK, PGAP capability, coverage, and authoring-drift checks all up to date
- New Rust tests: `only_numbered_pr_channels_are_test_channels`, `test_channel_env_key_is_used_only_on_pr_channels`, `test_channel_env_key_falls_through_when_unset_or_empty`, `native_python_bridge_decodes_tool_result_effect`, `native_python_bridge_rejects_non_object_tool_schema`, plus the tool assertions added to `native_python_bridge_runs_calc_lifecycle`. The channel tests inject their env lookup, so no test mutates process env and no key value appears in any test.
- AI diff review: Codex, 2 passes. Pass 1 raised one P2 (non-finite results serializing as invalid JSON) — fixed with a `math.isfinite` guard plus regression cases. Pass 2: no actionable defects.
- Pre-existing and unrelated: `sdk/python/tests/test_version_unification.py` fails identically on the untouched `main` worktree (a stale installed `plexi-sdk` dist leaks in via `importlib.metadata`).

**Conclusion:** binary install required — 0425 changes credential resolution in the running host and 0370 needs a live assistant to call the tools. Validate with `just pr-install <PR>`, then drive `plexi-pr-<PR>`. Export `PLEXI_TEST_OPENROUTER_API_KEY` in the pane that starts the PR host so the Keychain dialog cannot stall the round; `/tools` should list the five `calc.*` tools with the calc app open.