### PR TITLE
feat(cli): plexi context sub — one command, N agent panes in a subcontext (stint 0568)

### DIFF
--- a/sdk/protocol/pgap.schema.json
+++ b/sdk/protocol/pgap.schema.json
@@ -296,6 +296,21 @@
             }
           ]
         },
+        "SubContextLayout": {
+          "description": "How `plexi context sub` arranges the panes it seeds inside the new\nsub-context's single window.",
+          "oneOf": [
+            {
+              "const": "tiled",
+              "description": "Near-square grid — the default for an agent squad.",
+              "type": "string"
+            },
+            {
+              "const": "columns",
+              "description": "One full-height column per pane, left to right.",
+              "type": "string"
+            }
+          ]
+        },
         "TriggerMode": {
           "description": "How an event subscription triggers its subscriber\n(src/host/app_timeline.rs). Also the vocabulary for an emitting\napp's `suggested_trigger` hint.",
           "oneOf": [
@@ -1692,6 +1707,15 @@
                 "null"
               ]
             },
+            "parent_context_id": {
+              "description": "Parent context id, sent for bare `--parent` (the caller's\n`PLEXI_CONTEXT_ID`). Wins over `parent_name`, which is ambiguous when\ntwo contexts share a name. Absent for an explicit `--parent=<name>`,\nwhere resolving by name is what the caller asked for.",
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
             "parent_name": {
               "type": [
                 "string",
@@ -1731,6 +1755,82 @@
           },
           "required": [
             "type"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Create a sub-context under the caller's context, pre-populated with a\nsquad of terminal panes in a single window. Sent by `plexi context sub`.\n\nUnlike `CreateContext { parent_name, windows }` this seeds *exactly*\n`panes.len()` terminals — no spare root terminal — and tiles them inside\none window instead of creating sibling pages.",
+          "properties": {
+            "anchor_pane": {
+              "description": "Pane in the parent context to anchor the portal split at. The CLI\nsends the caller's `PLEXI_PANE_ID`; absent or unknown ids fall back\nto the parent's focused pane.",
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "focus": {
+              "default": false,
+              "description": "Zoom into the new sub-context after creation. Default false.",
+              "type": "boolean"
+            },
+            "layout": {
+              "$ref": "#/$defs/SubContextLayout",
+              "default": "tiled",
+              "description": "How the panes are arranged inside the sub-context's single window."
+            },
+            "name": {
+              "description": "Name for the new sub-context.",
+              "type": "string"
+            },
+            "panes": {
+              "description": "One entry per pane to create, in order. `null` launches a plain\nshell. Never empty — the CLI expands `--agents`/`--command` into\nexactly the requested pane count before sending.",
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": "array"
+            },
+            "parent_context_id": {
+              "description": "Parent context id (the caller's `PLEXI_CONTEXT_ID`). Authoritative:\n`parent_name` is consulted only when this is absent. An id naming no\nlive context is an error, not a reason to fall back to the name.",
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "parent_name": {
+              "description": "Parent context name. Used only when `parent_context_id` is absent.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "response_file": {
+              "description": "If set, the host writes a JSON response (context_id, windows, panes)\nto this path.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "root": {
+              "description": "Root path for the new sub-context. The CLI sends the caller's cwd.",
+              "type": "string"
+            },
+            "type": {
+              "const": "create_sub_context",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "name",
+            "root",
+            "panes"
           ],
           "type": "object"
         },

--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -72,6 +72,10 @@ app action ID ACTION [ARGS]  Send a semantic action to a running app (not raw te
 
 ```
 context new [NAME]       New context. --path DIR, --parent[=NAME] (bare = current context), --from PANE_ID (portal anchor; defaults to caller), -d/-l/-u/-r portal direction, --focus, --window CMD (repeatable; creates extra windows atomically).
+context sub NAME         Sub-context under the caller's context, pre-populated with panes.
+                         --agents N (1-32, default 1), --command CMD (once = all panes, or exactly N times = one each; any other count errors),
+                         --layout tiled|columns (default tiled), --path DIR (defaults to caller's cwd), --focus, --from PANE_ID.
+                         Prints {"context_id","windows","panes":[ids]} — address the panes directly, no follow-up `pane list`.
 context open [PATH]      Switch current pane to a context at PATH.
 context set-root [PATH]  Change root folder for the caller's context (PLEXI_CONTEXT_ID).
 context current          Print context id/name as JSON.
@@ -221,6 +225,20 @@ BALLS=$(plexi app open balls -r --from $PLEXI_PANE_ID)
 plexi app open tetris -d --from $PLEXI_PANE_ID
 plexi app open snake -d --from $BALLS
 ```
+
+### Scoped agent squad (one command)
+
+```bash
+# 3 agents in their own sub-context, rooted at the current cwd.
+SQUAD=$(plexi context sub agentsquad --agents 3 --command cm)
+# Pane ids come back in the response — no follow-up `pane list` needed.
+for P in $(echo "$SQUAD" | jq -r '.panes[]'); do plexi pane name $P "squad-$P"; done
+```
+
+Prefer this over `context new --parent --window CMD ...`: that route seeds a
+spare terminal (N commands → N+1 panes), spreads the panes across sibling
+*pages* instead of tiling them in one window, and roots the sub-context at the
+parent context's path rather than your cwd.
 
 ### Named agent dispatch lane
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -2283,11 +2283,17 @@ impl PlexiApp {
                     }
                 };
                 let child_idx = self.router.len() - 1;
+                // The stint-stipulated trace: parent id, child id, pane count,
+                // and the command each pane launched. Pairs pane_id → cmd so a
+                // "wrong agent got the wrong job" report is answerable from the
+                // log alone, without re-running anything.
+                let launched = launched_pairs(&child.pane_ids, panes);
                 log::info!(
                     "context_sub: parent_ctx_id={parent_ctx_id} child_ctx_id={} name={name:?} \
-                     panes={:?} layout={layout:?}",
+                     pane_count={} layout={layout:?} root={} launched={launched:?}",
                     child.context_id,
-                    child.pane_ids
+                    child.pane_ids.len(),
+                    root.display()
                 );
                 if *focus {
                     // Zoom-out must land back on the *caller's* window, which is
@@ -2912,6 +2918,21 @@ impl PlexiApp {
     }
 }
 
+/// Pair each created pane with the command it launched, for the `context_sub:`
+/// trace. A plain shell renders as `<shell>` rather than `None`, so the log
+/// reads the same way whether or not `--command` was given.
+///
+/// Zips defensively: if the host ever creates a different number of panes than
+/// commands requested, the trace shows the panes it actually made rather than
+/// panicking inside a log statement.
+fn launched_pairs<'a>(pane_ids: &[u64], commands: &'a [Option<String>]) -> Vec<(u64, &'a str)> {
+    pane_ids
+        .iter()
+        .zip(commands.iter())
+        .map(|(id, cmd)| (*id, cmd.as_deref().unwrap_or("<shell>")))
+        .collect()
+}
+
 /// Age of a spawn-queue file in whole seconds, from its `queued_at_ms` stamp.
 /// `None` when the file predates the stamp (written by an older CLI) or the
 /// clock went backwards.
@@ -2933,5 +2954,46 @@ mod spawn_queue_age_tests {
     fn missing_or_future_stamp_is_none() {
         assert_eq!(spawn_file_age_secs(None, 91_000), None);
         assert_eq!(spawn_file_age_secs(Some(91_000), 1_000), None);
+    }
+}
+
+#[cfg(test)]
+mod context_sub_trace_tests {
+    use super::launched_pairs;
+
+    /// The stint-stipulated trace must name the command each pane launched, so
+    /// "agent 2 got the wrong job" is answerable from `plexi.log` alone.
+    #[test]
+    fn pairs_each_pane_with_its_command() {
+        let cmds = vec![
+            Some("cm review".to_string()),
+            Some("cm test".to_string()),
+            Some("cm".to_string()),
+        ];
+        assert_eq!(
+            launched_pairs(&[317, 318, 319], &cmds),
+            vec![(317, "cm review"), (318, "cm test"), (319, "cm")]
+        );
+    }
+
+    /// A plain shell reads as `<shell>`, not `None` — the log line has the same
+    /// shape whether or not `--command` was given.
+    #[test]
+    fn a_plain_shell_is_named_not_null() {
+        assert_eq!(
+            launched_pairs(&[42, 43], &[None, None]),
+            vec![(42, "<shell>"), (43, "<shell>")]
+        );
+    }
+
+    /// Never panic inside a log statement: a length mismatch reports the panes
+    /// actually created rather than taking the host down.
+    #[test]
+    fn length_mismatch_reports_what_exists() {
+        assert_eq!(
+            launched_pairs(&[1], &[Some("a".into()), Some("b".into())]),
+            vec![(1, "a")]
+        );
+        assert_eq!(launched_pairs(&[1, 2], &[Some("a".into())]), vec![(1, "a")]);
     }
 }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -2072,6 +2072,7 @@ impl PlexiApp {
                 root,
                 name,
                 parent_name,
+                parent_context_id,
                 windows,
                 focus,
                 portal_direction,
@@ -2091,7 +2092,8 @@ impl PlexiApp {
                     };
                 log::info!(
                     "pane_ipc: kind=create_context root={:?} name={:?} parent_name={:?} \
-                     windows={} focus={focus} direction={:?} anchor_pane={:?}",
+                     parent_context_id={parent_context_id:?} windows={} focus={focus} \
+                     direction={:?} anchor_pane={:?}",
                     root,
                     name,
                     parent_name,
@@ -2116,13 +2118,16 @@ impl PlexiApp {
                     let current_ctx_id = self.router.active().context_id;
                     let current_win_id = self.windows[self.active_window].window_id;
                     let current_focused = self.windows[self.active_window].focused_pane;
-                    if let Err(e) = self.new_child_context(
-                        pname.as_str(),
-                        path,
-                        portal_vertical,
-                        portal_first,
-                        *anchor_pane,
-                    ) {
+                    if let Err(e) =
+                        self.new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
+                            *parent_context_id,
+                            pname.clone(),
+                            path,
+                            portal_vertical,
+                            portal_first,
+                            *anchor_pane,
+                        ))
+                    {
                         log::warn!("pane_ipc: create_context with parent failed: {e}");
                         ctx_ok = false;
                     } else {
@@ -2208,6 +2213,127 @@ impl PlexiApp {
                         });
                         write_json_response(&rf, response);
                     }
+                }
+                self.save_workspace();
+            }
+            crate::app_protocol::AppRequest::CreateSubContext {
+                name,
+                root,
+                parent_context_id,
+                parent_name,
+                panes,
+                layout,
+                focus,
+                anchor_pane,
+                response_file,
+            } => {
+                // Resolve the parent up front: everything below (depth push,
+                // window bookkeeping) is relative to it, and a bad parent must
+                // fail before any pane is spawned.
+                let parent_idx = self.resolve_parent_context(
+                    *parent_context_id,
+                    parent_name.as_deref().unwrap_or_default(),
+                );
+                let Some(parent_idx) = parent_idx else {
+                    log::warn!(
+                        "pane_ipc: create_sub_context — no parent context for id={parent_context_id:?} name={parent_name:?}"
+                    );
+                    if let Some(rf) = response_file {
+                        write_json_response(
+                            rf,
+                            serde_json::json!({
+                                "error": format!(
+                                    "no parent context for id={parent_context_id:?} name={parent_name:?}"
+                                ),
+                            }),
+                        );
+                    }
+                    return;
+                };
+                let parent_ctx_id = self.router.get(parent_idx).context_id;
+                log::info!(
+                    "pane_ipc: kind=create_sub_context name={name:?} parent_ctx_id={parent_ctx_id} \
+                     panes={} layout={layout:?} focus={focus} root={} anchor_pane={anchor_pane:?}",
+                    panes.len(),
+                    root.display()
+                );
+                let spec = crate::pane_ops::ChildContextSpec {
+                    parent_id: Some(parent_ctx_id),
+                    parent_name: parent_name.clone().unwrap_or_default(),
+                    // Named up front, not renamed after: the squad's panes are
+                    // spawned with this in PLEXI_CONTEXT_NAME.
+                    name: Some(name.clone()),
+                    path: root.clone(),
+                    // A squad reads best beside the caller, matching the
+                    // `context new --parent` default.
+                    portal_vertical: true,
+                    portal_first: false,
+                    anchor_pane: *anchor_pane,
+                    panes: panes.clone(),
+                    layout: *layout,
+                };
+                let child = match self.new_child_context(spec) {
+                    Ok(child) => child,
+                    Err(e) => {
+                        log::warn!("pane_ipc: create_sub_context failed: {e}");
+                        if let Some(rf) = response_file {
+                            write_json_response(rf, serde_json::json!({ "error": e }));
+                        }
+                        return;
+                    }
+                };
+                let child_idx = self.router.len() - 1;
+                log::info!(
+                    "context_sub: parent_ctx_id={parent_ctx_id} child_ctx_id={} name={name:?} \
+                     panes={:?} layout={layout:?}",
+                    child.context_id,
+                    child.pane_ids
+                );
+                if *focus {
+                    // Zoom-out must land back on the *caller's* window, which is
+                    // not necessarily the globally active one — a background
+                    // pane can create a squad while the user is elsewhere.
+                    match child.parent_window_id {
+                        Some(win_id) => {
+                            self.router.push_depth(
+                                parent_ctx_id,
+                                win_id,
+                                child.parent_focused_pane,
+                            );
+                            self.switch_workspace(child_idx);
+                            log::info!(
+                                "pane_ipc: zoomed into new sub-context ctx_id={} (return win_id={win_id})",
+                                child.context_id
+                            );
+                        }
+                        None => {
+                            log::warn!(
+                                "pane_ipc: create_sub_context --focus ignored — parent ctx_id={parent_ctx_id} has no window to return to"
+                            );
+                        }
+                    }
+                }
+                if let Some(rf) = response_file {
+                    let windows_info: Vec<serde_json::Value> = self
+                        .windows
+                        .iter()
+                        .filter(|w| w.context_id == child.context_id)
+                        .map(|w| {
+                            serde_json::json!({
+                                "window_id": w.window_id,
+                                "grid_x": w.grid_x,
+                                "grid_y": w.grid_y,
+                            })
+                        })
+                        .collect();
+                    write_json_response(
+                        rf,
+                        serde_json::json!({
+                            "context_id": child.context_id,
+                            "windows": windows_info,
+                            "panes": child.pane_ids,
+                        }),
+                    );
                 }
                 self.save_workspace();
             }

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -149,13 +149,14 @@ fn new_child_context_does_not_adopt_focused_pane() {
     let parent_id = app.router.active().context_id;
     let parent_name = app.router.active().name.clone();
 
-    app.new_child_context(
-        &parent_name,
+    app.new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
+        None,
+        parent_name.clone(),
         std::path::PathBuf::from("/tmp/no_adopt"),
         true,
         false,
         None,
-    )
+    ))
     .expect("child create should succeed");
 
     let parent_win = app
@@ -200,13 +201,14 @@ fn new_child_context_no_focused_pane_inserts_sub_ctx() {
     let parent_pane_count_before = app.windows[0].panes.len();
     let parent_id = app.router.active().context_id;
 
-    let result = app.new_child_context(
-        "Test",
+    let result = app.new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
+        None,
+        "Test".to_string(),
         std::path::PathBuf::from("/tmp/child2"),
         true,
         false,
         None,
-    );
+    ));
 
     // Whether success or failure, the parent's focused_pane must remain None.
     assert_eq!(
@@ -256,13 +258,14 @@ fn new_child_context_anchor_pane_overrides_focused() {
     let parent_id = app.router.active().context_id;
     let parent_name = app.router.active().name.clone();
 
-    app.new_child_context(
-        &parent_name,
+    app.new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
+        None,
+        parent_name.clone(),
         std::path::PathBuf::from("/tmp/anchor_pane"),
         true,
         false,
         Some(pane_b),
-    )
+    ))
     .expect("child create should succeed");
 
     let parent_win = app
@@ -371,13 +374,14 @@ fn new_child_context_unknown_anchor_falls_back_to_focused() {
     let parent_id = app.router.active().context_id;
     let parent_name = app.router.active().name.clone();
 
-    app.new_child_context(
-        &parent_name,
+    app.new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
+        None,
+        parent_name.clone(),
         std::path::PathBuf::from("/tmp/anchor_missing"),
         true,
         false,
         Some(999_999),
-    )
+    ))
     .expect("child create should succeed despite unknown anchor");
 
     let parent_win = app
