### PR TITLE
feat(ui/sidebar): subcontexts have no sidebar presence (stint 0241)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -109,6 +109,7 @@ use crate::host::pane::{Pane, TerminalPane};
 use crate::host::shell;
 use crate::spatial::tiling::PaneId;
 use crate::ui::theme::{self, Colors};
+use crate::workspace::router::ContextMove;
 use crate::workspace::WorkspaceFile;
 use egui_term::{BackendSettings, PtyEvent, TerminalTheme};
 use egui_tiles::{Tile, Tree};
@@ -4228,39 +4229,17 @@ impl eframe::App for PlexiApp {
                     }
                 }
                 Action::SwitchContext(n) => {
-                    // Map display position n (0-indexed) to the actual router index by
-                    // computing the same active display order the sidebar renders.
-                    let num = self.router.len();
-                    let mut display_order: Vec<usize> = Vec::with_capacity(num);
-                    for i in 0..num {
-                        if self.router.get(i).parent_id.is_none() {
-                            display_order.push(i);
-                            let ctx_id = self.router.get(i).context_id;
-                            for j in 0..num {
-                                if self.router.get(j).parent_id == Some(ctx_id) {
-                                    display_order.push(j);
-                                }
-                            }
-                        }
-                    }
-                    for i in 0..num {
-                        if !display_order.contains(&i) {
-                            display_order.push(i);
-                        }
-                    }
-                    let active_order: Vec<usize> = display_order
+                    // Map display position n (0-indexed) to the actual router
+                    // index through the same top-level order the sidebar
+                    // renders, so Cmd+1..9 stays pinned to the numbered rows
+                    // regardless of how many subcontexts exist.
+                    let active_order: Vec<usize> = self
+                        .router
+                        .top_level_order()
                         .into_iter()
                         .filter(|&i| !self.router.get(i).parked)
                         .collect();
                     if let Some(&router_idx) = active_order.get(n) {
-                        let target_parent = self.router.get(router_idx).parent_id;
-                        let current_ctx_id = self.router.active().context_id;
-                        if target_parent == Some(current_ctx_id) {
-                            let current_win_id = self.windows[self.active_window].window_id;
-                            let focused_tile = self.windows[self.active_window].focused_pane;
-                            self.router
-                                .push_depth(current_ctx_id, current_win_id, focused_tile);
-                        }
                         log::info!(
                             "SwitchContext: display_pos={} → router_idx={}",
                             n + 1,
@@ -4301,17 +4280,17 @@ impl eframe::App for PlexiApp {
                 }
                 Action::MoveContextUp => {
                     let active = self.router.active_idx();
-                    if active > 0 {
-                        self.router.swap_tracking_active(active, active - 1);
-                        log::info!("context: moved up — {} to {}", active, active - 1);
+                    let ctx_id = self.router.active().context_id;
+                    if self.router.reorder_top_level(active, ContextMove::Up) {
+                        log::info!("context: moved up — id={ctx_id}");
                         self.save_workspace();
                     }
                 }
                 Action::MoveContextDown => {
                     let active = self.router.active_idx();
-                    if active + 1 < self.router.len() {
-                        self.router.swap_tracking_active(active, active + 1);
-                        log::info!("context: moved down — {} to {}", active, active + 1);
+                    let ctx_id = self.router.active().context_id;
+                    if self.router.reorder_top_level(active, ContextMove::Down) {
+                        log::info!("context: moved down — id={ctx_id}");
                         self.save_workspace();
                     }
                 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -2,6 +2,7 @@ use crate::host::context::WindowMenuAction;
 use crate::ui::button;
 use crate::ui::list::ListDropdownHeader;
 use crate::ui::sidebar_row::{ContextItem, PaneDots, SidebarAction};
+use crate::workspace::router::ContextMove;
 use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 use egui_tiles::Tile;
 
@@ -199,26 +200,10 @@ impl PlexiApp {
             .and_then(|w| w.focused_pane.map(|tile| (w, tile)))
             .and_then(|(w, tile)| w.get_focused_pane_cwd(tile));
 
-        // Build display order: top-level contexts first, each followed by children.
-        // Separate into active (unparked) and parked lists.
-        let mut display_order: Vec<usize> = Vec::with_capacity(num_contexts);
-        for i in 0..num_contexts {
-            if self.router.get(i).parent_id.is_none() {
-                display_order.push(i);
-                let ctx_id = self.router.get(i).context_id;
-                for j in 0..num_contexts {
-                    if self.router.get(j).parent_id == Some(ctx_id) {
-                        display_order.push(j);
-                    }
-                }
-            }
-        }
-        // Catch orphans whose parent was deleted.
-        for i in 0..num_contexts {
-            if !display_order.contains(&i) {
-                display_order.push(i);
-            }
-        }
+        // Build display order: top-level contexts only. Subcontexts never appear
+        // in the sidebar — they are reached from inside their parent via its
+        // Portal tile — so they are never enumerated, numbered, or rendered.
+        let display_order: Vec<usize> = self.router.top_level_order();
 
         // Partition: active contexts render in the main list, parked ones below.
         let active_order: Vec<usize> = display_order
@@ -233,6 +218,7 @@ impl PlexiApp {
             .collect();
 
         // ── Active contexts ─────────────────────────────────────────────
+        let active_count = active_order.len();
         for (display_idx, &i) in active_order.iter().enumerate() {
             let is_active = i == self.router.active_idx();
             let is_renaming = self.renaming_window == Some(i);
@@ -324,7 +310,6 @@ impl PlexiApp {
                 .as_ref()
                 .map(|p| p.display().to_string());
 
-            let indent = self.router.get(i).depth;
             let (action, response) = ContextItem {
                 is_active,
                 is_dragging,
@@ -335,7 +320,6 @@ impl PlexiApp {
                 badge_count,
                 subtitle,
                 pane_dots,
-                indent,
                 draggable: true,
             }
             .draw(ui, egui::Id::new(("ctx", i)), &self.colors);
@@ -366,7 +350,7 @@ impl PlexiApp {
                         ui.close();
                     }
                     ui.separator();
-                    if i > 0 {
+                    if display_idx > 0 {
                         if ui.button("Move to Top").clicked() {
                             menu_action = Some((i, WindowMenuAction::MoveToTop));
                             ui.close();
@@ -376,7 +360,7 @@ impl PlexiApp {
                             ui.close();
                         }
                     }
-                    if i < num_ctxs - 1 {
+                    if display_idx + 1 < active_count {
                         if ui.button("Move Down").clicked() {
                             menu_action = Some((i, WindowMenuAction::MoveDown));
                             ui.close();
@@ -475,7 +459,6 @@ impl PlexiApp {
                     let ctx_name = ctx.name.clone();
                     let ctx_id = ctx.context_id;
                     let subtitle = ctx.root.as_ref().map(|p| p.display().to_string());
-                    let indent = ctx.depth;
 
                     let pane_dots = self.sidebar_pane_dots(ctx_id, false);
 
@@ -489,7 +472,6 @@ impl PlexiApp {
                         badge_count: 0,
                         subtitle,
                         pane_dots,
-                        indent,
                         draggable: true,
                     }
                     .draw(ui, egui::Id::new(("parked_ctx", i)), &self.colors);
@@ -609,6 +591,10 @@ impl PlexiApp {
                 self.router.get_mut(src).parked = drop.parked;
                 let mut new_order = new_active;
                 new_order.extend(new_parked);
+                // These lists hold top-level rows only; re-inflate each row's
+                // hidden subtree so `apply_order` receives a full permutation
+                // and the subcontexts travel with their parent.
+                let new_order = self.router.expand_subtrees(&new_order);
                 self.router.apply_order(&new_order);
                 self.renaming_window = None;
 
@@ -662,19 +648,19 @@ impl PlexiApp {
                 }
                 WindowMenuAction::MoveToTop => {
                     self.renaming_window = None;
-                    self.router.move_to_front_tracking_active(i);
+                    self.router.reorder_top_level(i, ContextMove::Top);
                 }
                 WindowMenuAction::MoveUp => {
                     self.renaming_window = None;
-                    self.router.swap_tracking_active(i, i - 1);
+                    self.router.reorder_top_level(i, ContextMove::Up);
                 }
                 WindowMenuAction::MoveDown => {
                     self.renaming_window = None;
-                    self.router.swap_tracking_active(i, i + 1);
+                    self.router.reorder_top_level(i, ContextMove::Down);
                 }
                 WindowMenuAction::MoveToBottom => {
                     self.renaming_window = None;
-                    self.router.move_to_back_tracking_active(i);
+                    self.router.reorder_top_level(i, ContextMove::Bottom);
                 }
                 WindowMenuAction::SetRoot(path) => {
                     log::info!(
@@ -722,14 +708,9 @@ impl PlexiApp {
         } else if let Some(i) = delete_context {
             self.delete_context(i);
         } else if let Some(i) = clicked_workspace {
-            let target_parent = self.router.get(i).parent_id;
-            let current_ctx_id = self.router.active().context_id;
-            if target_parent == Some(current_ctx_id) {
-                let current_win_id = self.windows[self.active_window].window_id;
-                let focused_tile = self.windows[self.active_window].focused_pane;
-                self.router
-                    .push_depth(current_ctx_id, current_win_id, focused_tile);
-            }
+            // Only top-level rows are rendered, so a click here is always a
+            // lateral move between master contexts — never a descent into a
+            // child, which is what the Portal tile is for. No depth push.
             self.switch_workspace(i);
         }
 

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -92,8 +92,6 @@ pub struct ContextItem {
     pub subtitle: Option<String>,
     /// Dots rendered below the name row representing panes.
     pub pane_dots: Option<PaneDots>,
-    /// Nesting depth for subcontexts (0 = top-level).
-    pub indent: u32,
     /// Whether this row supports drag reordering. When false, hover shows
     /// PointingHand instead of Grab and drag actions are suppressed.
     pub draggable: bool,
@@ -296,9 +294,9 @@ impl ContextItem {
         // Reserve background shape slot before rendering content.
         let bg_idx = ui.painter().add(egui::Shape::Noop);
 
-        // 6px base + 16px per nesting level — keeps the gutter number close to
-        // the sidebar edge for top-level contexts.
-        let indent = 6.0 + 16.0 * self.indent as f32;
+        // Every sidebar row is a top-level context, so the gutter is a fixed
+        // 6px inset — there is no nesting level to indent for.
+        let indent = 6.0;
 
         let is_active = self.is_active;
         let is_dragging = self.is_dragging;

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1317,6 +1317,116 @@ mod tests {
             .expect("render failed");
     }
 
+    /// Stint 0241: the sidebar is master-context navigation only. Every slot is
+    /// a numbered, keyboard-addressable top-level destination, so a subcontext
+    /// is never rendered and never consumes a number — it is reached from
+    /// inside its parent through the Portal tile instead. Removing the row must
+    /// not remove the *signal*: the child's state still rolls up to the parent.
+    #[test]
+    fn sidebar_renders_and_numbers_master_contexts_only() {
+        let mut h = PlexiUiHarness::new_sized(900.0, 620.0);
+        let child_ctx_id = h.with_app_mut(|app| {
+            app.sidebar_visible = true;
+            app.router.get_mut(0).name = "master-one".to_string();
+            let parent_ctx_id = app.router.get(0).context_id;
+            let child_ctx_id = parent_ctx_id + 9_000;
+
+            // A subcontext of the first master, sitting *between* the two
+            // masters in router order — the position that used to shift the
+            // second master's sidebar number from 2 to 3.
+            app.router.push(crate::host::context::Context {
+                name: "child-of-one".to_string(),
+                path: std::env::temp_dir().join("child-of-one"),
+                root: None,
+                description: None,
+                context_id: child_ctx_id,
+                parent_id: Some(parent_ctx_id),
+                depth: 1,
+                parked: false,
+            });
+            app.router.push(crate::host::context::Context {
+                name: "master-two".to_string(),
+                path: std::env::temp_dir().join("master-two"),
+                root: None,
+                description: None,
+                context_id: 72_002,
+                parent_id: None,
+                depth: 0,
+                parked: false,
+            });
+
+            // Give the child a window so it has real state to roll up.
+            let child_window_id = app.next_window_id;
+            app.next_window_id += 1;
+            app.windows.push(Window {
+                name: "child window".to_string(),
+                path: std::env::temp_dir(),
+                tree: egui_tiles::Tree::empty("child window"),
+                panes: std::collections::HashMap::new(),
+                focused_pane: None,
+                zoomed_pane: None,
+                grid_x: 0,
+                grid_y: 1,
+                window_id: child_window_id,
+                context_id: child_ctx_id,
+            });
+            child_ctx_id
+        });
+        let child_window_idx = h.with_app(|app| app.windows.len() - 1);
+        add_focused_pane_to_window(&mut h, child_window_idx);
+        h.run_steps(2);
+
+        // Rendered sidebar: both masters present, the subcontext absent.
+        assert!(
+            h.host_has_label("master-one"),
+            "top-level contexts must render in the sidebar"
+        );
+        assert!(
+            h.host_has_label("master-two"),
+            "top-level contexts must render in the sidebar"
+        );
+        assert!(
+            !h.host_has_label("child-of-one"),
+            "a subcontext must never render a sidebar row"
+        );
+
+        h.with_app(|app| {
+            // Numbering: the sidebar enumerates only masters, so master-two
+            // holds slot 2 (Cmd+2) despite the subcontext preceding it.
+            let order = app.router.top_level_order();
+            let names: Vec<&str> = order
+                .iter()
+                .map(|&i| app.router.get(i).name.as_str())
+                .collect();
+            assert_eq!(
+                names,
+                vec!["master-one", "master-two"],
+                "subcontexts must not be enumerated or shift top-level numbering"
+            );
+
+            // Rollup intact: the child is still observable from its parent,
+            // which is what the Portal tile paints.
+            let parent_state = crate::host::context_state::ContextState::compute(
+                app.router.get(0).context_id,
+                app.router.as_slice(),
+                &app.windows,
+            );
+            let child_state = parent_state
+                .children
+                .iter()
+                .find(|c| c.context_id == child_ctx_id)
+                .expect("parent must still roll up its subcontext");
+            assert_eq!(child_state.label, "child-of-one");
+            assert_eq!(
+                child_state.pane_count, 1,
+                "child pane activity must still surface through the parent"
+            );
+        });
+
+        h.save_screenshot("/tmp/plexi-0241-sidebar-masters-only.png")
+            .expect("render failed");
+    }
+
     /// Notes triage overlay: renders a note, and emptying the inbox returns
     /// to the picker instead of closing outright.
     #[test]

--- a/src/workspace/router.rs
+++ b/src/workspace/router.rs
@@ -9,6 +9,15 @@
 use crate::host::context::Context;
 use egui_tiles::TileId;
 
+/// Where a sidebar reorder sends a top-level context within the active list.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ContextMove {
+    Top,
+    Up,
+    Down,
+    Bottom,
+}
+
 pub(crate) struct WorkspaceRouter {
     active: usize,
     contexts: Vec<Context>,
@@ -62,6 +71,66 @@ impl WorkspaceRouter {
 
     pub(crate) fn position<F: Fn(&Context) -> bool>(&self, f: F) -> Option<usize> {
         self.contexts.iter().position(f)
+    }
+
+    /// Indices of the contexts the sidebar is allowed to enumerate, in router
+    /// order. The sidebar is top-level navigation only: every slot is a
+    /// numbered, keyboard-addressable destination, so a context with a live
+    /// parent is never listed. Subcontexts are reached from inside their parent
+    /// via its Portal tile, which already carries their rolled-up state.
+    ///
+    /// A context whose `parent_id` names a context that no longer exists is an
+    /// orphan and *is* included — otherwise deleting a parent would strand its
+    /// children with no reachable entry point anywhere in the UI.
+    pub(crate) fn top_level_order(&self) -> Vec<usize> {
+        self.contexts
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| match c.parent_id {
+                None => true,
+                Some(pid) => !self.contexts.iter().any(|p| p.context_id == pid),
+            })
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Expand a top-level-only ordering into a full permutation of `0..len` by
+    /// emitting each entry followed by its descendants in router order.
+    ///
+    /// `apply_order` requires every index exactly once; a sidebar reorder only
+    /// ever knows about top-level rows, so it must re-inflate the hidden
+    /// subtrees before committing or the omitted subcontexts would be dropped
+    /// from the router entirely. Any index not reachable from `top_level` is
+    /// appended, so the result is a permutation for any input.
+    pub(crate) fn expand_subtrees(&self, top_level: &[usize]) -> Vec<usize> {
+        let mut out: Vec<usize> = Vec::with_capacity(self.contexts.len());
+        let mut seen = vec![false; self.contexts.len()];
+        for &idx in top_level {
+            self.push_subtree(idx, &mut out, &mut seen);
+        }
+        for (i, visited) in seen.iter_mut().enumerate() {
+            if !*visited {
+                out.push(i);
+                *visited = true;
+            }
+        }
+        out
+    }
+
+    /// Depth-first emit of `idx` and every descendant, guarding against the
+    /// cycles a corrupt `parent_id` chain could otherwise turn into recursion.
+    fn push_subtree(&self, idx: usize, out: &mut Vec<usize>, seen: &mut [bool]) {
+        if seen[idx] {
+            return;
+        }
+        seen[idx] = true;
+        out.push(idx);
+        let id = self.contexts[idx].context_id;
+        for child in 0..self.contexts.len() {
+            if self.contexts[child].parent_id == Some(id) {
+                self.push_subtree(child, out, seen);
+            }
+        }
     }
 
     // ── Structural mutation (create / delete) ────────────────────────────────
@@ -120,13 +189,46 @@ impl WorkspaceRouter {
     // ── Reorder ops (sidebar drag / move-to-top etc.) ────────────────────────
     // Each op maintains active coherence atomically.
 
-    pub(crate) fn swap_tracking_active(&mut self, a: usize, b: usize) {
-        self.contexts.swap(a, b);
-        if self.active == a {
-            self.active = b;
-        } else if self.active == b {
-            self.active = a;
+    /// Move a top-level context one slot (or to an end) within the sidebar's
+    /// active list, carrying its subtree with it. Returns `false` when the move
+    /// is a no-op — `idx` is parked, is a subcontext with no sidebar row, or is
+    /// already at the requested end.
+    ///
+    /// Reordering must go through the visible list, never through raw router
+    /// indices: subcontexts sit between top-level entries in `contexts` but have
+    /// no sidebar row, so an index-adjacent swap would trade places with an
+    /// invisible context and read as a dead menu item.
+    pub(crate) fn reorder_top_level(&mut self, idx: usize, mv: ContextMove) -> bool {
+        let top_level = self.top_level_order();
+        let mut active: Vec<usize> = top_level
+            .iter()
+            .copied()
+            .filter(|&i| !self.contexts[i].parked)
+            .collect();
+        let parked: Vec<usize> = top_level
+            .iter()
+            .copied()
+            .filter(|&i| self.contexts[i].parked)
+            .collect();
+        let Some(pos) = active.iter().position(|&i| i == idx) else {
+            return false;
+        };
+        let last = active.len() - 1;
+        let new_pos = match mv {
+            ContextMove::Top => 0,
+            ContextMove::Up => pos.saturating_sub(1),
+            ContextMove::Down => (pos + 1).min(last),
+            ContextMove::Bottom => last,
+        };
+        if new_pos == pos {
+            return false;
         }
+        active.remove(pos);
+        active.insert(new_pos, idx);
+        active.extend(parked);
+        let order = self.expand_subtrees(&active);
+        self.apply_order(&order);
+        true
     }
 
     /// Reorder the entire context vec to match `new_order`, a permutation of
@@ -155,27 +257,6 @@ impl WorkspaceRouter {
             .iter()
             .position(|c| c.context_id == active_id)
             .expect("apply_order: active context survives reorder");
-    }
-
-    pub(crate) fn move_to_front_tracking_active(&mut self, idx: usize) {
-        let ctx = self.contexts.remove(idx);
-        self.contexts.insert(0, ctx);
-        if self.active == idx {
-            self.active = 0;
-        } else if self.active < idx {
-            self.active += 1;
-        }
-    }
-
-    pub(crate) fn move_to_back_tracking_active(&mut self, idx: usize) {
-        let last = self.contexts.len() - 1;
-        let ctx = self.contexts.remove(idx);
-        self.contexts.push(ctx);
-        if self.active == idx {
-            self.active = last;
-        } else if self.active > idx {
-            self.active -= 1;
-        }
     }
 
     // ── Depth stack (fractal zoom navigation) ───────────────────────────────
@@ -220,6 +301,159 @@ mod tests {
             depth,
             parked: false,
         }
+    }
+
+    /// Stint 0241: the sidebar lists master contexts only. A context with a
+    /// live parent is never enumerated, so it can never be numbered or rendered.
+    #[test]
+    fn top_level_order_excludes_subcontexts() {
+        let router = WorkspaceRouter::new(
+            vec![
+                make_ctx(10, None, 0),
+                make_ctx(11, Some(10), 1),
+                make_ctx(12, Some(10), 1),
+                make_ctx(20, None, 0),
+            ],
+            0,
+        );
+        assert_eq!(router.top_level_order(), vec![0, 3]);
+    }
+
+    /// Numbering must not shift when subcontexts appear: ctx 20 stays the
+    /// second sidebar slot (Cmd+2) no matter how many children ctx 10 grows.
+    #[test]
+    fn top_level_order_numbering_is_stable_across_subcontexts() {
+        let without = WorkspaceRouter::new(vec![make_ctx(10, None, 0), make_ctx(20, None, 0)], 0);
+        let ids_without: Vec<u64> = without
+            .top_level_order()
+            .iter()
+            .map(|&i| without.get(i).context_id)
+            .collect();
+
+        let with = WorkspaceRouter::new(
+            vec![
+                make_ctx(10, None, 0),
+                make_ctx(11, Some(10), 1),
+                make_ctx(12, Some(10), 1),
+                make_ctx(13, Some(11), 2),
+                make_ctx(20, None, 0),
+            ],
+            0,
+        );
+        let ids_with: Vec<u64> = with
+            .top_level_order()
+            .iter()
+            .map(|&i| with.get(i).context_id)
+            .collect();
+
+        assert_eq!(ids_without, vec![10, 20]);
+        assert_eq!(
+            ids_with, ids_without,
+            "subcontexts must not shift top-level sidebar numbering"
+        );
+    }
+
+    /// A context whose parent was deleted has no portal to be reached through,
+    /// so it must fall back to a top-level row rather than become unreachable.
+    #[test]
+    fn top_level_order_includes_orphans_whose_parent_is_gone() {
+        let router =
+            WorkspaceRouter::new(vec![make_ctx(10, None, 0), make_ctx(11, Some(999), 1)], 0);
+        assert_eq!(router.top_level_order(), vec![0, 1]);
+    }
+
+    /// A sidebar reorder only knows top-level rows; expanding must re-inflate
+    /// the hidden subtrees so `apply_order` still gets a full permutation and
+    /// no subcontext is dropped from the router.
+    #[test]
+    fn expand_subtrees_reinflates_hidden_children() {
+        let router = WorkspaceRouter::new(
+            vec![
+                make_ctx(10, None, 0),
+                make_ctx(11, Some(10), 1),
+                make_ctx(20, None, 0),
+                make_ctx(21, Some(20), 1),
+            ],
+            0,
+        );
+        // Sidebar drag put ctx 20 above ctx 10.
+        let expanded = router.expand_subtrees(&[2, 0]);
+        assert_eq!(expanded, vec![2, 3, 0, 1]);
+        assert_eq!(
+            expanded.len(),
+            router.len(),
+            "expand_subtrees must produce a full permutation"
+        );
+    }
+
+    /// The end-to-end guard for the drop path: reordering top-level rows must
+    /// move each parent's children with it and never delete a subcontext.
+    #[test]
+    fn reorder_top_level_carries_subtree_and_preserves_all_contexts() {
+        let mut router = WorkspaceRouter::new(
+            vec![
+                make_ctx(10, None, 0),
+                make_ctx(11, Some(10), 1),
+                make_ctx(20, None, 0),
+                make_ctx(21, Some(20), 1),
+            ],
+            0,
+        );
+        assert!(router.reorder_top_level(2, ContextMove::Top));
+        let ids: Vec<u64> = router.iter().map(|c| c.context_id).collect();
+        assert_eq!(ids, vec![20, 21, 10, 11]);
+        // Active context (ctx 10) tracked by identity through the reorder.
+        assert_eq!(router.active().context_id, 10);
+    }
+
+    /// An index-adjacent swap would have traded places with an invisible
+    /// subcontext; moving the *last* top-level row down must be a no-op even
+    /// though a subcontext sits after it in the router vec.
+    #[test]
+    fn reorder_top_level_down_at_end_is_noop_despite_trailing_subcontext() {
+        let mut router = WorkspaceRouter::new(
+            vec![
+                make_ctx(10, None, 0),
+                make_ctx(20, None, 0),
+                make_ctx(21, Some(20), 1),
+            ],
+            0,
+        );
+        assert!(!router.reorder_top_level(1, ContextMove::Down));
+        let ids: Vec<u64> = router.iter().map(|c| c.context_id).collect();
+        assert_eq!(ids, vec![10, 20, 21]);
+    }
+
+    /// A subcontext has no sidebar row, so it has nothing to reorder.
+    #[test]
+    fn reorder_top_level_rejects_a_subcontext() {
+        let mut router =
+            WorkspaceRouter::new(vec![make_ctx(10, None, 0), make_ctx(11, Some(10), 1)], 0);
+        assert!(!router.reorder_top_level(1, ContextMove::Top));
+        let ids: Vec<u64> = router.iter().map(|c| c.context_id).collect();
+        assert_eq!(ids, vec![10, 11]);
+    }
+
+    /// Parked contexts keep their own list; a move within the active list must
+    /// not drag a parked context into it.
+    #[test]
+    fn reorder_top_level_keeps_parked_contexts_in_their_section() {
+        let mut router = WorkspaceRouter::new(
+            vec![
+                make_ctx(10, None, 0),
+                make_ctx(20, None, 0),
+                make_ctx(30, None, 0),
+            ],
+            0,
+        );
+        router.get_mut(1).parked = true;
+        assert!(router.reorder_top_level(2, ContextMove::Top));
+        let ids: Vec<u64> = router.iter().map(|c| c.context_id).collect();
+        assert_eq!(
+            ids,
+            vec![30, 10, 20],
+            "parked ctx 20 stays after the active list"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Implements stint **0241 — subcontexts: no sidebar presence in v1 — close PR #2282, enforce master-contexts-only sidebar**. No linked GitHub issue; stint is authoritative.

Reaffirmed by Ian 2026-07-27: subcontexts must not render in the sidebar. This PR **closes #2282**, which pursued the rejected collapsible-in-sidebar model.

## Summary

The sidebar is master-context navigation only — every slot is a numbered, keyboard-addressable top-level destination, so interleaving children corrupted that ordering: a subcontext consumed a `Cmd+N` slot and shifted every master after it. Subcontexts are reached from inside their parent via its Portal tile, which already carries their rolled-up state.

- **`WorkspaceRouter::top_level_order` is the single source of truth** for sidebar enumeration, replacing the two-level `parent_id` display builder that was duplicated in `draw_sidebar` and the `SwitchContext` handler. A context with a live parent is never enumerated, numbered, or rendered (active or parked). Orphans whose parent was deleted still list — otherwise they would be unreachable from anywhere in the UI.
- **Reorders go through the visible list, not raw router indices.** Sidebar drag-drop feeds `apply_order`, which requires a full permutation; emitting top-level rows only would have *silently dropped every subcontext from the router*. `expand_subtrees` re-inflates the hidden subtrees so children travel with their parent. `Move Up/Down/Top/Bottom` and the keyboard `MoveContextUp/Down` actions now share `reorder_top_level`, so they can no longer swap with an invisible row and read as a dead menu item.
- **Dropped the now-unreachable `push_depth` branches** in the sidebar click handler and `SwitchContext`: a sidebar click is always a lateral move between masters, never a descent into a child.
- **Dropped `ContextItem::indent`** — it encoded the nesting this removes.

## Testing

- `cargo test --bin plexi` — **1946 passed, 0 failed, 3 ignored** (env-stripped)
- `cargo clippy --bin plexi` — no findings in the changed code
- `rustfmt --check` per file — clean (per-file only; alpha is not fmt-clean)

New regression coverage:
- `top_level_order_excludes_subcontexts`, `top_level_order_numbering_is_stable_across_subcontexts`, `top_level_order_includes_orphans_whose_parent_is_gone`
- `expand_subtrees_reinflates_hidden_children`, `reorder_top_level_carries_subtree_and_preserves_all_contexts`, `reorder_top_level_down_at_end_is_noop_despite_trailing_subcontext`, `reorder_top_level_rejects_a_subcontext`, `reorder_top_level_keeps_parked_contexts_in_their_section`
- `sidebar_renders_and_numbers_master_contexts_only` — harness test asserting the **rendered** tree contains both masters and not the child, that numbering is unshifted, and that the child's panes still roll up to the parent via `ContextState.children` (removing the row must not remove the signal)

Visual review: rendered sidebar shows two rows numbered 1 and 2, subcontext absent, no stray indent.

## Done-When

- [x] No sidebar code path enumerates a context with a non-`None` `parent_id`
- [x] Sidebar numbering is stable regardless of how many subcontexts exist
- [x] A subcontext with activity is still observable from its parent (Portal rollup intact)
- [x] Harness regression test green; `cargo test --bin plexi` green
- [x] PR #2282 closed with a pointer here

## Notes for the reviewer

Two **pre-existing, out-of-scope** behaviors observed by a tester tonight, not touched here: portal tiles have a stacking quirk and ambiguous close semantics. The flat-subcontext sidebar rendering they also saw is exactly what this PR removes.