### PR TITLE
feat(palette): agent panes as command palette results (stint 0565)

### DIFF
--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -115,6 +115,11 @@ agent report             Hook-only state report. --state working|blocked|idle, -
 agent status             Table of pane agent state. Adds DETAIL when any pane reports it.
 ```
 
+A reported agent is addressable, not just observable: every pane with agent state
+becomes a row in the human's Cmd+P palette, across every context and window, keyed
+on the `--agent` name and annotated with `--detail`. Blocked agents sort first.
+Report a name a human would search for; keep `--detail` to the active tool.
+
 ### workspace, run, routine
 
 ```

--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -117,8 +117,9 @@ agent status             Table of pane agent state. Adds DETAIL when any pane re
 
 A reported agent is addressable, not just observable: every pane with agent state
 becomes a row in the human's Cmd+P palette, across every context and window, keyed
-on the `--agent` name and annotated with `--detail`. Blocked agents sort first.
-Report a name a human would search for; keep `--detail` to the active tool.
+on the `--agent` name and annotated with `--detail`. Same-name agents are numbered
+within their context; blocked agents sort first. Report a name a human would
+search for; keep `--detail` to the active tool.
 
 ### workspace, run, routine
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -211,6 +211,10 @@ pub struct PlexiApp {
     /// Set to true on palette open; consumed on the first draw frame to reset
     /// the scroll area back to the top before egui can apply the stale offset.
     pub(crate) palette_scroll_reset: bool,
+    /// Last agent-pane count logged by the palette. The palette rebuilds its
+    /// rows every draw frame, so the collection trace fires only when the
+    /// count changes — never once per frame.
+    pub(crate) palette_agent_count_logged: Option<usize>,
     /// TTL cache for the cwd-derived fallback workspace root passed to
     /// `PlexiBehavior` each frame (#2023). The fallback
     /// (`config::active_workspace_root()`) stat-walks the filesystem from the
@@ -1320,6 +1324,7 @@ impl PlexiApp {
                     palette_notes: Vec::new(),
                     palette_commands: Vec::new(),
                     palette_scroll_reset: false,
+                    palette_agent_count_logged: None,
                     workspace_root_fallback_cache: None,
                     context_visit_history: Vec::new(),
                     renaming_pane: None,
@@ -1573,6 +1578,7 @@ impl PlexiApp {
             palette_notes: Vec::new(),
             palette_commands: Vec::new(),
             palette_scroll_reset: false,
+            palette_agent_count_logged: None,
             workspace_root_fallback_cache: None,
             context_visit_history: Vec::new(),
             renaming_pane: None,
@@ -2018,6 +2024,7 @@ impl PlexiApp {
                 palette_notes: Vec::new(),
                 palette_commands: Vec::new(),
                 palette_scroll_reset: false,
+                palette_agent_count_logged: None,
                 workspace_root_fallback_cache: None,
                 context_visit_history: Vec::new(),
                 renaming_pane: None,

--- a/src/cli/AGENTS.md
+++ b/src/cli/AGENTS.md
@@ -25,6 +25,7 @@ Every CLI command and feature must work identically on alpha, beta, main, and PR
 - **Repeatable flags fan out or they error.** A count flag paired with a repeatable value flag (`context sub --agents N --command CMD`) accepts the value once (applies to all) or exactly N times (one each). Any other count is a hard error — never truncate, never cycle. Expand to one entry per unit in the CLI so the host receives an unambiguous list; see `expand_pane_commands`.
 - **Resolve the caller's context by `PLEXI_CONTEXT_ID`, not `PLEXI_CONTEXT_NAME`.** Context names are not unique; the id is. Send the id; the host consults the name only when no id was sent (`resolve_parent_context`). An id naming no live context is an error, never a reason to fall back to the name — a stale id plus a name some other context happens to share would silently target a stranger.
 - **Agent-facing commands answer in one round trip.** A command that creates addressable objects returns their ids in its JSON response (`context sub` → `{"context_id","windows","panes":[…]}`), so the caller never needs a follow-up `pane list` to act on what it just made.
+- **Reported agent identity is human-facing.** The `agent report --agent` name and `--detail` active tool appear in Cmd+P across all contexts. Same-name agents are distinguished by their one-based position within the context, so repeated squad commands remain navigable.
 
 ## Documentation Rule for CLI Changes
 

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -51,7 +51,6 @@ enum PaletteEntry {
     },
     /// A pane running an agent, anywhere in the host. Enter focuses it.
     Agent {
-        win_idx: usize,
         window_id: u64,
         pane_id: u64,
         /// Hook-reported agent name (`PaneAgentState::agent`).
@@ -462,9 +461,11 @@ fn palette_pane_rows_for_context(
 /// sourced from every window of every context — the fleet is addressable from
 /// wherever you happen to be standing.
 struct AgentRow {
-    win_idx: usize,
     window_id: u64,
     pane_id: u64,
+    /// One-based position among agent panes in the owning context. This keeps
+    /// same-name squad members distinguishable without exposing tree ids.
+    context_agent_index: usize,
     agent_name: String,
     pane_title: String,
     context_name: String,
@@ -485,16 +486,18 @@ fn agent_state_label(state: &crate::app_protocol::AgentState) -> &'static str {
 /// hook-reported detail (the active tool) when there is one.
 fn agent_row_secondary(
     context_name: &str,
+    context_agent_index: usize,
     state: &crate::app_protocol::AgentState,
     detail: Option<&str>,
 ) -> String {
-    let mut parts: Vec<&str> = Vec::new();
+    let mut parts = Vec::new();
     if !context_name.is_empty() {
-        parts.push(context_name);
+        parts.push(context_name.to_string());
     }
-    parts.push(agent_state_label(state));
+    parts.push(format!("agent {context_agent_index}"));
+    parts.push(agent_state_label(state).to_string());
     if let Some(detail) = detail.filter(|d| !d.is_empty()) {
-        parts.push(detail);
+        parts.push(detail.to_string());
     }
     parts.join(" · ")
 }
@@ -504,7 +507,8 @@ fn palette_agent_rows(
     context_names: &[(u64, String)],
 ) -> Vec<AgentRow> {
     let mut rows = Vec::new();
-    for (win_idx, win) in windows.iter().enumerate() {
+    let mut context_agent_counts = std::collections::HashMap::<u64, usize>::new();
+    for win in windows {
         let Some(root) = win.tree.root() else {
             continue;
         };
@@ -526,6 +530,8 @@ fn palette_agent_rows(
             let Some(agent) = pane.agent() else {
                 continue;
             };
+            let context_agent_index = context_agent_counts.entry(win.context_id).or_default();
+            *context_agent_index += 1;
             let (pane_title, _) = pane_row_identity(pane, context_names);
             // A hook that reports no agent name still gets a nameable row.
             let agent_name = if agent.agent.is_empty() {
@@ -534,9 +540,9 @@ fn palette_agent_rows(
                 agent.agent.clone()
             };
             rows.push(AgentRow {
-                win_idx,
                 window_id: win.window_id,
                 pane_id,
+                context_agent_index: *context_agent_index,
                 agent_name,
                 pane_title,
                 context_name: context_name.clone(),
@@ -791,11 +797,11 @@ impl PlexiApp {
                 continue;
             }
             entries.push(PaletteEntry::Agent {
-                win_idx: row.win_idx,
                 window_id: row.window_id,
                 pane_id: row.pane_id,
                 secondary: agent_row_secondary(
                     &row.context_name,
+                    row.context_agent_index,
                     &row.state,
                     row.detail.as_deref(),
                 ),
@@ -959,7 +965,6 @@ impl PlexiApp {
             RunCommand(PaletteCommand),
             JumpContext(usize, u64, Option<u64>),
             JumpAgent {
-                win_idx: usize,
                 window_id: u64,
                 pane_id: u64,
                 agent_name: String,
@@ -1009,14 +1014,12 @@ impl PlexiApp {
                         action = Some(Action::JumpContext(*ctx_idx, *context_id, *pane_id));
                     }
                     Some(PaletteEntry::Agent {
-                        win_idx,
                         window_id,
                         pane_id,
                         agent_name,
                         ..
                     }) => {
                         action = Some(Action::JumpAgent {
-                            win_idx: *win_idx,
                             window_id: *window_id,
                             pane_id: *pane_id,
                             agent_name: agent_name.clone(),
@@ -1062,12 +1065,11 @@ impl PlexiApp {
                 return;
             }
             Some(Action::JumpAgent {
-                win_idx,
                 window_id,
                 pane_id,
                 agent_name,
             }) => {
-                self.jump_to_agent_pane(win_idx, window_id, pane_id, &agent_name);
+                self.jump_to_agent_pane(window_id, pane_id, &agent_name);
                 self.show_command_palette = false;
                 self.palette_query.clear();
                 return;
@@ -1239,7 +1241,6 @@ impl PlexiApp {
                                 }
                             }
                             PaletteEntry::Agent {
-                                win_idx,
                                 window_id,
                                 pane_id,
                                 agent_name,
@@ -1277,7 +1278,6 @@ impl PlexiApp {
                                 }
                                 if row_response.row_clicked() {
                                     click_action = Some(Action::JumpAgent {
-                                        win_idx: *win_idx,
                                         window_id: *window_id,
                                         pane_id: *pane_id,
                                         agent_name: agent_name.clone(),
@@ -1464,12 +1464,11 @@ impl PlexiApp {
                             self.palette_query.clear();
                         }
                         Action::JumpAgent {
-                            win_idx,
                             window_id,
                             pane_id,
                             agent_name,
                         } => {
-                            self.jump_to_agent_pane(win_idx, window_id, pane_id, &agent_name);
+                            self.jump_to_agent_pane(window_id, pane_id, &agent_name);
                             self.show_command_palette = false;
                             self.palette_query.clear();
                         }
@@ -1487,8 +1486,7 @@ impl PlexiApp {
                             self.show_command_palette = false;
                             self.palette_query.clear();
                             let path_str = path.display().to_string();
-                            if let Some(pane_id) =
-                                self.find_open_text_editor_pane_any_window(&path)
+                            if let Some(pane_id) = self.find_open_text_editor_pane_any_window(&path)
                             {
                                 log::info!(
                                     "palette: note already open in pane {pane_id}, navigating"
@@ -1570,15 +1568,21 @@ impl PlexiApp {
 
     /// Focus an agent pane selected in the palette. Routes through the same
     /// explicit-target navigation the context rows use — the target window
-    /// index and pane id are carried by the row, never read back out of
+    /// window id and pane id are carried by the row, never read back out of
     /// `active_window` or `router.active`.
-    fn jump_to_agent_pane(
-        &mut self,
-        win_idx: usize,
-        window_id: u64,
-        pane_id: u64,
-        agent_name: &str,
-    ) {
+    fn jump_to_agent_pane(&mut self, window_id: u64, pane_id: u64, agent_name: &str) {
+        let Some(win_idx) = self.windows.iter().position(|win| {
+            win.window_id == window_id
+                && win
+                    .panes
+                    .get(&pane_id)
+                    .is_some_and(|pane| pane.agent().is_some())
+        }) else {
+            log::warn!(
+                "palette: agent pane {pane_id} (agent '{agent_name}') disappeared before focus"
+            );
+            return;
+        };
         log::info!("palette: focusing agent pane {pane_id} (agent '{agent_name}')");
         self.jump_to_context(win_idx, window_id, Some(pane_id));
     }
@@ -1994,9 +1998,14 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["squad-alpha", "squad-alpha", "plexi"]
         );
-        // win_idx/window_id must address the owning window, not the active one.
-        assert_eq!(rows[2].win_idx, 1);
+        // The stable window id must address the owning window, not the active one.
         assert_eq!(rows[2].window_id, 80);
+        assert_eq!(
+            rows.iter()
+                .map(|r| r.context_agent_index)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 1]
+        );
         // Focus is per-window: pane 11 in the squad, pane 20 in the other context.
         assert_eq!(
             rows.iter().map(|r| r.focused).collect::<Vec<_>>(),
@@ -2006,26 +2015,26 @@ mod tests {
     }
 
     #[test]
-    fn squad_panes_sharing_a_title_stay_separable_by_agent_name() {
+    fn squad_panes_sharing_a_title_and_agent_name_stay_distinguishable() {
         use crate::app_protocol::AgentState;
 
-        // stint 0568 spawns N panes into one subcontext; their pane titles can
-        // all be the same, so the agent name has to carry the distinction.
+        // stint 0568 commonly launches the same agent command N times. Those
+        // panes can share both title and reported agent name.
         let squad = window_of(
             7,
             70,
             vec![
                 (
                     10,
-                    test_agent_pane(10, "claude", "impl-a", AgentState::Working, None),
+                    test_agent_pane(10, "claude", "claude-code", AgentState::Working, None),
                 ),
                 (
                     11,
-                    test_agent_pane(11, "claude", "impl-b", AgentState::Idle, None),
+                    test_agent_pane(11, "claude", "claude-code", AgentState::Idle, None),
                 ),
                 (
                     12,
-                    test_agent_pane(12, "claude", "tester", AgentState::Blocked, None),
+                    test_agent_pane(12, "claude", "claude-code", AgentState::Blocked, None),
                 ),
             ],
             0,
@@ -2044,16 +2053,18 @@ mod tests {
             })
             .collect();
 
-        // The shared title matches all three; the agent name narrows to one.
+        // Search still reaches the whole squad, while the visible one-based
+        // positions distinguish otherwise identical rows.
         assert_eq!(
             search.iter().filter(|s| s.contains("claude")).count(),
             3,
             "the shared pane title must reach every squad member"
         );
         assert_eq!(
-            search.iter().filter(|s| s.contains("tester")).count(),
-            1,
-            "the agent name must isolate one squad member"
+            rows.iter()
+                .map(|r| r.context_agent_index)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3]
         );
         // The context name reaches the whole squad — jump by squad, then pick.
         assert_eq!(
@@ -2067,7 +2078,6 @@ mod tests {
         use crate::app_protocol::AgentState;
 
         let agent = |agent_name: &str, state: AgentState| PaletteEntry::Agent {
-            win_idx: 0,
             window_id: 1,
             pane_id: 10,
             agent_name: agent_name.to_string(),
@@ -2124,7 +2134,6 @@ mod tests {
                 search_text: "claude-ctx".to_string(),
             },
             PaletteEntry::Agent {
-                win_idx: 0,
                 window_id: 1,
                 pane_id: 10,
                 agent_name: "blocked-one".to_string(),
@@ -2145,20 +2154,23 @@ mod tests {
         use crate::app_protocol::AgentState;
 
         assert_eq!(
-            agent_row_secondary("squad-alpha", &AgentState::Working, Some("Bash")),
-            "squad-alpha · working · Bash"
+            agent_row_secondary("squad-alpha", 2, &AgentState::Working, Some("Bash")),
+            "squad-alpha · agent 2 · working · Bash"
         );
         assert_eq!(
-            agent_row_secondary("squad-alpha", &AgentState::Blocked, None),
-            "squad-alpha · blocked"
+            agent_row_secondary("squad-alpha", 1, &AgentState::Blocked, None),
+            "squad-alpha · agent 1 · blocked"
         );
         // An empty detail string is not a detail.
         assert_eq!(
-            agent_row_secondary("plexi", &AgentState::Idle, Some("")),
-            "plexi · idle"
+            agent_row_secondary("plexi", 3, &AgentState::Idle, Some("")),
+            "plexi · agent 3 · idle"
         );
         // A context with no resolvable name still yields a usable line.
-        assert_eq!(agent_row_secondary("", &AgentState::Idle, None), "idle");
+        assert_eq!(
+            agent_row_secondary("", 1, &AgentState::Idle, None),
+            "agent 1 · idle"
+        );
     }
 
     #[test]
@@ -2176,6 +2188,59 @@ mod tests {
         );
         let rows = palette_agent_rows(&[win], &[(7, "squad-alpha".to_string())]);
         assert_eq!(rows[0].agent_name, "claude");
+    }
+
+    #[test]
+    fn agent_jump_switches_window_context_and_focused_pane_together() {
+        use crate::app_protocol::AgentState;
+        use crate::testing::HostHarness;
+
+        let mut h = HostHarness::new();
+        let target = window_of(
+            7,
+            70,
+            vec![(
+                10,
+                test_agent_pane(10, "claude", "claude-code", AgentState::Working, None),
+            )],
+            0,
+        );
+        h.app.windows.push(target);
+        h.app.router.push(crate::host::context::Context {
+            name: "squad-alpha".to_string(),
+            path: std::env::temp_dir(),
+            root: None,
+            description: None,
+            context_id: 7,
+            parent_id: None,
+            depth: 0,
+            parked: false,
+        });
+
+        h.app.jump_to_agent_pane(70, 10, "claude-code");
+
+        assert_eq!(h.app.active_window, 1);
+        assert_eq!(h.app.windows[h.app.active_window].context_id, 7);
+        assert_eq!(h.app.router.active().context_id, 7);
+        let focused = h.app.windows[1]
+            .focused_pane
+            .and_then(|tile| h.app.windows[1].tree.tiles.get(tile));
+        assert!(matches!(focused, Some(egui_tiles::Tile::Pane(10))));
+        assert_eq!(h.app.context_active_window.get(&7), Some(&70));
+    }
+
+    #[test]
+    fn stale_agent_jump_leaves_focus_unchanged() {
+        use crate::testing::HostHarness;
+
+        let mut h = HostHarness::new();
+        let active_window = h.app.active_window;
+        let active_context = h.app.router.active().context_id;
+
+        h.app.jump_to_agent_pane(999, 123, "gone");
+
+        assert_eq!(h.app.active_window, active_window);
+        assert_eq!(h.app.router.active().context_id, active_context);
     }
 
     fn test_pane(id: u64, hidden: bool) -> Pane {

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -49,6 +49,21 @@ enum PaletteEntry {
         preview: String,
         search_text: String,
     },
+    /// A pane running an agent, anywhere in the host. Enter focuses it.
+    Agent {
+        win_idx: usize,
+        window_id: u64,
+        pane_id: u64,
+        /// Hook-reported agent name (`PaneAgentState::agent`).
+        agent_name: String,
+        /// Owning context, live state, and the active tool when reported.
+        secondary: String,
+        state: crate::app_protocol::AgentState,
+        /// True when this pane is the focused pane of its own window — drives
+        /// the state dot's focused/dim rendering, same as every other pip.
+        focused: bool,
+        search_text: String,
+    },
     /// A user-authored command from `commands.toml` or a global script,
     /// executed via `plexi run <name>` in a new terminal pane.
     UserCommand {
@@ -64,10 +79,25 @@ impl PaletteEntry {
     fn group_rank(&self) -> usize {
         match self {
             PaletteEntry::Context { .. } => 0,
-            PaletteEntry::Note { .. } => 1,
-            PaletteEntry::App { .. } | PaletteEntry::Builtin { .. } => 2,
-            PaletteEntry::Command { .. } => 3,
-            PaletteEntry::UserCommand { .. } => 4,
+            PaletteEntry::Agent { .. } => 1,
+            PaletteEntry::Note { .. } => 2,
+            PaletteEntry::App { .. } | PaletteEntry::Builtin { .. } => 3,
+            PaletteEntry::Command { .. } => 4,
+            PaletteEntry::UserCommand { .. } => 5,
+        }
+    }
+
+    /// Tie-break within an equal (query, group) rank: an agent waiting on a
+    /// human surfaces above an equally-scoring one that is not. This is the
+    /// only state-aware ordering in the palette.
+    fn state_rank(&self) -> usize {
+        match self {
+            PaletteEntry::Agent { state, .. }
+                if *state == crate::app_protocol::AgentState::Blocked =>
+            {
+                0
+            }
+            _ => 1,
         }
     }
 
@@ -78,6 +108,7 @@ impl PaletteEntry {
         let search_text = match self {
             PaletteEntry::Command { search_text, .. } => *search_text,
             PaletteEntry::Context { search_text, .. }
+            | PaletteEntry::Agent { search_text, .. }
             | PaletteEntry::App { search_text, .. }
             | PaletteEntry::Builtin { search_text, .. }
             | PaletteEntry::Note { search_text, .. }
@@ -105,6 +136,7 @@ impl PaletteEntry {
         match self {
             PaletteEntry::Command { search_text, .. } => search_text.contains(query),
             PaletteEntry::Context { search_text, .. }
+            | PaletteEntry::Agent { search_text, .. }
             | PaletteEntry::App { search_text, .. }
             | PaletteEntry::Builtin { search_text, .. }
             | PaletteEntry::Note { search_text, .. }
@@ -174,7 +206,13 @@ fn shell_single_quote(s: &str) -> String {
 }
 
 fn sort_palette_entries(entries: &mut [PaletteEntry], query: &str) {
-    entries.sort_by_key(|entry| (entry.query_rank(query), entry.group_rank()));
+    entries.sort_by_key(|entry| {
+        (
+            entry.query_rank(query),
+            entry.group_rank(),
+            entry.state_rank(),
+        )
+    });
 }
 
 #[cfg(test)]
@@ -420,6 +458,97 @@ fn palette_pane_rows_for_context(
     rows
 }
 
+/// One palette row per agent-bearing pane. Unlike the context rows, these are
+/// sourced from every window of every context — the fleet is addressable from
+/// wherever you happen to be standing.
+struct AgentRow {
+    win_idx: usize,
+    window_id: u64,
+    pane_id: u64,
+    agent_name: String,
+    pane_title: String,
+    context_name: String,
+    state: crate::app_protocol::AgentState,
+    detail: Option<String>,
+    focused: bool,
+}
+
+fn agent_state_label(state: &crate::app_protocol::AgentState) -> &'static str {
+    match state {
+        crate::app_protocol::AgentState::Working => "working",
+        crate::app_protocol::AgentState::Blocked => "blocked",
+        crate::app_protocol::AgentState::Idle => "idle",
+    }
+}
+
+/// Secondary line for an agent row: owning context, live state, and the
+/// hook-reported detail (the active tool) when there is one.
+fn agent_row_secondary(
+    context_name: &str,
+    state: &crate::app_protocol::AgentState,
+    detail: Option<&str>,
+) -> String {
+    let mut parts: Vec<&str> = Vec::new();
+    if !context_name.is_empty() {
+        parts.push(context_name);
+    }
+    parts.push(agent_state_label(state));
+    if let Some(detail) = detail.filter(|d| !d.is_empty()) {
+        parts.push(detail);
+    }
+    parts.join(" · ")
+}
+
+fn palette_agent_rows(
+    windows: &[crate::host::context::Window],
+    context_names: &[(u64, String)],
+) -> Vec<AgentRow> {
+    let mut rows = Vec::new();
+    for (win_idx, win) in windows.iter().enumerate() {
+        let Some(root) = win.tree.root() else {
+            continue;
+        };
+        let context_name = context_names
+            .iter()
+            .find(|(id, _)| *id == win.context_id)
+            .map(|(_, name)| name.clone())
+            .unwrap_or_default();
+        let focused_pane_id =
+            win.focused_pane
+                .and_then(|tile_id| match win.tree.tiles.get(tile_id) {
+                    Some(egui_tiles::Tile::Pane(pid)) => Some(*pid),
+                    _ => None,
+                });
+        for pane_id in crate::spatial::tiling::collect_pane_ids_spatial(&win.tree.tiles, root) {
+            let Some(pane) = win.panes.get(&pane_id) else {
+                continue;
+            };
+            let Some(agent) = pane.agent() else {
+                continue;
+            };
+            let (pane_title, _) = pane_row_identity(pane, context_names);
+            // A hook that reports no agent name still gets a nameable row.
+            let agent_name = if agent.agent.is_empty() {
+                pane_title.clone()
+            } else {
+                agent.agent.clone()
+            };
+            rows.push(AgentRow {
+                win_idx,
+                window_id: win.window_id,
+                pane_id,
+                agent_name,
+                pane_title,
+                context_name: context_name.clone(),
+                state: agent.state.clone(),
+                detail: agent.detail.clone(),
+                focused: Some(pane_id) == focused_pane_id,
+            });
+        }
+    }
+    rows
+}
+
 /// Display name + type chip for a palette pane row.
 fn pane_row_identity(
     pane: &crate::host::pane::Pane,
@@ -492,6 +621,27 @@ impl PlexiApp {
 
         let mut entries: Vec<PaletteEntry> = Vec::new();
 
+        let context_names: Vec<(u64, String)> = self
+            .router
+            .iter()
+            .map(|c| (c.context_id, c.name.clone()))
+            .collect();
+
+        // ── Agent panes (every window, every context) ───────────────────────
+        // Collected fresh each frame, never snapshotted at open time: agent
+        // state arrives over pane IPC (`set_agent_state`) while the palette is
+        // up, and the rows must show it live.
+        let agent_rows = palette_agent_rows(&self.windows, &context_names);
+        if self.palette_agent_count_logged != Some(agent_rows.len()) {
+            self.palette_agent_count_logged = Some(agent_rows.len());
+            log::info!("palette: collected {} agent panes", agent_rows.len());
+        }
+        // An agent pane is represented once — by its agent row, which carries
+        // strictly more (agent name, live state, active tool) than the plain
+        // pane row would.
+        let agent_pane_ids: std::collections::HashSet<u64> =
+            agent_rows.iter().map(|row| row.pane_id).collect();
+
         let ctx_entries: Vec<PaletteEntry> = {
             // Context-scoped unpacking: the ACTIVE context expands to one row
             // per pane (each carrying a single status pip), while every OTHER
@@ -499,12 +649,6 @@ impl PlexiApp {
             // A non-empty query pierces the collapse — matching pane names
             // surface from inactive contexts so the palette stays a global
             // jump tool.
-            let context_names: Vec<(u64, String)> = self
-                .router
-                .iter()
-                .map(|c| (c.context_id, c.name.clone()))
-                .collect();
-
             // Non-parked contexts that own at least one window. The jump
             // target is context_active_window when it still belongs to the
             // context, else the context's first window.
@@ -560,6 +704,9 @@ impl PlexiApp {
                         active_focused_tile,
                         &self.pane_focus_history,
                     ) {
+                        if agent_pane_ids.contains(&row.pane_id) {
+                            continue;
+                        }
                         let search_text = searchable_text(&[row.name.as_str(), c.name.as_str()]);
                         if query.is_empty() || search_text.contains(&query) {
                             ctx_entries.push(PaletteEntry::Context {
@@ -606,6 +753,9 @@ impl PlexiApp {
                             active_focused_tile,
                             &self.pane_focus_history,
                         ) {
+                            if agent_pane_ids.contains(&row.pane_id) {
+                                continue;
+                            }
                             let search_text =
                                 searchable_text(&[row.name.as_str(), c.name.as_str()]);
                             if search_text.contains(&query) {
@@ -628,6 +778,33 @@ impl PlexiApp {
             ctx_entries
         };
         entries.extend(ctx_entries);
+
+        // Agent rows match on agent name, pane title, and context name through
+        // the same substring matcher every other result type uses.
+        for row in agent_rows {
+            let search_text = searchable_text(&[
+                row.agent_name.as_str(),
+                row.pane_title.as_str(),
+                row.context_name.as_str(),
+            ]);
+            if !query.is_empty() && !search_text.contains(&query) {
+                continue;
+            }
+            entries.push(PaletteEntry::Agent {
+                win_idx: row.win_idx,
+                window_id: row.window_id,
+                pane_id: row.pane_id,
+                secondary: agent_row_secondary(
+                    &row.context_name,
+                    &row.state,
+                    row.detail.as_deref(),
+                ),
+                agent_name: row.agent_name,
+                state: row.state,
+                focused: row.focused,
+                search_text,
+            });
+        }
 
         // ── Note entries ────────────────────────────────────────────────────
         for note in &self.palette_notes {
@@ -781,6 +958,12 @@ impl PlexiApp {
         enum Action {
             RunCommand(PaletteCommand),
             JumpContext(usize, u64, Option<u64>),
+            JumpAgent {
+                win_idx: usize,
+                window_id: u64,
+                pane_id: u64,
+                agent_name: String,
+            },
             LaunchApp(String),
             LaunchBuiltin(&'static str),
             OpenNote(std::path::PathBuf),
@@ -825,6 +1008,20 @@ impl PlexiApp {
                     }) => {
                         action = Some(Action::JumpContext(*ctx_idx, *context_id, *pane_id));
                     }
+                    Some(PaletteEntry::Agent {
+                        win_idx,
+                        window_id,
+                        pane_id,
+                        agent_name,
+                        ..
+                    }) => {
+                        action = Some(Action::JumpAgent {
+                            win_idx: *win_idx,
+                            window_id: *window_id,
+                            pane_id: *pane_id,
+                            agent_name: agent_name.clone(),
+                        });
+                    }
                     Some(PaletteEntry::App { id, .. }) => {
                         action = Some(Action::LaunchApp(id.clone()));
                     }
@@ -860,6 +1057,17 @@ impl PlexiApp {
             }
             Some(Action::JumpContext(ctx_idx, context_id, pane_id)) => {
                 self.jump_to_context(ctx_idx, context_id, pane_id);
+                self.show_command_palette = false;
+                self.palette_query.clear();
+                return;
+            }
+            Some(Action::JumpAgent {
+                win_idx,
+                window_id,
+                pane_id,
+                agent_name,
+            }) => {
+                self.jump_to_agent_pane(win_idx, window_id, pane_id, &agent_name);
                 self.show_command_palette = false;
                 self.palette_query.clear();
                 return;
@@ -942,6 +1150,7 @@ impl PlexiApp {
                 let mut hover_select: Option<usize> = None;
                 let mouse_moved = ctx.input(|i| i.pointer.delta().length_sq() > 0.5);
                 let should_scroll = self.palette_selected != prev_selected;
+                let mut shown_agents_header = false;
                 let mut shown_apps_header = false;
                 let mut shown_notes_header = false;
                 let mut shown_commands_header = false;
@@ -1024,6 +1233,55 @@ impl PlexiApp {
                                 if row_response.row_clicked() {
                                     click_action =
                                         Some(Action::JumpContext(*ctx_idx, *context_id, *pane_id));
+                                }
+                                if row_response.row_hovered() {
+                                    hover_select = Some(i);
+                                }
+                            }
+                            PaletteEntry::Agent {
+                                win_idx,
+                                window_id,
+                                pane_id,
+                                agent_name,
+                                secondary,
+                                state,
+                                focused,
+                                ..
+                            } => {
+                                if !shown_agents_header {
+                                    shown_agents_header = true;
+                                    ui.add_space(style::SPACE_XS);
+                                    ui.label(
+                                        RichText::new("AGENTS")
+                                            .size(style::TEXT_HINT)
+                                            .color(colors.text_dim),
+                                    );
+                                    ui.add_space(style::SPACE_XS);
+                                }
+                                // The dot goes through the shared pip lane, so
+                                // palette, sidebar, and pane chrome can never
+                                // disagree about what a state looks like.
+                                let row_response = ListRow::new(agent_name.as_str())
+                                    .metadata_chips(&["agent"])
+                                    .secondary(secondary.as_str())
+                                    .pane_pips(ListRowPips {
+                                        count: 1,
+                                        focused_idx: focused.then_some(0),
+                                        hidden_indices: Vec::new(),
+                                        activities: vec![Some(state.clone())],
+                                    })
+                                    .selected(is_selected)
+                                    .show(ui, &colors);
+                                if is_selected {
+                                    row_response.scroll_into_view(ui, should_scroll);
+                                }
+                                if row_response.row_clicked() {
+                                    click_action = Some(Action::JumpAgent {
+                                        win_idx: *win_idx,
+                                        window_id: *window_id,
+                                        pane_id: *pane_id,
+                                        agent_name: agent_name.clone(),
+                                    });
                                 }
                                 if row_response.row_hovered() {
                                     hover_select = Some(i);
@@ -1205,6 +1463,16 @@ impl PlexiApp {
                             self.show_command_palette = false;
                             self.palette_query.clear();
                         }
+                        Action::JumpAgent {
+                            win_idx,
+                            window_id,
+                            pane_id,
+                            agent_name,
+                        } => {
+                            self.jump_to_agent_pane(win_idx, window_id, pane_id, &agent_name);
+                            self.show_command_palette = false;
+                            self.palette_query.clear();
+                        }
                         Action::LaunchApp(id) => {
                             self.show_command_palette = false;
                             self.palette_query.clear();
@@ -1298,6 +1566,21 @@ impl PlexiApp {
         let initial_cmd = format!("plexi run {}", shell_single_quote(name));
         self.split_focused(false, Some(&initial_cmd), false, false, cwd);
         self.save_workspace();
+    }
+
+    /// Focus an agent pane selected in the palette. Routes through the same
+    /// explicit-target navigation the context rows use — the target window
+    /// index and pane id are carried by the row, never read back out of
+    /// `active_window` or `router.active`.
+    fn jump_to_agent_pane(
+        &mut self,
+        win_idx: usize,
+        window_id: u64,
+        pane_id: u64,
+        agent_name: &str,
+    ) {
+        log::info!("palette: focusing agent pane {pane_id} (agent '{agent_name}')");
+        self.jump_to_context(win_idx, window_id, Some(pane_id));
     }
 
     /// Jump to a window by index, switching context if necessary.
@@ -1588,6 +1871,311 @@ mod tests {
             window_id,
             context_id,
         }
+    }
+
+    /// An app pane carrying hook-reported agent state.
+    fn test_agent_pane(
+        id: u64,
+        pane_name: &str,
+        agent: &str,
+        state: crate::app_protocol::AgentState,
+        detail: Option<&str>,
+    ) -> Pane {
+        use crate::app::permissions::AppPermissions;
+        use crate::host::pane::{AppPane, AppRuntime};
+
+        Pane::App(Box::new(AppPane {
+            pip_status: None,
+            id,
+            runtime: AppRuntime::Builtin(Box::new(crate::file_browser::FileBrowserApp::new(
+                std::env::temp_dir(),
+            ))),
+            workspace_root: std::env::temp_dir(),
+            permissions: AppPermissions::builtin(),
+            manifest_id: "terminal".to_string(),
+            name: pane_name.to_string(),
+            pane_group: None,
+            linked_pane_id: None,
+            overlay_replaced: None,
+            hidden: false,
+            agent: Some(crate::app_protocol::PaneAgentState {
+                pane_id: id,
+                state,
+                agent: agent.to_string(),
+                detail: detail.map(str::to_string),
+                session_id: None,
+            }),
+            slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
+        }))
+    }
+
+    /// A window built from explicit panes, so a test can mix agent-bearing and
+    /// plain panes in one tree.
+    fn window_of(
+        context_id: u64,
+        window_id: u64,
+        panes_spec: Vec<(u64, Pane)>,
+        focused_idx: usize,
+    ) -> crate::host::context::Window {
+        let mut panes = std::collections::HashMap::new();
+        let mut tiles = egui_tiles::Tiles::default();
+        let mut tile_ids = Vec::new();
+        for (pane_id, pane) in panes_spec {
+            panes.insert(pane_id, pane);
+            tile_ids.push(tiles.insert_pane(pane_id));
+        }
+        let focused_pane = tile_ids.get(focused_idx).copied();
+        let root = match tile_ids.as_slice() {
+            [only] => *only,
+            _ => tiles.insert_horizontal_tile(tile_ids),
+        };
+        crate::host::context::Window {
+            name: "test".to_string(),
+            path: std::path::PathBuf::from("/tmp"),
+            tree: egui_tiles::Tree::new("test", root, tiles),
+            panes,
+            focused_pane,
+            zoomed_pane: None,
+            grid_x: 0,
+            grid_y: 0,
+            window_id,
+            context_id,
+        }
+    }
+
+    #[test]
+    fn agent_rows_collect_from_every_window_and_context() {
+        use crate::app_protocol::AgentState;
+
+        let squad = window_of(
+            7,
+            70,
+            vec![
+                (
+                    10,
+                    test_agent_pane(10, "claude", "impl-a", AgentState::Working, Some("Bash")),
+                ),
+                (
+                    11,
+                    test_agent_pane(11, "claude", "tester", AgentState::Blocked, None),
+                ),
+                (12, test_pane(12, false)),
+            ],
+            1,
+        );
+        let other_ctx = window_of(
+            8,
+            80,
+            vec![(
+                20,
+                test_agent_pane(20, "codex", "reviewer", AgentState::Idle, None),
+            )],
+            0,
+        );
+        let names = vec![(7, "squad-alpha".to_string()), (8, "plexi".to_string())];
+
+        let rows = palette_agent_rows(&[squad, other_ctx], &names);
+
+        // The non-agent pane is skipped; both contexts contribute.
+        assert_eq!(
+            rows.iter().map(|r| r.pane_id).collect::<Vec<_>>(),
+            vec![10, 11, 20]
+        );
+        assert_eq!(
+            rows.iter()
+                .map(|r| r.agent_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["impl-a", "tester", "reviewer"]
+        );
+        assert_eq!(
+            rows.iter()
+                .map(|r| r.context_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["squad-alpha", "squad-alpha", "plexi"]
+        );
+        // win_idx/window_id must address the owning window, not the active one.
+        assert_eq!(rows[2].win_idx, 1);
+        assert_eq!(rows[2].window_id, 80);
+        // Focus is per-window: pane 11 in the squad, pane 20 in the other context.
+        assert_eq!(
+            rows.iter().map(|r| r.focused).collect::<Vec<_>>(),
+            vec![false, true, true]
+        );
+        assert_eq!(rows[0].detail.as_deref(), Some("Bash"));
+    }
+
+    #[test]
+    fn squad_panes_sharing_a_title_stay_separable_by_agent_name() {
+        use crate::app_protocol::AgentState;
+
+        // stint 0568 spawns N panes into one subcontext; their pane titles can
+        // all be the same, so the agent name has to carry the distinction.
+        let squad = window_of(
+            7,
+            70,
+            vec![
+                (
+                    10,
+                    test_agent_pane(10, "claude", "impl-a", AgentState::Working, None),
+                ),
+                (
+                    11,
+                    test_agent_pane(11, "claude", "impl-b", AgentState::Idle, None),
+                ),
+                (
+                    12,
+                    test_agent_pane(12, "claude", "tester", AgentState::Blocked, None),
+                ),
+            ],
+            0,
+        );
+        let names = vec![(7, "squad-alpha".to_string())];
+        let rows = palette_agent_rows(&[squad], &names);
+
+        let search: Vec<String> = rows
+            .iter()
+            .map(|r| {
+                searchable_text(&[
+                    r.agent_name.as_str(),
+                    r.pane_title.as_str(),
+                    r.context_name.as_str(),
+                ])
+            })
+            .collect();
+
+        // The shared title matches all three; the agent name narrows to one.
+        assert_eq!(
+            search.iter().filter(|s| s.contains("claude")).count(),
+            3,
+            "the shared pane title must reach every squad member"
+        );
+        assert_eq!(
+            search.iter().filter(|s| s.contains("tester")).count(),
+            1,
+            "the agent name must isolate one squad member"
+        );
+        // The context name reaches the whole squad — jump by squad, then pick.
+        assert_eq!(
+            search.iter().filter(|s| s.contains("squad-alpha")).count(),
+            3
+        );
+    }
+
+    #[test]
+    fn blocked_agent_outranks_equally_scoring_agent() {
+        use crate::app_protocol::AgentState;
+
+        let agent = |agent_name: &str, state: AgentState| PaletteEntry::Agent {
+            win_idx: 0,
+            window_id: 1,
+            pane_id: 10,
+            agent_name: agent_name.to_string(),
+            secondary: String::new(),
+            state,
+            focused: false,
+            search_text: "claude squad-alpha".to_string(),
+        };
+
+        let mut entries = vec![
+            agent("idle-one", AgentState::Idle),
+            agent("working-one", AgentState::Working),
+            agent("blocked-one", AgentState::Blocked),
+        ];
+        sort_palette_entries(&mut entries, "claude");
+
+        match &entries[0] {
+            PaletteEntry::Agent { agent_name, .. } => assert_eq!(agent_name, "blocked-one"),
+            other => panic!("expected an agent row first, got {:?}", other.group_rank()),
+        }
+        // Non-blocked rows keep their relative order — the sort is stable and
+        // state only breaks exact ties.
+        match (&entries[1], &entries[2]) {
+            (
+                PaletteEntry::Agent {
+                    agent_name: second, ..
+                },
+                PaletteEntry::Agent {
+                    agent_name: third, ..
+                },
+            ) => {
+                assert_eq!(second, "idle-one");
+                assert_eq!(third, "working-one");
+            }
+            _ => panic!("expected agent rows"),
+        }
+    }
+
+    #[test]
+    fn agent_state_never_reorders_other_result_types() {
+        use crate::app_protocol::AgentState;
+
+        // A blocked agent must not jump ahead of a context row that scores the
+        // same — state ordering is scoped to the agent group.
+        let mut entries = vec![
+            PaletteEntry::Context {
+                ctx_idx: 0,
+                context_id: 1,
+                name: "claude-ctx".to_string(),
+                workspace_name: String::new(),
+                metadata_chip: "ctx",
+                pane_pips: None,
+                pane_id: None,
+                search_text: "claude-ctx".to_string(),
+            },
+            PaletteEntry::Agent {
+                win_idx: 0,
+                window_id: 1,
+                pane_id: 10,
+                agent_name: "blocked-one".to_string(),
+                secondary: String::new(),
+                state: AgentState::Blocked,
+                focused: false,
+                search_text: "claude-ctx".to_string(),
+            },
+        ];
+        sort_palette_entries(&mut entries, "claude");
+
+        assert!(matches!(entries[0], PaletteEntry::Context { .. }));
+        assert!(matches!(entries[1], PaletteEntry::Agent { .. }));
+    }
+
+    #[test]
+    fn agent_secondary_reads_context_state_and_active_tool() {
+        use crate::app_protocol::AgentState;
+
+        assert_eq!(
+            agent_row_secondary("squad-alpha", &AgentState::Working, Some("Bash")),
+            "squad-alpha · working · Bash"
+        );
+        assert_eq!(
+            agent_row_secondary("squad-alpha", &AgentState::Blocked, None),
+            "squad-alpha · blocked"
+        );
+        // An empty detail string is not a detail.
+        assert_eq!(
+            agent_row_secondary("plexi", &AgentState::Idle, Some("")),
+            "plexi · idle"
+        );
+        // A context with no resolvable name still yields a usable line.
+        assert_eq!(agent_row_secondary("", &AgentState::Idle, None), "idle");
+    }
+
+    #[test]
+    fn agent_row_falls_back_to_pane_title_when_the_hook_reports_no_name() {
+        use crate::app_protocol::AgentState;
+
+        let win = window_of(
+            7,
+            70,
+            vec![(
+                10,
+                test_agent_pane(10, "claude", "", AgentState::Idle, None),
+            )],
+            0,
+        );
+        let rows = palette_agent_rows(&[win], &[(7, "squad-alpha".to_string())]);
+        assert_eq!(rows[0].agent_name, "claude");
     }
 
     fn test_pane(id: u64, hidden: bool) -> Pane {

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -2231,6 +2231,155 @@ mod tests {
         println!("Screenshot saved to /tmp/plexi_command_palette_metadata_lane.png");
     }
 
+    /// Visual review surface for stint 0565: the palette rendering an agent
+    /// fleet spread across two contexts, including a stint-0568-style squad
+    /// whose three panes share one title. Empty query shows the whole fleet;
+    /// the typed query proves the squad stays separable by agent name.
+    #[test]
+    fn screenshot_command_palette_agent_fleet() {
+        let mut h = PlexiUiHarness::new_sized(1168.0, 800.0);
+        add_focused_pane(&mut h);
+        let browser_root = h.workspace.path().to_path_buf();
+
+        h.with_app_mut(|app| {
+            let ctx_idx = app.router.active_idx();
+            app.router.get_mut(ctx_idx).name = "plexi".to_string();
+
+            let agent_pane = |app: &mut crate::app::PlexiApp,
+                              pane_name: &str,
+                              agent: &str,
+                              state: crate::app_protocol::AgentState,
+                              detail: Option<&str>| {
+                let pane_id = app.host.alloc_pane_id();
+                let pane = Pane::App(Box::new(AppPane {
+                    pip_status: None,
+                    id: pane_id,
+                    runtime: AppRuntime::Builtin(Box::new(
+                        crate::file_browser::FileBrowserApp::new(browser_root.clone()),
+                    )),
+                    workspace_root: browser_root.clone(),
+                    permissions: AppPermissions::builtin(),
+                    manifest_id: "terminal".to_string(),
+                    name: pane_name.to_string(),
+                    pane_group: None,
+                    linked_pane_id: None,
+                    overlay_replaced: None,
+                    hidden: false,
+                    agent: Some(crate::app_protocol::PaneAgentState {
+                        pane_id,
+                        state,
+                        agent: agent.to_string(),
+                        detail: detail.map(str::to_string),
+                        session_id: None,
+                    }),
+                    slots: std::collections::HashMap::new(),
+                    semantic_state: Default::default(),
+                }));
+                (pane_id, pane)
+            };
+
+            // One agent alongside the ordinary pane in the active context.
+            let (solo_id, solo) = agent_pane(
+                app,
+                "codex",
+                "reviewer",
+                crate::app_protocol::AgentState::Working,
+                Some("Read"),
+            );
+            let win = &mut app.windows[app.active_window];
+            win.panes.insert(solo_id, solo);
+            let solo_tile = win.tree.tiles.insert_pane(solo_id);
+            if let Some(first_tile) = win.tree.root {
+                let root = win
+                    .tree
+                    .tiles
+                    .insert_horizontal_tile(vec![first_tile, solo_tile]);
+                win.tree.root = Some(root);
+                win.focused_pane = Some(first_tile);
+            }
+
+            // A three-pane squad in its own subcontext, all panes titled
+            // "claude" — the stint 0568 shape this palette has to navigate.
+            let squad_ctx_id = app.next_window_id;
+            app.next_window_id += 1;
+            app.router.push(crate::host::context::Context {
+                name: "squad-alpha".to_string(),
+                path: browser_root.clone(),
+                root: Some(browser_root.clone()),
+                description: None,
+                context_id: squad_ctx_id,
+                parent_id: None,
+                depth: 0,
+                parked: false,
+            });
+
+            let squad: Vec<(u64, Pane)> = [
+                (
+                    "impl-a",
+                    crate::app_protocol::AgentState::Working,
+                    Some("Edit"),
+                ),
+                ("impl-b", crate::app_protocol::AgentState::Idle, None),
+                (
+                    "tester",
+                    crate::app_protocol::AgentState::Blocked,
+                    Some("Bash(just pr-install)"),
+                ),
+            ]
+            .into_iter()
+            .map(|(agent, state, detail)| agent_pane(app, "claude", agent, state, detail))
+            .collect();
+
+            let mut squad_panes = std::collections::HashMap::new();
+            let mut squad_tiles = egui_tiles::Tiles::default();
+            let mut squad_tile_ids = Vec::new();
+            for (pane_id, pane) in squad {
+                squad_panes.insert(pane_id, pane);
+                squad_tile_ids.push(squad_tiles.insert_pane(pane_id));
+            }
+            let squad_focused = squad_tile_ids[0];
+            let squad_root = squad_tiles.insert_horizontal_tile(squad_tile_ids);
+            let squad_window_id = app.next_window_id;
+            app.next_window_id += 1;
+            app.windows.push(Window {
+                name: "squad-alpha".to_string(),
+                path: browser_root.clone(),
+                tree: egui_tiles::Tree::new("squad-alpha", squad_root, squad_tiles),
+                panes: squad_panes,
+                focused_pane: Some(squad_focused),
+                zoomed_pane: None,
+                grid_x: 1,
+                grid_y: 0,
+                window_id: squad_window_id,
+                context_id: squad_ctx_id,
+            });
+            app.context_active_window
+                .insert(squad_ctx_id, squad_window_id);
+
+            app.show_command_palette = true;
+            app.palette_selected = 0;
+            app.sync_command_palette_focus();
+        });
+
+        h.run_steps(3);
+        h.save_screenshot("/tmp/plexi_command_palette_agent_fleet.png")
+            .expect("render failed");
+
+        h.with_app_mut(|app| {
+            app.palette_query = "claude".to_string();
+            app.palette_selected = 0;
+        });
+        h.run_steps(3);
+        h.save_screenshot("/tmp/plexi_command_palette_agent_fleet_query.png")
+            .expect("render failed");
+
+        assert!(
+            h.with_app(|app| app.show_command_palette && app.palette_agent_count_logged == Some(4)),
+            "the palette should be open over all four agent panes"
+        );
+        println!("Screenshots saved to /tmp/plexi_command_palette_agent_fleet*.png");
+    }
+
     #[test]
     fn screenshot_catppuccin_latte_command_palette() {
         let mut h = PlexiUiHarness::new_sized(1168.0, 720.0);

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1077,14 +1077,24 @@ mod tests {
                     true,
                     None,
                 ),
-                mk("release checklist", "tag, changelog, notarize, publish", true, None),
+                mk(
+                    "release checklist",
+                    "tag, changelog, notarize, publish",
+                    true,
+                    None,
+                ),
                 mk(
                     "north star — what v1 has to prove",
                     "one workspace you never leave",
                     false,
                     None,
                 ),
-                mk("pricing notes", "seat-based vs usage, land on seats", false, None),
+                mk(
+                    "pricing notes",
+                    "seat-based vs usage, land on seats",
+                    false,
+                    None,
+                ),
                 mk(
                     "wasm wire format decisions",
                     "postcard over JSON for frame payloads",
@@ -1527,8 +1537,9 @@ mod tests {
         };
         let mut tool = row(TurnRole::Tool, "host.files.write", "2026-07-27T00:00:02Z");
         tool.status = Some(crate::assistant::model::ToolStatus::Succeeded);
-        tool.input_summary =
-            Some(r#"{path: notes/log.md, body: line one line two, note: he said "hi"}"#.to_string());
+        tool.input_summary = Some(
+            r#"{path: notes/log.md, body: line one line two, note: he said "hi"}"#.to_string(),
+        );
         tool.output_preview = Some("stdout: wrote 2 lines\nline one\nline two".to_string());
 
         assistant.model.turns = vec![
@@ -2315,13 +2326,13 @@ mod tests {
 
             let squad: Vec<(u64, Pane)> = [
                 (
-                    "impl-a",
+                    "claude-code",
                     crate::app_protocol::AgentState::Working,
                     Some("Edit"),
                 ),
-                ("impl-b", crate::app_protocol::AgentState::Idle, None),
+                ("claude-code", crate::app_protocol::AgentState::Idle, None),
                 (
-                    "tester",
+                    "claude-code",
                     crate::app_protocol::AgentState::Blocked,
                     Some("Bash(just pr-install)"),
                 ),


### PR DESCRIPTION
Closes stint **0565 — host: agent panes as command palette results, fuzzy jump across contexts**. No linked GitHub issue; stint is authoritative.

## What

Every pane whose `Pane::agent()` is `Some` is now a Cmd+P result. Type in the palette you already use and the fleet is addressable by name — across every window and every context, not just the one you are standing in. Enter focuses that pane, activating its window and context.

Each row shows the agent name, its owning context, its live state, and the hook-reported active tool when there is one (`squad-alpha · blocked · Bash(just pr-install)`).

## Reuse, not rebuild

- **Rows** render through the palette's existing `ListRow` path with an `agent` type chip, consistent with `ctx` / `app` / `text` / `cmd` / `run`.
- **The state dot** goes through the shared pip lane (`ListRowPips` → `ui::activity::pip_color`), so `src/ui/activity.rs` remains the single color source. Palette, sidebar, and pane chrome cannot disagree.
- **Matching** runs through the palette's existing substring matcher and single query state, against agent name, pane title, and context name. No second matcher, no separate query field.
- **Navigation** reuses `jump_to_context` with the row's own `win_idx` / `window_id` / `pane_id`. Per the CLAUDE.md trap, the target is passed explicitly — nothing temporarily mutates `active_window` or `router.active` to steer a helper.
- **One row per pane.** An agent pane is skipped in the context pane-row unpacking, because the agent row carries strictly more than the plain pane row would. No duplicate rows.

## Ranking

Agent rows interleave with existing results by match score. A third sort key breaks *exact* ties in favor of `Blocked`, so the pane waiting on a human surfaces first. `agent_state_never_reorders_other_result_types` pins that this stays scoped to the agent group and never reorders contexts, notes, apps, or commands.

## Live, not snapshotted

Rows are rebuilt every draw frame from host state, so state arriving over pane IPC (`set_agent_state`) shows while the palette is open. The collection trace fires only when the agent count changes (`palette_agent_count_logged`) — a per-frame `info!` in the egui draw loop would flood `plexi.log`.

## Instrumentation

- `palette: collected N agent panes` on collection (count-change gated).
- `palette: focusing agent pane <id> (agent '<name>')` on enter/click.

## Docs

`skills/plexi-cli/SKILL.md` gains a note under `agent report`: the `--agent` and `--detail` values an agent reports now determine what a human sees and searches in Cmd+P, and blocked sorts first. That is the agent-facing consequence of this change — no CLI verb or flag changed, so `src/cli/AGENTS.md` needs no edit. Edited through the real `skills/` path, not the `.agents/` symlink.

## Test evidence

- **cargo test:** `1935 passed; 0 failed; 3 ignored` — full `cargo test --bin plexi`, env-stripped (`PLEXI_CHANNEL` / `PLEXI_CONTEXT_*` / `PLEXI_SOCKET` / `PLEXI_RUNNING` / `PLEXI_PANE_ID` unset), run under an 8 GB RSS watchdog (no kills). An earlier run of the same suite hit one timeout flake in `host::wasm_python::tests::headless_frame_fails_fast_when_the_guest_dies_at_import` (15s backstop under parallel load); it passes in isolation in 12.25s and passed on the clean rerun. Unrelated to this diff, which touches no WASM or Python path.
- **New unit tests** (`src/overlays/command_palette.rs`): `agent_rows_collect_from_every_window_and_context` (cross-context sourcing, per-window focus, non-agent panes skipped, `win_idx`/`window_id` address the owning window), `squad_panes_sharing_a_title_stay_separable_by_agent_name`, `blocked_agent_outranks_equally_scoring_agent`, `agent_state_never_reorders_other_result_types`, `agent_secondary_reads_context_state_and_active_tool`, `agent_row_falls_back_to_pane_title_when_the_hook_reports_no_name`.
- **Visual review (mandatory step, ran):** `screenshot_command_palette_agent_fleet` seeds a stint-0568-shaped fleet — one agent in the active context plus a three-pane `squad-alpha` subcontext whose panes all share the title `claude` — and renders two PNGs. I opened both with Read and looked at them: the AGENTS section renders with the `agent` chip, the `context · state · detail` secondary line, and the state dot at the right of the row (red blocked / amber working / green idle, matching the sidebar vocabulary); blocked `tester` is first; the active-context agent appears once, as an agent row, not also as a ctx pane row. With `claude` typed, the three same-titled squad panes are the only results, blocked first, each separable by agent name. Screenshots deleted from `/tmp` after review.
- **Generator gates:** `just check-docs` green (CLI, config, SDK, capability, coverage, authoring). Nothing generated was hand-edited.
- **Formatting:** `rustfmt --check` per touched file — the only remaining diffs are the ones already present on alpha (alpha is not fmt-clean; no bare `cargo fmt` was run).
- **Clippy:** `cargo clippy --bin plexi --all-targets` reports no new warnings against the touched files.
- **Conclusion:** binary install required — this is host UI in a live overlay; a tester should drive Cmd+P against a real fleet via `just pr-install <PR>`, then `plexi-pr-<N>`. Headless-only from this side, per the worker gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)