### PR TITLE
feat(ai): local OpenAI-compatible broker backend for Meridian testing (stint 0579)

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -80,6 +80,19 @@ model_medium = "llama3.3:70b"
 model_high   = "qwq:32b"
 ```
 
+Use `local` for any other OpenAI-compatible chat-completions server (e.g. a Meridian proxy). `base_url` is required. `api_key_env` is optional: when set, the named environment variable must hold the key; when unset, no auth header is sent.
+
+```toml
+[ai]
+backend = "local"
+
+[ai.local]
+base_url     = "http://127.0.0.1:3456"
+model_low    = "claude-haiku-4-5"
+model_medium = "claude-opus-5"
+model_high   = "claude-fable-5"
+```
+
 Optional AI spend caps:
 
 ```toml
@@ -168,7 +181,7 @@ ghost_opacity = 0.75
 # interrupt_threshold = 100    # 0=LOW 50=NORMAL 100=HIGH 200=CRITICAL
 
 [ai]
-backend = "openrouter"         # "openrouter" (cloud) or "ollama" (local)
+backend = "openrouter"         # "openrouter" (cloud), "ollama", or "local" (OpenAI-compatible server)
 
 [ai.openrouter]
 api_key_env  = "OPENROUTER_API_KEY"
@@ -181,6 +194,12 @@ model_high   = "anthropic/claude-fable-5"
 # model_low    = "llama3.2:3b"
 # model_medium = "llama3.3:70b"
 # model_high   = "qwq:32b"
+
+# [ai.local]                   # any OpenAI-compatible server; api_key_env optional
+# base_url     = "http://127.0.0.1:3456"
+# model_low    = "claude-haiku-4-5"
+# model_medium = "claude-opus-5"
+# model_high   = "claude-fable-5"
 
 # [log]
 # level = "info"               # error | warn | info | debug — applies live on save, no restart

--- a/scripts/default-config.toml
+++ b/scripts/default-config.toml
@@ -35,7 +35,7 @@ ghost_opacity = 0.75
 # interrupt_threshold = 100    # 0=LOW 50=NORMAL 100=HIGH 200=CRITICAL
 
 [ai]
-backend = "openrouter"         # "openrouter" (cloud) or "ollama" (local)
+backend = "openrouter"         # "openrouter" (cloud), "ollama", or "local" (OpenAI-compatible server)
 
 [ai.openrouter]
 api_key_env  = "OPENROUTER_API_KEY"
@@ -48,6 +48,12 @@ model_high   = "anthropic/claude-fable-5"
 # model_low    = "llama3.2:3b"
 # model_medium = "llama3.3:70b"
 # model_high   = "qwq:32b"
+
+# [ai.local]                   # any OpenAI-compatible server; api_key_env optional
+# base_url     = "http://127.0.0.1:3456"
+# model_low    = "claude-haiku-4-5"
+# model_medium = "claude-opus-5"
+# model_high   = "claude-fable-5"
 
 # [log]
 # level = "info"               # error | warn | info | debug — applies live on save, no restart

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -128,11 +128,19 @@ const KNOWN_AI: &[&str] = &[
     "backend",
     "openrouter",
     "ollama",
+    "local",
     "per_app_daily_usd",
     "global_daily_usd",
 ];
 const KNOWN_AI_OPENROUTER: &[&str] = &["api_key_env", "model_low", "model_medium", "model_high"];
 const KNOWN_AI_OLLAMA: &[&str] = &["host", "model_low", "model_medium", "model_high"];