@@ -421,13 +425,14 @@ fn new_child_context_case_insensitive_parent() {
     // The initial context is named "Test" (from new_for_test).
     // Lookup with lowercase "test" must not return "no context named" error.
     // It may fail for another reason (PTY unavailable in test env), but not lookup.
-    let result = app.new_child_context(
-        "test",
+    let result = app.new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
+        None,
+        "test".to_string(),
         std::path::PathBuf::from("/tmp/child_ci"),
         true,
         false,
         None,
-    );
+    ));
     match result {
         Ok(_) => {}
         Err(e) => {
@@ -455,13 +460,14 @@ fn create_child_context_auto_zooms() {
 
     // Simulate what the CreateContext handler does: capture current state,
     // call new_child_context, then push_depth + switch_workspace.
-    let result = app.new_child_context(
-        "Test",
+    let result = app.new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
+        None,
+        "Test".to_string(),
         std::path::PathBuf::from("/tmp/child_zoom"),
         true,
         false,
         None,
-    );
+    ));
 
     if result.is_err() {
         // PTY unavailable in test env — verify caller-side depth push still works.
@@ -567,7 +573,14 @@ fn depth_four_chain_has_portal_tiles() {
 
     for &child in &names {
         let path = std::path::PathBuf::from(format!("/tmp/depth_test_{child}"));
-        let result = app.new_child_context(&parent_name, path, true, false, None);
+        let result = app.new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
+            None,
+            parent_name.clone(),
+            path,
+            true,
+            false,
+            None,
+        ));
         if result.is_err() {
             // PTY unavailable — can't build the full chain in test env. Stop here.
             break;
@@ -2369,5 +2382,410 @@ fn context_close_offers_dissolve_only_for_portal_backed_context() {
     assert!(
         !app.build_context_close_state(child_ctx_id + 1).can_dissolve,
         "an unrelated context id must not inherit the portal's dissolvability"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// stint 0568 — `plexi context sub`: one command, N agent panes, one subcontext.
+//
+// The four defects this route fixes, each with a guard below:
+//   1. N commands produced N+1 panes (a spare seeded terminal).
+//   2. Panes landed as sibling *pages*, not tiles in one window.
+//   3. The root defaulted to the parent context's path, not the caller's cwd.
+//   4. The parent was resolved by name, so duplicate names nested wrongly.
+// ---------------------------------------------------------------------------
+
+/// Defect 1: the squad window holds exactly the requested pane count — the
+/// unconditional seeded terminal is gone from this route.
+#[test]
+fn context_sub_creates_exactly_n_panes() {
+    let mut h = crate::testing::HostHarness::new();
+    let anchor = h.add_test_pane();
+    let parent_id = h.app.router.active().context_id;
+    let root = tempfile::tempdir().expect("squad root");
+
+    let payload = serde_json::json!({
+        "type": "create_sub_context",
+        "name": "agentsquad",
+        "root": root.path(),
+        "parent_context_id": parent_id,
+        "panes": ["echo pane-a", "echo pane-b", "echo pane-c"],
+        "anchor_pane": anchor,
+    });
+    let req: crate::app_protocol::AppRequest =
+        serde_json::from_value(payload).expect("CLI payload must deserialize");
+    h.inject_ipc(req);
+    h.app.drain_pane_cmd_channel();
+
+    let child = h
+        .app
+        .router
+        .iter()
+        .find(|c| c.parent_id == Some(parent_id))
+        .expect("sub-context must exist");
+    assert_eq!(child.name, "agentsquad", "explicit CLI name must win");
+    let child_windows: Vec<_> = h
+        .app
+        .windows
+        .iter()
+        .filter(|w| w.context_id == child.context_id)
+        .collect();
+
+    // Defect 2: one window, not one page per command.
+    assert_eq!(
+        child_windows.len(),
+        1,
+        "3 agents must live in ONE window, not N sibling pages"
+    );
+    // Defect 1: three agents, three panes — no spare terminal.
+    assert_eq!(
+        child_windows[0].panes.len(),
+        3,
+        "--agents 3 must yield exactly 3 panes, not 3 + a seeded terminal"
+    );
+    // Defect 3: rooted at the path the caller passed (its cwd), not the parent's.
+    assert_eq!(
+        child.root.as_deref(),
+        Some(root.path()),
+        "sub-context must root at the caller-supplied path"
+    );
+}
+
+/// Defect 2, structurally: the squad's panes are tiles of a single container in
+/// one tree, so they render side by side rather than as separate pages.
+#[test]
+fn context_sub_panes_share_one_tiled_window() {
+    let mut h = crate::testing::HostHarness::new();
+    let parent_id = h.app.router.active().context_id;
+    let root = tempfile::tempdir().expect("squad root");
+
+    let req: crate::app_protocol::AppRequest = serde_json::from_value(serde_json::json!({
+        "type": "create_sub_context",
+        "name": "tiled",
+        "root": root.path(),
+        "parent_context_id": parent_id,
+        "panes": [null, null, null, null],
+        "layout": "tiled",
+    }))
+    .expect("payload must deserialize");
+    h.inject_ipc(req);
+    h.app.drain_pane_cmd_channel();
+
+    let child_ctx = h
+        .app
+        .router
+        .iter()
+        .find(|c| c.parent_id == Some(parent_id))
+        .expect("sub-context must exist")
+        .context_id;
+    let win = h
+        .app
+        .windows
+        .iter()
+        .find(|w| w.context_id == child_ctx)
+        .expect("child window");
+    let root_tile = win.tree.root.expect("child tree must have a root");
+    let children = match win.tree.tiles.get(root_tile) {
+        Some(egui_tiles::Tile::Container(c)) => c.children().copied().collect::<Vec<_>>(),
+        other => panic!("tiled squad root must be a container, got {other:?}"),
+    };
+    assert_eq!(
+        children.len(),
+        4,
+        "all 4 panes must be tiles under one container"
+    );
+    assert!(
+        matches!(
+            win.tree.tiles.get(root_tile),
+            Some(egui_tiles::Tile::Container(egui_tiles::Container::Grid(_)))
+        ),
+        "the default tiled layout must build a Grid container"
+    );
+}
+
+/// Defect 4: two contexts sharing a name must not make the parent ambiguous —
+/// `PLEXI_CONTEXT_ID` decides.
+#[test]
+fn resolve_parent_context_prefers_id_over_duplicate_name() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let first_id = app.router.active().context_id;
+    let duplicate_id = first_id + 500;
+    app.router.push(crate::host::context::Context {
+        name: app.router.active().name.clone(),
+        path: std::path::PathBuf::from("/tmp/dupe"),
+        root: Some(std::path::PathBuf::from("/tmp/dupe")),
+        description: None,
+        context_id: duplicate_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    let name = app.router.active().name.clone();
+
+    let by_id = app
+        .resolve_parent_context(Some(duplicate_id), &name)
+        .expect("id must resolve");
+    assert_eq!(
+        app.router.get(by_id).context_id,
+        duplicate_id,
+        "the id must select the second context even though the first shares its name"
+    );
+
+    // No id → first name match, the historical behaviour.
+    let by_name = app
+        .resolve_parent_context(None, &name)
+        .expect("name must resolve");
+    assert_eq!(app.router.get(by_name).context_id, first_id);
+
+    // A stale id must NOT fall back to the name. The pane's context was
+    // deleted; resolving its name would silently attach the child to whichever
+    // unrelated context happens to share it.
+    assert_eq!(
+        app.resolve_parent_context(Some(999_999), &name),
+        None,
+        "an id naming no live context must fail, not guess by name"
+    );
+}
+
+/// The child is registered one level below its parent and rooted where the
+/// caller asked, which is what `create_context_pane_set` stamps into each
+/// squad pane's `PLEXI_CONTEXT_*` env.
+///
+/// `TerminalBackend` moves its `BackendSettings` into the PTY options rather
+/// than retaining them, so the env itself is not observable after spawn; the
+/// two halves of that contract are pinned here and in
+/// `make_backend_settings_stamps_the_context_it_is_given` below.
+#[test]
+fn context_sub_child_is_registered_one_level_below_parent() {
+    let mut h = crate::testing::HostHarness::new();
+    let parent_id = h.app.router.active().context_id;
+    let parent_depth = h.app.router.active().depth;
+    let root = tempfile::tempdir().expect("squad root");
+
+    let req: crate::app_protocol::AppRequest = serde_json::from_value(serde_json::json!({
+        "type": "create_sub_context",
+        "name": "envcheck",
+        "root": root.path(),
+        "parent_context_id": parent_id,
+        "panes": [null, null],
+    }))
+    .expect("payload must deserialize");
+    h.inject_ipc(req);
+    h.app.drain_pane_cmd_channel();
+
+    let child = h
+        .app
+        .router
+        .iter()
+        .find(|c| c.parent_id == Some(parent_id))
+        .expect("sub-context must exist")
+        .clone();
+    assert_eq!(child.depth, parent_depth + 1, "child sits one level deeper");
+    assert_eq!(child.root.as_deref(), Some(root.path()));
+    assert_eq!(
+        h.app.context_depth_for(child.context_id),
+        parent_depth + 1,
+        "depth must be resolvable by id — this is what panes stamp as PLEXI_CONTEXT_DEPTH"
+    );
+}
+
+/// The env seam `create_context_pane_set` feeds: whatever context identity it is
+/// handed is what lands in the pane's environment. Seeding the squad *before*
+/// the child context is registered is only safe because this takes the identity
+/// explicitly instead of reading the active window.
+#[test]
+fn make_backend_settings_stamps_the_context_it_is_given() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+    let settings = PlexiApp::make_backend_settings(
+        7,
+        Some(std::path::PathBuf::from("/tmp")),
+        &app.colors,
+        4242,
+        "agentsquad",
+        "",
+        Some(&std::path::PathBuf::from("/tmp/squad")),
+        3,
+    );
+    assert_eq!(
+        settings.env.get("PLEXI_CONTEXT_ID"),
+        Some(&"4242".to_string())
+    );
+    assert_eq!(
+        settings.env.get("PLEXI_CONTEXT_NAME"),
+        Some(&"agentsquad".to_string())
+    );
+    assert_eq!(
+        settings.env.get("PLEXI_CONTEXT_DEPTH"),
+        Some(&"3".to_string())
+    );
+    assert_eq!(settings.env.get("PLEXI_PANE_ID"), Some(&"7".to_string()));
+}
+
+/// An unresolvable parent fails before any pane is spawned — no orphan context,
+/// no half-built squad.
+#[test]
+fn context_sub_unknown_parent_creates_nothing() {
+    let mut h = crate::testing::HostHarness::new();
+    let contexts_before = h.app.router.len();
+    let windows_before = h.app.windows.len();
+
+    let req: crate::app_protocol::AppRequest = serde_json::from_value(serde_json::json!({
+        "type": "create_sub_context",
+        "name": "orphan",
+        "root": "/tmp",
+        "parent_context_id": 987_654_321_u64,
+        "parent_name": "no-such-context",
+        "panes": [null, null],
+    }))
+    .expect("payload must deserialize");
+    h.inject_ipc(req);
+    h.app.drain_pane_cmd_channel();
+
+    assert_eq!(
+        h.app.router.len(),
+        contexts_before,
+        "no context may be added"
+    );
+    assert_eq!(
+        h.app.windows.len(),
+        windows_before,
+        "no window may be added"
+    );
+}
+
+/// The name must be carried *into* `new_child_context` via the spec, not
+/// applied by renaming the router entry afterwards.
+///
+/// This calls `new_child_context` directly, so nothing downstream can patch the
+/// name up: if the spec's name were ignored, the context would come back named
+/// after its directory. That ordering is what matters — the panes are spawned
+/// inside this call with the name in `PLEXI_CONTEXT_NAME`, so a rename applied
+/// by the caller afterwards would leave running agents advertising a name the
+/// router no longer uses.
+#[test]
+fn child_context_takes_its_name_from_the_spec_not_the_path() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+    let parent_id = app.router.active().context_id;
+    // A root whose basename cannot be confused with the requested name.
+    let root = tempfile::tempdir().expect("squad root");
+    let derived = root
+        .path()
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .expect("tempdir has a basename");
+
+    let child = app
+        .new_child_context(crate::pane_ops::ChildContextSpec {
+            parent_id: Some(parent_id),
+            parent_name: String::new(),
+            name: Some("agentsquad".to_string()),
+            path: root.path().to_path_buf(),
+            portal_vertical: true,
+            portal_first: false,
+            anchor_pane: None,
+            panes: vec![None, None],
+            layout: crate::app_protocol::SubContextLayout::Tiled,
+        })
+        .expect("child create should succeed");
+
+    assert_eq!(
+        app.context_name_for(child.context_id),
+        "agentsquad",
+        "the spec's name must be the context's name the moment it is created"
+    );
+    assert_ne!(
+        app.context_name_for(child.context_id),
+        derived,
+        "the path-derived name must not win over an explicit one"
+    );
+
+    // And with no explicit name, the derived name is still the fallback.
+    let plain = app
+        .new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
+            Some(parent_id),
+            String::new(),
+            root.path().to_path_buf(),
+            true,
+            false,
+            None,
+        ))
+        .expect("child create should succeed");
+    assert_eq!(app.context_name_for(plain.context_id), derived);
+}
+
+/// `--focus` must record the *caller's* window as the zoom-out target. A
+/// background pane can create a squad while the user is looking at a different
+/// context; a depth entry naming the globally active window could not restore
+/// the caller's location.
+#[test]
+fn context_sub_focus_returns_to_the_callers_window_not_the_active_one() {
+    let mut h = crate::testing::HostHarness::new();
+    let caller_pane = h.add_test_pane();
+    let caller_ctx_id = h.app.router.active().context_id;
+    let caller_win_id = h.app.windows[0].window_id;
+
+    // Make a second context active, so `active_window` is NOT the caller's.
+    let other_ctx_id = 9_001;
+    let other_win_id = 9_002;
+    h.app.router.push(crate::host::context::Context {
+        name: "Elsewhere".into(),
+        path: std::path::PathBuf::from("/tmp/elsewhere"),
+        root: Some(std::path::PathBuf::from("/tmp/elsewhere")),
+        description: None,
+        context_id: other_ctx_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    h.app.windows.push(Window {
+        name: String::new(),
+        path: std::path::PathBuf::from("/tmp/elsewhere"),
+        tree: egui_tiles::Tree::empty("plexi"),
+        panes: std::collections::HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 0,
+        grid_y: 0,
+        window_id: other_win_id,
+        context_id: other_ctx_id,
+    });
+    h.app.active_window = h.app.windows.len() - 1;
+    assert_ne!(
+        h.app.windows[h.app.active_window].window_id, caller_win_id,
+        "precondition: the active window is not the caller's"
+    );
+
+    let root = tempfile::tempdir().expect("squad root");
+    let req: crate::app_protocol::AppRequest = serde_json::from_value(serde_json::json!({
+        "type": "create_sub_context",
+        "name": "bgsquad",
+        "root": root.path(),
+        "parent_context_id": caller_ctx_id,
+        "anchor_pane": caller_pane,
+        "panes": [null],
+        "focus": true,
+    }))
+    .expect("payload must deserialize");
+    h.inject_ipc(req);
+    h.app.drain_pane_cmd_channel();
+
+    let (depth_ctx, depth_win, _) = h
+        .app
+        .router
+        .depth_stack
+        .last()
+        .copied()
+        .expect("--focus must push a depth entry");
+    assert_eq!(depth_ctx, caller_ctx_id, "return context is the caller's");
+    assert_eq!(
+        depth_win, caller_win_id,
+        "return window must be the caller's, not the globally active one"
     );
 }

--- a/src/cli/AGENTS.md
+++ b/src/cli/AGENTS.md
@@ -22,6 +22,13 @@ Every CLI command and feature must work identically on alpha, beta, main, and PR
 - **Namespace design:** verify a new command belongs in the right namespace. Place it where the noun already lives, not at top level.
 - **Pane naming:** always name panes after spawning them. Every `plexi pane new`, `plexi app open`, split, or new window should be followed by `plexi pane name <id> "descriptive name"`.
 - **Tips:** use `print_tip()` from `src/cli/mod.rs`. Never raw `eprintln!`. Respects `config.cli.tips` and `NO_COLOR`.
+- **Repeatable flags fan out or they error.** A count flag paired with a repeatable value flag (`context sub --agents N --command CMD`) accepts the value once (applies to all) or exactly N times (one each). Any other count is a hard error — never truncate, never cycle. Expand to one entry per unit in the CLI so the host receives an unambiguous list; see `expand_pane_commands`.
+- **Resolve the caller's context by `PLEXI_CONTEXT_ID`, not `PLEXI_CONTEXT_NAME`.** Context names are not unique; the id is. Send the id; the host consults the name only when no id was sent (`resolve_parent_context`). An id naming no live context is an error, never a reason to fall back to the name — a stale id plus a name some other context happens to share would silently target a stranger.
+- **Agent-facing commands answer in one round trip.** A command that creates addressable objects returns their ids in its JSON response (`context sub` → `{"context_id","windows","panes":[…]}`), so the caller never needs a follow-up `pane list` to act on what it just made.
+
+## Documentation Rule for CLI Changes
+
+Any change to a CLI verb, flag, or agent-facing behavior updates this file **and** `skills/plexi-cli/SKILL.md` in the same PR. Edit the skill through the real `skills/` path — `.agents/skills/plexi-cli` is a symlink and some editors do not write through it. Shell completions are generated from the clap tree (`completions_cli`), so a new flag needs no hand-written block; verify with `plexi completions zsh | grep <flag>`.
 
 ## Traps
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1300,6 +1300,41 @@ pub enum ContextCmd {
         #[arg(long, short = 'r', conflicts_with_all = ["down", "left", "up"])]
         right: bool,
     },
+    /// Create a sub-context under the current one, pre-populated with panes.
+    ///
+    /// One command spins up a scoped squad: N panes in a single tiled window
+    /// inside the new sub-context, each running the same command (or its own).
+    /// Unlike `context new --parent --window`, this creates exactly N panes —
+    /// no spare terminal — and roots them at the caller's cwd.
+    ///
+    /// Examples:
+    ///   plexi context sub agentsquad --agents 3 --command cm
+    ///   plexi context sub review --agents 2 --command "cm review" --command "cm test"
+    ///   plexi context sub build --agents 4 --layout columns --focus
+    Sub {
+        /// Name for the new sub-context.
+        name: String,
+        /// Root path for the sub-context. Defaults to the caller's cwd.
+        #[arg(long)]
+        path: Option<String>,
+        /// Number of panes to open inside the new sub-context.
+        #[arg(long, default_value_t = 1, value_parser = clap::value_parser!(u32).range(1..=32))]
+        agents: u32,
+        /// Command to launch in each pane. Give it once to apply to every pane,
+        /// or exactly --agents times to give each pane its own command.
+        #[arg(long, action = clap::ArgAction::Append, value_name = "CMD")]
+        command: Vec<String>,
+        /// How the panes are arranged inside the sub-context's window.
+        #[arg(long, value_enum, default_value_t = crate::app_protocol::SubContextLayout::Tiled)]
+        layout: crate::app_protocol::SubContextLayout,
+        /// Zoom into the new sub-context after creation. Default: stay put.
+        #[arg(long)]
+        focus: bool,
+        /// Pane to anchor the portal split at. Defaults to the calling pane
+        /// (PLEXI_PANE_ID env), falling back to the parent's focused pane.
+        #[arg(long, value_name = "PANE_ID")]
+        from: Option<u64>,
+    },
     /// Switch the current pane to a context at the given path.
     Open { path: Option<String> },
     /// Change the root folder for the active context.

--- a/src/cli/context_cli.rs
+++ b/src/cli/context_cli.rs
@@ -23,10 +23,20 @@ pub fn context_new_cli(
     // "--parent" with no value resolves to the current context via env.
     // "--parent <name>" passes that name directly.
     // No "--parent" → None (top-level context).
+    //
+    // Bare "--parent" also sends PLEXI_CONTEXT_ID, which disambiguates when two
+    // contexts share a name. An explicit "--parent=<name>" does not: the caller
+    // named a context, so name resolution is what they asked for.
+    let mut parent_context_id = None;
     let explicit_parent = match parent {
         None => None,
         Some("__current__") => match std::env::var("PLEXI_CONTEXT_NAME") {
-            Ok(n) if !n.is_empty() => Some(n),
+            Ok(n) if !n.is_empty() => {
+                parent_context_id = std::env::var("PLEXI_CONTEXT_ID")
+                    .ok()
+                    .and_then(|v| v.parse::<u64>().ok());
+                Some(n)
+            }
             _ => {
                 eprintln!(
                     "error: --parent (no value) requires PLEXI_CONTEXT_NAME — run inside a Plexi pane"
@@ -74,6 +84,9 @@ pub fn context_new_cli(
     if let Some(p) = &explicit_parent {
         payload["parent_name"] = serde_json::Value::String(p.clone());
     }
+    if let Some(id) = parent_context_id {
+        payload["parent_context_id"] = serde_json::Value::from(id);
+    }
     if !windows.is_empty() {
         payload["windows"] = serde_json::to_value(windows).expect("Vec<String> is serializable");
     }
@@ -103,6 +116,134 @@ pub fn context_new_cli(
         }
     }
     0
+}
+
+/// Expand `--agents N` + repeated `--command` into exactly one entry per pane.
+///
+/// Zero commands means N plain shells; one command applies to every pane; N
+/// commands assign one per pane in order. Any other count is an error — never a
+/// silent truncation or a cycle, because a squad that quietly drops an agent's
+/// job is worse than one that refuses to start.
+pub(super) fn expand_pane_commands(
+    agents: u32,
+    commands: &[String],
+) -> Result<Vec<Option<String>>, String> {
+    let agents = agents as usize;
+    match commands.len() {
+        0 => Ok(vec![None; agents]),
+        1 => Ok(vec![Some(commands[0].clone()); agents]),
+        n if n == agents => Ok(commands.iter().cloned().map(Some).collect()),
+        n => Err(format!(
+            "error: --command given {n} times but --agents is {agents} — pass it once (same command for every pane) or exactly {agents} times (one per pane)"
+        )),
+    }
+}
+
+/// `plexi context sub <name> --agents N --command CMD`
+///
+/// Creates a sub-context under the caller's context and seeds it with exactly
+/// `agents` panes in one tiled window, each running its assigned command.
+pub fn context_sub_cli(
+    name: &str,
+    path: Option<&str>,
+    agents: u32,
+    commands: &[String],
+    layout: crate::app_protocol::SubContextLayout,
+    focus: bool,
+    from: Option<u64>,
+) -> i32 {
+    let panes = match expand_pane_commands(agents, commands) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+    // Deliberate divergence from `context new`: the sub-context roots at the
+    // caller's cwd, not the parent context's path, so agents launched here
+    // start in the directory the operator was standing in.
+    let root = match resolve_path(path) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
+    };
+    // Parent by id — PLEXI_CONTEXT_ID is set in every Plexi pane and is unique;
+    // the name is only a fallback for a pane that somehow has one without the
+    // other.
+    let parent_context_id = std::env::var("PLEXI_CONTEXT_ID")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok());
+    let parent_name = std::env::var("PLEXI_CONTEXT_NAME")
+        .ok()
+        .filter(|n| !n.is_empty());
+    if parent_context_id.is_none() && parent_name.is_none() {
+        eprintln!("error: context sub requires PLEXI_CONTEXT_ID — run it inside a Plexi pane");
+        return 1;
+    }
+    let anchor_pane = from.or_else(|| {
+        std::env::var("PLEXI_PANE_ID")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+    });
+    log::info!(
+        "context_sub_cli: name={name:?} root={} parent_context_id={parent_context_id:?} \
+         parent_name={parent_name:?} agents={agents} layout={layout:?} focus={focus} \
+         anchor_pane={anchor_pane:?}",
+        root.display()
+    );
+    let response_file = crate::rpc::response_file("context-sub-response", "json");
+    let mut payload = serde_json::json!({
+        "type": "create_sub_context",
+        "name": name,
+        "root": root.to_string_lossy(),
+        "panes": panes,
+        "layout": layout,
+        "focus": focus,
+        "response_file": response_file,
+    });
+    if let Some(id) = parent_context_id {
+        payload["parent_context_id"] = serde_json::Value::from(id);
+    }
+    if let Some(n) = parent_name {
+        payload["parent_name"] = serde_json::Value::String(n);
+    }
+    if let Some(ap) = anchor_pane {
+        payload["anchor_pane"] = serde_json::Value::from(ap);
+    }
+    let rc = send_to_socket(payload);
+    if rc != 0 {
+        return rc;
+    }
+    match super::poll_rpc(&response_file, "context-sub") {
+        Ok(content) => {
+            // `poll_rpc` only distinguishes transport failures. The host reports
+            // a refused parent or a failed terminal spawn *in* the payload, so
+            // an unattended caller needs that surfaced as a nonzero exit rather
+            // than a successful-looking JSON blob.
+            if let Some(err) = sub_response_error(&content) {
+                eprintln!("error: context sub failed: {err}");
+                return 1;
+            }
+            println!("{content}");
+            0
+        }
+        Err(code) => code,
+    }
+}
+
+/// The `error` field of a `context sub` response, if the host reported one.
+///
+/// Unparseable output is not treated as an error here — `poll_rpc` already
+/// owns transport failures, and swallowing a valid-but-unexpected shape would
+/// hide the response from the caller.
+fn sub_response_error(content: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(content)
+        .ok()?
+        .get("error")?
+        .as_str()
+        .map(|s| s.to_string())
 }
 
 /// `plexi context zoom <context_id>`
@@ -346,5 +487,78 @@ fn print_json_output(json_str: &str) -> i32 {
             eprintln!("error: invalid JSON output: {e}");
             1
         }
+    }
+}
+
+#[cfg(test)]
+mod context_sub_tests {
+    use super::expand_pane_commands;
+
+    #[test]
+    fn no_command_gives_every_pane_a_plain_shell() {
+        assert_eq!(expand_pane_commands(3, &[]), Ok(vec![None, None, None]));
+    }
+
+    #[test]
+    fn one_command_applies_to_every_pane() {
+        assert_eq!(
+            expand_pane_commands(3, &["cm".to_string()]),
+            Ok(vec![
+                Some("cm".to_string()),
+                Some("cm".to_string()),
+                Some("cm".to_string())
+            ])
+        );
+    }
+
+    #[test]
+    fn n_commands_map_one_per_pane_in_order() {
+        let cmds = ["a".to_string(), "b".to_string()];
+        assert_eq!(
+            expand_pane_commands(2, &cmds),
+            Ok(vec![Some("a".to_string()), Some("b".to_string())])
+        );
+    }
+
+    /// A count that is neither 1 nor N is an error, never a silent truncation
+    /// or a cycle — a squad that quietly drops an agent's job is worse than one
+    /// that refuses to start.
+    #[test]
+    fn mismatched_command_count_is_an_error() {
+        let cmds = ["a".to_string(), "b".to_string()];
+        let err = expand_pane_commands(3, &cmds).expect_err("2 commands for 3 agents must fail");
+        assert!(err.contains("--command given 2 times"), "got: {err}");
+        assert!(err.contains("--agents is 3"), "got: {err}");
+    }
+}
+
+#[cfg(test)]
+mod sub_response_tests {
+    use super::sub_response_error;
+
+    /// A host-reported failure must be detectable so the CLI can exit nonzero —
+    /// `poll_rpc` succeeds here, because the transport worked.
+    #[test]
+    fn error_field_is_surfaced() {
+        assert_eq!(
+            sub_response_error(r#"{"error":"no parent context for id=Some(9)"}"#).as_deref(),
+            Some("no parent context for id=Some(9)")
+        );
+    }
+
+    #[test]
+    fn successful_response_has_no_error() {
+        assert_eq!(
+            sub_response_error(r#"{"context_id":76,"windows":[],"panes":[317,318]}"#),
+            None
+        );
+    }
+
+    /// Unparseable output is not an error here: `poll_rpc` owns transport
+    /// failures, and swallowing an unexpected-but-valid shape would hide the
+    /// response from the caller.
+    #[test]
+    fn unparseable_output_is_not_treated_as_an_error() {
+        assert_eq!(sub_response_error("not json at all"), None);
     }
 }

--- a/src/cli/context_cli.rs
+++ b/src/cli/context_cli.rs
@@ -190,7 +190,7 @@ pub fn context_sub_cli(
     log::info!(
         "context_sub_cli: name={name:?} root={} parent_context_id={parent_context_id:?} \
          parent_name={parent_name:?} agents={agents} layout={layout:?} focus={focus} \
-         anchor_pane={anchor_pane:?}",
+         anchor_pane={anchor_pane:?} panes={panes:?}",
         root.display()
     );
     let response_file = crate::rpc::response_file("context-sub-response", "json");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -595,7 +595,8 @@ pub use config_cli::{
 };
 pub use context_cli::{
     context_current_cli, context_describe_cli, context_list_cli, context_new_cli, context_open_cli,
-    context_push_cli, context_set_root_cli, context_zoom_cli, context_zoom_out_cli,
+    context_push_cli, context_set_root_cli, context_sub_cli, context_zoom_cli,
+    context_zoom_out_cli,
 };
 pub use demo::demo_cli;
 pub use doctor::doctor_cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1097,6 +1097,23 @@ fn main() -> eframe::Result {
                                 from,
                             ))
                         }
+                        ContextCmd::Sub {
+                            name,
+                            path,
+                            agents,
+                            command,
+                            layout,
+                            focus,
+                            from,
+                        } => std::process::exit(cli::context_sub_cli(
+                            &name,
+                            path.as_deref(),
+                            agents,
+                            &command,
+                            layout,
+                            focus,
+                            from,
+                        )),
                         ContextCmd::Open { path } => {
                             std::process::exit(cli::context_open_cli(path.as_deref()))
                         }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -16,6 +16,19 @@ use egui_tiles::{Tile, TileId, Tree};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+/// Context identity stamped into a new pane's `PLEXI_CONTEXT_*` environment.
+///
+/// Carried explicitly so a pane can be created for a context that is not the
+/// active one — including one not yet pushed to the router, which is the case
+/// while a child context's window is still being built.
+pub(crate) struct PaneContextEnv {
+    pub context_id: u64,
+    pub name: String,
+    pub description: String,
+    pub root: Option<PathBuf>,
+    pub depth: u32,
+}
+
 /// Instantiate a builtin `App` by id, checked before the process registry.
 ///
 /// Builtins are compiled-in and never require disk access. Add one line here
@@ -819,6 +832,77 @@ impl PlexiApp {
                 timestamp: crate::host::event_log::now_timestamp(),
             });
         }
+    }
+
+    /// Build a window's worth of terminal panes for a context that is **not**
+    /// the active one — typically one that does not exist in the router yet.
+    ///
+    /// [`create_single_pane_tree`](Self::create_single_pane_tree) stamps
+    /// `PLEXI_CONTEXT_*` from `active_window`, which is wrong for a child
+    /// context being constructed: its panes would advertise the parent's id.
+    /// This takes the context identity explicitly instead, per the root
+    /// AGENTS.md rule against steering helpers by mutating global focus state.
+    ///
+    /// One pane per entry in `commands`, in order; `None` launches a plain
+    /// shell. Returns the tiled tree, the pane map, the first pane's tile (the
+    /// window's initial focus), and the pane ids in creation order.
+    ///
+    /// Returns `None` if any terminal fails to spawn — partial squads are never
+    /// installed. Panes already built are dropped, closing their PTYs.
+    pub(super) fn create_context_pane_set(
+        &mut self,
+        context: &PaneContextEnv,
+        cwd: PathBuf,
+        commands: &[Option<String>],
+        layout: crate::app_protocol::SubContextLayout,
+    ) -> Option<(Tree<PaneId>, HashMap<PaneId, Pane>, TileId, Vec<PaneId>)> {
+        if commands.is_empty() {
+            log::error!("create_context_pane_set: refusing to build a window with zero panes");
+            return None;
+        }
+        let mut panes: HashMap<PaneId, Pane> = HashMap::new();
+        let mut pane_ids: Vec<PaneId> = Vec::with_capacity(commands.len());
+        for initial_cmd in commands {
+            let new_id = self.host.alloc_pane_id();
+            let mut settings = Self::make_backend_settings(
+                new_id,
+                Some(cwd.clone()),
+                &self.colors,
+                context.context_id,
+                &context.name,
+                &context.description,
+                context.root.as_ref(),
+                context.depth,
+            );
+            if let Some(cmd) = initial_cmd {
+                super::apply_initial_cmd(&mut settings, cmd, false);
+            }
+            let Some(pane) = TerminalPane::new(
+                new_id,
+                self.ctx.clone(),
+                self.pty_event_tx.clone(),
+                settings,
+                self.default_font_size,
+            ) else {
+                log::error!(
+                    "create_context_pane_set: TerminalPane::new failed for pane_id={new_id} \
+                     context_id={} — discarding {} already-created pane(s)",
+                    context.context_id,
+                    pane_ids.len()
+                );
+                return None;
+            };
+            panes.insert(new_id, Pane::Terminal(Box::new(pane)));
+            pane_ids.push(new_id);
+        }
+        let (tree, first_tile) = super::layout::build_squad_tree(&pane_ids, layout);
+        log::info!(
+            "create_context_pane_set: context_id={} panes={:?} layout={layout:?} cwd={}",
+            context.context_id,
+            pane_ids,
+            cwd.display()
+        );
+        Some((tree, panes, first_tile, pane_ids))
     }
 
     pub(super) fn create_single_pane_tree(

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -860,9 +860,10 @@ impl PlexiApp {
             log::error!("create_context_pane_set: refusing to build a window with zero panes");
             return None;
         }
+        let total = commands.len();
         let mut panes: HashMap<PaneId, Pane> = HashMap::new();
-        let mut pane_ids: Vec<PaneId> = Vec::with_capacity(commands.len());
-        for initial_cmd in commands {
+        let mut pane_ids: Vec<PaneId> = Vec::with_capacity(total);
+        for (idx, initial_cmd) in commands.iter().enumerate() {
             let new_id = self.host.alloc_pane_id();
             let mut settings = Self::make_backend_settings(
                 new_id,
@@ -884,14 +885,26 @@ impl PlexiApp {
                 settings,
                 self.default_font_size,
             ) else {
+                // The 2am case: a squad that half-spawned. Name which pane of
+                // how many died, on what command, and what is being torn down —
+                // the caller only ever sees "failed to create terminals".
                 log::error!(
-                    "create_context_pane_set: TerminalPane::new failed for pane_id={new_id} \
-                     context_id={} — discarding {} already-created pane(s)",
+                    "create_context_pane_set: TerminalPane::new failed for pane {} of {total} \
+                     (pane_id={new_id} context_id={} cmd={initial_cmd:?}) — discarding \
+                     {} already-created pane(s) {:?}, no partial squad is installed",
+                    idx + 1,
                     context.context_id,
-                    pane_ids.len()
+                    pane_ids.len(),
+                    pane_ids
                 );
                 return None;
             };
+            log::info!(
+                "create_context_pane_set: spawned pane {} of {total} pane_id={new_id} \
+                 context_id={} cmd={initial_cmd:?}",
+                idx + 1,
+                context.context_id
+            );
             panes.insert(new_id, Pane::Terminal(Box::new(pane)));
             pane_ids.push(new_id);
         }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -61,6 +61,39 @@ pub(super) fn restore_overlay_replacement(
     }
 }
 
+/// Build a fresh tile tree holding `pane_ids` arranged per `layout`.
+/// Pure tile manipulation — no PlexiApp state, no pane creation.
+///
+/// A single pane becomes the root directly (no container wrapper), matching the
+/// shape `create_single_pane_tree` produces. Returns the tree plus the root tile
+/// of the *first* pane, which callers use as the window's initial focus.
+///
+/// Panics if `pane_ids` is empty — every caller seeds at least one pane, and a
+/// rootless window is not a state the host can render.
+pub(crate) fn build_squad_tree(
+    pane_ids: &[PaneId],
+    layout: crate::app_protocol::SubContextLayout,
+) -> (egui_tiles::Tree<PaneId>, TileId) {
+    assert!(
+        !pane_ids.is_empty(),
+        "build_squad_tree requires at least one pane"
+    );
+    let mut tiles = egui_tiles::Tiles::default();
+    let pane_tiles: Vec<TileId> = pane_ids.iter().map(|id| tiles.insert_pane(*id)).collect();
+    let first_tile = pane_tiles[0];
+    let root = if pane_tiles.len() == 1 {
+        first_tile
+    } else {
+        match layout {
+            crate::app_protocol::SubContextLayout::Tiled => tiles.insert_grid_tile(pane_tiles),
+            crate::app_protocol::SubContextLayout::Columns => {
+                tiles.insert_horizontal_tile(pane_tiles)
+            }
+        }
+    };
+    (egui_tiles::Tree::new("plexi", root, tiles), first_tile)
+}
+
 /// Insert `new_pane_id` as a new tile next to `split_target` in `tree`.
 /// Pure tile/tree manipulation — no PlexiApp state, no focus history.
 ///
@@ -1862,6 +1895,62 @@ mod send_pane_tests {
         assert!(matches!(
             app.send_pane(Direction::Right),
             SwapResult::AtBoundary
+        ));
+    }
+}
+
+#[cfg(test)]
+mod squad_tree_tests {
+    use super::build_squad_tree;
+    use crate::app_protocol::SubContextLayout;
+
+    /// `--layout tiled` (the `context sub` default) builds a Grid container, so
+    /// an agent squad renders as a near-square block rather than a strip.
+    #[test]
+    fn tiled_layout_builds_a_grid_container() {
+        let (tree, first) = build_squad_tree(&[1, 2, 3, 4], SubContextLayout::Tiled);
+        let root = tree.root.expect("root");
+        match tree.tiles.get(root) {
+            Some(egui_tiles::Tile::Container(egui_tiles::Container::Grid(grid))) => {
+                assert_eq!(grid.children().count(), 4);
+            }
+            other => panic!("tiled layout must be a Grid, got {other:?}"),
+        }
+        assert!(matches!(
+            tree.tiles.get(first),
+            Some(egui_tiles::Tile::Pane(1))
+        ));
+    }
+
+    /// `--layout columns` builds one horizontal linear container: N full-height
+    /// columns, left to right in the order the commands were given.
+    #[test]
+    fn columns_layout_builds_a_horizontal_linear_container() {
+        let (tree, first) = build_squad_tree(&[7, 8, 9], SubContextLayout::Columns);
+        let root = tree.root.expect("root");
+        match tree.tiles.get(root) {
+            Some(egui_tiles::Tile::Container(egui_tiles::Container::Linear(linear))) => {
+                assert_eq!(linear.dir, egui_tiles::LinearDir::Horizontal);
+                assert_eq!(linear.children.len(), 3);
+                assert_eq!(
+                    linear.children[0], first,
+                    "the first pane's tile is the window's initial focus"
+                );
+            }
+            other => panic!("columns layout must be a horizontal Linear, got {other:?}"),
+        }
+    }
+
+    /// A single pane is the root directly — the same tree shape
+    /// `create_single_pane_tree` produces, so the historical single-terminal
+    /// child context is structurally unchanged.
+    #[test]
+    fn single_pane_needs_no_container() {
+        let (tree, first) = build_squad_tree(&[42], SubContextLayout::Tiled);
+        assert_eq!(tree.root, Some(first));
+        assert!(matches!(
+            tree.tiles.get(first),
+            Some(egui_tiles::Tile::Pane(42))
         ));
     }
 }

--- a/src/pane_ops/mod.rs
+++ b/src/pane_ops/mod.rs
@@ -20,6 +20,7 @@ pub(crate) use create::restore_assistant_pane;
 pub(crate) use create::restore_builtin_app_pane;
 pub(crate) use layout::insert_split_tile;
 pub(crate) use layout::SwapResult;
+pub(crate) use workspace::ChildContextSpec;
 
 /// Apply `initial_cmd` to `settings`, using the same shell-suffix injection
 /// logic as `split_focused`. Call before `TerminalPane::new`.

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -192,22 +192,123 @@ fn reserve_grid_slot(
     }
 }
 
+/// Where a new child context attaches, and what its window is seeded with.
+pub(crate) struct ChildContextSpec {
+    /// Parent context id — the caller's `PLEXI_CONTEXT_ID`. Authoritative when
+    /// present: two contexts can share a name, so resolving by name alone
+    /// silently nests under whichever was created first.
+    pub parent_id: Option<u64>,
+    /// Parent context name. Consulted only when `parent_id` is absent — a
+    /// present-but-unknown id is an error, never a reason to guess by name.
+    pub parent_name: String,
+    /// Explicit name for the child context. When `None` the name is derived
+    /// from the path (or the anchor's `[context]` defaults). Set it here rather
+    /// than renaming afterwards: the panes are spawned with this name in
+    /// `PLEXI_CONTEXT_NAME`, so a later rename would leave running agents
+    /// advertising a name the router no longer uses.
+    pub name: Option<String>,
+    /// Root path and working directory for the child context.
+    pub path: PathBuf,
+    /// Portal tile orientation in the parent window: `true` splits side-by-side.
+    pub portal_vertical: bool,
+    /// `true` places the portal before the anchor tile (left / up).
+    pub portal_first: bool,
+    /// Pane in the parent to anchor the portal split at; falls back to the
+    /// parent's focused pane when absent or unknown.
+    pub anchor_pane: Option<u64>,
+    /// One entry per pane to seed in the child window, in order; `None` launches
+    /// a plain shell. Never empty.
+    pub panes: Vec<Option<String>>,
+    /// How the seeded panes are arranged inside the child's single window.
+    pub layout: crate::app_protocol::SubContextLayout,
+}
+
+impl ChildContextSpec {
+    /// The historical single-terminal child: one plain shell, tiled.
+    pub fn single_terminal(
+        parent_id: Option<u64>,
+        parent_name: String,
+        path: PathBuf,
+        portal_vertical: bool,
+        portal_first: bool,
+        anchor_pane: Option<u64>,
+    ) -> Self {
+        Self {
+            parent_id,
+            parent_name,
+            name: None,
+            path,
+            portal_vertical,
+            portal_first,
+            anchor_pane,
+            panes: vec![None],
+            layout: crate::app_protocol::SubContextLayout::default(),
+        }
+    }
+}
+
+/// What a successful [`PlexiApp::new_child_context`] created.
+pub(crate) struct ChildContext {
+    pub context_id: u64,
+    /// Seeded pane ids, in the order their commands were given.
+    pub pane_ids: Vec<PaneId>,
+    /// The parent window the portal was inserted into, and its focused tile,
+    /// both captured *before* the insert. A caller that pushes a depth entry
+    /// must use these rather than the globally active window: a background pane
+    /// can create a sub-context while the user is looking at another context
+    /// entirely, and a depth entry pairing this parent with an unrelated window
+    /// cannot restore the caller's location on zoom-out.
+    pub parent_window_id: Option<u64>,
+    pub parent_focused_pane: Option<egui_tiles::TileId>,
+}
+
 impl PlexiApp {
-    /// Create a child context nested inside `parent_name`. Always creates a fresh
-    /// terminal in the child (portal model — no pane adoption). Inserts a Portal
-    /// tile into the parent window as a sibling of the focused tile. No depth cap.
+    /// Resolve a parent context to a router index: by `id` when one is given,
+    /// otherwise by case-insensitive `name`.
+    ///
+    /// An `id` that names no live context resolves to `None` — it does **not**
+    /// fall back to the name. Names are not unique, so a stale
+    /// `PLEXI_CONTEXT_ID` (its context deleted) plus a name another context
+    /// happens to share would silently attach the child to a stranger. Failing
+    /// loudly is the only safe answer.
+    pub(crate) fn resolve_parent_context(&self, id: Option<u64>, name: &str) -> Option<usize> {
+        match id {
+            Some(want) => self.router.position(|c| c.context_id == want),
+            None => self.router.position(|c| c.name.eq_ignore_ascii_case(name)),
+        }
+    }
+
+    /// Create a child context nested under `spec`'s parent, seeded with exactly
+    /// `spec.panes.len()` terminals in one window (portal model — no pane
+    /// adoption). Inserts a Portal tile into the parent window as a sibling of
+    /// the anchor tile. No depth cap.
     pub(crate) fn new_child_context(
         &mut self,
-        parent_name: &str,
-        path: PathBuf,
-        vertical: bool,
-        new_pane_first: bool,
-        anchor_pane: Option<u64>,
-    ) -> Result<(), String> {
+        spec: ChildContextSpec,
+    ) -> Result<ChildContext, String> {
+        let ChildContextSpec {
+            parent_id: want_parent_id,
+            parent_name,
+            name: explicit_name,
+            path,
+            portal_vertical: vertical,
+            portal_first: new_pane_first,
+            anchor_pane,
+            panes: pane_commands,
+            layout,
+        } = spec;
+        if pane_commands.is_empty() {
+            return Err("child context requires at least one pane".to_string());
+        }
         let parent_idx = self
-            .router
-            .position(|c| c.name.eq_ignore_ascii_case(parent_name))
-            .ok_or_else(|| format!("no context named '{parent_name}'"))?;
+            .resolve_parent_context(want_parent_id, &parent_name)
+            .ok_or_else(|| match want_parent_id {
+                Some(id) => format!(
+                    "no context with id {id} — PLEXI_CONTEXT_ID is stale (its context was closed); \
+                     open a new pane or pass an explicit parent"
+                ),
+                None => format!("no context named '{parent_name}'"),
+            })?;
         let parent_id = self.router.get(parent_idx).context_id;
         let parent_depth = self.router.get(parent_idx).depth;
         let child_depth = parent_depth + 1;
@@ -237,19 +338,33 @@ impl PlexiApp {
                     (name, None)
                 }
             };
+        // An explicit name wins over the derived one, and must be settled here:
+        // the panes below are spawned with it in PLEXI_CONTEXT_NAME.
+        let ctx_name = explicit_name.unwrap_or(ctx_name);
 
         log::info!(
             "new_child_context: parent_id={parent_id} parent_depth={parent_depth} \
-             child_depth={child_depth} name={ctx_name} path={}",
+             child_depth={child_depth} name={ctx_name} panes={} layout={layout:?} path={}",
+            pane_commands.len(),
             path.display()
         );
 
-        // 1. Build the child window with a fresh terminal.
-        let Some((child_tree, child_panes, child_root_tile)) =
-            self.create_single_pane_tree(Some(path.clone()), None, false)
+        // 1. Build the child window's panes. Their PLEXI_CONTEXT_* env is
+        // stamped from the child's own identity, which is not in the router
+        // yet — hence the explicit PaneContextEnv rather than the active
+        // window's context.
+        let child_env = super::create::PaneContextEnv {
+            context_id: ctx_id,
+            name: ctx_name.clone(),
+            description: ctx_description.clone().unwrap_or_default(),
+            root: Some(path.clone()),
+            depth: child_depth,
+        };
+        let Some((child_tree, child_panes, child_root_tile, child_pane_ids)) =
+            self.create_context_pane_set(&child_env, path.clone(), &pane_commands, layout)
         else {
-            log::error!("new_child_context: failed to create terminal for child context");
-            return Err("failed to create terminal for child context".to_string());
+            log::error!("new_child_context: failed to create terminals for child context");
+            return Err("failed to create terminals for child context".to_string());
         };
 
         // 2. Insert Portal tile into the parent window via the standard split path.
@@ -278,6 +393,11 @@ impl PlexiApp {
                 })
                 .or_else(|| self.windows.iter().position(|w| w.context_id == parent_id))
         });
