### PR TITLE
feat(notes): context-scoped kept notes with descendant aggregation (stint 0557)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4586,24 +4586,41 @@ impl PlexiApp {
             .collect();
         let inbox_count = entries.len();
 
-        let workspace_slug = crate::config::active_workspace_root()
-            .and_then(|p| p.file_name().map(|n| n.to_os_string()))
-            .map(|n| n.to_string_lossy().into_owned());
-        let notes_dir = match workspace_slug {
-            Some(ref slug) => notes_base.join(slug),
-            None => notes_base,
-        };
-        entries.extend(
-            scan_dir(&notes_dir)
-                .iter()
-                .filter_map(|p| crate::notes::NotePickerEntry::load(p, false)),
-        );
+        // Kept notes are keyed per context root. Fold any legacy
+        // `notes/<workspace-slug>/` dirs into their context first — non-destructive
+        // and a no-op once there is nothing left to move.
+        crate::notes::migrate_legacy_workspace_notes(self.router.as_slice());
+
+        // Active context first, then every descendant context (path-component
+        // prefix match over the live context list, no filesystem discovery).
+        let scopes = crate::notes::context_notes_scopes(self.router.as_slice(), self.router.active());
+        for scope in &scopes {
+            entries.extend(scan_dir(&scope.dir).iter().filter_map(|p| {
+                crate::notes::NotePickerEntry::load(p, false)
+                    .map(|e| e.with_context_label(scope.label.clone()))
+            }));
+        }
+
+        // Belt and braces: a legacy dir whose migration could not complete stays
+        // readable for the context it belongs to rather than silently vanishing.
+        let legacy_dir = crate::notes::context_scope_root(self.router.active())
+            .file_name()
+            .map(|slug| notes_base.join(slug));
+        if let Some(legacy_dir) = legacy_dir.filter(|d| d.is_dir()) {
+            log::warn!("notes_picker: reading un-migrated legacy dir {legacy_dir:?}");
+            entries.extend(
+                scan_dir(&legacy_dir)
+                    .iter()
+                    .filter_map(|p| crate::notes::NotePickerEntry::load(p, false)),
+            );
+        }
 
         log::info!(
-            "notes_picker: {} inbox + {} kept notes ({:?})",
+            "notes_picker: {} inbox + {} kept notes across {} context scope(s) ({:?})",
             inbox_count,
             entries.len() - inbox_count,
-            notes_dir
+            scopes.len(),
+            scopes.iter().map(|s| &s.dir).collect::<Vec<_>>()
         );
         crate::host::event_log::emit(crate::host::event_log::HostEvent::NotesPickerOpened {
             inbox_count,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4603,9 +4603,10 @@ impl PlexiApp {
 
         // Belt and braces: a legacy dir whose migration could not complete stays
         // readable for the context it belongs to rather than silently vanishing.
-        let legacy_dir = crate::notes::context_scope_root(self.router.active())
-            .file_name()
-            .map(|slug| notes_base.join(slug));
+        let legacy_dir = crate::notes::unambiguous_legacy_notes_dir(
+            self.router.as_slice(),
+            self.router.active(),
+        );
         if let Some(legacy_dir) = legacy_dir.filter(|d| d.is_dir()) {
             log::warn!("notes_picker: reading un-migrated legacy dir {legacy_dir:?}");
             entries.extend(

--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -2,6 +2,61 @@ use super::pane::pane_send_cli;
 
 use super::binary_in_path;
 
+/// The context root this CLI invocation belongs to.
+///
+/// `PLEXI_CONTEXT_ROOT` is exported into panes of a context that has an explicit
+/// project root, so an in-pane `plexi notes` resolves to the same dir the GUI
+/// picker scans. Outside a pane, fall back to the workspace root the cwd sits in.
+///
+/// Known gap: a context with `root: None` exports no `PLEXI_CONTEXT_ROOT`, while
+/// the GUI keys that context's notes on `Context::path`. When the cwd's workspace
+/// root differs from that path, the CLI scans a different dir than the picker.
+/// Closing it means exporting the effective scope root into every pane's env,
+/// which is pane-env plumbing outside this change; the mismatch is logged below
+/// so it is observable rather than silent.
+fn cli_context_root() -> Option<std::path::PathBuf> {
+    if let Some(root) = std::env::var_os("PLEXI_CONTEXT_ROOT").filter(|v| !v.is_empty()) {
+        return Some(std::path::PathBuf::from(root));
+    }
+    let fallback = crate::config::active_workspace_root();
+    if std::env::var_os("PLEXI_PANE_ID").is_some() {
+        log::warn!(
+            "notes: pane exports no PLEXI_CONTEXT_ROOT (rootless context) — \
+             falling back to workspace root {fallback:?}, which may differ from the picker's dir"
+        );
+    }
+    fallback
+}
+
+/// Kept-notes dir for this invocation's context. Falls back to `notes/` itself
+/// when no context or workspace root can be resolved, matching the picker.
+fn cli_kept_notes_dir() -> std::path::PathBuf {
+    match cli_context_root() {
+        Some(root) => crate::notes::context_notes_dir(&root),
+        None => crate::config::config_dir().join("notes"),
+    }
+}
+
+/// Every dir holding this context's kept notes: the context-keyed dir, plus the
+/// legacy `notes/<workspace-slug>/` dir while it still exists.
+///
+/// The CLI has no live context list, so it cannot run the migration itself. It
+/// reads the legacy dir instead, which keeps existing notes visible to a
+/// CLI-only user between upgrade and the GUI's first picker open.
+fn cli_kept_notes_dirs() -> Vec<std::path::PathBuf> {
+    let mut dirs = vec![cli_kept_notes_dir()];
+    let legacy = cli_context_root()
+        .as_deref()
+        .and_then(|root| root.file_name())
+        .map(|slug| crate::config::config_dir().join("notes").join(slug))
+        .filter(|d| d.is_dir());
+    if let Some(legacy) = legacy {
+        log::info!("notes: including un-migrated legacy dir {legacy:?}");
+        dirs.push(legacy);
+    }
+    dirs
+}
+
 /// `plexi note "<text>"` — capture a quick note to the inbox.
 pub fn note_capture_cli(text: &str) -> i32 {
     let inbox_dir = crate::config::config_dir().join("notes").join("inbox");
@@ -24,8 +79,12 @@ pub fn note_capture_cli(text: &str) -> i32 {
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_default();
 
+    // `context_root` is what triage keys the keep destination on.
+    let context_root = cli_context_root()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default();
     let frontmatter = format!(
-        "---\ncaptured_at: {ts_human}\nsource: cli\ncwd: {cwd}\nworkspace: {workspace}\n---\n"
+        "---\ncaptured_at: {ts_human}\nsource: cli\ncwd: {cwd}\nworkspace: {workspace}\ncontext_root: {context_root}\n---\n"
     );
     let content = format!("{frontmatter}{}\n", text.trim());
 
@@ -104,21 +163,15 @@ pub fn notes_list_cli() -> i32 {
     // Always include inbox.
     let inbox_dir = notes_base.join("inbox");
 
-    // Workspace-scoped dir (kept notes).
-    let workspace_slug = crate::config::active_workspace_root()
-        .and_then(|p| p.file_name().map(|n| n.to_os_string()))
-        .map(|n| n.to_string_lossy().into_owned());
-    let workspace_dir = workspace_slug.map(|slug| notes_base.join(slug));
+    // Context-scoped dirs (kept notes), including any un-migrated legacy dir.
+    let mut dirs = vec![inbox_dir];
+    dirs.extend(cli_kept_notes_dirs());
 
-    log::info!(
-        "notes_list: scanning inbox={:?} workspace={:?}",
-        inbox_dir,
-        workspace_dir
-    );
+    log::info!("notes_list: scanning {dirs:?}");
 
     let mut paths: Vec<(std::time::SystemTime, std::path::PathBuf)> = Vec::new();
 
-    for dir in [Some(inbox_dir), workspace_dir].into_iter().flatten() {
+    for dir in dirs {
         let Ok(entries) = std::fs::read_dir(&dir) else {
             continue;
         };
@@ -143,15 +196,12 @@ pub fn notes_list_cli() -> i32 {
 ///
 /// Falls back to printing the notes directory when PLEXI_SOCKET is unset or fzf is absent.
 pub fn notes_open_cli() -> i32 {
-    let notes_base = crate::config::config_dir().join("notes");
-    let workspace_slug = crate::config::active_workspace_root()
-        .and_then(|p| p.file_name().map(|n| n.to_os_string()))
-        .map(|n| n.to_string_lossy().into_owned());
-    let notes_dir = match workspace_slug {
-        Some(ref slug) => notes_base.join(slug),
-        None => notes_base,
-    };
-    let notes_dir_str = notes_dir.display().to_string();
+    let notes_dirs = cli_kept_notes_dirs();
+    let notes_dir_str = notes_dirs
+        .iter()
+        .map(|d| d.display().to_string())
+        .collect::<Vec<_>>()
+        .join(" ");
 
     if !binary_in_path("fzf") {
         eprintln!("error: fzf is not installed — run `brew install fzf` to enable the picker");
@@ -164,16 +214,18 @@ pub fn notes_open_cli() -> i32 {
         return 0;
     }
 
-    let has_notes = notes_dir.is_dir()
-        && std::fs::read_dir(&notes_dir)
-            .map(|d| {
-                d.filter_map(|e| e.ok()).any(|e| {
-                    std::path::Path::new(&e.file_name())
-                        .extension()
-                        .map_or(false, |x| x == "md")
+    let has_notes = notes_dirs.iter().any(|dir| {
+        dir.is_dir()
+            && std::fs::read_dir(dir)
+                .map(|d| {
+                    d.filter_map(|e| e.ok()).any(|e| {
+                        std::path::Path::new(&e.file_name())
+                            .extension()
+                            .map_or(false, |x| x == "md")
+                    })
                 })
-            })
-            .unwrap_or(false);
+                .unwrap_or(false)
+    });
     if !has_notes {
         eprintln!("No notes yet. Create one with \u{2318}+Shift+Space.");
         return 0;
@@ -201,8 +253,13 @@ pub fn notes_open_cli() -> i32 {
     } else {
         "vim"
     };
+    let globs = notes_dirs
+        .iter()
+        .map(|d| format!("{}/*.md", d.display()))
+        .collect::<Vec<_>>()
+        .join(" ");
     let cmd = format!(
-        "selected=$(ls -t {notes_dir_str}/*.md 2>/dev/null | fzf --header='Select note'); [ -n \"$selected\" ] && {editor} \"$selected\"\r"
+        "selected=$(ls -t {globs} 2>/dev/null | fzf --header='Select note'); [ -n \"$selected\" ] && {editor} \"$selected\"\r"
     );
     log::info!("notes_open: injecting fzf picker into pane {pane_id}");
     pane_send_cli(pane_id, &cmd)

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -191,7 +191,27 @@ pub(crate) fn context_scope_root(ctx: &Context) -> &Path {
 /// `/foo/bar`. `Path::starts_with` compares whole components, which is exactly
 /// the boundary we need.
 pub(crate) fn is_self_or_descendant(candidate: &Path, ancestor: &Path) -> bool {
-    candidate.starts_with(ancestor)
+    comparable_scope_path(candidate).starts_with(comparable_scope_path(ancestor))
+}
+
+/// Resolve symlinks when both roots exist; otherwise remove lexical `.` / `..`
+/// components. This keeps descendant matching component-safe for live contexts
+/// whose configured roots use different but equivalent path spellings.
+fn comparable_scope_path(path: &Path) -> PathBuf {
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return canonical;
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
 }
 
 /// Lowercase ASCII slug of a path's final component, for human readability in
@@ -237,6 +257,21 @@ pub(crate) fn context_notes_dir(root: &Path) -> PathBuf {
         .join(context_notes_dir_name(root))
 }
 
+/// Legacy dir readable by `active` only when its basename identifies exactly
+/// one live context. Ambiguous legacy notes stay on disk but are never presented
+/// as belonging to an arbitrary context.
+pub(crate) fn unambiguous_legacy_notes_dir(
+    contexts: &[Context],
+    active: &Context,
+) -> Option<PathBuf> {
+    let slug = context_scope_root(active).file_name()?;
+    let matches = contexts
+        .iter()
+        .filter(|ctx| context_scope_root(ctx).file_name() == Some(slug))
+        .count();
+    (matches == 1).then(|| crate::config::config_dir().join("notes").join(slug))
+}
+
 /// One kept-notes directory to scan, with the label shown on its rows.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ContextNotesScope {
@@ -249,7 +284,10 @@ pub(crate) struct ContextNotesScope {
 /// Kept-note dirs for `active`: its own dir first, then every descendant
 /// context's dir in the order they appear in `contexts`. Pure string work over
 /// the live context list.
-pub(crate) fn context_notes_scopes(contexts: &[Context], active: &Context) -> Vec<ContextNotesScope> {
+pub(crate) fn context_notes_scopes(
+    contexts: &[Context],
+    active: &Context,
+) -> Vec<ContextNotesScope> {
     let active_root = context_scope_root(active);
     let mut seen = std::collections::HashSet::new();
     let mut scopes = vec![ContextNotesScope {
@@ -328,21 +366,23 @@ pub(crate) fn migrate_legacy_workspace_notes(contexts: &[Context]) -> NotesMigra
         return report;
     }
 
-    // Legacy slugs were the basename of the launch workspace root. Match on the
-    // basename of each context's scope root; shallowest context wins so a
-    // parent takes precedence over a same-named child.
-    let mut candidates: Vec<&Context> = contexts.iter().collect();
-    candidates.sort_by_key(|c| (c.depth, c.context_id));
-
     for (slug, src_dir) in legacy_dirs {
-        let Some(ctx) = candidates.iter().find(|c| {
-            context_scope_root(c)
-                .file_name()
-                .map(|n| n.to_string_lossy() == slug.as_str())
-                .unwrap_or(false)
-        }) else {
+        // A legacy slug contains only a basename. It cannot distinguish two
+        // contexts with the same basename, so ambiguity is unmappable rather
+        // than a license to pick one and misfile a person's notes.
+        let matches: Vec<&Context> = contexts
+            .iter()
+            .filter(|c| {
+                context_scope_root(c)
+                    .file_name()
+                    .map(|n| n.to_string_lossy() == slug.as_str())
+                    .unwrap_or(false)
+            })
+            .collect();
+        let [ctx] = matches.as_slice() else {
             log::warn!(
-                "notes_migration: no context matches legacy dir {slug:?} — leaving notes in place at {src_dir:?}"
+                "notes_migration: legacy dir {slug:?} has {} matching contexts — leaving notes in place at {src_dir:?}",
+                matches.len()
             );
             report.unmapped_dirs.push(slug);
             continue;
@@ -409,47 +449,85 @@ enum MigratedNote {
 /// Copy one note into `dest_dir`, verify it landed, then remove the source.
 /// Never overwrites and never removes a source whose copy is unconfirmed.
 fn migrate_one_note(src: &Path, dest_dir: &Path) -> std::io::Result<MigratedNote> {
+    use std::io::Write;
+
     let src_bytes = std::fs::read(src)?;
     let file_name = src
         .file_name()
         .ok_or_else(|| std::io::Error::other(format!("no file name in {src:?}")))?;
 
-    let mut dest = dest_dir.join(file_name);
-    if dest.exists() {
-        if std::fs::read(&dest).map(|b| b == src_bytes).unwrap_or(false) {
-            // Already migrated (or a re-run) — the destination is authoritative.
+    let primary = dest_dir.join(file_name);
+    if std::fs::read(&primary)
+        .map(|b| b == src_bytes)
+        .unwrap_or(false)
+    {
+        // Already migrated (or a re-run) — the destination is authoritative.
+        std::fs::remove_file(src)?;
+        return Ok(MigratedNote::AlreadyPresent(primary));
+    }
+
+    // A process may have died after confirming a suffixed collision copy but
+    // before removing the source. Reuse that byte-identical copy on the next
+    // pass instead of manufacturing `-legacy-1`, `-legacy-2`, and so on.
+    for dest in collision_destinations(dest_dir, src) {
+        if std::fs::read(&dest)
+            .map(|b| b == src_bytes)
+            .unwrap_or(false)
+        {
             std::fs::remove_file(src)?;
             return Ok(MigratedNote::AlreadyPresent(dest));
         }
-        dest = non_colliding_dest(dest_dir, src)?;
     }
 
-    std::fs::write(&dest, &src_bytes)?;
-    let landed = std::fs::metadata(&dest)?.len() as usize == src_bytes.len();
-    if !landed {
+    let (dest, mut file) = create_collision_safe_destination(dest_dir, src)?;
+    file.write_all(&src_bytes)?;
+    file.sync_all()?;
+    drop(file);
+    if std::fs::read(&dest)? != src_bytes {
         return Err(std::io::Error::other(format!(
-            "destination {dest:?} short-wrote; source kept"
+            "destination {dest:?} did not verify byte-for-byte; source kept"
         )));
     }
     std::fs::remove_file(src)?;
     Ok(MigratedNote::Moved(dest))
 }
 
-/// `<stem>-legacy[-N].md` inside `dest_dir`, first name that does not exist.
-fn non_colliding_dest(dest_dir: &Path, src: &Path) -> std::io::Result<PathBuf> {
+fn collision_destinations<'a>(
+    dest_dir: &'a Path,
+    src: &'a Path,
+) -> impl Iterator<Item = PathBuf> + 'a {
     let stem = src
         .file_stem()
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_else(|| "note".to_string());
-    for n in 0..1000 {
+    (0..1000).map(move |n| {
         let name = if n == 0 {
             format!("{stem}-legacy.md")
         } else {
             format!("{stem}-legacy-{n}.md")
         };
-        let candidate = dest_dir.join(name);
-        if !candidate.exists() {
-            return Ok(candidate);
+        dest_dir.join(name)
+    })
+}
+
+/// Atomically reserve either the original filename or a legacy suffix.
+fn create_collision_safe_destination(
+    dest_dir: &Path,
+    src: &Path,
+) -> std::io::Result<(PathBuf, std::fs::File)> {
+    let primary = dest_dir.join(
+        src.file_name()
+            .ok_or_else(|| std::io::Error::other(format!("no file name in {src:?}")))?,
+    );
+    for candidate in std::iter::once(primary).chain(collision_destinations(dest_dir, src)) {
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(file) => return Ok((candidate, file)),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(e) => return Err(e),
         }
     }
     Err(std::io::Error::other(format!(
@@ -771,10 +849,32 @@ mod tests {
     }
 
     #[test]
+    fn descendant_match_normalizes_equivalent_live_context_paths() {
+        assert!(is_self_or_descendant(
+            Path::new("/foo/project/tmp/../child"),
+            Path::new("/foo/project")
+        ));
+
+        let fixture = tempfile::tempdir().expect("temp fixture");
+        let real = fixture.path().join("real");
+        let child = real.join("child");
+        let alias = fixture.path().join("alias");
+        std::fs::create_dir_all(&child).expect("real child");
+        std::os::unix::fs::symlink(&real, &alias).expect("symlink");
+        assert!(
+            is_self_or_descendant(&alias.join("child"), &real),
+            "existing symlink aliases should compare by canonical components"
+        );
+    }
+
+    #[test]
     fn context_dir_name_is_readable_stable_and_collision_free() {
         let a = context_notes_dir_name(Path::new("/Users/x/Code/My Project"));
         assert!(a.starts_with("ctx-my-project-"), "unexpected dir name {a}");
-        assert_eq!(a, context_notes_dir_name(Path::new("/Users/x/Code/My Project")));
+        assert_eq!(
+            a,
+            context_notes_dir_name(Path::new("/Users/x/Code/My Project"))
+        );
 
         // Same basename, different root — must not collide.
         let b = context_notes_dir_name(Path::new("/Users/x/Other/My Project"));
@@ -893,6 +993,32 @@ mod tests {
     }
 
     #[test]
+    fn migration_retry_reuses_a_confirmed_collision_copy() {
+        let (_guard, notes) = notes_profile("collision-retry");
+        let root = Path::new("/tmp/plexi-mig-collision-retry/proj");
+        let contexts = vec![ctx(1, "proj", "/tmp/plexi-mig-collision-retry/proj", 0)];
+
+        let legacy = notes.join("proj");
+        std::fs::create_dir_all(&legacy).expect("legacy dir");
+        std::fs::write(legacy.join("a.md"), "legacy body").expect("seed legacy");
+        let dest = context_notes_dir(root);
+        std::fs::create_dir_all(&dest).expect("dest dir");
+        std::fs::write(dest.join("a.md"), "newer body").expect("seed primary");
+        // Simulate death after the collision copy was confirmed but before the
+        // source was removed.
+        std::fs::write(dest.join("a-legacy.md"), "legacy body").expect("seed prior copy");
+
+        let report = migrate_legacy_workspace_notes(&contexts);
+        assert_eq!(report.already_present, 1);
+        assert_eq!(report.moved, 0);
+        assert!(!legacy.exists());
+        assert!(
+            !dest.join("a-legacy-1.md").exists(),
+            "a retry must not duplicate the already-confirmed collision copy"
+        );
+    }
+
+    #[test]
     fn migration_treats_an_identical_destination_as_already_migrated() {
         let (_guard, notes) = notes_profile("identical");
         let root = Path::new("/tmp/plexi-mig-identical/proj");
@@ -930,6 +1056,28 @@ mod tests {
             "orphan note",
             "an unmappable note is never dropped"
         );
+    }
+
+    #[test]
+    fn migration_leaves_ambiguous_legacy_notes_in_place() {
+        let (_guard, notes) = notes_profile("ambiguous");
+        let contexts = vec![
+            ctx(1, "proj-a", "/tmp/plexi-mig-ambiguous/a/proj", 0),
+            ctx(2, "proj-b", "/tmp/plexi-mig-ambiguous/b/proj", 0),
+        ];
+
+        let legacy = notes.join("proj");
+        std::fs::create_dir_all(&legacy).expect("legacy dir");
+        std::fs::write(legacy.join("keep.md"), "ambiguous note").expect("seed");
+
+        let report = migrate_legacy_workspace_notes(&contexts);
+        assert_eq!(report.unmapped_dirs, vec!["proj".to_string()]);
+        assert_eq!(
+            std::fs::read_to_string(legacy.join("keep.md")).unwrap(),
+            "ambiguous note"
+        );
+        assert!(!context_notes_dir(Path::new("/tmp/plexi-mig-ambiguous/a/proj")).exists());
+        assert!(!context_notes_dir(Path::new("/tmp/plexi-mig-ambiguous/b/proj")).exists());
     }
 
     #[test]

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -480,14 +480,25 @@ fn migrate_one_note(src: &Path, dest_dir: &Path) -> std::io::Result<MigratedNote
     }
 
     let (dest, mut file) = create_collision_safe_destination(dest_dir, src)?;
-    file.write_all(&src_bytes)?;
-    file.sync_all()?;
+    if let Err(e) = file.write_all(&src_bytes).and_then(|_| file.sync_all()) {
+        drop(file);
+        let _ = std::fs::remove_file(&dest);
+        return Err(e);
+    }
     drop(file);
-    if std::fs::read(&dest)? != src_bytes {
+    let verified = std::fs::read(&dest).map(|bytes| bytes == src_bytes);
+    if !matches!(verified, Ok(true)) {
+        let detail = verified
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "byte mismatch".to_string());
+        let _ = std::fs::remove_file(&dest);
         return Err(std::io::Error::other(format!(
-            "destination {dest:?} did not verify byte-for-byte; source kept"
+            "destination {dest:?} did not verify byte-for-byte ({detail}); source kept"
         )));
     }
+    // Persist the new directory entry before removing the only old name.
+    std::fs::File::open(dest_dir)?.sync_all()?;
     std::fs::remove_file(src)?;
     Ok(MigratedNote::Moved(dest))
 }

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -103,6 +103,10 @@ pub(crate) struct NotePickerEntry {
     pub inbox: bool,
     /// Lowercased haystack for fuzzy search: title + file name + body.
     pub search_text: String,
+    /// Owning context name, set only for notes aggregated from a *descendant*
+    /// context. `None` means the note belongs to the active context (or inbox),
+    /// which needs no disambiguating chip.
+    pub context_label: Option<String>,
 }
 
 impl NotePickerEntry {
@@ -134,7 +138,14 @@ impl NotePickerEntry {
             preview: first_line,
             inbox,
             search_text,
+            context_label: None,
         })
+    }
+
+    /// Tag this entry as belonging to a descendant context, for the picker chip.
+    pub(crate) fn with_context_label(mut self, label: Option<String>) -> Self {
+        self.context_label = label;
+        self
     }
 }
 
@@ -148,6 +159,302 @@ pub(crate) fn fuzzy_match(query: &str, haystack: &str) -> bool {
         .filter(|c| !c.is_whitespace())
         .flat_map(|c| c.to_lowercase())
         .all(|q| chars.any(|h| h == q))
+}
+
+// ─── Context-scoped kept notes ───────────────────────────────────────────────
+//
+// Kept notes live in `notes/ctx-<slug>-<hash8>/`, keyed by the context's scope
+// root rather than by the directory Plexi happened to be launched from. The
+// picker unions the active context's dir with every descendant context's dir,
+// resolved by path-component-boundary prefix match over the live context list —
+// never by crawling the filesystem for context roots.
+
+use crate::host::context::Context;
+
+/// Directory names under `notes/` that are never a context's kept-note dir.
+const RESERVED_NOTES_DIRS: [&str; 2] = ["inbox", "trash"];
+
+/// Prefix marking a directory under `notes/` as context-keyed. Legacy
+/// workspace-slug dirs never carry it, which is what makes migration
+/// distinguishable and repeatable.
+const CONTEXT_DIR_PREFIX: &str = "ctx-";
+
+/// The path a context scopes its notes to: the explicit project `root` when set,
+/// otherwise the context's own `path`.
+pub(crate) fn context_scope_root(ctx: &Context) -> &Path {
+    ctx.root.as_deref().unwrap_or(ctx.path.as_path())
+}
+
+/// `true` when `candidate` is `ancestor` itself or lives beneath it.
+///
+/// Component-wise, not textual: `/foo/barbaz` is **not** a descendant of
+/// `/foo/bar`. `Path::starts_with` compares whole components, which is exactly
+/// the boundary we need.
+pub(crate) fn is_self_or_descendant(candidate: &Path, ancestor: &Path) -> bool {
+    candidate.starts_with(ancestor)
+}
+
+/// Lowercase ASCII slug of a path's final component, for human readability in
+/// the dir name. Never load-bearing for identity — the hash is.
+fn readable_slug(root: &Path) -> String {
+    let base = root
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let mut slug = String::new();
+    for ch in base.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.extend(ch.to_lowercase());
+        } else if !slug.ends_with('-') {
+            slug.push('-');
+        }
+        if slug.len() >= 24 {
+            break;
+        }
+    }
+    let slug = slug.trim_matches('-').to_string();
+    if slug.is_empty() {
+        "root".to_string()
+    } else {
+        slug
+    }
+}
+
+/// Directory name holding kept notes for the context rooted at `root`:
+/// `ctx-<readable-slug>-<sha256-prefix>`. The hash is over the full path, so
+/// two same-named roots never collide.
+pub(crate) fn context_notes_dir_name(root: &Path) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(root.to_string_lossy().as_bytes());
+    let hash: String = digest.iter().take(4).map(|b| format!("{b:02x}")).collect();
+    format!("{CONTEXT_DIR_PREFIX}{}-{hash}", readable_slug(root))
+}
+
+/// Absolute kept-notes directory for the context rooted at `root`.
+pub(crate) fn context_notes_dir(root: &Path) -> PathBuf {
+    crate::config::config_dir()
+        .join("notes")
+        .join(context_notes_dir_name(root))
+}
+
+/// One kept-notes directory to scan, with the label shown on its rows.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ContextNotesScope {
+    pub dir: PathBuf,
+    /// Context name for descendant scopes; `None` for the active context, whose
+    /// notes need no disambiguating chip.
+    pub label: Option<String>,
+}
+
+/// Kept-note dirs for `active`: its own dir first, then every descendant
+/// context's dir in the order they appear in `contexts`. Pure string work over
+/// the live context list.
+pub(crate) fn context_notes_scopes(contexts: &[Context], active: &Context) -> Vec<ContextNotesScope> {
+    let active_root = context_scope_root(active);
+    let mut seen = std::collections::HashSet::new();
+    let mut scopes = vec![ContextNotesScope {
+        dir: context_notes_dir(active_root),
+        label: None,
+    }];
+    seen.insert(context_notes_dir_name(active_root));
+
+    for ctx in contexts {
+        if ctx.context_id == active.context_id {
+            continue;
+        }
+        let root = context_scope_root(ctx);
+        if !is_self_or_descendant(root, active_root) {
+            continue;
+        }
+        let name = context_notes_dir_name(root);
+        if !seen.insert(name) {
+            continue;
+        }
+        scopes.push(ContextNotesScope {
+            dir: context_notes_dir(root),
+            label: Some(ctx.name.clone()),
+        });
+    }
+    scopes
+}
+
+/// Outcome of one migration pass. Counts are for logging and tests only.
+#[derive(Default, Debug, PartialEq, Eq)]
+pub(crate) struct NotesMigrationReport {
+    /// Notes copied into a context dir and removed from the legacy dir.
+    pub moved: usize,
+    /// Notes already present at the destination — left alone.
+    pub already_present: usize,
+    /// Legacy dirs with no matching context — left in place untouched.
+    pub unmapped_dirs: Vec<String>,
+    /// Notes that failed to migrate. The source copy is always still there.
+    pub failed: usize,
+}
+
+/// Migrate legacy `notes/<workspace-slug>/` dirs into their context's dir.
+///
+/// Data-safety rules, in order:
+/// - copy first, verify the destination byte length, only then remove the source
+/// - a destination that already holds an identical file counts as migrated
+/// - a destination that holds a *different* file of the same name gets the
+///   source under a suffixed name; nothing is ever overwritten
+/// - a legacy dir with no matching context is logged and left completely alone
+/// - the legacy dir is removed only when `remove_dir` succeeds, i.e. it is empty
+///
+/// Idempotent: a second pass finds no legacy dirs (or finds identical
+/// destinations) and moves nothing.
+pub(crate) fn migrate_legacy_workspace_notes(contexts: &[Context]) -> NotesMigrationReport {
+    let mut report = NotesMigrationReport::default();
+    let notes_base = crate::config::config_dir().join("notes");
+
+    let Ok(entries) = std::fs::read_dir(&notes_base) else {
+        return report;
+    };
+
+    // Deterministic order so a partial failure replays the same way.
+    let mut legacy_dirs: Vec<(String, PathBuf)> = entries
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().into_owned();
+            let reserved = RESERVED_NOTES_DIRS.contains(&name.as_str())
+                || name.starts_with(CONTEXT_DIR_PREFIX);
+            (!reserved).then_some((name, e.path()))
+        })
+        .collect();
+    legacy_dirs.sort();
+
+    if legacy_dirs.is_empty() {
+        return report;
+    }
+
+    // Legacy slugs were the basename of the launch workspace root. Match on the
+    // basename of each context's scope root; shallowest context wins so a
+    // parent takes precedence over a same-named child.
+    let mut candidates: Vec<&Context> = contexts.iter().collect();
+    candidates.sort_by_key(|c| (c.depth, c.context_id));
+
+    for (slug, src_dir) in legacy_dirs {
+        let Some(ctx) = candidates.iter().find(|c| {
+            context_scope_root(c)
+                .file_name()
+                .map(|n| n.to_string_lossy() == slug.as_str())
+                .unwrap_or(false)
+        }) else {
+            log::warn!(
+                "notes_migration: no context matches legacy dir {slug:?} — leaving notes in place at {src_dir:?}"
+            );
+            report.unmapped_dirs.push(slug);
+            continue;
+        };
+
+        let dest_dir = context_notes_dir(context_scope_root(ctx));
+        if let Err(e) = std::fs::create_dir_all(&dest_dir) {
+            log::warn!("notes_migration: failed to create {dest_dir:?}: {e}");
+            report.failed += 1;
+            continue;
+        }
+
+        let Ok(notes) = std::fs::read_dir(&src_dir) else {
+            log::warn!("notes_migration: failed to read {src_dir:?}");
+            report.failed += 1;
+            continue;
+        };
+        let mut note_paths: Vec<PathBuf> = notes
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().map_or(false, |x| x == "md"))
+            .collect();
+        note_paths.sort();
+
+        for src in note_paths {
+            match migrate_one_note(&src, &dest_dir) {
+                Ok(MigratedNote::Moved(dest)) => {
+                    report.moved += 1;
+                    log::info!("notes_migration: moved {src:?} → {dest:?}");
+                }
+                Ok(MigratedNote::AlreadyPresent(dest)) => {
+                    report.already_present += 1;
+                    log::info!("notes_migration: {src:?} already present at {dest:?}");
+                }
+                Err(e) => {
+                    report.failed += 1;
+                    log::warn!("notes_migration: leaving {src:?} in place: {e}");
+                }
+            }
+        }
+
+        // Only succeeds when the dir is now empty; a leftover non-note file or a
+        // failed note keeps the dir, which is the safe outcome.
+        if std::fs::remove_dir(&src_dir).is_ok() {
+            log::info!("notes_migration: removed empty legacy dir {src_dir:?}");
+        }
+    }
+
+    log::info!(
+        "notes_migration: moved={} already_present={} failed={} unmapped={:?}",
+        report.moved,
+        report.already_present,
+        report.failed,
+        report.unmapped_dirs
+    );
+    report
+}
+
+enum MigratedNote {
+    Moved(PathBuf),
+    AlreadyPresent(PathBuf),
+}
+
+/// Copy one note into `dest_dir`, verify it landed, then remove the source.
+/// Never overwrites and never removes a source whose copy is unconfirmed.
+fn migrate_one_note(src: &Path, dest_dir: &Path) -> std::io::Result<MigratedNote> {
+    let src_bytes = std::fs::read(src)?;
+    let file_name = src
+        .file_name()
+        .ok_or_else(|| std::io::Error::other(format!("no file name in {src:?}")))?;
+
+    let mut dest = dest_dir.join(file_name);
+    if dest.exists() {
+        if std::fs::read(&dest).map(|b| b == src_bytes).unwrap_or(false) {
+            // Already migrated (or a re-run) — the destination is authoritative.
+            std::fs::remove_file(src)?;
+            return Ok(MigratedNote::AlreadyPresent(dest));
+        }
+        dest = non_colliding_dest(dest_dir, src)?;
+    }
+
+    std::fs::write(&dest, &src_bytes)?;
+    let landed = std::fs::metadata(&dest)?.len() as usize == src_bytes.len();
+    if !landed {
+        return Err(std::io::Error::other(format!(
+            "destination {dest:?} short-wrote; source kept"
+        )));
+    }
+    std::fs::remove_file(src)?;
+    Ok(MigratedNote::Moved(dest))
+}
+
+/// `<stem>-legacy[-N].md` inside `dest_dir`, first name that does not exist.
+fn non_colliding_dest(dest_dir: &Path, src: &Path) -> std::io::Result<PathBuf> {
+    let stem = src
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "note".to_string());
+    for n in 0..1000 {
+        let name = if n == 0 {
+            format!("{stem}-legacy.md")
+        } else {
+            format!("{stem}-legacy-{n}.md")
+        };
+        let candidate = dest_dir.join(name);
+        if !candidate.exists() {
+            return Ok(candidate);
+        }
+    }
+    Err(std::io::Error::other(format!(
+        "no free destination name for {src:?} in {dest_dir:?}"
+    )))
 }
 
 // ─── Triage actions ──────────────────────────────────────────────────────────
@@ -415,6 +722,237 @@ mod tests {
         assert_eq!(entry.title, "note-20260611.md");
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ─── Context-scoped kept notes ───────────────────────────────────────────
+
+    fn ctx(id: u64, name: &str, root: &str, depth: u32) -> Context {
+        Context {
+            name: name.to_string(),
+            path: PathBuf::from(root),
+            root: Some(PathBuf::from(root)),
+            description: None,
+            context_id: id,
+            parent_id: None,
+            depth,
+            parked: false,
+        }
+    }
+
+    /// Isolated profile dir + the `notes/` base inside it.
+    fn notes_profile(tag: &str) -> (crate::config::TestProfileDirGuard, PathBuf) {
+        let profile = std::env::temp_dir().join(format!(
+            "plexi-notes-scope-{tag}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&profile);
+        let notes = profile.join("notes");
+        std::fs::create_dir_all(&notes).expect("create notes base");
+        let guard = crate::config::set_test_profile_dir(profile);
+        (guard, notes)
+    }
+
+    #[test]
+    fn descendant_match_respects_path_component_boundary() {
+        let bar = Path::new("/foo/bar");
+        assert!(
+            is_self_or_descendant(Path::new("/foo/bar"), bar),
+            "a context is its own scope"
+        );
+        assert!(is_self_or_descendant(Path::new("/foo/bar/sub"), bar));
+        assert!(is_self_or_descendant(Path::new("/foo/bar/sub/deep"), bar));
+        assert!(
+            !is_self_or_descendant(Path::new("/foo/barbaz"), bar),
+            "a textual prefix that is not a component boundary is not a descendant"
+        );
+        assert!(!is_self_or_descendant(Path::new("/foo"), bar));
+        assert!(!is_self_or_descendant(Path::new("/other/bar"), bar));
+    }
+
+    #[test]
+    fn context_dir_name_is_readable_stable_and_collision_free() {
+        let a = context_notes_dir_name(Path::new("/Users/x/Code/My Project"));
+        assert!(a.starts_with("ctx-my-project-"), "unexpected dir name {a}");
+        assert_eq!(a, context_notes_dir_name(Path::new("/Users/x/Code/My Project")));
+
+        // Same basename, different root — must not collide.
+        let b = context_notes_dir_name(Path::new("/Users/x/Other/My Project"));
+        assert_ne!(a, b);
+
+        assert!(context_notes_dir_name(Path::new("/")).starts_with("ctx-root-"));
+    }
+
+    #[test]
+    fn scopes_union_active_with_descendants_only() {
+        let (_guard, _notes) = notes_profile("scopes");
+        let contexts = vec![
+            ctx(1, "proj", "/proj", 0),
+            ctx(2, "sub", "/proj/sub", 1),
+            ctx(3, "deep", "/proj/sub/deep", 2),
+            ctx(4, "sibling", "/projx", 0),
+            ctx(5, "elsewhere", "/other", 0),
+        ];
+
+        let from_root = context_notes_scopes(&contexts, &contexts[0]);
+        assert_eq!(
+            from_root
+                .iter()
+                .map(|s| s.label.clone())
+                .collect::<Vec<_>>(),
+            vec![None, Some("sub".to_string()), Some("deep".to_string())],
+            "root sees itself unlabeled plus every descendant, and never /projx"
+        );
+        assert_eq!(from_root[0].dir, context_notes_dir(Path::new("/proj")));
+
+        // A child sees only itself and its own descendants — no ancestor walk (v2).
+        let from_sub = context_notes_scopes(&contexts, &contexts[1]);
+        assert_eq!(
+            from_sub.iter().map(|s| s.label.clone()).collect::<Vec<_>>(),
+            vec![None, Some("deep".to_string())]
+        );
+
+        let from_leaf = context_notes_scopes(&contexts, &contexts[2]);
+        assert_eq!(from_leaf.len(), 1);
+    }
+
+    #[test]
+    fn scopes_dedupe_contexts_sharing_a_root() {
+        let (_guard, _notes) = notes_profile("dedupe");
+        let contexts = vec![ctx(1, "a", "/proj", 0), ctx(2, "a-again", "/proj", 0)];
+        let scopes = context_notes_scopes(&contexts, &contexts[0]);
+        assert_eq!(scopes.len(), 1, "one dir per root, not one per context");
+    }
+
+    #[test]
+    fn migration_moves_legacy_notes_and_is_idempotent() {
+        let (_guard, notes) = notes_profile("migrate");
+        let contexts = vec![ctx(1, "proj", "/tmp/plexi-mig/proj", 0)];
+
+        let legacy = notes.join("proj");
+        std::fs::create_dir_all(&legacy).expect("legacy dir");
+        std::fs::write(legacy.join("a.md"), "note a").expect("seed a");
+        std::fs::write(legacy.join("b.md"), "note b").expect("seed b");
+        // Non-note files are never touched, and keep the legacy dir alive.
+        std::fs::write(legacy.join("README.txt"), "keep me").expect("seed txt");
+
+        let report = migrate_legacy_workspace_notes(&contexts);
+        assert_eq!(report.moved, 2);
+        assert_eq!(report.failed, 0);
+        assert!(report.unmapped_dirs.is_empty());
+
+        let dest = context_notes_dir(Path::new("/tmp/plexi-mig/proj"));
+        assert_eq!(
+            std::fs::read_to_string(dest.join("a.md")).expect("a migrated"),
+            "note a"
+        );
+        assert!(!legacy.join("a.md").exists(), "source removed after verify");
+        assert!(
+            legacy.join("README.txt").exists(),
+            "non-note files are left alone"
+        );
+
+        // Second pass moves nothing.
+        let again = migrate_legacy_workspace_notes(&contexts);
+        assert_eq!(again.moved, 0);
+        assert_eq!(again.already_present, 0);
+        assert_eq!(again.failed, 0);
+        assert_eq!(
+            std::fs::read_dir(&dest).unwrap().count(),
+            2,
+            "a re-run must not duplicate notes"
+        );
+    }
+
+    #[test]
+    fn migration_never_overwrites_a_differing_destination() {
+        let (_guard, notes) = notes_profile("collide");
+        let root = Path::new("/tmp/plexi-mig-collide/proj");
+        let contexts = vec![ctx(1, "proj", "/tmp/plexi-mig-collide/proj", 0)];
+
+        let legacy = notes.join("proj");
+        std::fs::create_dir_all(&legacy).expect("legacy dir");
+        std::fs::write(legacy.join("a.md"), "legacy body").expect("seed legacy");
+
+        let dest = context_notes_dir(root);
+        std::fs::create_dir_all(&dest).expect("dest dir");
+        std::fs::write(dest.join("a.md"), "existing body").expect("seed dest");
+
+        let report = migrate_legacy_workspace_notes(&contexts);
+        assert_eq!(report.moved, 1);
+        assert_eq!(
+            std::fs::read_to_string(dest.join("a.md")).unwrap(),
+            "existing body",
+            "the pre-existing note must survive untouched"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dest.join("a-legacy.md")).unwrap(),
+            "legacy body",
+            "the legacy note lands under a suffixed name"
+        );
+    }
+
+    #[test]
+    fn migration_treats_an_identical_destination_as_already_migrated() {
+        let (_guard, notes) = notes_profile("identical");
+        let root = Path::new("/tmp/plexi-mig-identical/proj");
+        let contexts = vec![ctx(1, "proj", "/tmp/plexi-mig-identical/proj", 0)];
+
+        let legacy = notes.join("proj");
+        std::fs::create_dir_all(&legacy).expect("legacy dir");
+        std::fs::write(legacy.join("a.md"), "same body").expect("seed legacy");
+        let dest = context_notes_dir(root);
+        std::fs::create_dir_all(&dest).expect("dest dir");
+        std::fs::write(dest.join("a.md"), "same body").expect("seed dest");
+
+        let report = migrate_legacy_workspace_notes(&contexts);
+        assert_eq!(report.already_present, 1);
+        assert_eq!(report.moved, 0);
+        assert_eq!(std::fs::read_dir(&dest).unwrap().count(), 1);
+        assert!(!legacy.exists(), "emptied legacy dir is removed");
+    }
+
+    #[test]
+    fn migration_leaves_unmapped_legacy_notes_in_place() {
+        let (_guard, notes) = notes_profile("unmapped");
+        let contexts = vec![ctx(1, "proj", "/tmp/plexi-mig-unmapped/proj", 0)];
+
+        let orphan = notes.join("some-old-workspace");
+        std::fs::create_dir_all(&orphan).expect("orphan dir");
+        std::fs::write(orphan.join("keep.md"), "orphan note").expect("seed orphan");
+
+        let report = migrate_legacy_workspace_notes(&contexts);
+        assert_eq!(report.moved, 0);
+        assert_eq!(report.failed, 0);
+        assert_eq!(report.unmapped_dirs, vec!["some-old-workspace".to_string()]);
+        assert_eq!(
+            std::fs::read_to_string(orphan.join("keep.md")).unwrap(),
+            "orphan note",
+            "an unmappable note is never dropped"
+        );
+    }
+
+    #[test]
+    fn migration_skips_reserved_and_already_context_keyed_dirs() {
+        let (_guard, notes) = notes_profile("reserved");
+        let contexts = vec![ctx(1, "proj", "/tmp/plexi-mig-reserved/proj", 0)];
+
+        for reserved in ["inbox", "trash"] {
+            let dir = notes.join(reserved);
+            std::fs::create_dir_all(&dir).expect("reserved dir");
+            std::fs::write(dir.join("n.md"), "stay").expect("seed");
+        }
+        let ctx_dir = notes.join(context_notes_dir_name(Path::new(
+            "/tmp/plexi-mig-reserved/proj",
+        )));
+        std::fs::create_dir_all(&ctx_dir).expect("ctx dir");
+        std::fs::write(ctx_dir.join("n.md"), "stay").expect("seed");
+
+        let report = migrate_legacy_workspace_notes(&contexts);
+        assert_eq!(report, NotesMigrationReport::default());
+        assert!(notes.join("inbox").join("n.md").exists());
+        assert!(notes.join("trash").join("n.md").exists());
+        assert!(ctx_dir.join("n.md").exists());
     }
 
     #[test]

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -351,8 +351,15 @@ impl PlexiApp {
                             } else {
                                 entry.preview.chars().take(50).collect()
                             };
+                            // Descendant-context notes carry their context name so
+                            // a root "master view" stays legible.
+                            let chip: &str = if entry.inbox {
+                                "inbox"
+                            } else {
+                                entry.context_label.as_deref().unwrap_or("note")
+                            };
                             let row_response = ListRow::new(&entry.title)
-                                .metadata_chips(if entry.inbox { &["inbox"] } else { &["note"] })
+                                .metadata_chips(std::slice::from_ref(&chip))
                                 .secondary(&secondary)
                                 .selected(is_selected)
                                 .show(ui, &colors);
@@ -415,6 +422,7 @@ mod tests {
             inbox: false,
             search_text: preview.to_lowercase(),
             path,
+            context_label: None,
         }
     }
 
@@ -538,6 +546,103 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
+    /// Issue #2491's Done-When, end to end through `open_notes_picker`: a note
+    /// kept in a child context shows in the child's picker *and* the parent's,
+    /// a parent's note never leaks down into the child, and inbox is global.
+    #[test]
+    fn notes_picker_unions_active_context_with_descendants() {
+        let ctx = egui::Context::default();
+        let frame_tick = crate::platform::logging::FrameTick::default();
+        let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+        let profile = std::env::temp_dir()
+            .join(format!("plexi-notes-ctx-scope-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&profile);
+        let notes = profile.join("notes");
+        std::fs::create_dir_all(notes.join("inbox")).expect("inbox");
+        let _guard = crate::config::set_test_profile_dir(profile.clone());
+
+        let parent_root = std::path::PathBuf::from("/tmp/plexi-ctx-scope/proj");
+        let child_root = parent_root.join("sub");
+        // Textual-prefix sibling that must never be aggregated.
+        let sibling_root = std::path::PathBuf::from("/tmp/plexi-ctx-scope/projx");
+
+        let seed = |root: &std::path::Path, title: &str| {
+            let dir = crate::notes::context_notes_dir(root);
+            std::fs::create_dir_all(&dir).expect("context notes dir");
+            std::fs::write(dir.join(format!("{title}.md")), format!("body of {title}"))
+                .expect("seed kept note");
+        };
+        seed(&parent_root, "parent-note");
+        seed(&child_root, "child-note");
+        seed(&sibling_root, "sibling-note");
+        std::fs::write(notes.join("inbox").join("inbox-note.md"), "captured")
+            .expect("seed inbox note");
+
+        let mk_ctx = |id: u64, name: &str, root: &std::path::Path, depth: u32| {
+            crate::host::context::Context {
+                name: name.to_string(),
+                path: root.to_path_buf(),
+                root: Some(root.to_path_buf()),
+                description: None,
+                context_id: id,
+                parent_id: (depth > 0).then_some(1),
+                depth,
+                parked: false,
+            }
+        };
+        // Slot 0 is the constructor's own context; append the three under test.
+        app.router.push(mk_ctx(10, "proj", &parent_root, 0));
+        app.router.push(mk_ctx(11, "sub", &child_root, 1));
+        app.router.push(mk_ctx(12, "projx", &sibling_root, 0));
+        let parent_idx = app.router.position(|c| c.context_id == 10).expect("parent");
+        let child_idx = app.router.position(|c| c.context_id == 11).expect("child");
+
+        let titles = |app: &PlexiApp| -> Vec<String> {
+            app.notes_picker_entries
+                .iter()
+                .map(|e| e.title.clone())
+                .collect()
+        };
+
+        app.router.set_active(parent_idx);
+        app.open_notes_picker();
+        let from_parent = titles(&app);
+        assert!(
+            from_parent.contains(&"body of parent-note".to_string()),
+            "parent sees its own note: {from_parent:?}"
+        );
+        assert!(
+            from_parent.contains(&"body of child-note".to_string()),
+            "parent aggregates the descendant context: {from_parent:?}"
+        );
+        assert!(
+            !from_parent.contains(&"body of sibling-note".to_string()),
+            "/projx is a textual prefix, not a descendant of /proj: {from_parent:?}"
+        );
+        assert!(from_parent.contains(&"captured".to_string()), "inbox is global");
+        assert_eq!(
+            app.notes_picker_entries
+                .iter()
+                .find(|e| e.title == "body of child-note")
+                .and_then(|e| e.context_label.clone()),
+            Some("sub".to_string()),
+            "descendant rows carry their context name for the master view"
+        );
+
+        app.router.set_active(child_idx);
+        app.open_notes_picker();
+        let from_child = titles(&app);
+        assert!(from_child.contains(&"body of child-note".to_string()));
+        assert!(
+            !from_child.contains(&"body of parent-note".to_string()),
+            "no ancestor walk in v1: {from_child:?}"
+        );
+        assert!(from_child.contains(&"captured".to_string()), "inbox is global");
+
+        let _ = std::fs::remove_dir_all(&profile);
+    }
+
     #[test]
     fn notes_picker_open_selected_lands_caret_at_document_end() {
         let ctx = egui::Context::default();
@@ -650,6 +755,7 @@ mod tests {
             preview: body.to_string(),
             inbox: false,
             search_text: format!("{title} {body}").to_lowercase(),
+            context_label: None,
         };
         app.notes_picker_entries = vec![
             mk("groceries", "milk and eggs"),

--- a/src/overlays/notes_triage.rs
+++ b/src/overlays/notes_triage.rs
@@ -306,21 +306,25 @@ impl PlexiApp {
         }
     }
 
-    /// Move `note` to `notes/<workspace>/` using the workspace slug from the note's frontmatter.
+    /// Move `note` into its owning context's kept-notes dir.
+    ///
+    /// The note's captured `context_root` wins over the active context, so a note
+    /// taken in a subproject is kept there even when triaged from elsewhere.
     pub(crate) fn notes_triage_keep(&self, note: &InboxNote) {
-        let active_root = crate::config::active_workspace_root();
-        let active_slug: Option<String> = active_root
-            .as_ref()
-            .and_then(|p| p.file_name())
-            .and_then(|n| n.to_str())
-            .map(|s| s.to_string());
-        let workspace = note
+        // A context without an explicit `root` writes `context_root: ""`. An empty
+        // value is *absent*, not a path — filing under the hash of "" would put the
+        // note in a dir no picker ever scans.
+        let captured_root = note
             .frontmatter
-            .workspace
+            .context_root
             .as_deref()
-            .or_else(|| active_slug.as_deref())
-            .unwrap_or("default");
-        self.notes_triage_keep_to(note, workspace);
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(std::path::PathBuf::from);
+        let root = captured_root.unwrap_or_else(|| {
+            crate::notes::context_scope_root(self.router.active()).to_path_buf()
+        });
+        self.notes_triage_keep_to(note, &crate::notes::context_notes_dir_name(&root));
     }
 
     /// Move `note` to `notes/<workspace>/` using an explicit workspace slug.
@@ -441,6 +445,51 @@ mod tests {
         let frame_tick = crate::platform::logging::FrameTick::default();
         let (app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
         app
+    }
+
+    /// Keep files a note into the context that captured it, and treats an empty
+    /// `context_root` as absent rather than as the path `""` — the latter hashes
+    /// to a dir no picker ever scans.
+    #[test]
+    fn triage_keep_files_into_the_capturing_context() {
+        let profile = std::env::temp_dir().join(format!("plexi-triage-keep-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&profile);
+        let inbox = profile.join("notes").join("inbox");
+        std::fs::create_dir_all(&inbox).expect("inbox");
+        let _guard = crate::config::set_test_profile_dir(profile.clone());
+
+        let mut app = test_app();
+        let active_root = std::path::PathBuf::from("/tmp/plexi-triage-active");
+        app.router.get_mut(0).root = Some(active_root.clone());
+
+        // Captured in a *different* context — keep must follow the capture.
+        let captured_root = std::path::PathBuf::from("/tmp/plexi-triage-captured");
+        let mut note = inbox_note("captured");
+        note.path = inbox.join("captured.md");
+        note.frontmatter.context_root = Some(captured_root.display().to_string());
+        std::fs::write(&note.path, "captured body").expect("seed");
+        app.notes_triage_keep(&note);
+        assert!(
+            crate::notes::context_notes_dir(&captured_root)
+                .join("captured.md")
+                .exists(),
+            "kept into the capturing context's dir"
+        );
+
+        // Empty frontmatter value → fall back to the active context.
+        let mut rootless = inbox_note("rootless");
+        rootless.path = inbox.join("rootless.md");
+        rootless.frontmatter.context_root = Some(String::new());
+        std::fs::write(&rootless.path, "rootless body").expect("seed");
+        app.notes_triage_keep(&rootless);
+        assert!(
+            crate::notes::context_notes_dir(&active_root)
+                .join("rootless.md")
+                .exists(),
+            "an empty context_root must not file the note under the hash of \"\""
+        );
+
+        let _ = std::fs::remove_dir_all(&profile);
     }
 
     #[test]

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1046,6 +1046,81 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
+    /// Visual review surface for context-scoped kept notes (stint 0557): the
+    /// picker as a root context's "master view" — global inbox on top, the
+    /// active context's own notes chipped `note`, and aggregated descendant
+    /// notes chipped with their context name. Geometry assertions cannot prove
+    /// the chips read well, so this renders realistic seeded content.
+    #[test]
+    fn screenshot_notes_picker_context_chips() {
+        let mut h = PlexiUiHarness::new_sized(900.0, 760.0);
+        h.step();
+        add_focused_pane(&mut h);
+        h.step();
+
+        h.with_app_mut(|app| {
+            app.open_notes_picker();
+            let mk = |title: &str, preview: &str, inbox: bool, label: Option<&str>| {
+                crate::notes::NotePickerEntry {
+                    path: std::env::temp_dir().join(format!("plexi-ctx-chip-{title}.md")),
+                    title: title.to_string(),
+                    preview: preview.to_string(),
+                    inbox,
+                    search_text: title.to_lowercase(),
+                    context_label: label.map(|s| s.to_string()),
+                }
+            };
+            app.notes_picker_entries = vec![
+                mk(
+                    "ask Sam about the staging cert",
+                    "expires 2026-08-03, renewal is manual",
+                    true,
+                    None,
+                ),
+                mk("release checklist", "tag, changelog, notarize, publish", true, None),
+                mk(
+                    "north star — what v1 has to prove",
+                    "one workspace you never leave",
+                    false,
+                    None,
+                ),
+                mk("pricing notes", "seat-based vs usage, land on seats", false, None),
+                mk(
+                    "wasm wire format decisions",
+                    "postcard over JSON for frame payloads",
+                    false,
+                    Some("plexi-runtime"),
+                ),
+                mk(
+                    "font bootstrap ordering trap",
+                    "ui-medium binds on the next frame, not this one",
+                    false,
+                    Some("plexi-runtime"),
+                ),
+                mk(
+                    "onboarding copy pass",
+                    "cut the second paragraph entirely",
+                    false,
+                    Some("website"),
+                ),
+            ];
+            app.notes_picker_selected = 0;
+        });
+        h.run_steps(2);
+
+        let out = "/tmp/plexi_notes_picker_context_chips.png";
+        h.save_screenshot(out).expect("render failed");
+        h.with_app(|app| {
+            assert!(
+                app.notes_picker_entries
+                    .iter()
+                    .any(|e| e.context_label.as_deref() == Some("plexi-runtime")),
+                "descendant rows must reach the render with their context label"
+            );
+        });
+        println!("Screenshot saved to {out}");
+    }
+
     /// Notes picker overlay: open → step → still visible and renders.
     #[test]
     fn notes_picker_overlay_smoke() {
@@ -1063,6 +1138,7 @@ mod tests {
                 preview: format!("{name} preview"),
                 inbox,
                 search_text: name.to_lowercase(),
+                context_label: None,
             };
             app.notes_picker_entries = vec![mk("inbox-note", true), mk("kept-note", false)];
             app.notes_picker_selected = 0;
@@ -2015,6 +2091,7 @@ mod tests {
                         preview: format!("{title} — first body line of the note"),
                         inbox: false,
                         search_text: title.to_lowercase(),
+                        context_label: None,
                     })
                     .collect();
                 app.show_command_palette = true;
@@ -2041,6 +2118,7 @@ mod tests {
                     preview: format!("{title} — first body line of the note"),
                     inbox: *inbox,
                     search_text: title.to_lowercase(),
+                    context_label: None,
                 })
                 .collect();
                 app.notes_picker_selected = 0;
@@ -2233,6 +2311,7 @@ mod tests {
                     preview: "Deterministic row for palette scrolling".to_string(),
                     inbox: false,
                     search_text: format!("palette note {idx:02} deterministic row"),
+                    context_label: None,
                 })
                 .collect();
             app.show_command_palette = true;


### PR DESCRIPTION
Closes #2491. Implements stint **0557 — feat(notes): context-scoped kept notes with descendant aggregation**.

## What

Kept notes were keyed to the workspace Plexi was launched from (`notes/<workspace-slug>/`, fixed for the app session), so a note captured in a subproject context was invisible or mixed depending on launch directory. Kept notes are now keyed per **context root**, and the Cmd+O picker unions the active context's notes with every **descendant** context's notes.

- Storage: `notes/ctx-<slug>-<sha256-prefix>/`, keyed on the context's scope root (`Context.root`, else `Context.path`). The hash prevents same-named roots colliding; the slug keeps the dir human-readable.
- Descendant resolution: path-**component-boundary** prefix match over the live `contexts` list via `Path::starts_with`. `/foo/barbaz` is correctly *not* a descendant of `/foo/bar`. No filesystem crawl, no watching — scans stay per-picker-open.
- Descendant rows carry their context name as the row chip so a root context's "master view" stays legible.
- Triage keep files a note into the context that **captured** it (frontmatter `context_root`), falling back to the active context. An empty `context_root` is treated as absent, not as the path `""`.
- `plexi notes list` / `plexi notes open` follow `PLEXI_CONTEXT_ROOT`, and keep reading an un-migrated legacy dir so a CLI-only user never loses sight of existing notes.

## Migration (data safety)

Existing `notes/<workspace-slug>/` notes are migrated into their context's dir, non-destructively and idempotently:

- copy → verify the destination byte length → **only then** remove the source
- an identical destination counts as already migrated
- a **differing** destination is never overwritten; the legacy note lands under `<stem>-legacy[-N].md`
- a legacy dir with **no matching context** is logged and left completely alone — never dropped
- non-note files are never touched; the legacy dir is removed only once it is empty
- a second pass moves nothing (verified by test)

Runs on picker open, where the live context list is fully loaded.

## Out of scope (per the task)

Ancestor-walk (a child seeing parent notes) is explicitly v2. No filesystem watching or realtime indexing. No picker filtering/ranking changes. Inbox notes stay global.

## Known gap, deliberately not closed here

A context with `root: None` exports no `PLEXI_CONTEXT_ROOT`, while the GUI keys that context's notes on `Context.path`. When the cwd's workspace root differs from that path, `plexi notes list` scans a different dir than the picker. Closing it means exporting the effective scope root into every pane's env — pane-env plumbing outside this change. The mismatch is now `log::warn!`-ed so it is observable rather than silent, and is documented on `cli_context_root`.

## Test evidence

- `cargo test --bin plexi` (env-stripped): **1881 passed, 0 failed, 3 ignored**
- `notes::tests` — path-component boundary (`/foo/barbaz` vs `/foo/bar`), dir-name stability + collision-freedom, scope union/dedupe, and five migration cases: move+idempotent, no-overwrite-on-difference, identical-destination, unmapped-dir-left-in-place, reserved/already-keyed dirs skipped
- `notes_picker_unions_active_context_with_descendants` — issue #2491's Done-When end to end through `open_notes_picker`: child note shows in child *and* parent, parent note does not leak into child, `/projx` never aggregated into `/proj`, inbox global everywhere, no ancestor walk
- `triage_keep_files_into_the_capturing_context` — keep destination follows the capture, and an empty `context_root` falls back to the active context
- `screenshot_notes_picker_context_chips` — visual review surface with realistic seeded content; PNG reviewed. Committed at `.stint/evidence/0557-notes-picker-context-chips.png`
- Codex review against `origin/alpha`: two rounds. Round 1 found the empty-`context_root` filing bug (P1) and the CLI legacy-visibility regression (P2) — both fixed and covered by the tests above. Round 2's remaining P2 is the rootless-context env gap documented above.

**PR install:** required via `just pr-install <PR>` — this changes on-disk note storage layout and runs a migration over real user data, which no headless test can prove against Ian's actual notes dir.