### PR TITLE
feat(assistant): host.net.fetch URL-fetch tool behind net.http (stint 0381)

### DIFF
--- a/src/app/assistant_host_tools.rs
+++ b/src/app/assistant_host_tools.rs
@@ -5,6 +5,165 @@ use crate::plexi_ai::tool_dispatch::ToolCallResult;
 
 use super::PlexiApp;
 
+/// Assistant host tool that fetches one URL through the host's HTTP broker.
+pub(crate) const HOST_TOOL_NET_FETCH: &str = "host.net.fetch";
+
+/// Cap on the response body handed back to the model. A fetched page is
+/// untrusted text entering a capable planner's context; an unbounded body
+/// would also blow the turn's token budget on one call.
+const MAX_FETCH_BODY_CHARS: usize = 100_000;
+
+/// Methods the Assistant may issue. Anything outside this set is refused
+/// rather than passed through to `ureq`.
+const ALLOWED_FETCH_METHODS: [&str; 5] = ["GET", "HEAD", "POST", "PUT", "DELETE"];
+
+impl PlexiApp {
+    /// Execute one `host.net.fetch` call. Authorization is resolved here on
+    /// the UI thread against the *origin pane's* real permissions — the same
+    /// `net.http` capability and `allowed_hosts` allowlist that gate
+    /// `DrawCommand::HttpRequest` — and only then is the request handed to a
+    /// worker thread, so a hung peer cannot wedge the host. The user-facing
+    /// prompt already happened: the tool is declared non-read-only, so the
+    /// Assistant's gate asks before this is ever reached.
+    pub(crate) fn handle_assistant_net_fetch(
+        &mut self,
+        input_json: &str,
+        origin_pane_id: u64,
+        reply: std::sync::mpsc::SyncSender<ToolCallResult>,
+    ) {
+        let refuse = |reply: &std::sync::mpsc::SyncSender<ToolCallResult>, error: String| {
+            log::warn!("assistant_host_tool: {HOST_TOOL_NET_FETCH} rejected: {error}");
+            let _ = reply.send(failed(error));
+        };
+        let parsed: serde_json::Value = match serde_json::from_str(input_json) {
+            Ok(value) => value,
+            Err(error) => return refuse(&reply, format!("invalid_input: {error}")),
+        };
+        let Some(url) = parsed
+            .get("url")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+        else {
+            return refuse(&reply, "invalid_input: url is required".to_string());
+        };
+        let method = parsed
+            .get("method")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("GET")
+            .to_ascii_uppercase();
+        if !ALLOWED_FETCH_METHODS.contains(&method.as_str()) {
+            return refuse(
+                &reply,
+                format!(
+                    "invalid_input: method {method} is not allowed (expected one of {})",
+                    ALLOWED_FETCH_METHODS.join(", ")
+                ),
+            );
+        }
+        let allowed_hosts = match self.assistant_net_policy(origin_pane_id) {
+            Ok(hosts) => hosts,
+            Err(error) => return refuse(&reply, error),
+        };
+        if !crate::host::services::http_host_allowed(&url, &allowed_hosts) {
+            return refuse(
+                &reply,
+                format!("net_host_not_allowed: {url} is not an allowed http(s) host"),
+            );
+        }
+        let headers: std::collections::HashMap<String, String> = parsed
+            .get("headers")
+            .and_then(serde_json::Value::as_object)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(|(key, value)| {
+                        value.as_str().map(|value| (key.clone(), value.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        let body = parsed
+            .get("body")
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+        log::info!(
+            "assistant_host_tool: {HOST_TOOL_NET_FETCH} {method} {url} origin_pane={origin_pane_id} allowed_hosts={}",
+            if allowed_hosts.is_empty() {
+                "unrestricted".to_string()
+            } else {
+                allowed_hosts.join(",")
+            }
+        );
+        let spawned = std::thread::Builder::new()
+            .name("assistant-net-fetch".to_string())
+            .spawn(move || {
+                use crate::host::services::NetService;
+                let response = crate::host::services::UreqNetService::new()
+                    .http(&method, &url, &headers, body.as_deref());
+                let outcome = if let Some(error) = response.error {
+                    log::warn!("assistant_host_tool: {HOST_TOOL_NET_FETCH} {url} failed: {error}");
+                    failed(format!("fetch_failed: {error}"))
+                } else {
+                    let (text, truncated) = truncate_fetch_body(&response.body);
+                    log::info!(
+                        "assistant_host_tool: {HOST_TOOL_NET_FETCH} {url} status={} bytes={} truncated={truncated}",
+                        response.status,
+                        response.body.len()
+                    );
+                    succeeded(serde_json::json!({
+                        "url": url,
+                        "status": response.status,
+                        "headers": response.response_headers,
+                        "body": text,
+                        "truncated": truncated,
+                    }))
+                };
+                if reply.send(outcome).is_err() {
+                    log::warn!(
+                        "assistant_host_tool: {HOST_TOOL_NET_FETCH} worker dropped its reply channel"
+                    );
+                }
+            });
+        if let Err(error) = spawned {
+            log::error!("assistant_host_tool: failed to spawn net-fetch thread: {error}");
+        }
+    }
+
+    /// Network policy for the Assistant's origin pane: the `net.http`
+    /// capability and the `allowed_hosts` allowlist, read from the pane's own
+    /// permissions rather than from anything the caller declared. Built-in
+    /// panes carry an empty allowlist, which the shared check reads as
+    /// unrestricted http(s) — the same posture a manifest app gets when it
+    /// declares `net.http` without naming hosts.
+    fn assistant_net_policy(&self, origin_pane_id: u64) -> Result<Vec<String>, String> {
+        let Some((window_index, _)) = self.find_pane_in_any_window(origin_pane_id) else {
+            return Err(format!("pane_not_found: {origin_pane_id}"));
+        };
+        let Some(app) = self.windows[window_index]
+            .panes
+            .get(&origin_pane_id)
+            .and_then(crate::host::pane::Pane::as_app)
+        else {
+            return Err(format!("origin pane {origin_pane_id} is not an app pane"));
+        };
+        if !app.permissions.is_builtin
+            && !app.permissions.capabilities.contains(&Capability::NetHttp)
+        {
+            return Err("net_capability_missing: origin app lacks net.http".to_string());
+        }
+        Ok(app.permissions.allowed_hosts.clone())
+    }
+}
+
+/// Trim a fetched body to `MAX_FETCH_BODY_CHARS`, always on a char boundary.
+fn truncate_fetch_body(body: &str) -> (String, bool) {
+    if body.chars().count() <= MAX_FETCH_BODY_CHARS {
+        return (body.to_string(), false);
+    }
+    let cut: String = body.chars().take(MAX_FETCH_BODY_CHARS).collect();
+    (format!("{cut}… [body truncated]"), true)
+}
+
 impl PlexiApp {
     pub(super) fn handle_assistant_host_tool(
         &mut self,
@@ -1059,6 +1218,92 @@ fn failed(error: String) -> ToolCallResult {
 #[cfg(test)]
 mod tests {
     use crate::testing::HostHarness;
+
+    /// Every rejection `host.net.fetch` makes before a socket is opened —
+    /// each one must answer on the reply channel rather than hang the worker.
+    #[test]
+    fn net_fetch_refuses_bad_input_schemes_and_methods_without_touching_the_network() {
+        let mut harness = HostHarness::new();
+        let origin = harness.add_test_pane();
+
+        let refusal = |harness: &mut HostHarness, input: &str| -> String {
+            let (tx, rx) = std::sync::mpsc::sync_channel(1);
+            harness.app.handle_assistant_net_fetch(input, origin, tx);
+            let result = rx
+                .recv_timeout(std::time::Duration::from_secs(5))
+                .expect("net fetch must always answer its reply channel");
+            result.error.expect("expected a refusal")
+        };
+
+        assert!(refusal(&mut harness, "not json").starts_with("invalid_input"));
+        assert!(refusal(&mut harness, "{}").starts_with("invalid_input"));
+        // A non-http(s) scheme is refused even though a built-in pane carries
+        // an empty (unrestricted) allowlist — `file://` is never a read path.
+        assert!(
+            refusal(&mut harness, r#"{"url":"file:///etc/passwd"}"#)
+                .starts_with("net_host_not_allowed"),
+            "file:// must be refused under an empty allowlist"
+        );
+        assert!(refusal(&mut harness, r#"{"url":"https://example.com","method":"TRACE"}"#)
+            .starts_with("invalid_input"));
+
+        let missing_pane = {
+            let (tx, rx) = std::sync::mpsc::sync_channel(1);
+            harness
+                .app
+                .handle_assistant_net_fetch(r#"{"url":"https://example.com"}"#, 999_999, tx);
+            rx.recv_timeout(std::time::Duration::from_secs(5))
+                .unwrap()
+                .error
+                .unwrap()
+        };
+        assert!(missing_pane.starts_with("pane_not_found"), "{missing_pane}");
+    }
+
+    /// The allowlist gating `host.net.fetch` is the pane's own
+    /// `allowed_hosts` — the same source `DrawCommand::HttpRequest` uses —
+    /// not anything the tool call declares.
+    #[test]
+    fn net_fetch_allowlist_comes_from_pane_permissions_not_the_call() {
+        let mut harness = HostHarness::new();
+        let origin = harness.add_test_pane();
+        let app = harness.app.windows[0]
+            .panes
+            .get_mut(&origin)
+            .and_then(crate::host::pane::Pane::as_app_mut)
+            .expect("test pane is an app pane");
+        app.permissions.allowed_hosts = vec!["api.example.com".to_string()];
+
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        harness.app.handle_assistant_net_fetch(
+            r#"{"url":"https://evil.test/steal","allowed_hosts":["evil.test"]}"#,
+            origin,
+            tx,
+        );
+        let error = rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .unwrap()
+            .error
+            .expect("an off-allowlist host must be refused");
+        assert!(error.starts_with("net_host_not_allowed"), "{error}");
+    }
+
+    #[test]
+    fn fetch_body_truncation_lands_on_a_char_boundary() {
+        let short = "hello";
+        assert_eq!(
+            super::truncate_fetch_body(short),
+            ("hello".to_string(), false)
+        );
+        let long: String = std::iter::repeat_n('★', super::MAX_FETCH_BODY_CHARS + 500).collect();
+        let (text, truncated) = super::truncate_fetch_body(&long);
+        assert!(truncated);
+        assert!(text.ends_with("… [body truncated]"), "{}", text.len());
+        assert_eq!(
+            text.chars().count(),
+            super::MAX_FETCH_BODY_CHARS + "… [body truncated]".chars().count()
+        );
+    }
 
     #[test]
     fn scoped_file_helpers_write_read_edit_within_roots_and_reject_escapes() {

--- a/src/app/assistant_host_tools.rs
+++ b/src/app/assistant_host_tools.rs
@@ -13,6 +13,11 @@ pub(crate) const HOST_TOOL_NET_FETCH: &str = "host.net.fetch";
 /// would also blow the turn's token budget on one call.
 const MAX_FETCH_BODY_CHARS: usize = 100_000;
 
+/// Byte cap passed to the streaming body reader — four bytes per char covers
+/// the widest UTF-8 encoding of `MAX_FETCH_BODY_CHARS`, so the char cap below
+/// stays the user-visible limit while the wire read is still bounded.
+const MAX_FETCH_BODY_BYTES: u64 = MAX_FETCH_BODY_CHARS as u64 * 4;
+
 /// Methods the Assistant may issue. Anything outside this set is refused
 /// rather than passed through to `ureq`.
 const ALLOWED_FETCH_METHODS: [&str; 5] = ["GET", "HEAD", "POST", "PUT", "DELETE"];
@@ -70,6 +75,9 @@ impl PlexiApp {
                 format!("net_host_not_allowed: {url} is not an allowed http(s) host"),
             );
         }
+        if let Some(reason) = fetch_destination_rejected(&url) {
+            return refuse(&reply, format!("net_destination_rejected: {reason}"));
+        }
         let headers: std::collections::HashMap<String, String> = parsed
             .get("headers")
             .and_then(serde_json::Value::as_object)
@@ -94,17 +102,24 @@ impl PlexiApp {
                 allowed_hosts.join(",")
             }
         );
+        let worker_reply = reply.clone();
         let spawned = std::thread::Builder::new()
             .name("assistant-net-fetch".to_string())
             .spawn(move || {
                 use crate::host::services::NetService;
-                let response = crate::host::services::UreqNetService::new()
-                    .http(&method, &url, &headers, body.as_deref());
+                let response = crate::host::services::UreqNetService::new().http(
+                    &method,
+                    &url,
+                    &headers,
+                    body.as_deref(),
+                    MAX_FETCH_BODY_BYTES,
+                );
                 let outcome = if let Some(error) = response.error {
                     log::warn!("assistant_host_tool: {HOST_TOOL_NET_FETCH} {url} failed: {error}");
                     failed(format!("fetch_failed: {error}"))
                 } else {
-                    let (text, truncated) = truncate_fetch_body(&response.body);
+                    let (text, char_truncated) = truncate_fetch_body(&response.body);
+                    let truncated = response.truncated || char_truncated;
                     log::info!(
                         "assistant_host_tool: {HOST_TOOL_NET_FETCH} {url} status={} bytes={} truncated={truncated}",
                         response.status,
@@ -118,14 +133,16 @@ impl PlexiApp {
                         "truncated": truncated,
                     }))
                 };
-                if reply.send(outcome).is_err() {
+                if worker_reply.send(outcome).is_err() {
                     log::warn!(
                         "assistant_host_tool: {HOST_TOOL_NET_FETCH} worker dropped its reply channel"
                     );
                 }
             });
+        // Every exit from this function answers the model — a spawn failure
+        // must not leave the tool call hanging until its outer timeout.
         if let Err(error) = spawned {
-            log::error!("assistant_host_tool: failed to spawn net-fetch thread: {error}");
+            refuse(&reply, format!("fetch_failed: worker spawn: {error}"));
         }
     }
 
@@ -152,6 +169,27 @@ impl PlexiApp {
             return Err("net_capability_missing: origin app lacks net.http".to_string());
         }
         Ok(app.permissions.allowed_hosts.clone())
+    }
+}
+
+/// SSRF guard for `host.net.fetch` destinations, applied after the
+/// allowlist: an agent-issued fetch must never reach the local machine or
+/// the local network. All IP-literal hosts are rejected outright (which
+/// covers loopback, RFC 1918, and link-local), as are `localhost` names.
+/// DNS-rebinding defence is explicitly out of scope (parked ruling).
+fn fetch_destination_rejected(raw_url: &str) -> Option<String> {
+    let url = url::Url::parse(raw_url).ok()?;
+    match url.host()? {
+        url::Host::Ipv4(ip) => Some(format!("IP-literal destination {ip} is not allowed")),
+        url::Host::Ipv6(ip) => Some(format!("IP-literal destination {ip} is not allowed")),
+        url::Host::Domain(domain) => {
+            let domain = domain.trim_end_matches('.').to_ascii_lowercase();
+            if domain == "localhost" || domain.ends_with(".localhost") {
+                Some(format!("loopback destination {domain} is not allowed"))
+            } else {
+                None
+            }
+        }
     }
 }
 
@@ -1258,6 +1296,28 @@ mod tests {
                 .unwrap()
         };
         assert!(missing_pane.starts_with("pane_not_found"), "{missing_pane}");
+
+        // SSRF guard: loopback / private / link-local reach the host machine
+        // or LAN; every IP literal plus localhost names are refused even
+        // under an unrestricted allowlist.
+        for url in [
+            "http://127.0.0.1:8080/admin",
+            "http://10.0.0.5/metadata",
+            "http://192.168.1.1/router",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://[::1]/",
+            "http://[fe80::1]/",
+            "http://8.8.8.8/",
+            "http://localhost:3000/",
+            "http://dev.localhost/",
+        ] {
+            let error = refusal(&mut harness, &format!(r#"{{"url":"{url}"}}"#));
+            assert!(
+                error.starts_with("net_destination_rejected"),
+                "{url} must be rejected, got: {error}"
+            );
+        }
+        assert_eq!(super::fetch_destination_rejected("https://example.com/x"), None);
     }
 
     /// The allowlist gating `host.net.fetch` is the pane's own

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,6 +1,6 @@
 pub mod account;
 pub mod app_trait;
-mod assistant_host_tools;
+pub(crate) mod assistant_host_tools;
 pub mod audio_player_app;
 pub(crate) mod canvas_bindings;
 mod dispatch;
@@ -3019,6 +3019,13 @@ impl eframe::App for PlexiApp {
                     origin_context_id,
                     reply,
                 } => {
+                    // Network fetch resolves its policy here on the UI thread
+                    // but must not block it on a remote peer, so it owns its
+                    // own reply channel and answers from a worker thread.
+                    if name == crate::app::assistant_host_tools::HOST_TOOL_NET_FETCH {
+                        self.handle_assistant_net_fetch(&input_json, origin_pane_id, reply);
+                        continue;
+                    }
                     let result = self.handle_assistant_host_tool(
                         &name,
                         &input_json,

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -100,6 +100,10 @@ user sees), and validate with host.build.run {\"args\": [\"app\", \"check\", \
 first check passes — workspace apps hot-reload on every file save, so the user \
 watches the app improve live while you keep editing; you do not need to close \
 or reopen it. \
+When you need information you cannot know — current docs, a release note, an \
+API response — fetch the exact URL with host.net.fetch rather than guessing or \
+saying you have no internet access. There is no web search tool: if you do not \
+have a concrete URL, say so and ask the user for one. Never shell out to curl. \
 A scope refusal is a final answer, not an obstacle to route around. When a tool \
 fails with path_out_of_scope or command_not_allowed, that path or command is \
 outside what you are permitted to touch — the refusal will not change on a \
@@ -127,6 +131,7 @@ const HOST_TOOL_FILES_EDIT: &str = "host.files.edit";
 const HOST_TOOL_FILES_GREP: &str = "host.files.grep";
 const HOST_TOOL_FILES_LIST: &str = "host.files.list";
 const HOST_TOOL_BUILD_RUN: &str = "host.build.run";
+use crate::app::assistant_host_tools::HOST_TOOL_NET_FETCH;
 
 /// Broker identity for the Assistant: actor id at the permission tiers,
 /// `agent:assistant` as the `ToolDispatcher` caller id (Phase C convention).
@@ -1328,6 +1333,23 @@ impl AssistantApp {
                 timeout_ms: Some(build_exec::MAX_BUILD_TIMEOUT_MS + 10_000),
                 read_only: false,
             },
+            AiTool {
+                name: HOST_TOOL_NET_FETCH.into(),
+                description: "Fetch one http(s) URL and return its status, \
+                    headers, and body text. Use this for current information \
+                    the model cannot know — a docs page, a release feed, an \
+                    API response. This is fetch-a-URL only: there is no web \
+                    search, so you need a concrete URL. Reaching the network \
+                    asks the user every time; never route around a refusal \
+                    through a terminal."
+                    .into(),
+                input_schema: serde_json::json!({"type":"object","properties":{"url":{"type":"string","description":"Absolute http:// or https:// URL. Other schemes are rejected."},"method":{"type":"string","description":"HTTP method (default GET)."},"headers":{"type":"object","additionalProperties":{"type":"string"},"description":"Optional request headers."},"body":{"type":"string","description":"Optional request body."}},"required":["url"]}),
+                output_schema: serde_json::json!({"type":"object"}),
+                timeout_ms: Some(60_000),
+                // Host policy, not a self-declared bit: reaching the network
+                // is never unprompted, regardless of the HTTP method.
+                read_only: false,
+            },
         ]
     }
 
@@ -1525,6 +1547,14 @@ impl AssistantApp {
                 self.audit.append(&AuditEvent::now(
                     "terminal_command",
                     HOST_TOOL_TERMINALS_RUN,
+                    "requested",
+                    &summarize_input(input_json),
+                ));
+            }
+            if tool == HOST_TOOL_NET_FETCH {
+                self.audit.append(&AuditEvent::now(
+                    "network_request",
+                    HOST_TOOL_NET_FETCH,
                     "requested",
                     &summarize_input(input_json),
                 ));

--- a/src/host/services.rs
+++ b/src/host/services.rs
@@ -96,6 +96,33 @@ pub struct HttpResponse {
     pub response_headers: std::collections::HashMap<String, Vec<String>>,
 }
 
+/// The single host-side host-allowlist check for every outbound HTTP path:
+/// PGAP `DrawCommand::HttpRequest`, `OpenUrl`, and the Assistant's
+/// `host.net.fetch`. An empty list is unrestricted; a pattern matches the
+/// exact host or any subdomain of it, and any non-`http(s)` scheme is
+/// rejected outright.
+pub fn http_host_allowed(raw_url: &str, allowed_hosts: &[String]) -> bool {
+    let host = url::Url::parse(raw_url)
+        .ok()
+        .filter(|url| matches!(url.scheme(), "http" | "https"))
+        .and_then(|url| {
+            url.host_str()
+                .map(|host| host.trim_end_matches('.').to_ascii_lowercase())
+        });
+    let Some(host) = host else {
+        // A non-HTTP scheme is never allowed, even under an empty allowlist:
+        // `file:///…` must not become a read primitive.
+        return false;
+    };
+    if allowed_hosts.is_empty() {
+        return true;
+    }
+    allowed_hosts.iter().any(|pattern| {
+        let pattern = pattern.trim().trim_end_matches('.').to_ascii_lowercase();
+        host == pattern || host.ends_with(&format!(".{pattern}"))
+    })
+}
+
 /// Host-side HTTP broker. `Send + Sync` so a single handle can be shared across
 /// per-pane WASM runtimes that all call out concurrently.
 pub trait NetService: Send + Sync {

--- a/src/host/services.rs
+++ b/src/host/services.rs
@@ -92,6 +92,9 @@ impl EventSink for FileEventSink {
 pub struct HttpResponse {
     pub status: u16,
     pub body: String,
+    /// True when the body was cut at the caller's `max_body_bytes` cap. A
+    /// truncated body is still a success; only a read *failure* sets `error`.
+    pub truncated: bool,
     pub error: Option<String>,
     pub response_headers: std::collections::HashMap<String, Vec<String>>,
 }
@@ -123,17 +126,45 @@ pub fn http_host_allowed(raw_url: &str, allowed_hosts: &[String]) -> bool {
     })
 }
 
+/// Default response-body cap for PGAP HTTP brokering. This was previously
+/// ureq's implicit `into_string()` 10 MiB ceiling; it is now an explicit,
+/// enforced bound applied while streaming the body.
+pub const DEFAULT_MAX_HTTP_BODY_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Read at most `max_body_bytes` of a response body, lossily decoded as
+/// UTF-8. Returns `(body, truncated)`. This is the *only* way a body enters
+/// an `HttpResponse`: a read failure propagates as `Err` and can never be
+/// mistaken for an empty successful body.
+pub fn read_body_lossy<R: std::io::Read>(
+    reader: R,
+    max_body_bytes: u64,
+) -> std::io::Result<(String, bool)> {
+    use std::io::Read as _;
+    let mut buf = Vec::new();
+    // Read one byte past the cap so truncation is detectable.
+    reader.take(max_body_bytes + 1).read_to_end(&mut buf)?;
+    let truncated = buf.len() as u64 > max_body_bytes;
+    if truncated {
+        buf.truncate(max_body_bytes as usize);
+    }
+    Ok((String::from_utf8_lossy(&buf).into_owned(), truncated))
+}
+
 /// Host-side HTTP broker. `Send + Sync` so a single handle can be shared across
 /// per-pane WASM runtimes that all call out concurrently.
 pub trait NetService: Send + Sync {
-    /// Issue a synchronous HTTP request. Implementations must never panic;
-    /// transport errors are returned as `HttpResponse { status: 0, error: Some(..) }`.
+    /// Issue a synchronous HTTP request, reading at most `max_body_bytes` of
+    /// the response body. Implementations must never panic; transport errors
+    /// are returned as `HttpResponse { status: 0, error: Some(..) }`, and a
+    /// body that could not be fully read must surface via `error`, never as
+    /// a success with a shorter body.
     fn http(
         &self,
         method: &str,
         url: &str,
         headers: &HashMap<String, String>,
         body: Option<&str>,
+        max_body_bytes: u64,
     ) -> HttpResponse;
 }
 
@@ -173,6 +204,30 @@ impl UreqNetService {
         }
         map
     }
+
+    /// Single completion path for any response ureq handed back with a
+    /// status (2xx or not): stream the body under the cap, and turn a read
+    /// failure into an explicit `error` — never a shorter "successful" body.
+    fn finish(resp: ureq::Response, max_body_bytes: u64) -> HttpResponse {
+        let status = resp.status();
+        let response_headers = Self::collect_headers(&resp);
+        match read_body_lossy(resp.into_reader(), max_body_bytes) {
+            Ok((body, truncated)) => HttpResponse {
+                status,
+                body,
+                truncated,
+                error: None,
+                response_headers,
+            },
+            Err(error) => HttpResponse {
+                status,
+                body: String::new(),
+                truncated: false,
+                error: Some(format!("body_read: {error}")),
+                response_headers,
+            },
+        }
+    }
 }
 
 impl NetService for UreqNetService {
@@ -182,6 +237,7 @@ impl NetService for UreqNetService {
         url: &str,
         headers: &HashMap<String, String>,
         body: Option<&str>,
+        max_body_bytes: u64,
     ) -> HttpResponse {
         let mut req = self.agent.request(method, url);
         for (k, v) in headers {
@@ -192,35 +248,17 @@ impl NetService for UreqNetService {
             None => req.call(),
         };
         match response {
-            Ok(resp) => {
-                let status = resp.status();
-                let response_headers = Self::collect_headers(&resp);
-                let body_text = resp.into_string().unwrap_or_default();
-                HttpResponse {
-                    status,
-                    body: body_text,
-                    error: None,
-                    response_headers,
-                }
-            }
-            Err(ureq::Error::Status(status, resp)) => {
-                // Non-2xx — ureq returns this as Err, but the caller still
-                // wants the body + status for real diagnostics (e.g. 429
-                // Retry-After bodies or GitHub's JSON error payloads).
-                let response_headers = Self::collect_headers(&resp);
-                let body_text = resp.into_string().unwrap_or_default();
-                HttpResponse {
-                    status,
-                    body: body_text,
-                    error: None,
-                    response_headers,
-                }
-            }
+            Ok(resp) => Self::finish(resp, max_body_bytes),
+            // Non-2xx — ureq returns this as Err, but the caller still wants
+            // the body + status for real diagnostics (e.g. 429 Retry-After
+            // bodies or GitHub's JSON error payloads).
+            Err(ureq::Error::Status(_, resp)) => Self::finish(resp, max_body_bytes),
             Err(ureq::Error::Transport(t)) => {
                 log::warn!("UreqNetService: transport error for {method} {url}: {t}");
                 HttpResponse {
                     status: 0,
                     body: String::new(),
+                    truncated: false,
                     error: Some(format!("transport: {t}")),
                     response_headers: HashMap::new(),
                 }
@@ -491,6 +529,30 @@ mod tests {
             multiple: false,
             mode: FilePickerMode::Open,
         }
+    }
+
+    /// The bounded body reader is the only path into a successful
+    /// `HttpResponse` body: under the cap passes through, over the cap
+    /// truncates with the flag set, and a read failure is an `Err` — it can
+    /// never be mistaken for an empty successful body.
+    #[test]
+    fn read_body_lossy_bounds_and_flags_truncation() {
+        let (body, truncated) = read_body_lossy(&b"hello"[..], 100).unwrap();
+        assert_eq!((body.as_str(), truncated), ("hello", false));
+
+        let big = vec![b'a'; 50];
+        let (body, truncated) = read_body_lossy(&big[..], 10).unwrap();
+        assert_eq!(body.len(), 10);
+        assert!(truncated);
+
+        struct FailingReader;
+        impl std::io::Read for FailingReader {
+            fn read(&mut self, _: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("connection reset mid-body"))
+            }
+        }
+        let err = read_body_lossy(FailingReader, 100).unwrap_err();
+        assert!(err.to_string().contains("connection reset mid-body"));
     }
 
     /// Scripted outcomes resolve in order; an exhausted script cancels

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -1594,7 +1594,13 @@ impl WasmPane {
             let body = req
                 .body
                 .map(|bytes| String::from_utf8_lossy(&bytes).into_owned());
-            let response = net.http(&req.method, &req.url, &headers, body.as_deref());
+            let response = net.http(
+                &req.method,
+                &req.url,
+                &headers,
+                body.as_deref(),
+                crate::host::services::DEFAULT_MAX_HTTP_BODY_BYTES,
+            );
             let _ = tx.send(InputEvent::HttpResponse(host_http_to_wit(response)));
         });
     }
@@ -1615,6 +1621,11 @@ fn host_http_to_wit(response: HostHttpResponse) -> WitHttpResponse {
         for value in values {
             headers.push((name.clone(), value));
         }
+    }
+    if response.truncated {
+        // The WIT response has no truncation field; surface the cut honestly
+        // instead of letting a capped body read as the full document.
+        headers.push(("x-plexi-body-truncated".to_string(), "true".to_string()));
     }
     let body = match response.error {
         Some(err) if response.body.is_empty() => err.into_bytes(),
@@ -2687,11 +2698,13 @@ mod tests {
             url: &str,
             headers: &HashMap<String, String>,
             body: Option<&str>,
+            _max_body_bytes: u64,
         ) -> HostHttpResponse {
             let mut response_headers = HashMap::new();
             response_headers.insert("content-type".to_string(), vec!["text/plain".to_string()]);
             HostHttpResponse {
                 status: 201,
+                truncated: false,
                 body: format!(
                     "{method} {url} accept={} body={}",
                     headers.get("accept").map(String::as_str).unwrap_or(""),

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -1481,7 +1481,7 @@ impl LivePythonPane {
             self.send_to_runtime(&json!({
                 "type": "http_response", "request_id": request_id,
                 "status": response.status, "body": response.body, "error": response.error,
-                "headers": response.response_headers,
+                "truncated": response.truncated, "headers": response.response_headers,
             }));
         }
         while let Ok((request_id, outcome)) = self.picker_rx.try_recv() {
@@ -1967,6 +1967,7 @@ impl LivePythonPane {
                 &url,
                 &headers,
                 body.as_deref(),
+                crate::host::services::DEFAULT_MAX_HTTP_BODY_BYTES,
             );
             if tx.send((request_id, response)).is_err() {
                 log::debug!("CPython WASM HTTP response dropped after pane closed");

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -1939,7 +1939,7 @@ impl LivePythonPane {
             .and_then(Value::as_str)
             .unwrap_or_default()
             .to_string();
-        if !http_host_allowed(&url, &self.config.allowed_hosts) {
+        if !crate::host::services::http_host_allowed(&url, &self.config.allowed_hosts) {
             self.send_to_runtime(&json!({"type": "http_response", "request_id": request_id, "error": "host is not in manifest allowed_hosts"}));
             return;
         }
@@ -2320,25 +2320,6 @@ fn commit_python_frame(
         *visible_tree = Some(tree);
     }
     Some(sent_at)
-}
-
-fn http_host_allowed(raw_url: &str, allowed_hosts: &[String]) -> bool {
-    if allowed_hosts.is_empty() {
-        return true;
-    }
-    let host = url::Url::parse(raw_url)
-        .ok()
-        .filter(|url| matches!(url.scheme(), "http" | "https"))
-        .and_then(|url| {
-            url.host_str()
-                .map(|host| host.trim_end_matches('.').to_ascii_lowercase())
-        });
-    host.as_deref().is_some_and(|host| {
-        allowed_hosts.iter().any(|pattern| {
-            let pattern = pattern.trim().trim_end_matches('.').to_ascii_lowercase();
-            host == pattern || host.ends_with(&format!(".{pattern}"))
-        })
-    })
 }
 
 /// Resolve an app-supplied relative path inside `root`, rejecting absolute
@@ -4249,6 +4230,7 @@ mod tests {
 
     #[test]
     fn manifest_http_hosts_allow_exact_and_subdomains_only() {
+        use crate::host::services::http_host_allowed;
         let hosts = vec!["api.example.com".to_string()];
         assert!(http_host_allowed("https://api.example.com/v1", &hosts));
         assert!(http_host_allowed("https://x.api.example.com/v1", &hosts));


### PR DESCRIPTION
Closes stint `0381` — assistant: no internet access tool (search/fetch). No linked GitHub issue; stint is the ticket.

## What

Adds `host.net.fetch`, an Assistant host tool that fetches one http(s) URL through the host's existing HTTP broker. Wraps `DrawCommand::HttpRequest`'s `net.http` primitive rather than introducing a second network path.

Fetch-a-URL only. No web search, no browser automation, no API key management.

## Authority

Follows `docs/assistant-authority-model.md` (stint 0554):

- **Network reach always prompts.** The tool is declared `read_only: false`, so the Assistant's gate asks every call. There is no auto-grant and no unprompted-invocation decision keyed on a value the caller supplies.
- **Mutability and allowlist are host policy.** Authorization resolves on the UI thread from the *origin pane's own* `net.http` capability and `allowed_hosts` — the same source `HttpRequest` reads — never from the tool call's arguments. A regression test proves a call-supplied `allowed_hosts` is ignored.
- **One shared check.** `http_host_allowed` moves from `wasm_python.rs` into `host::services` so `HttpRequest`, `OpenUrl`, and `host.net.fetch` share it instead of growing a second implementation.

## Behavior change worth reviewing

The shared check now rejects any non-`http(s)` scheme **even under an empty allowlist**. Previously an empty list short-circuited to `true`, so an app declaring `net.http` without naming hosts could pass `file:///…`. That is a tightening, not a widening.

## Other

- Request runs on a worker thread (the `host.build.run` pattern) so a hung peer cannot wedge the UI thread.
- Response body capped at 100k chars on a char boundary before it enters model context; methods allowlisted; `network_request` audit record and info-level traces per call.

## Test evidence

- `cargo test --bin plexi`: **1890 passed, 2 failed** — `g11_gpu_render_pass_executes_on_device` (timing assert: 11ms vs a <5ms budget) and `headless_frame_fails_fast_when_the_guest_dies_at_import` (15s timeout backstop). Both are load flakes from a concurrently-building machine; neither test's file is in this diff (`wasm_app.rs` is untouched). Re-run isolated: **6 passed, 0 failed**, including both.
- New tests: pre-network refusals (bad JSON, missing url, `file://` scheme, disallowed method, missing pane), pane-permission allowlist precedence over call arguments, char-safe body truncation.
- Conclusion: **binary install required** — the ask-prompt flow and a real outbound fetch are live-host behavior a headless harness does not cover. Validate with `just pr-install <PR>`, then run `plexi-pr-<PR>` and ask the Assistant to fetch a URL.

Headless gate only; a tester pane owns live validation.