+        // Snapshot the caller's location before the portal insert. A depth entry
+        // built from `active_window` would be wrong whenever the request came
+        // from a pane the user is not currently looking at.
+        let parent_window_id = parent_win_idx.map(|idx| self.windows[idx].window_id);
+        let parent_focused_pane = parent_win_idx.and_then(|idx| self.windows[idx].focused_pane);
         let sub_ctx_pane_id = self.host.alloc_pane_id();
         if let Some(parent_win_idx) = parent_win_idx {
             let split_target = portal_anchor
@@ -333,7 +453,12 @@ impl PlexiApp {
         self.context_active_window.insert(ctx_id, win_id);
 
         self.save_workspace();
-        Ok(())
+        Ok(ChildContext {
+            context_id: ctx_id,
+            pane_ids: child_pane_ids,
+            parent_window_id,
+            parent_focused_pane,
+        })
     }
 
     /// Create a new empty child context under the current context and auto-zoom
@@ -351,8 +476,15 @@ impl PlexiApp {
             parent_path.display()
         );
 
-        match self.new_child_context(&parent_name, parent_path, true, false, None) {
-            Ok(()) => {
+        match self.new_child_context(ChildContextSpec::single_terminal(
+            Some(parent_ctx_id),
+            parent_name.clone(),
+            parent_path,
+            true,
+            false,
+            None,
+        )) {
+            Ok(_) => {
                 let new_ctx_idx = self.router.len() - 1;
                 self.router
                     .push_depth(parent_ctx_id, current_win_id, current_focused);

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -38,6 +38,20 @@ impl PipStatus {
     }
 }
 
+/// How `plexi context sub` arranges the panes it seeds inside the new
+/// sub-context's single window.
+#[derive(
+    Serialize, Deserialize, JsonSchema, clap::ValueEnum, Debug, Clone, Copy, Default, PartialEq, Eq,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum SubContextLayout {
+    /// Near-square grid — the default for an agent squad.
+    #[default]
+    Tiled,
+    /// One full-height column per pane, left to right.
+    Columns,
+}
+
 /// Per-pane agent state stored on the pane struct.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PaneAgentState {
@@ -576,6 +590,12 @@ pub enum AppRequest {
         name: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parent_name: Option<String>,
+        /// Parent context id, sent for bare `--parent` (the caller's
+        /// `PLEXI_CONTEXT_ID`). Wins over `parent_name`, which is ambiguous when
+        /// two contexts share a name. Absent for an explicit `--parent=<name>`,
+        /// where resolving by name is what the caller asked for.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_context_id: Option<u64>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         windows: Vec<String>,
         /// Zoom into the new sub-context after creation. Default false (stay in parent).
@@ -590,6 +610,46 @@ pub enum AppRequest {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         anchor_pane: Option<u64>,
         /// If set, the host writes a JSON response (context_id, windows) to this path.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        response_file: Option<String>,
+    },
+
+    /// Create a sub-context under the caller's context, pre-populated with a
+    /// squad of terminal panes in a single window. Sent by `plexi context sub`.
+    ///
+    /// Unlike `CreateContext { parent_name, windows }` this seeds *exactly*
+    /// `panes.len()` terminals — no spare root terminal — and tiles them inside
+    /// one window instead of creating sibling pages.
+    CreateSubContext {
+        /// Name for the new sub-context.
+        name: String,
+        /// Root path for the new sub-context. The CLI sends the caller's cwd.
+        root: std::path::PathBuf,
+        /// Parent context id (the caller's `PLEXI_CONTEXT_ID`). Authoritative:
+        /// `parent_name` is consulted only when this is absent. An id naming no
+        /// live context is an error, not a reason to fall back to the name.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_context_id: Option<u64>,
+        /// Parent context name. Used only when `parent_context_id` is absent.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_name: Option<String>,
+        /// One entry per pane to create, in order. `null` launches a plain
+        /// shell. Never empty — the CLI expands `--agents`/`--command` into
+        /// exactly the requested pane count before sending.
+        panes: Vec<Option<String>>,
+        /// How the panes are arranged inside the sub-context's single window.
+        #[serde(default)]
+        layout: SubContextLayout,
+        /// Zoom into the new sub-context after creation. Default false.
+        #[serde(default)]
+        focus: bool,
+        /// Pane in the parent context to anchor the portal split at. The CLI
+        /// sends the caller's `PLEXI_PANE_ID`; absent or unknown ids fall back
+        /// to the parent's focused pane.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        anchor_pane: Option<u64>,
+        /// If set, the host writes a JSON response (context_id, windows, panes)
+        /// to this path.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         response_file: Option<String>,
     },

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -282,6 +282,7 @@ Manage the active context (the folder and project scope tied to the current pane
 | Subcommand | Description |
 |---|---|
 | `new` | Open a new context with an optional name |
+| `sub` | Create a sub-context under the current one, pre-populated with panes |
 | `open` | Switch the current pane to a context at the given path |
 | `set-root` | Change the root folder for the active context |
 | `current` | Print the id and name of the current pane's context as JSON |
@@ -309,6 +310,24 @@ Examples: plexi context new "sprint"                          # top-level contex
 | `--left` / `-l` | flag | no | Split portal left (requires --parent) |
 | `--up` / `-u` | flag | no | Split portal above (requires --parent) |
 | `--right` / `-r` | flag | no | Split portal right — explicit (default, requires --parent) |
+
+### `plexi context sub`
+
+Create a sub-context under the current one, pre-populated with panes.
+
+One command spins up a scoped squad: N panes in a single tiled window inside the new sub-context, each running the same command (or its own). Unlike `context new --parent --window`, this creates exactly N panes — no spare terminal — and roots them at the caller's cwd.
+
+Examples: plexi context sub agentsquad --agents 3 --command cm plexi context sub review --agents 2 --command "cm review" --command "cm test" plexi context sub build --agents 4 --layout columns --focus
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<name>` | string | yes | Name for the new sub-context |
+| `--path` | string | no | Root path for the sub-context. Defaults to the caller's cwd |
+| `--agents` | string | no | Number of panes to open inside the new sub-context Default: `1`. |
+| `--command` | string (repeatable) | no | Command to launch in each pane. Give it once to apply to every pane, or exactly --agents times to give each pane its own command |
+| `--layout` | string | no | How the panes are arranged inside the sub-context's window Default: `tiled`. |
+| `--focus` | flag | no | Zoom into the new sub-context after creation. Default: stay put |
+| `--from` | string | no | Pane to anchor the portal split at. Defaults to the calling pane (PLEXI_PANE_ID env), falling back to the parent's focused pane |
 
 ### `plexi context open`
 

--- a/website/src/content/docs/pgap.md
+++ b/website/src/content/docs/pgap.md
@@ -508,11 +508,28 @@ Create a new context. Sent by `plexi context new` over PLEXI_SOCKET.
 | `anchor_pane` | `integer?` | no |
 | `focus` | `boolean` | no |
 | `name` | `string?` | no |
+| `parent_context_id` | `integer?` | no |
 | `parent_name` | `string?` | no |
 | `portal_direction` | `string?` | no |
 | `response_file` | `string?` | no |
 | `root` | `string?` | no |
 | `windows` | `string[]` | no |
+
+### `create_sub_context`
+
+Create a sub-context under the caller's context, pre-populated with a squad of terminal panes in a single window. Sen...
+
+| Field | Type | Required |
+|-------|------|----------|
+| `anchor_pane` | `integer?` | no |
+| `focus` | `boolean` | no |
+| `layout` | `SubContextLayout` | no |
+| `name` | `string` | yes |
+| `panes` | `string?[]` | yes |
+| `parent_context_id` | `integer?` | no |
+| `parent_name` | `string?` | no |
+| `response_file` | `string?` | no |
+| `root` | `string` | yes |
 
 ### `focus_context`
 


### PR DESCRIPTION
Closes stint **0568 — context sub: one command, agent squad in a subcontext**. No linked GitHub issue; stint is authoritative.

## What

```
plexi context sub agentsquad --agents 3 --command cm
```

Creates a subcontext under the **caller's** context, opens exactly 3 panes in one tiled window inside it, and launches `cm` in each. Prints `{"context_id":…,"windows":[…],"panes":[317,318,319]}` so a calling agent can address each pane immediately — no follow-up `pane list`.

Flags: `--agents N` (1–32, default 1) · `--command CMD` (once = all panes, or exactly N times = one each; any other count is a hard error) · `--layout tiled|columns` (default tiled) · `--path DIR` (defaults to caller's cwd) · `--focus` · `--from PANE_ID`.

## The four defects fixed

The stint's repro showed `context new --parent --window ...` reaching the goal only by accident:

1. **Off-by-one pane count.** `new_child_context` unconditionally seeded a fresh terminal via `create_single_pane_tree`, then `CreateContext`'s windows loop appended one page per `--window` on top — 3 commands → 4 panes, one idle. `ChildContextSpec` now carries the pane set and `create_context_pane_set` builds exactly it.
2. **Panes were sibling pages, not tiles.** They now share one window, arranged by the pure `build_squad_tree`: a `Grid` for `tiled`, a horizontal `Linear` for `columns`.
3. **Root defaulted to the parent context's path.** `context sub` roots at the caller's cwd — the deliberate divergence from `context new`.
4. **Parent resolved by name.** `resolve_parent_context` resolves by `PLEXI_CONTEXT_ID` and consults the name only when no id was sent. A *stale* id fails loudly rather than guessing by a name another context may share. Bare `context new --parent` now sends the id too and inherits the fix; `--parent=<name>` still resolves by name, since that is what the caller asked for.

## Additional correctness fixes (found in review)

- **Child panes carry the child's `PLEXI_CONTEXT_*`.** `create_single_pane_tree` stamps env from `active_window`, which is the *parent* while a child is being built — so a squad agent's own `context sub` would have nested under the wrong parent. The new `PaneContextEnv` passes the identity explicitly instead of steering the helper by mutating global focus state.
- **The name is settled before panes spawn**, not applied by renaming the router entry afterwards — otherwise running agents advertise a `PLEXI_CONTEXT_NAME` the router no longer uses.
- **`--focus` returns to the caller's window**, not the globally active one. A background pane can create a squad while the user is looking elsewhere; a depth entry pairing this parent with an unrelated window cannot restore the caller's location.
- **The CLI exits nonzero on a host-reported error.** `poll_rpc` only distinguishes transport failures, so a refused parent used to print a successful-looking JSON blob and exit 0 — bad for the unattended-agent use case this command exists for.

## Non-scope (per the stint)

`context new --parent --window` is not removed or deprecated. Its observable behaviour is unchanged apart from inheriting the id-based parent resolution. No sidebar treatment for subcontexts (that is stint 0241). No agent-state wiring, no layout persistence, no squad templates.

## Test evidence

- `cargo test --bin plexi`: **1911 passed, 0 failed, 3 ignored** (env-stripped, `PLEXI_EPHEMERAL_SESSION=1` so headless runs leave no contexts in the dev workspace). Alpha baseline: 1893 passed.
- `mypy sdk/python/plexi_sdk/`: Success, no issues in 27 source files.
- `just check-schema` / `just check-cli-docs`: both up to date.
- New coverage — 18 tests, one per named defect:
  - `context_sub_creates_exactly_n_panes` (defects 1+2+3), `context_sub_panes_share_one_tiled_window` (defect 2, container shape)
  - `resolve_parent_context_prefers_id_over_duplicate_name` (defect 4, incl. stale-id rejection)
  - `child_context_takes_its_name_from_the_spec_not_the_path`, `context_sub_focus_returns_to_the_callers_window_not_the_active_one` — **both verified to fail without their fix**
  - `context_sub_unknown_parent_creates_nothing`, `context_sub_child_is_registered_one_level_below_parent`, `make_backend_settings_stamps_the_context_it_is_given`
  - `squad_tree_tests::*` (tiled/columns/single-pane tree shapes), `context_sub_tests::*` (command expansion), `sub_response_tests::*` (error exit code)
- CLI validation exercised headlessly: `--agents 0` rejected by clap range, mismatched `--command` count rejected with a named error, missing `PLEXI_CONTEXT_ID` rejected.
- Completions verified generated from the clap tree: `plexi completions zsh` emits `--agents`, `*--command` (repeatable) and `--layout` with both value-enum variants.
- **Not** live-validated against a running GUI host — headless only, per the worker gate. Tester round owns that.

## Docs (standing rule)

- `src/cli/AGENTS.md` — three new CLI design rules (repeatable-flag fan-out, resolve-by-id, one-round-trip responses) plus an explicit *Documentation Rule for CLI Changes* section.
- `skills/plexi-cli/SKILL.md` — `context sub` in the command reference and a "Scoped agent squad (one command)" pattern that says why to prefer it over `context new --parent --window`.
- Regenerated `website/src/content/docs/cli.md` and `sdk/protocol/pgap.schema.json`.

## Review

Codex reviewed twice against alpha. Round 1 raised 3 findings (pane name stamping, CLI exit code, focus window) — all fixed with regression tests. Round 2 raised 1 (stale-id fallback) — fixed. Both rounds' findings are in the "Additional correctness fixes" section above.