+const KNOWN_AI_LOCAL: &[&str] = &[
+    "base_url",
+    "api_key_env",
+    "model_low",
+    "model_medium",
+    "model_high",
+];
 const KNOWN_MARKETPLACE: &[&str] = &[
     "registry_url",
     "cdn_url",
@@ -259,6 +267,9 @@ pub fn validate_from_path(path: &Path) -> Vec<ConfigDiagnostic> {
                 }
                 if let Some(toml::Value::Table(ol)) = t.get("ollama") {
                     check_unknown_keys(ol, "ai.ollama", KNOWN_AI_OLLAMA, &path_str, &mut diags);
+                }
+                if let Some(toml::Value::Table(lo)) = t.get("local") {
+                    check_unknown_keys(lo, "ai.local", KNOWN_AI_LOCAL, &path_str, &mut diags);
                 }
             }
             if let Some(toml::Value::Table(t)) = table.get("keybindings") {
@@ -533,16 +544,17 @@ pub struct MarketplaceConfig {
 
 /// Plexi AI broker configuration (`ai.query` capability).
 ///
-/// `backend` selects the provider: `"openrouter"` (default) or `"ollama"`.
-/// API keys are NOT stored here — export `OPENROUTER_API_KEY` in your shell
-/// profile (`~/.zshrc`, `~/.zprofile`, etc.). Never store API keys in
-/// plaintext config files.
+/// `backend` selects the provider: `"openrouter"` (default), `"ollama"`, or
+/// `"local"` (any OpenAI-compatible server). API keys are NOT stored here —
+/// export `OPENROUTER_API_KEY` in your shell profile (`~/.zshrc`,
+/// `~/.zprofile`, etc.). Never store API keys in plaintext config files.
 #[derive(Deserialize, Default, Clone)]
 pub struct AiConfig {
-    /// Backend selection: `"openrouter"` (default) or `"ollama"`.
+    /// Backend selection: `"openrouter"` (default), `"ollama"`, or `"local"`.
     pub backend: Option<String>,
     pub openrouter: Option<OpenRouterBackendConfig>,
     pub ollama: Option<OllamaBackendConfig>,
+    pub local: Option<LocalBackendConfig>,
     /// Per-app daily spend cap in USD. Default $1.00.
     pub per_app_daily_usd: Option<f64>,
     /// Global daily spend cap across all apps in USD. Default $10.00.
@@ -587,6 +599,23 @@ pub struct OllamaBackendConfig {
     pub model_high: Option<String>,
 }
 
+/// Local OpenAI-compatible backend configuration (any server speaking the
+/// OpenAI chat-completions API, e.g. a Meridian proxy).
+#[derive(Deserialize, Default, Clone)]
+pub struct LocalBackendConfig {
+    /// Server base URL. Required — no default. e.g. "http://127.0.0.1:3456"
+    pub base_url: Option<String>,
+    /// Environment variable name for the API key. Unset = no auth header
+    /// (for local proxies that accept unauthenticated requests).
+    pub api_key_env: Option<String>,
+    /// Low-tier model. e.g. "claude-haiku-4-5"
+    pub model_low: Option<String>,
+    /// Medium-tier model. e.g. "claude-opus-5"
+    pub model_medium: Option<String>,
+    /// High-tier model. e.g. "claude-fable-5"
+    pub model_high: Option<String>,
+}
+
 impl AiConfig {
     /// Overlay `other` on top of `self` — any `Some` field in `other` wins.
     pub fn overlay(&mut self, other: Self) {
@@ -607,6 +636,11 @@ impl AiConfig {
         match (self.ollama.as_mut(), other.ollama) {
             (Some(existing), Some(incoming)) => existing.overlay(incoming),
             (None, Some(incoming)) => self.ollama = Some(incoming),
+            _ => {}
+        }
+        match (self.local.as_mut(), other.local) {
+            (Some(existing), Some(incoming)) => existing.overlay(incoming),
+            (None, Some(incoming)) => self.local = Some(incoming),
             _ => {}
         }
     }
@@ -633,6 +667,26 @@ impl OllamaBackendConfig {
     fn overlay(&mut self, other: Self) {
         if other.host.is_some() {
             self.host = other.host;
+        }
+        if other.model_low.is_some() {
+            self.model_low = other.model_low;
+        }
+        if other.model_medium.is_some() {
+            self.model_medium = other.model_medium;
+        }
+        if other.model_high.is_some() {
+            self.model_high = other.model_high;
+        }
+    }
+}
+
+impl LocalBackendConfig {
+    fn overlay(&mut self, other: Self) {
+        if other.base_url.is_some() {
+            self.base_url = other.base_url;
+        }
+        if other.api_key_env.is_some() {
+            self.api_key_env = other.api_key_env;
         }
         if other.model_low.is_some() {
             self.model_low = other.model_low;
@@ -1812,6 +1866,90 @@ mod tests {
         .unwrap();
         let diags = validate_from_path(&path);
         assert!(diags.is_empty(), "expected no diagnostics, got: {diags:?}");
+    }
+
+    #[test]
+    fn validate_ai_local_config_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(
+            &path,
+            "[ai]\nbackend = \"local\"\n\
+             [ai.local]\n\
+             base_url = \"http://127.0.0.1:3456\"\n\
+             api_key_env = \"MERIDIAN_API_KEY\"\n\
+             model_low = \"claude-haiku-4-5\"\n\
+             model_medium = \"claude-opus-5\"\n\
+             model_high = \"claude-fable-5\"\n",
+        )
+        .unwrap();
+        let diags = validate_from_path(&path);
+        assert!(diags.is_empty(), "expected no diagnostics, got: {diags:?}");
+    }
+
+    #[test]
+    fn validate_ai_local_unknown_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "[ai.local]\nhost = \"http://127.0.0.1:3456\"\n").unwrap();
+        let diags = validate_from_path(&path);
+        assert_eq!(diags.len(), 1);
+        assert!(diags[0].to_string().contains("host"));
+        assert!(diags[0].to_string().contains("[ai.local]"));
+    }
+
+    #[test]
+    fn ai_local_config_parses_round_trip() {
+        let cfg: PlexiConfig = toml::from_str(
+            "[ai]\nbackend = \"local\"\n\
+             [ai.local]\n\
+             base_url = \"http://127.0.0.1:3456\"\n\
+             model_high = \"claude-fable-5\"\n",
+        )
+        .unwrap();
+        let ai = cfg.ai.unwrap();
+        assert_eq!(ai.backend.as_deref(), Some("local"));
+        let local = ai.local.unwrap();
+        assert_eq!(local.base_url.as_deref(), Some("http://127.0.0.1:3456"));
+        assert_eq!(local.api_key_env, None);
+        assert_eq!(local.model_high.as_deref(), Some("claude-fable-5"));
+    }
+
+    #[test]
+    fn ai_local_overlay_merges_fields() {
+        let mut base: AiConfig = toml::from_str(
+            "backend = \"openrouter\"\n\
+             [local]\n\
+             base_url = \"http://127.0.0.1:3456\"\n\
+             model_low = \"claude-haiku-4-5\"\n",
+        )
+        .unwrap();
+        let project: AiConfig = toml::from_str(
+            "backend = \"local\"\n\
+             [local]\n\
+             model_low = \"claude-opus-5\"\n\
+             model_high = \"claude-fable-5\"\n",
+        )
+        .unwrap();
+        base.overlay(project);
+        assert_eq!(base.backend.as_deref(), Some("local"));
+        let local = base.local.unwrap();
+        // Project value wins; unset project fields keep the base value.
+        assert_eq!(local.base_url.as_deref(), Some("http://127.0.0.1:3456"));
+        assert_eq!(local.model_low.as_deref(), Some("claude-opus-5"));
+        assert_eq!(local.model_high.as_deref(), Some("claude-fable-5"));
+    }
+
+    #[test]
+    fn ai_local_overlay_adopts_section_when_base_absent() {
+        let mut base = AiConfig::default();
+        let project: AiConfig =
+            toml::from_str("[local]\nbase_url = \"http://127.0.0.1:3456\"\n").unwrap();
+        base.overlay(project);
+        assert_eq!(
+            base.local.unwrap().base_url.as_deref(),
+            Some("http://127.0.0.1:3456")
+        );
     }
 
     #[test]

--- a/src/plexi_ai/backend/local.rs
+++ b/src/plexi_ai/backend/local.rs
@@ -1,0 +1,102 @@
+//! Local OpenAI-compatible backend for the Plexi AI broker (stint 0579).
+//!
+//! Speaks the OpenAI chat-completions SSE protocol against a configurable
+//! `base_url` (e.g. a Meridian proxy at `http://127.0.0.1:3456`), reusing the
+//! shared streaming worker in `super::openrouter`. Auth is optional: an
+//! `Authorization: Bearer <key>` header is sent only when an API key is
+//! configured — local proxies commonly accept unauthenticated requests.
+//! OpenRouter's nonstandard `reasoning` body field is never sent — strict
+//! OpenAI-compatible servers reject unknown request properties.
+
+use std::sync::mpsc;
+use std::thread;
+
+use super::openrouter::stream_openai_compatible;
+use super::{AiBackend, AiBackendError, AiBackendRequest, StreamEvent};
+
+/// Local OpenAI-compatible streaming backend.
+pub struct LocalOpenAiBackend {
+    /// Server base URL, e.g. `"http://127.0.0.1:3456"`. The chat-completions
+    /// path is appended by [`endpoint_url`].
+    pub base_url: String,
+    /// Optional API key. `None` = no auth header.
+    pub api_key: Option<String>,
+    /// Model ID as understood by the server, e.g. `"claude-fable-5"`.
+    pub model: String,
+}
+
+impl std::fmt::Debug for LocalOpenAiBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalOpenAiBackend")
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .field("api_key", &self.api_key.as_ref().map(|_| "[redacted]"))
+            .finish()
+    }
+}
+
+/// Chat-completions endpoint for a base URL — a trailing `/` on the base is
+/// trimmed so both `http://host:port` and `http://host:port/` work.
+fn endpoint_url(base_url: &str) -> String {
+    format!("{}/v1/chat/completions", base_url.trim_end_matches('/'))
+}
+
+impl AiBackend for LocalOpenAiBackend {
+    fn name(&self) -> &str {
+        "local"
+    }
+
+    fn stream_to_channel(
+        &self,
+        request: AiBackendRequest,
+        tx: mpsc::Sender<StreamEvent>,
+    ) -> Result<(), AiBackendError> {
+        let endpoint = endpoint_url(&self.base_url);
+        let api_key = self.api_key.clone();
+        let model = self.model.clone();
+
+        thread::Builder::new()
+            .name("plexi-ai-local".to_string())
+            .spawn(move || {
+                stream_openai_compatible(&endpoint, api_key, model, false, request, tx);
+            })
+            .map_err(|e| {
+                AiBackendError::Io(format!("failed to spawn local AI stream thread: {e}"))
+            })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_url_appends_chat_completions_path() {
+        assert_eq!(
+            endpoint_url("http://127.0.0.1:3456"),
+            "http://127.0.0.1:3456/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn endpoint_url_trims_trailing_slash() {
+        assert_eq!(
+            endpoint_url("http://127.0.0.1:3456/"),
+            "http://127.0.0.1:3456/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn debug_redacts_api_key() {
+        let backend = LocalOpenAiBackend {
+            base_url: "http://127.0.0.1:3456".to_string(),
+            api_key: Some("sk-secret".to_string()),
+            model: "claude-fable-5".to_string(),
+        };
+        let dbg = format!("{backend:?}");
+        assert!(!dbg.contains("sk-secret"), "api key must be redacted: {dbg}");
+        assert!(dbg.contains("[redacted]"));
+    }
+}

--- a/src/plexi_ai/backend/mod.rs
+++ b/src/plexi_ai/backend/mod.rs
@@ -1,12 +1,15 @@
 //! AI backend abstraction for the Plexi AI broker.
 //!
-//! Concrete backends: `OpenRouterBackend` (SSE streaming via OpenRouter) and
-//! `OllamaBackend` (NDJSON streaming via local Ollama). The host reads API
-//! keys from the environment at dispatch time; apps never see keys.
+//! Concrete backends: `OpenRouterBackend` (SSE streaming via OpenRouter),
+//! `OllamaBackend` (NDJSON streaming via local Ollama), and
+//! `LocalOpenAiBackend` (OpenAI-compatible SSE streaming against a
+//! configurable base URL). The host reads API keys from the environment at
+//! dispatch time; apps never see keys.
 //!
 //! Backends deliver events through an `mpsc::Sender<StreamEvent>` so the
 //! caller can drain a receiver each frame without blocking the UI.
 
+pub mod local;
 pub mod ollama;
 pub mod openrouter;
 

--- a/src/plexi_ai/backend/openrouter.rs
+++ b/src/plexi_ai/backend/openrouter.rs
@@ -4,6 +4,10 @@
 //! no tokio). The host reads `OPENROUTER_API_KEY` from the environment at
 //! dispatch time; apps never see the key.
 //!
+//! The SSE streaming worker (`stream_openai_compatible`) speaks the plain
+//! OpenAI chat-completions protocol against any endpoint URL — the `local`
+//! backend (`super::local`) reuses it against a configurable base URL.
+//!
 //! **System prompt format:** OpenRouter uses the OpenAI message format.
 //! The system prompt is injected as a leading `{"role":"system","content":"…"}`
 //! entry in the messages array — NOT as a top-level `"system"` field (which
@@ -67,7 +71,14 @@ impl AiBackend for OpenRouterBackend {
         thread::Builder::new()
             .name("plexi-ai-openrouter".to_string())
             .spawn(move || {
-                stream_openrouter(api_key, model, request, tx);
+                stream_openai_compatible(
+                    OPENROUTER_ENDPOINT,
+                    Some(api_key),
+                    model,
+                    true,
+                    request,
+                    tx,
+                );
             })
             .map_err(|e| {
                 AiBackendError::Io(format!("failed to spawn OpenRouter stream thread: {e}"))
@@ -127,10 +138,31 @@ fn sanitize_message_tool_names(message: &mut serde_json::Value) {
     }
 }
 
-/// Worker: calls OpenRouter SSE endpoint and delivers events to `tx`.
-fn stream_openrouter(
-    api_key: String,
+/// Canonical OpenRouter chat-completions endpoint.
+const OPENROUTER_ENDPOINT: &str = "https://openrouter.ai/api/v1/chat/completions";
+
+/// `Authorization` header value for an OpenAI-compatible request — present
+/// only when an API key is configured (local proxies may accept
+/// unauthenticated requests).
+fn authorization_header(api_key: Option<&str>) -> Option<String> {
+    api_key.map(|key| format!("Bearer {key}"))
+}
+
+/// Worker: streams a turn from any OpenAI-compatible chat-completions SSE
+/// endpoint and delivers events to `tx`. OpenRouter passes its canonical
+/// endpoint and required key; the `local` backend passes `{base_url}/v1/…`
+/// and an optional key. The `X-Generation-Id` capture is OpenRouter-specific
+/// — other endpoints simply omit the header and `Done.generation_id` is None.
+///
+/// `openrouter_reasoning` gates the nonstandard `reasoning` body field
+/// (OpenRouter's extension for reasoning-effort control): strict
+/// OpenAI-compatible servers reject unknown request properties, so the
+/// `local` backend passes `false`.
+pub(super) fn stream_openai_compatible(
+    endpoint: &str,
+    api_key: Option<String>,
     model: String,
+    openrouter_reasoning: bool,
     request: AiBackendRequest,
     tx: mpsc::Sender<StreamEvent>,
 ) {
@@ -191,13 +223,15 @@ fn stream_openrouter(
         body["tools"] = serde_json::Value::Array(tools_json);
     }
 
-    apply_reasoning_config(&mut body, request.model_tier, request.reasoning_effort);
+    if openrouter_reasoning {
+        apply_reasoning_config(&mut body, request.model_tier, request.reasoning_effort);
+    }
 
     let body_str = match serde_json::to_string(&body) {
         Ok(s) => s,
         Err(e) => {
             let _ = tx.send(StreamEvent::Error(format!(
-                "failed to serialize OpenRouter request: {e}"
+                "failed to serialize chat-completions request: {e}"
             )));
             return;
         }
@@ -209,13 +243,15 @@ fn stream_openrouter(
         .timeout(std::time::Duration::from_secs(90))
         .build();
 
-    let resp = agent
-        .post("https://openrouter.ai/api/v1/chat/completions")
-        .set("Authorization", &format!("Bearer {api_key}"))
+    let mut req = agent
+        .post(endpoint)
         .set("Content-Type", "application/json")
         .set("HTTP-Referer", "https://plexiapp.com")
-        .set("X-Title", "Plexi")
-        .send_string(&body_str);
+        .set("X-Title", "Plexi");
+    if let Some(auth) = authorization_header(api_key.as_deref()) {
+        req = req.set("Authorization", &auth);
+    }
+    let resp = req.send_string(&body_str);
 
     let resp = match resp {
         Ok(r) => r,
@@ -225,7 +261,7 @@ fn stream_openrouter(
             // "metadata":{"raw":"<the upstream provider's actual error>"}}}.
             // "Provider returned error" alone is undiagnosable — always
             // surface metadata.raw when present and log the full body.
-            log::warn!("openrouter: http {status} error body: {body}");
+            log::warn!("openai_compat[{endpoint}]: http {status} error body: {body}");
             let parsed = serde_json::from_str::<serde_json::Value>(&body).ok();
             let message = parsed
                 .as_ref()
@@ -241,12 +277,14 @@ fn stream_openrouter(
                 (None, _) => body.clone(),
             };
             let _ = tx.send(StreamEvent::Error(format!(
-                "openrouter http error {status}: {msg}"
+                "http error {status} from {endpoint}: {msg}"
             )));
             return;
         }
         Err(e) => {
-            let _ = tx.send(StreamEvent::Error(format!("openrouter io error: {e}")));
+            let _ = tx.send(StreamEvent::Error(format!(
+                "io error from {endpoint}: {e}"
+            )));
             return;
         }
     };
@@ -267,7 +305,7 @@ fn stream_openrouter(
         // the token. Stop reading and drop `tx` — the turn loop returns the
         // partial text accumulated so far rather than draining the full stream.
         if request.cancel.is_cancelled() {
-            log::info!("openrouter: stream cancelled by caller — aborting read mid-stream");
+            log::info!("openai_compat[{endpoint}]: stream cancelled by caller — aborting read mid-stream");
             return;
         }
         let line = match line_result {
@@ -296,7 +334,7 @@ fn stream_openrouter(
         let chunk: serde_json::Value = match serde_json::from_str(data) {
             Ok(v) => v,
             Err(e) => {
-                log::debug!("openrouter: failed to parse SSE chunk: {e} — data={data}");
+                log::debug!("openai_compat[{endpoint}]: failed to parse SSE chunk: {e} — data={data}");
                 continue;
             }
         };
@@ -321,7 +359,7 @@ fn stream_openrouter(
                 .unwrap_or("unknown error")
                 .to_string();
             let _ = tx.send(StreamEvent::Error(format!(
-                "openrouter stream error: {msg}"
+                "stream error from {endpoint}: {msg}"
             )));
             return;
         }
@@ -423,7 +461,7 @@ fn stream_openrouter(
     });
     if input_tokens.is_none() && output_tokens.is_none() {
         log::debug!(
-            "openrouter: stream completed without usage metadata; broker will use generation endpoint fallback"
+            "openai_compat[{endpoint}]: stream completed without usage metadata; broker will use generation endpoint fallback"
         );
     }
 }
@@ -474,6 +512,17 @@ mod tests {
         });
         sanitize_message_tool_names(&mut tool_msg);
         assert_eq!(tool_msg["name"], serde_json::json!("host_build_run"));
+    }
+
+    /// Auth header is present only when an API key is configured — the local
+    /// backend passes `None` for unauthenticated proxies (e.g. Meridian).
+    #[test]
+    fn authorization_header_present_only_with_key() {
+        assert_eq!(
+            authorization_header(Some("sk-test")).as_deref(),
+            Some("Bearer sk-test")
+        );
+        assert_eq!(authorization_header(None), None);
     }
 
     #[test]

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -18,8 +18,9 @@
 use std::sync::{Arc, OnceLock, RwLock};
 
 use crate::app_protocol::{AiMessage, AiTool, ModelTier};
-use crate::config::{AiConfig, OllamaBackendConfig, OpenRouterBackendConfig};
+use crate::config::{AiConfig, LocalBackendConfig, OllamaBackendConfig, OpenRouterBackendConfig};
 use crate::host::event_log::{self, HostEvent};
+use crate::plexi_ai::backend::local::LocalOpenAiBackend;
 use crate::plexi_ai::backend::ollama::OllamaBackend;
 use crate::plexi_ai::backend::openrouter::OpenRouterBackend;
 use crate::plexi_ai::backend::{AiBackend, AiBackendRequest, BillingModel};
@@ -151,8 +152,9 @@ pub trait AiBroker: Send + Sync {
 }
 
 /// Production broker: reads config from `AiConfig`, routes to the configured
-/// backend (OpenRouter or Ollama), fetches real per-call cost (OpenRouter only),
-/// writes the ledger, and emits `HostEvent::AgentTurn`.
+/// backend (OpenRouter, Ollama, or a local OpenAI-compatible server), fetches
+/// real per-call cost (OpenRouter only), writes the ledger, and emits
+/// `HostEvent::AgentTurn`.
 ///
 /// `AiConfig` is cloned at construction from `PlexiConfig::load().ai`.
 /// If the config section is absent, `dispatch` fails fast with a clear error.
@@ -204,6 +206,7 @@ impl AiBroker for LiveAiBroker {
         match backend_name.as_str() {
             "ollama" => dispatch_ollama(request, ai_config, on_delta),
             "openrouter" => dispatch_openrouter(request, ai_config, on_delta),
+            "local" => dispatch_local(request, ai_config, on_delta),
             other => AiBrokerResponse::err(format!("unsupported_model_provider: {other}")),
         }
     }
@@ -505,6 +508,110 @@ fn dispatch_ollama(
         String::new(),
         on_delta,
     )
+}
+
+/// Dispatch through a local OpenAI-compatible backend (`[ai.local]`).
+fn dispatch_local(
+    request: AiBrokerRequest,
+    ai_config: &AiConfig,
+    on_delta: &mut dyn FnMut(turn_loop::TurnDelta<'_>),
+) -> AiBrokerResponse {
+    let local_config = match ai_config.local.as_ref() {
+        Some(c) => c,
+        None => {
+            let msg = "ai_config_missing: [ai.local] section required for local backend";
+            log::warn!("ai_broker[{}]: dispatch failed — {}", request.app_id, msg);
+            return AiBrokerResponse::err(msg);
+        }
+    };
+
+    // base_url is required — no default (missing required config throws).
+    let base_url = match local_config.base_url.as_deref() {
+        Some(u) => u.to_string(),
+        None => {
+            let msg = "ai_config_missing: base_url not set in [ai.local] config section — required for local backend";
+            log::warn!("ai_broker[{}]: dispatch failed — {}", request.app_id, msg);
+            return AiBrokerResponse::err(msg);
+        }
+    };
+
+    if let Some(route) = request
+        .concrete_model
+        .as_ref()
+        .filter(|route| route.provider != "local")
+    {
+        return AiBrokerResponse::err(format!("unsupported_model_provider: {}", route.provider));
+    }
+    let model_id = request
+        .concrete_model
+        .as_ref()
+        .map(|route| route.model.clone())
+        .or_else(|| resolve_local_model_tier(&request.model_tier, local_config));
+    let model_id = match model_id {
+        Some(m) => m,
+        None => {
+            let msg = format!(
+                "ai_config_missing: model_{} not set in [ai.local] config section",
+                tier_name(&request.model_tier)
+            );
+            log::warn!("ai_broker[{}]: dispatch failed — {}", request.app_id, msg);
+            return AiBrokerResponse::err(msg);
+        }
+    };
+
+    // Never touches the Keychain or workspace secrets: local proxies either
+    // need no key or take one from a plain env var named in api_key_env.
+    let api_key = match resolve_local_api_key(local_config.api_key_env.as_deref(), |name| {
+        std::env::var(name).ok()
+    }) {
+        Ok(k) => k,
+        Err(msg) => {
+            log::warn!("ai_broker[{}]: {msg} — denying ai.query", request.app_id);
+            return AiBrokerResponse::err(msg);
+        }
+    };
+
+    log::info!(
+        "ai_broker[{}]: dispatch backend=local base_url={} model={}",
+        request.app_id,
+        base_url,
+        model_id
+    );
+
+    let backend = LocalOpenAiBackend {
+        base_url,
+        api_key,
+        model: model_id.clone(),
+    };
+
+    run_turn_and_respond(
+        request,
+        &backend,
+        BillingModel::Subscription,
+        model_id,
+        String::new(),
+        on_delta,
+    )
+}
+
+/// Resolve the local backend API key. `api_key_env = None` means no auth —
+/// `Ok(None)` — for proxies that accept unauthenticated requests. When
+/// `api_key_env` names a variable, it must be set non-empty or the dispatch
+/// fails with an error naming the variable. `lookup` is injected so this
+/// stays testable without mutating process env.
+fn resolve_local_api_key(
+    api_key_env: Option<&str>,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Result<Option<String>, String> {
+    let Some(env_name) = api_key_env else {
+        return Ok(None);
+    };
+    match lookup(env_name).filter(|v| !v.is_empty()) {
+        Some(key) => Ok(Some(key)),
+        None => Err(format!(
+            "api_key_missing: {env_name} not set — export it in your shell profile, or remove api_key_env from [ai.local] if the server needs no auth"
+        )),
+    }
 }
 
 /// Build a compact host context block to prepend to the system prompt.
@@ -979,6 +1086,14 @@ fn resolve_model_tier(tier: &ModelTier, config: &OpenRouterBackendConfig) -> Opt
 }
 
 fn resolve_ollama_model_tier(tier: &ModelTier, config: &OllamaBackendConfig) -> Option<String> {
+    match tier {
+        ModelTier::Low => config.model_low.clone(),
+        ModelTier::Medium => config.model_medium.clone(),
+        ModelTier::High => config.model_high.clone(),
+    }
+}
+
+fn resolve_local_model_tier(tier: &ModelTier, config: &LocalBackendConfig) -> Option<String> {
     match tier {
         ModelTier::Low => config.model_low.clone(),
         ModelTier::Medium => config.model_medium.clone(),
@@ -1556,6 +1671,148 @@ mod tests {
             resp.error.as_deref().unwrap_or("").contains("[ai.ollama]"),
             "error must mention missing [ai.ollama] section"
         );
+    }
+
+    /// Minimal dispatch request for local-backend error-path tests.
+    fn local_test_request() -> AiBrokerRequest {
+        AiBrokerRequest {
+            app_id: "test".to_string(),
+            model_tier: ModelTier::Low,
+            concrete_model: None,
+            reasoning_effort: None,
+            system: String::new(),
+            messages: vec![AiMessage {
+                role: "user".to_string(),
+                content: "hi".to_string(),
+            }],
+            tools: vec![],
+            workspace_root: None,
+            open_panes: Arc::new(Vec::new()),
+            tool_dispatcher: None,
+            cancel: CancelToken::new(),
+            max_tool_iterations: None,
+        }
+    }
+
+    #[test]
+    fn live_broker_errors_when_local_selected_but_config_missing() {
+        let broker = LiveAiBroker::new(Some(AiConfig {
+            backend: Some("local".to_string()),
+            openrouter: None,
+            ollama: None,
+            local: None,
+            ..Default::default()
+        }));
+        let resp = broker.dispatch(local_test_request(), &mut |_| {});
+        let err = resp.error.as_deref().unwrap_or("");
+        assert!(
+            err.contains("ai_config_missing") && err.contains("[ai.local]"),
+            "error must carry the ai_config_missing tag and name [ai.local]: {err}"
+        );
+    }
+
+    #[test]
+    fn live_broker_errors_when_local_base_url_missing() {
+        let broker = LiveAiBroker::new(Some(AiConfig {
+            backend: Some("local".to_string()),
+            local: Some(crate::config::LocalBackendConfig {
+                base_url: None,
+                api_key_env: None,
+                model_low: Some("claude-haiku-4-5".to_string()),
+                model_medium: None,
+                model_high: None,
+            }),
+            ..Default::default()
+        }));
+        let resp = broker.dispatch(local_test_request(), &mut |_| {});
+        let err = resp.error.as_deref().unwrap_or("");
+        assert!(
+            err.contains("base_url") && err.contains("[ai.local]"),
+            "error must name base_url and [ai.local]: {err}"
+        );
+    }
+
+    #[test]
+    fn live_broker_errors_when_local_model_tier_missing() {
+        let broker = LiveAiBroker::new(Some(AiConfig {
+            backend: Some("local".to_string()),
+            local: Some(crate::config::LocalBackendConfig {
+                base_url: Some("http://127.0.0.1:3456".to_string()),
+                api_key_env: None,
+                model_low: None,
+                model_medium: None,
+                model_high: Some("claude-fable-5".to_string()),
+            }),
+            ..Default::default()
+        }));
+        // Request is Low tier — only model_high is configured.
+        let resp = broker.dispatch(local_test_request(), &mut |_| {});
+        let err = resp.error.as_deref().unwrap_or("");
+        assert!(
+            err.contains("model_low") && err.contains("[ai.local]"),
+            "error must name model_low in [ai.local]: {err}"
+        );
+    }
+
+    /// `dispatch_local` guards against a concrete route naming a foreign
+    /// provider (same defensive check as the openrouter/ollama paths —
+    /// unreachable through `LiveAiBroker::dispatch`, which routes by
+    /// provider first, but load-bearing for any direct caller).
+    #[test]
+    fn dispatch_local_rejects_foreign_provider_route() {
+        let ai_config = AiConfig {
+            backend: Some("local".to_string()),
+            local: Some(crate::config::LocalBackendConfig {
+                base_url: Some("http://127.0.0.1:3456".to_string()),
+                api_key_env: None,
+                model_low: Some("claude-haiku-4-5".to_string()),
+                model_medium: None,
+                model_high: None,
+            }),
+            ..Default::default()
+        };
+        let mut request = local_test_request();
+        request.concrete_model = Some(ConcreteModelRoute {
+            provider: "openrouter".to_string(),
+            model: "anthropic/claude-fable-5".to_string(),
+        });
+        let resp = dispatch_local(request, &ai_config, &mut |_| {});
+        assert!(
+            resp.error
+                .as_deref()
+                .unwrap_or("")
+                .contains("unsupported_model_provider"),
+            "foreign provider route must be rejected"
+        );
+    }
+
+    /// `api_key_env` unset = unauthenticated proxy; set = env var must be
+    /// non-empty. Lookup is injected — never mutates process env.
+    #[test]
+    fn resolve_local_api_key_contract() {
+        // No api_key_env configured — no auth, no lookup needed.
+        assert_eq!(resolve_local_api_key(None, |_| None), Ok(None));
+
+        // Configured and set non-empty — key flows through.
+        assert_eq!(
+            resolve_local_api_key(Some("MERIDIAN_KEY"), |name| {
+                assert_eq!(name, "MERIDIAN_KEY");
+                Some("sk-abc".to_string())
+            }),
+            Ok(Some("sk-abc".to_string()))
+        );
+
+        // Configured but unset or empty — error names the variable.
+        for lookup in [
+            (|_: &str| None) as fn(&str) -> Option<String>,
+            (|_: &str| Some(String::new())) as fn(&str) -> Option<String>,
+        ] {
+            let err = resolve_local_api_key(Some("MERIDIAN_KEY"), lookup).unwrap_err();
+            assert!(
+                err.contains("api_key_missing") && err.contains("MERIDIAN_KEY"),
+                "error must tag api_key_missing and name the env var: {err}"
+            );
+        }
     }
 
     /// Verify the tool loop: a backend that returns one tool call on the first

--- a/tools/gen_config_docs/src/main.rs
+++ b/tools/gen_config_docs/src/main.rs
@@ -325,7 +325,7 @@ plexi secret set openrouter-api-key --global
         let scalar: Vec<&FieldInfo> = s
             .fields
             .iter()
-            .filter(|f| f.name != "openrouter" && f.name != "ollama")
+            .filter(|f| f.name != "openrouter" && f.name != "ollama" && f.name != "local")
             .collect();
         emit_table_refs(&scalar);
     }
@@ -337,6 +337,11 @@ plexi secret set openrouter-api-key --global
 
     println!("#### Ollama (`[ai.ollama]`)\n");
     if let Some(s) = structs.get("OllamaBackendConfig") {
+        emit_table(&s.fields);
+    }
+
+    println!("#### Local OpenAI-compatible (`[ai.local]`)\n");
+    if let Some(s) = structs.get("LocalBackendConfig") {
         emit_table(&s.fields);
     }
 

--- a/website/src/content/docs/config.md
+++ b/website/src/content/docs/config.md
@@ -125,7 +125,7 @@ plexi secret set openrouter-api-key --global
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `backend` | string | — | Backend selection: `"openrouter"` (default) or `"ollama"`. |
+| `backend` | string | — | Backend selection: `"openrouter"` (default), `"ollama"`, or `"local"`. |
 | `per_app_daily_usd` | float | $1.00 | Per-app daily spend cap in USD. Default $1.00. |
 | `global_daily_usd` | float | $10.00 | Global daily spend cap across all apps in USD. Default $10.00. |
 
@@ -146,6 +146,16 @@ plexi secret set openrouter-api-key --global
 | `model_low` | string | — | Low-tier model. e.g. "llama3.2:3b" |
 | `model_medium` | string | — | Medium-tier model. e.g. "llama3.3:70b" |
 | `model_high` | string | — | High-tier model. e.g. "qwq:32b" |
+
+#### Local OpenAI-compatible (`[ai.local]`)
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `base_url` | string | — | Server base URL. Required — no default. e.g. "http://127.0.0.1:3456" |
+| `api_key_env` | string | — | Environment variable name for the API key. Unset = no auth header (for local proxies that accept unauthenticated requests). |
+| `model_low` | string | — | Low-tier model. e.g. "claude-haiku-4-5" |
+| `model_medium` | string | — | Medium-tier model. e.g. "claude-opus-5" |
+| `model_high` | string | — | High-tier model. e.g. "claude-fable-5" |
 
 ### Agents (`[agents]`)
 
@@ -299,7 +309,7 @@ ghost_opacity = 0.75
 # interrupt_threshold = 100    # 0=LOW 50=NORMAL 100=HIGH 200=CRITICAL
 
 [ai]
-backend = "openrouter"         # "openrouter" (cloud) or "ollama" (local)
+backend = "openrouter"         # "openrouter" (cloud), "ollama", or "local" (OpenAI-compatible server)
 
 [ai.openrouter]
 api_key_env  = "OPENROUTER_API_KEY"
@@ -312,6 +322,12 @@ model_high   = "anthropic/claude-fable-5"
 # model_low    = "llama3.2:3b"
 # model_medium = "llama3.3:70b"
 # model_high   = "qwq:32b"
+
+# [ai.local]                   # any OpenAI-compatible server; api_key_env optional
+# base_url     = "http://127.0.0.1:3456"
+# model_low    = "claude-haiku-4-5"
+# model_medium = "claude-opus-5"
+# model_high   = "claude-fable-5"
 
 # [log]
 # level = "info"               # error | warn | info | debug — applies live on save, no restart


### PR DESCRIPTION
## Summary

Implements stint 0579. No linked GitHub issue — stint is authoritative.

- Adds a third AI broker backend, `backend = "local"` in `[ai]`: OpenAI-compatible chat-completions against a configurable `base_url` (dev target: Meridian proxy at `http://127.0.0.1:3456`, Claude Max subscription) so dev/testing assistant rounds stop burning OpenRouter credit.
- `[ai.local]`: `base_url` required with no default (missing throws at dispatch), `api_key_env` optional (unset = no auth header; verified live that Meridian accepts unauthenticated), `model_low/medium/high` tier mapping. Never touches Keychain or workspace secrets. `BillingModel::Subscription`, like ollama.
- The OpenRouter SSE worker is parameterized into `stream_openai_compatible` (endpoint, optional key, `openrouter_reasoning` gate — OpenRouter's nonstandard `reasoning` body field is never sent to strict OpenAI-compatible servers).
- Info trace on dispatch names backend, base_url, and model.
- Shipped/stable default stays `openrouter`. Example model ids in docs/default-config are verified against live Meridian 1.57.0 `/v1/models` (`claude-haiku-4-5` / `claude-opus-5` / `claude-fable-5`).
- Docs updated in same PR: `docs/CONFIG.md`, generated `website/src/content/docs/config.md` (via `gen_config_docs`, tool updated), `scripts/default-config.toml`. `.agents/skills/plexi-cli/SKILL.md` untouched — it does not document `[ai]` config; no AGENTS.md enumerates backends.

## Done When

- An assistant query on an alpha or pr build observably round-trips through Meridian: info log naming backend + base_url fires (manual validation step — live Meridian chat calls take seconds and are deliberately NOT in the automated suite).
- `cargo test --bin plexi` green.
- Channel defaults: shipped default untouched; the two-line `[ai]` change (`backend = "local"` + `[ai.local]` section) is documented in docs/CONFIG.md and applied to `~/.plexi-alpha/config.toml` during validation.

## Test evidence (attempt 1)

- cargo test: 1907 passed, 0 failed — full bin suite, env-stripped, plus scoped filters `plexi_ai` (61) and `config::` (39)
- Codex review: 2 runs; run-2 finding (OpenRouter `reasoning` field leaking to strict servers) fixed and re-green; no findings remaining
- Note: `host::wasm_python::tests::headless_frame_fails_fast_when_the_guest_dies_at_import` failed once in an earlier full-suite run on BOTH this diff and the stashed clean baseline; passes 2x in isolation and in the final full suite. Pre-existing intermittent, recurrence of task 0501's flake — follow-up filed as task 0580.
- Conclusion: binary install required — the live backend round-trip through Meridian is only observable in an installed build (`just pr-install`, then an assistant query on the pr channel with `[ai] backend = "local"`).

**Validate attempt 1:** PASS — live Meridian round-trip observed (dispatch backend=local base_url=http://127.0.0.1:3456 model=claude-opus-5), assistant replies rendered
**Test date:** 2026-07-27
