### PR TITLE
fix(routines): schedule parser accepts documented syntax; lifecycle hardening; firing-path tests (stints 0571, 0573, 0575)

### DIFF
--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plexi-cli
 description: Operating inside Plexi — spawn/name panes, focus, launch apps, manage contexts, surface notifications. Use when working in a Plexi pane or orchestrating other panes.
-skill_version: "4.2.0"
+skill_version: "4.2.1"
 plexi_version: "0.2.0"
 last_verified: "2026-07-28"
 ---
@@ -135,7 +135,7 @@ search for; keep `--detail` to the active tool.
 ```
 workspace init           Set up .plexi/ in current dir. NEVER run from ~.
 run [COMMAND]            Run a named command from .plexi/commands.toml. Omit to list.
-routine list             Show routines from .plexi/routines.toml with schedule/next fire.
+routine list             Show routines from the workspace channel dir's routines.toml with schedule/next fire.
 routine run NAME         Manually trigger a routine.
 ```
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -2735,31 +2735,36 @@ impl PlexiApp {
                 )
             };
 
-            // Overlap guard: while the previous run's command is still going,
-            // skip — never stack panes. The skip does NOT stamp last_fire, so
-            // the routine fires on the next tick after the run finishes rather
-            // than waiting a full interval.
+            // Overlap guard: while the previous run's pane is alive (exists
+            // and its PTY child has not exited), skip — never stack panes.
+            // Ephemeral panes free the routine when the command exits (the
+            // pane auto-closes); a non-ephemeral pane frees it when its shell
+            // session ends or the pane is closed — an exited "[process
+            // exited]" placeholder never holds a routine hostage. The skip
+            // does NOT stamp last_fire, so the routine fires on the next
+            // tick after the run ends rather than waiting a full interval.
             if let Some(run) = self.scheduler.live_run(&source_root, &name) {
                 let pane_id = run.pane_id;
                 let skip_notified = run.skip_notified;
                 if self.routine_run_is_alive(pane_id) {
                     log::info!(
-                        "scheduler: routine '{name}' skipped — previous run (pane {pane_id}) still active"
+                        "scheduler: routine '{name}' skipped — previous run's pane {pane_id} is still open"
                     );
                     if !skip_notified {
                         self.notify_routine_issue(
                             &source_root,
                             &format!("Routine '{name}' skipped"),
                             &format!(
-                                "The previous run (pane {pane_id}) is still going; the routine will fire again once it finishes."
+                                "The previous run's pane ({pane_id}) is still running; the routine fires again once it exits or the pane is closed."
                             ),
                         );
                         self.scheduler.mark_skip_notified(&source_root, &name);
                     }
                     continue;
                 }
-                // Run finished (or its pane vanished through a path that
-                // skipped the close hook) — reap and fall through to fire.
+                // Run ended (PTY child exited, or the pane vanished through a
+                // path that skipped the close hook) — reap and fall through
+                // to fire.
                 self.scheduler.reap_run(&source_root, &name);
             }
 
@@ -2777,18 +2782,19 @@ impl PlexiApp {
         }
     }
 
-    /// True while a routine's spawned pane exists and its command is still
-    /// running (foreground process or children, as sampled by
-    /// `tick_terminal_activity`). A pane sitting at an idle shell — or gone
-    /// entirely — is not a live run.
+    /// True while a routine run's pane exists and its PTY child has not
+    /// exited. Liveness is this kernel fact (`PtyEvent::Exit` → `t.exited`)
+    /// and never the `activity` sampler: activity is a UI affordance whose
+    /// heuristics (fg pgid, child scan) go blind when the shell
+    /// exec-optimises a bare command into itself — an ephemeral run's
+    /// `zsh -c "sleep 30"` IS the sleep, has no children, and never moves
+    /// the fg pgid, so sampling it read live runs as finished and stacked
+    /// panes without bound.
     fn routine_run_is_alive(&self, pane_id: u64) -> bool {
         self.windows.iter().any(|w| {
-            w.panes.get(&pane_id).is_some_and(|p| {
-                p.as_terminal().is_some_and(|t| {
-                    !t.exited
-                        && matches!(t.activity, Some(crate::app_protocol::AgentState::Working))
-                })
-            })
+            w.panes
+                .get(&pane_id)
+                .is_some_and(|p| p.as_terminal().is_some_and(|t| !t.exited))
         })
     }
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -2707,7 +2707,7 @@ impl PlexiApp {
         }
     }
 
-    pub(super) fn tick_scheduler(&mut self) {
+    pub(crate) fn tick_scheduler(&mut self) {
         // Load routines from every context that has a root set
         let roots: Vec<std::path::PathBuf> = self
             .router
@@ -2715,33 +2715,148 @@ impl PlexiApp {
             .filter_map(|ctx| ctx.root.clone())
             .collect();
         for root in &roots {
-            self.scheduler.load_from_root(root);
+            let failures = self.scheduler.load_from_root(root);
+            for f in failures {
+                self.notify_routine_issue(root, &f.title, &f.body);
+            }
         }
 
         let now = chrono::Local::now();
         let due = self.scheduler.due_routines(now);
         for idx in due {
-            let (name, command, context_name, ephemeral) = {
+            let (name, command, context_name, ephemeral, source_root) = {
                 let entry = &self.scheduler.entries[idx];
                 (
                     entry.routine.name.clone(),
                     entry.routine.command.clone(),
                     entry.routine.context.clone(),
                     entry.routine.ephemeral,
+                    entry.source_root.clone(),
                 )
             };
+
+            // Overlap guard: while the previous run's command is still going,
+            // skip — never stack panes. The skip does NOT stamp last_fire, so
+            // the routine fires on the next tick after the run finishes rather
+            // than waiting a full interval.
+            if let Some(run) = self.scheduler.live_run(&source_root, &name) {
+                let pane_id = run.pane_id;
+                let skip_notified = run.skip_notified;
+                if self.routine_run_is_alive(pane_id) {
+                    log::info!(
+                        "scheduler: routine '{name}' skipped — previous run (pane {pane_id}) still active"
+                    );
+                    if !skip_notified {
+                        self.notify_routine_issue(
+                            &source_root,
+                            &format!("Routine '{name}' skipped"),
+                            &format!(
+                                "The previous run (pane {pane_id}) is still going; the routine will fire again once it finishes."
+                            ),
+                        );
+                        self.scheduler.mark_skip_notified(&source_root, &name);
+                    }
+                    continue;
+                }
+                // Run finished (or its pane vanished through a path that
+                // skipped the close hook) — reap and fall through to fire.
+                self.scheduler.reap_run(&source_root, &name);
+            }
+
             self.scheduler.mark_fired(idx, now);
-            self.fire_routine(&name, &command, &context_name, ephemeral);
+            if let Some(pane_id) =
+                self.fire_routine(&name, &command, &context_name, ephemeral, &source_root)
+            {
+                self.scheduler.register_run(&source_root, &name, pane_id);
+                let root_key = source_root.display();
+                self.scheduler
+                    .clear_failure(&format!("{root_key}|{name}|context-missing"));
+                self.scheduler
+                    .clear_failure(&format!("{root_key}|{name}|spawn-failed"));
+            }
         }
     }
 
-    pub(super) fn fire_routine(
+    /// True while a routine's spawned pane exists and its command is still
+    /// running (foreground process or children, as sampled by
+    /// `tick_terminal_activity`). A pane sitting at an idle shell — or gone
+    /// entirely — is not a live run.
+    fn routine_run_is_alive(&self, pane_id: u64) -> bool {
+        self.windows.iter().any(|w| {
+            w.panes.get(&pane_id).is_some_and(|p| {
+                p.as_terminal().is_some_and(|t| {
+                    !t.exited
+                        && matches!(t.activity, Some(crate::app_protocol::AgentState::Working))
+                })
+            })
+        })
+    }
+
+    /// Surface a routine problem as a user-visible notification, scoped to the
+    /// context that owns the routine's workspace root (global when no context
+    /// matches). Routed through the single notification choke point; passive
+    /// priority — never auto-opens the modal, never triggers the audible cue.
+    fn notify_routine_issue(&mut self, source_root: &std::path::Path, title: &str, body: &str) {
+        let ctx_id = self
+            .router
+            .iter()
+            .find(|c| c.root.as_deref() == Some(source_root))
+            .map(|c| c.context_id);
+        let (scope, source_context_id) = match ctx_id {
+            Some(id) => (crate::app_protocol::NotifyScope::Context, id),
+            None => (crate::app_protocol::NotifyScope::Global, 0),
+        };
+        // Millis alone can collide when two routine issues surface in the same
+        // tick; notify_id is an identity key, so disambiguate with a counter.
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let millis = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis())
+            .unwrap_or(0);
+        let queued = self.enqueue_notification(
+            crate::app::notifications::NotifySource::HostInternal,
+            crate::app::notifications::PendingNotification {
+                notify_id: format!("routine-{millis}-{seq}"),
+                sender_pane_id: 0,
+                source_context_id,
+                source_window_id: 0,
+                level: "warn".to_string(),
+                title: title.to_string(),
+                body: body.to_string(),
+                kind: crate::app_protocol::NotifyKind::Message,
+                options: vec![],
+                input_prompt: None,
+                required: false,
+                // Passive (below the default interrupt threshold of 100): a
+                // routine hiccup informs, it never steals focus.
+                priority: 50,
+                scope,
+                image_inline: None,
+                image_pipe_id: None,
+                response_file: None,
+                timeout_secs: None,
+                on_dismiss: None,
+                enqueued_at: std::time::Instant::now(),
+                tombstoned: false,
+                deliver_after: None,
+            },
+        );
+        log::info!("scheduler: routine notification queued={queued} title='{title}' body='{body}'");
+    }
+
+    /// Fire a routine into its target context. Returns the spawned pane id,
+    /// or `None` when the routine could not run (missing context, spawn
+    /// failure) — both surfaced as notifications on transition into the
+    /// failure state.
+    pub(crate) fn fire_routine(
         &mut self,
         name: &str,
         command: &str,
         context_name: &str,
         ephemeral: bool,
-    ) {
+        source_root: &std::path::Path,
+    ) -> Option<u64> {
         log::info!(
             "scheduler: routine '{}' fired context='{}' ephemeral={}",
             name,
@@ -2749,7 +2864,9 @@ impl PlexiApp {
             ephemeral
         );
 
-        // Find target context index
+        // Find target context index. A named context is a *target*, not a
+        // gate: the routine fires into it regardless of which context is
+        // active, and is skipped only when no context by that name exists.
         let target_ctx_idx = if context_name.is_empty() {
             self.router.active_idx()
         } else {
@@ -2761,7 +2878,17 @@ impl PlexiApp {
                         name,
                         context_name
                     );
-                    return;
+                    let key = format!("{}|{name}|context-missing", source_root.display());
+                    if self.scheduler.note_failure(key) {
+                        self.notify_routine_issue(
+                            source_root,
+                            &format!("Routine '{name}' skipped"),
+                            &format!(
+                                "Context '{context_name}' does not exist — the routine cannot fire until it does."
+                            ),
+                        );
+                    }
+                    return None;
                 }
             }
         };
@@ -2783,13 +2910,26 @@ impl PlexiApp {
         }
 
         let cwd = self.router.get(target_ctx_idx).root.clone();
-        self.split_focused(false, Some(command), ephemeral, false, cwd);
+        let spawned = self.split_focused(false, Some(command), ephemeral, false, cwd);
 
         // Restore original context
         if target_ctx_idx != original_ctx_idx {
             self.router.set_active(original_ctx_idx);
             self.active_window = original_active_win;
         }
+
+        if spawned.is_none() {
+            log::warn!("scheduler: routine '{name}' — failed to spawn a pane");
+            let key = format!("{}|{name}|spawn-failed", source_root.display());
+            if self.scheduler.note_failure(key) {
+                self.notify_routine_issue(
+                    source_root,
+                    &format!("Routine '{name}' failed"),
+                    "Could not spawn a pane for the routine's command.",
+                );
+            }
+        }
+        spawned
     }
 
     pub(super) fn drain_spawn_queue(&mut self) {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -56,9 +56,13 @@ impl PlexiApp {
             let now = std::time::Instant::now();
             self.last_notify_poll = now;
             self.drain_spawn_queue();
+            // Activity must be sampled before the scheduler runs: the routine
+            // overlap guard reads each terminal's `activity` to decide whether
+            // a prior run is still going, and a stale pre-spawn sample would
+            // read as "finished" and stack a duplicate pane.
+            self.tick_terminal_activity();
             self.tick_scheduler();
             self.tick_notification_timeouts();
-            self.tick_terminal_activity();
             if update_check_due(self.last_update_check, now) {
                 let config_dir = crate::config::config_dir();
                 if !crate::cli::updater::update_cache_fresh(&config_dir) {

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -56,10 +56,6 @@ impl PlexiApp {
             let now = std::time::Instant::now();
             self.last_notify_poll = now;
             self.drain_spawn_queue();
-            // Activity must be sampled before the scheduler runs: the routine
-            // overlap guard reads each terminal's `activity` to decide whether
-            // a prior run is still going, and a stale pre-spawn sample would
-            // read as "finished" and stack a duplicate pane.
             self.tick_terminal_activity();
             self.tick_scheduler();
             self.tick_notification_timeouts();

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -74,7 +74,9 @@ pub enum Commands {
     },
     /// Manage workspace routines — scheduled shell commands.
     ///
-    /// Routines are declared in `.plexi/routines.toml` and run automatically on schedule.
+    /// Routines are declared in `routines.toml` inside the workspace channel directory —
+    /// `{workspace_channel_dir}/routines.toml`, e.g. `.plexi-alpha/routines.toml` on the
+    /// alpha channel — and run automatically on schedule.
     /// **Requires Plexi to be running** — there is no background daemon. Routines only fire
     /// while the host process is open.
     ///
@@ -1466,9 +1468,9 @@ pub fn normalize_config_scope_aliases(args: Vec<String>) -> Vec<String> {
 
 #[derive(Subcommand)]
 pub enum RoutineCmd {
-    /// List routines defined in .plexi/routines.toml with their schedule and next fire time.
+    /// List routines defined in the workspace channel dir's routines.toml with their schedule and next fire time.
     List,
-    /// Manually trigger a named routine from .plexi/routines.toml.
+    /// Manually trigger a named routine from the workspace channel dir's routines.toml.
     Run {
         /// Name of the routine to run
         name: String,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -291,7 +291,7 @@ pub(super) fn routines_file() -> String {
     format!("{}/routines.toml", crate::config::workspace_channel_dir())
 }
 
-/// Parsed `.plexi/routines.toml` for CLI use
+/// Parsed `{workspace_channel_dir}/routines.toml` for CLI use
 #[derive(serde::Deserialize)]
 pub(super) struct RoutinesCliConfig {
     #[serde(default)]
@@ -309,7 +309,7 @@ pub(super) struct RoutineCliDef {
     pub(super) ephemeral: bool,
 }
 
-/// `plexi routine list` — list routines from .plexi/routines.toml
+/// `plexi routine list` — list routines from the workspace channel dir's routines.toml
 #[cfg(test)]
 mod command_parse_tests {
     use crate::cli::{CommandEntry, PlexiCommands};

--- a/src/host/scheduler.rs
+++ b/src/host/scheduler.rs
@@ -1,16 +1,35 @@
-use serde::Deserialize;
-use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 fn routines_file() -> String {
     format!("{}/routines.toml", crate::config::workspace_channel_dir())
 }
 
-/// Parsed `.plexi/routines.toml`
+/// Machine-local runtime state beside `routines.toml` — currently just
+/// last-fire timestamps, so interval routines survive a host restart without
+/// re-firing (stint 0573). Safe to delete; a missing or corrupt file degrades
+/// to firing once on next launch.
+fn routine_state_file() -> String {
+    format!(
+        "{}/routine-state.toml",
+        crate::config::workspace_channel_dir()
+    )
+}
+
+/// Parsed `{workspace_channel_dir}/routines.toml` (e.g. `.plexi-alpha/routines.toml`
+/// on the alpha channel).
 #[derive(Deserialize, Default)]
 pub(crate) struct RoutinesConfig {
     #[serde(default)]
     pub routine: Vec<Routine>,
+}
+
+/// On-disk shape of `routine-state.toml`: routine name → RFC 3339 last-fire.
+#[derive(Deserialize, Serialize, Default)]
+struct RoutineState {
+    #[serde(default)]
+    last_fire: HashMap<String, String>,
 }
 
 #[derive(Deserialize, Clone)]
@@ -56,10 +75,35 @@ pub(crate) struct SchedulerEntry {
     pub source_root: PathBuf,
 }
 
+/// A routine whose spawned pane is still open with its command running.
+/// Tracked so `tick_scheduler` can skip (never stack) overlapping runs.
+pub(crate) struct LiveRun {
+    pub pane_id: u64,
+    /// One notification per skip streak: set after the first skip of this run
+    /// is surfaced, cleared when the run is reaped (the streak ends with it).
+    pub skip_notified: bool,
+}
+
+/// A user-visible problem discovered while (re)loading a root's routines,
+/// returned only on the transition into that failure state — repeated reloads
+/// observing the same failure return nothing (stint 0573).
+pub(crate) struct RoutineLoadFailure {
+    pub title: String,
+    pub body: String,
+}
+
 pub(crate) struct Scheduler {
     pub entries: Vec<SchedulerEntry>,
     /// Per-workspace-root → last loaded entries (avoid re-parsing every tick)
     loaded_roots: HashMap<PathBuf, std::time::Instant>,
+    /// Overlap guard: (source_root, routine name) → the run's spawned pane.
+    /// Registered on fire, reaped when the pane closes (`reap_pane`) or when
+    /// the run is observed finished at skip-decision time (`reap_run`).
+    live_runs: HashMap<(PathBuf, String), LiveRun>,
+    /// Failure states currently known (and already notified). Keyed by
+    /// "{root}|{subject}|{kind}[|detail]" so each (routine, reason) pair
+    /// notifies once on transition into failure, not on every observation.
+    known_failures: HashSet<String>,
 }
 
 impl Scheduler {
@@ -67,42 +111,66 @@ impl Scheduler {
         Self {
             entries: Vec::new(),
             loaded_roots: HashMap::new(),
+            live_runs: HashMap::new(),
+            known_failures: HashSet::new(),
         }
     }
 
-    /// Load (or reload) routines from `root/.plexi/routines.toml`.
+    /// Load (or reload) routines from `root/{workspace_channel_dir}/routines.toml`.
     /// Called once per context root. Re-reads if not yet loaded or 60s have passed.
-    pub fn load_from_root(&mut self, root: &Path) {
+    /// Returns newly-entered failure states for the caller to surface.
+    pub fn load_from_root(&mut self, root: &Path) -> Vec<RoutineLoadFailure> {
         // Cache check first — avoids path.exists() syscall every second
         if let Some(last) = self.loaded_roots.get(root) {
             if last.elapsed().as_secs() < 60 {
-                return;
+                return Vec::new();
             }
         }
         self.loaded_roots
             .insert(root.to_path_buf(), std::time::Instant::now());
 
+        let root_key = root.display();
         let path = root.join(routines_file());
         if !path.exists() {
-            // Prune any entries that came from this root (file was deleted)
+            // Prune any entries and failure states that came from this root
+            // (file was deleted — nothing about it can still be failing).
             self.entries.retain(|e| e.source_root != root);
-            return;
+            let prefix = format!("{root_key}|");
+            self.known_failures.retain(|k| !k.starts_with(&prefix));
+            return Vec::new();
         }
         let contents = match std::fs::read_to_string(&path) {
             Ok(c) => c,
             Err(e) => {
                 log::warn!("scheduler: failed to read {}: {e}", path.display());
-                return;
+                return self.note_load_failure(
+                    format!("{root_key}|<file>|unreadable"),
+                    "Routines file unreadable".to_string(),
+                    format!("Could not read {}: {e}", path.display()),
+                );
             }
         };
         let config: RoutinesConfig = match toml::from_str(&contents) {
             Ok(c) => c,
             Err(e) => {
                 log::warn!("scheduler: failed to parse {}: {e}", path.display());
-                return;
+                return self.note_load_failure(
+                    format!("{root_key}|<file>|malformed"),
+                    "Routines file malformed".to_string(),
+                    format!("Failed to parse {}: {e}", path.display()),
+                );
             }
         };
-        // Preserve last_fire for routines that survive the reload (avoid re-firing immediately)
+        // The file read and parsed — those failure states (if any) are over.
+        self.known_failures
+            .remove(&format!("{root_key}|<file>|unreadable"));
+        self.known_failures
+            .remove(&format!("{root_key}|<file>|malformed"));
+
+        // Preserve last_fire for routines that survive the reload (avoid re-firing
+        // immediately); seed from the persisted state file where memory has nothing.
+        // In-memory wins — a reload must never rewind a fire that already happened
+        // this session.
         let mut last_fires: HashMap<String, Option<chrono::DateTime<chrono::Local>>> =
             HashMap::new();
         for e in &self.entries {
@@ -110,22 +178,48 @@ impl Scheduler {
                 last_fires.insert(e.routine.name.clone(), e.last_fire);
             }
         }
+        let persisted = load_routine_state(root);
         // Replace all entries from this root with the freshly parsed set
         self.entries.retain(|e| e.source_root != root);
         let count = config.routine.len();
+        let mut new_failures = Vec::new();
         for routine in config.routine {
+            // A schedule edit resolves the routine's previous bad-schedule
+            // state whether or not the new string parses; a *different* bad
+            // string is a new failure and notifies again.
+            let bad_schedule_prefix = format!("{root_key}|{}|bad-schedule|", routine.name);
+            let current_key = format!("{bad_schedule_prefix}{}", routine.schedule);
             let schedule = match parse_schedule(&routine.schedule) {
-                Some(s) => s,
+                Some(s) => {
+                    self.known_failures
+                        .retain(|k| !k.starts_with(&bad_schedule_prefix));
+                    s
+                }
                 None => {
                     log::warn!(
                         "scheduler: routine '{}' has unparseable schedule '{}', skipping",
                         routine.name,
                         routine.schedule
                     );
+                    self.known_failures
+                        .retain(|k| !k.starts_with(&bad_schedule_prefix) || *k == current_key);
+                    if self.known_failures.insert(current_key) {
+                        new_failures.push(RoutineLoadFailure {
+                            title: format!("Routine '{}'", routine.name),
+                            body: format!(
+                                "Schedule '{}' is not a recognized format — the routine will never fire. See `plexi routine --help` for accepted forms.",
+                                routine.schedule
+                            ),
+                        });
+                    }
                     continue;
                 }
             };
-            let last_fire = last_fires.get(&routine.name).copied().flatten();
+            let last_fire = last_fires
+                .get(&routine.name)
+                .copied()
+                .flatten()
+                .or_else(|| persisted.get(&routine.name).copied());
             self.entries.push(SchedulerEntry {
                 routine,
                 schedule,
@@ -134,6 +228,32 @@ impl Scheduler {
             });
         }
         log::info!("scheduler: loaded {count} routines from {}", path.display());
+        new_failures
+    }
+
+    /// Record a file-level load failure; returns it only on the transition in.
+    fn note_load_failure(
+        &mut self,
+        key: String,
+        title: String,
+        body: String,
+    ) -> Vec<RoutineLoadFailure> {
+        if self.known_failures.insert(key) {
+            vec![RoutineLoadFailure { title, body }]
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Record a fire-time failure state (missing context, spawn failure).
+    /// Returns true when this is a new state — i.e. the caller should notify.
+    pub fn note_failure(&mut self, key: String) -> bool {
+        self.known_failures.insert(key)
+    }
+
+    /// Clear a fire-time failure state so a future recurrence notifies again.
+    pub fn clear_failure(&mut self, key: &str) {
+        self.known_failures.remove(key);
     }
 
     /// Check which routines are due. Returns their indices.
@@ -150,8 +270,142 @@ impl Scheduler {
     pub fn mark_fired(&mut self, idx: usize, now: chrono::DateTime<chrono::Local>) {
         if let Some(entry) = self.entries.get_mut(idx) {
             entry.last_fire = Some(now);
+            let root = entry.source_root.clone();
+            self.persist_state_for_root(&root);
         }
     }
+
+    /// Write this root's last-fire map to `routine-state.toml`, atomically
+    /// (temp + rename) and best-effort: a write failure is logged and never
+    /// aborts the fire that triggered it.
+    fn persist_state_for_root(&self, root: &Path) {
+        let mut state = RoutineState::default();
+        for e in &self.entries {
+            if e.source_root == root {
+                if let Some(lf) = e.last_fire {
+                    state
+                        .last_fire
+                        .insert(e.routine.name.clone(), lf.to_rfc3339());
+                }
+            }
+        }
+        let path = root.join(routine_state_file());
+        let toml_str = match toml::to_string(&state) {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!("scheduler: failed to serialize routine state for {root:?}: {e}");
+                return;
+            }
+        };
+        let tmp = path.with_extension("toml.tmp");
+        if let Err(e) = std::fs::write(&tmp, &toml_str).and_then(|_| std::fs::rename(&tmp, &path)) {
+            log::warn!(
+                "scheduler: failed to persist routine state to {}: {e}",
+                path.display()
+            );
+        }
+    }
+
+    // ── Overlap guard registry ───────────────────────────────────────────────
+
+    pub fn register_run(&mut self, root: &Path, name: &str, pane_id: u64) {
+        self.live_runs.insert(
+            (root.to_path_buf(), name.to_string()),
+            LiveRun {
+                pane_id,
+                skip_notified: false,
+            },
+        );
+    }
+
+    pub fn live_run(&self, root: &Path, name: &str) -> Option<&LiveRun> {
+        self.live_runs.get(&(root.to_path_buf(), name.to_string()))
+    }
+
+    pub fn mark_skip_notified(&mut self, root: &Path, name: &str) {
+        if let Some(run) = self
+            .live_runs
+            .get_mut(&(root.to_path_buf(), name.to_string()))
+        {
+            run.skip_notified = true;
+        }
+    }
+
+    /// Drop the live-run record for a routine observed finished.
+    pub fn reap_run(&mut self, root: &Path, name: &str) {
+        self.live_runs
+            .remove(&(root.to_path_buf(), name.to_string()));
+    }
+
+    /// Drop any live-run record whose pane just closed. Returns the reaped
+    /// routine names. This is the destroy half of the register/reap coupling —
+    /// called from the host's pane-close path (`close_tile`).
+    pub fn reap_pane(&mut self, pane_id: u64) -> Vec<String> {
+        let reaped: Vec<String> = self
+            .live_runs
+            .iter()
+            .filter(|(_, run)| run.pane_id == pane_id)
+            .map(|((_, name), _)| name.clone())
+            .collect();
+        self.live_runs.retain(|_, run| run.pane_id != pane_id);
+        reaped
+    }
+
+    /// Number of live routine runs currently tracked (test observability).
+    #[cfg(test)]
+    pub fn live_run_count(&self) -> usize {
+        self.live_runs.len()
+    }
+
+    /// Test-only: drop the 60s reload cache so the next `load_from_root`
+    /// re-reads the file immediately.
+    #[cfg(test)]
+    pub fn clear_reload_cache(&mut self) {
+        self.loaded_roots.clear();
+    }
+}
+
+/// Read the persisted last-fire map for a root. Missing or corrupt state is
+/// not an error — it degrades to the routine firing once on next launch.
+fn load_routine_state(root: &Path) -> HashMap<String, chrono::DateTime<chrono::Local>> {
+    let path = root.join(routine_state_file());
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return HashMap::new(),
+        Err(e) => {
+            log::warn!(
+                "scheduler: failed to read routine state {}: {e} — ignoring",
+                path.display()
+            );
+            return HashMap::new();
+        }
+    };
+    let state: RoutineState = match toml::from_str(&contents) {
+        Ok(s) => s,
+        Err(e) => {
+            log::warn!(
+                "scheduler: corrupt routine state {}: {e} — ignoring",
+                path.display()
+            );
+            return HashMap::new();
+        }
+    };
+    state
+        .last_fire
+        .iter()
+        .filter_map(
+            |(name, ts)| match chrono::DateTime::parse_from_rfc3339(ts) {
+                Ok(t) => Some((name.clone(), t.with_timezone(&chrono::Local))),
+                Err(e) => {
+                    log::warn!(
+                        "scheduler: bad last_fire timestamp for '{name}' in {}: {e} — ignoring",
+                        path.display()
+                    );
+                    None
+                }
+            },
+        )
+        .collect()
 }
 
 fn is_due(
@@ -210,29 +464,36 @@ fn field_matches(field: &CronField, value: u32) -> bool {
     }
 }
 
+/// Case-insensitive ASCII prefix strip.
+fn strip_prefix_ci<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    let head = s.get(..prefix.len())?;
+    if head.eq_ignore_ascii_case(prefix) {
+        Some(&s[prefix.len()..])
+    } else {
+        None
+    }
+}
+
+/// Seconds per one of the given interval unit: short suffix or full word,
+/// singular or plural. Unit-token matching — never strip single characters,
+/// so `"30 second"` can never be produced from `"30 seconds"`.
+fn interval_unit_secs(unit: &str) -> Option<u64> {
+    match unit.to_ascii_lowercase().as_str() {
+        "s" | "second" | "seconds" => Some(1),
+        "m" | "minute" | "minutes" => Some(60),
+        "h" | "hour" | "hours" => Some(3600),
+        _ => None,
+    }
+}
+
 /// Parse a schedule string into a `ParsedSchedule`.
 /// Returns `None` if the string cannot be parsed.
 pub(crate) fn parse_schedule(s: &str) -> Option<ParsedSchedule> {
     let s = s.trim();
 
-    // "every 30m" / "every 2h" / "every 5s"
-    if let Some(rest) = s
-        .strip_prefix("every ")
-        .or_else(|| s.strip_prefix("Every "))
-    {
+    // "every 30s" / "every 30 seconds" / "every 5 minutes" / "every 2 hours"
+    if let Some(rest) = strip_prefix_ci(s, "every ") {
         let rest = rest.trim();
-        if let Some(n_str) = rest.strip_suffix('m') {
-            let n: u64 = n_str.trim().parse().ok()?;
-            return Some(ParsedSchedule::Interval { secs: n * 60 });
-        }
-        if let Some(n_str) = rest.strip_suffix('h') {
-            let n: u64 = n_str.trim().parse().ok()?;
-            return Some(ParsedSchedule::Interval { secs: n * 3600 });
-        }
-        if let Some(n_str) = rest.strip_suffix('s') {
-            let n: u64 = n_str.trim().parse().ok()?;
-            return Some(ParsedSchedule::Interval { secs: n });
-        }
         // "every minute" / "every hour"
         if rest.eq_ignore_ascii_case("minute") {
             return Some(ParsedSchedule::Interval { secs: 60 });
@@ -240,14 +501,18 @@ pub(crate) fn parse_schedule(s: &str) -> Option<ParsedSchedule> {
         if rest.eq_ignore_ascii_case("hour") {
             return Some(ParsedSchedule::Interval { secs: 3600 });
         }
-        return None;
+        // Number and unit as two tokens ("30 seconds") or glued ("30s").
+        let (n_str, unit) = match rest.split_once(char::is_whitespace) {
+            Some((n, u)) => (n.trim(), u.trim()),
+            None => rest.split_at(rest.find(|c: char| !c.is_ascii_digit())?),
+        };
+        let n: u64 = n_str.parse().ok()?;
+        let secs = n.checked_mul(interval_unit_secs(unit)?)?;
+        return Some(ParsedSchedule::Interval { secs });
     }
 
     // "daily at 9am" / "daily at 10:30am"
-    if let Some(rest) = s
-        .strip_prefix("daily at ")
-        .or_else(|| s.strip_prefix("Daily at "))
-    {
+    if let Some(rest) = strip_prefix_ci(s, "daily at ") {
         let (hour, minute) = parse_time(rest)?;
         return Some(ParsedSchedule::Cron(CronExpr {
             minute: CronField::Single(minute),
@@ -259,10 +524,7 @@ pub(crate) fn parse_schedule(s: &str) -> Option<ParsedSchedule> {
     }
 
     // "weekdays at 9am"
-    if let Some(rest) = s
-        .strip_prefix("weekdays at ")
-        .or_else(|| s.strip_prefix("Weekdays at "))
-    {
+    if let Some(rest) = strip_prefix_ci(s, "weekdays at ") {
         let (hour, minute) = parse_time(rest)?;
         return Some(ParsedSchedule::Cron(CronExpr {
             minute: CronField::Single(minute),
@@ -274,10 +536,7 @@ pub(crate) fn parse_schedule(s: &str) -> Option<ParsedSchedule> {
     }
 
     // "weekends at 9am"
-    if let Some(rest) = s
-        .strip_prefix("weekends at ")
-        .or_else(|| s.strip_prefix("Weekends at "))
-    {
+    if let Some(rest) = strip_prefix_ci(s, "weekends at ") {
         let (hour, minute) = parse_time(rest)?;
         return Some(ParsedSchedule::Cron(CronExpr {
             minute: CronField::Single(minute),
@@ -285,6 +544,37 @@ pub(crate) fn parse_schedule(s: &str) -> Option<ParsedSchedule> {
             day_of_month: CronField::Any,
             month: CronField::Any,
             day_of_week: CronField::List(vec![6, 7]), // Sat-Sun
+        }));
+    }
+
+    // "weekly on monday at 09:00" / "weekly on mon at 9am"
+    if let Some(rest) = strip_prefix_ci(s, "weekly on ") {
+        let (day_str, time_str) = rest.split_once(" at ")?;
+        let dow = parse_day_name(day_str)?;
+        let (hour, minute) = parse_time(time_str)?;
+        return Some(ParsedSchedule::Cron(CronExpr {
+            minute: CronField::Single(minute),
+            hour: CronField::Single(hour),
+            day_of_month: CronField::Any,
+            month: CronField::Any,
+            day_of_week: CronField::Single(dow),
+        }));
+    }
+
+    // "monthly on 1 at 08:00"
+    if let Some(rest) = strip_prefix_ci(s, "monthly on ") {
+        let (day_str, time_str) = rest.split_once(" at ")?;
+        let day: u32 = day_str.trim().parse().ok()?;
+        if !(1..=31).contains(&day) {
+            return None;
+        }
+        let (hour, minute) = parse_time(time_str)?;
+        return Some(ParsedSchedule::Cron(CronExpr {
+            minute: CronField::Single(minute),
+            hour: CronField::Single(hour),
+            day_of_month: CronField::Single(day),
+            month: CronField::Any,
+            day_of_week: CronField::Any,
         }));
     }
 
@@ -359,11 +649,34 @@ fn parse_cron_field(s: &str) -> Option<CronField> {
     Some(CronField::Single(n))
 }
 
+/// Short day names, indexed sun=0..sat=6 (converted to cron 1=Mon..7=Sun).
+const DAY_NAMES: [&str; 7] = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+const DAY_NAMES_FULL: [&str; 7] = [
+    "sunday",
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+];
+
+/// Parse a day name — short (`mon`) or full (`monday`) spelling — into the
+/// cron day-of-week number (1=Mon..7=Sun).
+fn parse_day_name(s: &str) -> Option<u32> {
+    let s = s.trim().to_ascii_lowercase();
+    let idx = DAY_NAMES
+        .iter()
+        .position(|d| *d == s)
+        .or_else(|| DAY_NAMES_FULL.iter().position(|d| *d == s))?;
+    Some(if idx == 0 { 7 } else { idx as u32 })
+}
+
 /// Parse day-of-week field, supporting mon-fri names
 fn parse_cron_field_dow(s: &str) -> Option<CronField> {
     let s_lower = s.to_lowercase();
     // Named day ranges like "mon-fri"
-    let day_names = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"];
+    let day_names = DAY_NAMES;
     let s_lo = s_lower.as_str();
     // Check for named range
     if let Some((a_str, b_str)) = s_lo.split_once('-') {
@@ -500,5 +813,285 @@ mod tests {
     fn parse_invalid_returns_none() {
         assert!(parse_schedule("garbage schedule").is_none());
         assert!(parse_schedule("").is_none());
+        assert!(parse_schedule("every 30 parsecs").is_none());
+        assert!(parse_schedule("every fast").is_none());
+        assert!(parse_schedule("weekly on funday at 9am").is_none());
+        assert!(parse_schedule("weekly on monday").is_none());
+        assert!(parse_schedule("monthly on x at 8am").is_none());
+        assert!(parse_schedule("monthly on 32 at 8am").is_none());
+        assert!(parse_schedule("monthly on 0 at 8am").is_none());
+    }
+
+    fn interval_secs(s: &str) -> u64 {
+        match parse_schedule(s) {
+            Some(ParsedSchedule::Interval { secs }) => secs,
+            _ => panic!("expected Interval for {s:?}"),
+        }
+    }
+
+    /// Every row of the documented schedule table (website cli.md), both
+    /// spellings where two exist (stint 0571).
+    #[test]
+    fn parse_documented_interval_forms() {
+        assert_eq!(interval_secs("every 30 seconds"), 30);
+        assert_eq!(interval_secs("every 1 second"), 1);
+        assert_eq!(interval_secs("every 5 minutes"), 300);
+        assert_eq!(interval_secs("every 1 minute"), 60);
+        assert_eq!(interval_secs("every 2 hours"), 7200);
+        assert_eq!(interval_secs("every 1 hour"), 3600);
+        // Short forms and bare units keep working.
+        assert_eq!(interval_secs("every 30s"), 30);
+        assert_eq!(interval_secs("every 30m"), 1800);
+        assert_eq!(interval_secs("every 2h"), 7200);
+        assert_eq!(interval_secs("every minute"), 60);
+        assert_eq!(interval_secs("every hour"), 3600);
+        assert_eq!(interval_secs("Every 5 minutes"), 300);
+    }
+
+    #[test]
+    fn parse_weekly_on_day() {
+        for s in ["weekly on monday at 09:00", "weekly on mon at 9am"] {
+            match parse_schedule(s).unwrap_or_else(|| panic!("should parse {s:?}")) {
+                ParsedSchedule::Cron(expr) => {
+                    assert!(matches!(expr.hour, CronField::Single(9)), "{s}");
+                    assert!(matches!(expr.minute, CronField::Single(0)), "{s}");
+                    assert!(matches!(expr.day_of_week, CronField::Single(1)), "{s}");
+                    assert!(matches!(expr.day_of_month, CronField::Any), "{s}");
+                }
+                _ => panic!("expected Cron for {s:?}"),
+            }
+        }
+        // Sunday maps to cron 7, both spellings.
+        for s in ["weekly on sun at 8am", "weekly on sunday at 8am"] {
+            match parse_schedule(s).unwrap_or_else(|| panic!("should parse {s:?}")) {
+                ParsedSchedule::Cron(expr) => {
+                    assert!(matches!(expr.day_of_week, CronField::Single(7)), "{s}");
+                }
+                _ => panic!("expected Cron for {s:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn parse_monthly_on_day() {
+        match parse_schedule("monthly on 1 at 08:00").expect("should parse") {
+            ParsedSchedule::Cron(expr) => {
+                assert!(matches!(expr.hour, CronField::Single(8)));
+                assert!(matches!(expr.minute, CronField::Single(0)));
+                assert!(matches!(expr.day_of_month, CronField::Single(1)));
+                assert!(matches!(expr.day_of_week, CronField::Any));
+            }
+            _ => panic!("expected Cron"),
+        }
+    }
+
+    #[test]
+    fn parse_weekends() {
+        match parse_schedule("weekends at 10:30am").expect("should parse") {
+            ParsedSchedule::Cron(expr) => {
+                assert!(matches!(expr.hour, CronField::Single(10)));
+                assert!(matches!(expr.minute, CronField::Single(30)));
+                assert!(matches!(expr.day_of_week, CronField::List(_)));
+            }
+            _ => panic!("expected Cron"),
+        }
+    }
+
+    #[test]
+    fn parse_daily_at_24h_time() {
+        match parse_schedule("daily at 09:00").expect("should parse") {
+            ParsedSchedule::Cron(expr) => {
+                assert!(matches!(expr.hour, CronField::Single(9)));
+                assert!(matches!(expr.minute, CronField::Single(0)));
+            }
+            _ => panic!("expected Cron"),
+        }
+    }
+
+    // ── last_fire persistence (stint 0573) ──────────────────────────────────
+
+    fn write_routines(root: &Path, body: &str) {
+        let dir = root.join(crate::config::workspace_channel_dir());
+        std::fs::create_dir_all(&dir).expect("create channel dir");
+        std::fs::write(dir.join("routines.toml"), body).expect("write routines.toml");
+    }
+
+    const ONE_ROUTINE: &str = r#"
+        [[routine]]
+        name = "sync"
+        command = "true"
+        schedule = "every 2 hours"
+    "#;
+
+    #[test]
+    fn last_fire_survives_scheduler_rebuild() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        write_routines(root, ONE_ROUTINE);
+
+        let now = chrono::Local::now();
+        let mut s1 = Scheduler::new();
+        assert!(s1.load_from_root(root).is_empty());
+        assert_eq!(s1.due_routines(now).len(), 1, "fresh routine is due");
+        s1.mark_fired(0, now);
+        assert!(s1.due_routines(now).is_empty());
+
+        // Simulated restart: a brand-new Scheduler seeds from the state file
+        // and must NOT re-fire inside the interval.
+        let mut s2 = Scheduler::new();
+        assert!(s2.load_from_root(root).is_empty());
+        assert!(
+            s2.due_routines(chrono::Local::now()).is_empty(),
+            "persisted last_fire must suppress the startup fire"
+        );
+        // …but a last_fire older than the interval is due again.
+        let mut s3 = Scheduler::new();
+        s3.load_from_root(root);
+        assert_eq!(
+            s3.due_routines(now + chrono::Duration::hours(3)).len(),
+            1,
+            "overdue routine fires once on next launch"
+        );
+    }
+
+    #[test]
+    fn in_memory_last_fire_wins_over_persisted_on_reload() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        write_routines(root, ONE_ROUTINE);
+
+        let mut s = Scheduler::new();
+        s.load_from_root(root);
+        let session_fire = chrono::Local::now();
+        s.mark_fired(0, session_fire);
+
+        // Rewind the *persisted* value to 3 hours ago — a reload must not let
+        // it win over the fire that already happened this session.
+        let stale = (session_fire - chrono::Duration::hours(3)).to_rfc3339();
+        let state_path = root
+            .join(crate::config::workspace_channel_dir())
+            .join("routine-state.toml");
+        std::fs::write(&state_path, format!("[last_fire]\nsync = \"{stale}\"\n"))
+            .expect("write state");
+
+        s.clear_reload_cache();
+        s.load_from_root(root);
+        assert!(
+            s.due_routines(chrono::Local::now()).is_empty(),
+            "reload must not rewind an in-session fire"
+        );
+    }
+
+    #[test]
+    fn corrupt_state_file_degrades_to_startup_fire() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        write_routines(root, ONE_ROUTINE);
+        std::fs::write(
+            root.join(crate::config::workspace_channel_dir())
+                .join("routine-state.toml"),
+            "not [ valid { toml",
+        )
+        .expect("write corrupt state");
+
+        let mut s = Scheduler::new();
+        assert!(
+            s.load_from_root(root).is_empty(),
+            "corrupt state is not a load failure"
+        );
+        assert_eq!(s.due_routines(chrono::Local::now()).len(), 1);
+    }
+
+    #[test]
+    fn state_write_failure_does_not_abort_the_fire() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        write_routines(root, ONE_ROUTINE);
+
+        let mut s = Scheduler::new();
+        s.load_from_root(root);
+        // Remove the channel dir so the state write fails.
+        std::fs::remove_dir_all(root.join(crate::config::workspace_channel_dir()))
+            .expect("remove channel dir");
+        let now = chrono::Local::now();
+        s.mark_fired(0, now);
+        assert_eq!(
+            s.entries[0].last_fire,
+            Some(now),
+            "in-memory last_fire must be stamped even when persistence fails"
+        );
+    }
+
+    // ── load-failure transitions (stint 0573) ───────────────────────────────
+
+    #[test]
+    fn bad_schedule_notifies_once_per_distinct_schedule() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let bad = r#"
+            [[routine]]
+            name = "sync"
+            command = "true"
+            schedule = "every fortnight"
+        "#;
+        write_routines(root, bad);
+
+        let mut s = Scheduler::new();
+        let first = s.load_from_root(root);
+        assert_eq!(first.len(), 1, "transition into failure notifies");
+        s.clear_reload_cache();
+        assert!(
+            s.load_from_root(root).is_empty(),
+            "same failure must not re-notify on reload"
+        );
+
+        // A *different* bad schedule is a new failure state.
+        write_routines(
+            root,
+            r#"
+            [[routine]]
+            name = "sync"
+            command = "true"
+            schedule = "every blue moon"
+        "#,
+        );
+        s.clear_reload_cache();
+        assert_eq!(s.load_from_root(root).len(), 1);
+
+        // Fixing the schedule clears the state; breaking it again re-notifies.
+        write_routines(root, ONE_ROUTINE);
+        s.clear_reload_cache();
+        assert!(s.load_from_root(root).is_empty());
+        write_routines(root, bad);
+        s.clear_reload_cache();
+        assert_eq!(s.load_from_root(root).len(), 1, "recurrence re-notifies");
+    }
+
+    #[test]
+    fn malformed_file_notifies_once() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        write_routines(root, "not [ valid { toml");
+
+        let mut s = Scheduler::new();
+        assert_eq!(s.load_from_root(root).len(), 1);
+        s.clear_reload_cache();
+        assert!(s.load_from_root(root).is_empty());
+    }
+
+    // ── overlap-guard registry (stint 0573) ─────────────────────────────────
+
+    #[test]
+    fn reap_pane_drops_matching_runs() {
+        let mut s = Scheduler::new();
+        let root = PathBuf::from("/w");
+        s.register_run(&root, "a", 7);
+        s.register_run(&root, "b", 9);
+        assert_eq!(s.live_run_count(), 2);
+        let reaped = s.reap_pane(7);
+        assert_eq!(reaped, vec!["a".to_string()]);
+        assert_eq!(s.live_run_count(), 1);
+        assert!(s.live_run(&root, "a").is_none());
+        assert!(s.live_run(&root, "b").is_some());
     }
 }

--- a/src/host/scheduler.rs
+++ b/src/host/scheduler.rs
@@ -441,18 +441,21 @@ fn is_due(
 }
 
 fn cron_matches(expr: &CronExpr, now: &chrono::DateTime<chrono::Local>) -> bool {
-    use chrono::{Datelike, Timelike};
-    let minute = now.minute();
-    let hour = now.hour();
-    let day = now.day();
-    let month = now.month();
+    cron_date_matches(expr, now.date_naive()) && cron_time_matches(expr, now.time())
+}
+
+fn cron_date_matches(expr: &CronExpr, date: chrono::NaiveDate) -> bool {
+    use chrono::Datelike;
     // chrono: weekday().num_days_from_monday() gives 0=Mon..6=Sun; cron 1=Mon..7=Sun
-    let weekday = now.weekday().num_days_from_monday() + 1;
-    field_matches(&expr.minute, minute)
-        && field_matches(&expr.hour, hour)
-        && field_matches(&expr.day_of_month, day)
-        && field_matches(&expr.month, month)
+    let weekday = date.weekday().num_days_from_monday() + 1;
+    field_matches(&expr.day_of_month, date.day())
+        && field_matches(&expr.month, date.month())
         && field_matches(&expr.day_of_week, weekday)
+}
+
+fn cron_time_matches(expr: &CronExpr, time: chrono::NaiveTime) -> bool {
+    use chrono::Timelike;
+    field_matches(&expr.minute, time.minute()) && field_matches(&expr.hour, time.hour())
 }
 
 fn field_matches(field: &CronField, value: u32) -> bool {
@@ -709,7 +712,14 @@ pub(crate) fn next_fire_description(
     schedule: &ParsedSchedule,
     last_fire: Option<&chrono::DateTime<chrono::Local>>,
 ) -> String {
-    let now = chrono::Local::now();
+    next_fire_description_at(schedule, last_fire, chrono::Local::now())
+}
+
+fn next_fire_description_at(
+    schedule: &ParsedSchedule,
+    last_fire: Option<&chrono::DateTime<chrono::Local>>,
+    now: chrono::DateTime<chrono::Local>,
+) -> String {
     match schedule {
         ParsedSchedule::Interval { secs } => match last_fire {
             None => format!("in {}s (never fired)", secs),
@@ -730,16 +740,51 @@ pub(crate) fn next_fire_description(
             }
         },
         ParsedSchedule::Cron(expr) => {
-            // Find the next minute that matches
-            use chrono::Duration;
-            let mut t = now + Duration::minutes(1);
-            for _ in 0..10080 {
-                // search up to 7 days
-                if cron_matches(expr, &t) {
-                    use chrono::Timelike;
-                    return format!("at {:02}:{:02}", t.hour(), t.minute());
+            // Walk days with the date half of the fire matcher, then take
+            // the earliest matching wall-clock slot of the first matching
+            // day — the same `cron_date_matches`/`cron_time_matches` pair
+            // `cron_matches` fires on, so the display can never disagree
+            // with an actual fire. The horizon must cover the sparsest
+            // reachable schedule: a leap-day cron across the 2100-style
+            // century gap (Feb 29 2096 → Feb 29 2104) is eight years out,
+            // so nine years of days bounds it. Anything unmatched by then
+            // is genuinely unreachable (e.g. `0 8 30 2 *`, Feb 30).
+            use chrono::{Duration, Timelike};
+            let day_slots: Vec<(u32, u32)> = (0..24u32)
+                .filter(|h| field_matches(&expr.hour, *h))
+                .flat_map(|h| {
+                    (0..60u32)
+                        .filter(|m| field_matches(&expr.minute, *m))
+                        .map(move |m| (h, m))
+                })
+                .collect();
+            if day_slots.is_empty() {
+                return "unknown".to_string();
+            }
+            const MAX_DAYS: i64 = 366 * 9;
+            for d in 0..=MAX_DAYS {
+                let date = now.date_naive() + Duration::days(d);
+                if !cron_date_matches(expr, date) {
+                    continue;
                 }
-                t = t + Duration::minutes(1);
+                // Today only counts slots strictly after the current minute.
+                let slot = if d == 0 {
+                    day_slots
+                        .iter()
+                        .copied()
+                        .find(|&(h, m)| (h, m) > (now.hour(), now.minute()))
+                } else {
+                    day_slots.first().copied()
+                };
+                let Some((h, m)) = slot else { continue };
+                let when = if d == 0 {
+                    String::new()
+                } else if d == 1 {
+                    "tomorrow ".to_string()
+                } else {
+                    format!("{date} ")
+                };
+                return format!("{when}at {h:02}:{m:02}");
             }
             "unknown".to_string()
         }
@@ -1093,5 +1138,80 @@ mod tests {
         assert_eq!(s.live_run_count(), 1);
         assert!(s.live_run(&root, "a").is_none());
         assert!(s.live_run(&root, "b").is_some());
+    }
+
+    fn local(y: i32, mo: u32, d: u32, h: u32, mi: u32) -> chrono::DateTime<chrono::Local> {
+        use chrono::TimeZone;
+        chrono::Local
+            .with_ymd_and_hms(y, mo, d, h, mi, 0)
+            .single()
+            .expect("unambiguous local time")
+    }
+
+    fn next_desc(schedule: &str, now: chrono::DateTime<chrono::Local>) -> String {
+        let s = parse_schedule(schedule).expect("schedule parses");
+        next_fire_description_at(&s, None, now)
+    }
+
+    #[test]
+    fn next_fire_same_day_omits_date() {
+        assert_eq!(
+            next_desc("daily at 09:00", local(2026, 7, 28, 8, 0)),
+            "at 09:00"
+        );
+    }
+
+    #[test]
+    fn next_fire_next_day_says_tomorrow() {
+        assert_eq!(
+            next_desc("daily at 09:00", local(2026, 7, 28, 12, 0)),
+            "tomorrow at 09:00"
+        );
+    }
+
+    #[test]
+    fn next_fire_monthly_resolves_a_full_cycle_out() {
+        // 31 days out — beyond the old 7-day search window that returned
+        // "unknown" for `monthly on N` most of every month.
+        assert_eq!(
+            next_desc("monthly on 28 at 08:00", local(2026, 7, 28, 12, 0)),
+            "2026-08-28 at 08:00"
+        );
+    }
+
+    #[test]
+    fn next_fire_monthly_on_31_reaches_across_february() {
+        assert_eq!(
+            next_desc("monthly on 31 at 08:00", local(2026, 2, 1, 12, 0)),
+            "2026-03-31 at 08:00"
+        );
+    }
+
+    #[test]
+    fn next_fire_weekly_shows_the_date() {
+        // 2026-07-28 is a Tuesday; next Monday is 2026-08-03.
+        assert_eq!(
+            next_desc("weekly on monday at 09:00", local(2026, 7, 28, 12, 0)),
+            "2026-08-03 at 09:00"
+        );
+    }
+
+    #[test]
+    fn next_fire_leap_day_cron_resolves_across_years() {
+        let s = parse_schedule("0 8 29 2 *").expect("leap-day cron parses");
+        assert_eq!(
+            next_fire_description_at(&s, None, local(2026, 7, 28, 12, 0)),
+            "2028-02-29 at 08:00"
+        );
+    }
+
+    #[test]
+    fn next_fire_unreachable_cron_stays_unknown() {
+        // February 30th never exists.
+        let s = parse_schedule("0 8 30 2 *").expect("raw cron parses");
+        assert_eq!(
+            next_fire_description_at(&s, None, local(2026, 7, 28, 12, 0)),
+            "unknown"
+        );
     }
 }

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -294,6 +294,9 @@ impl PlexiApp {
         }
     }
 
+    /// Split the focused pane and spawn a terminal in the new slot. Returns
+    /// the new pane's id, or `None` when nothing was spawned (no focused pane,
+    /// or terminal creation failed).
     pub(crate) fn split_focused(
         &mut self,
         vertical: bool,
@@ -301,11 +304,11 @@ impl PlexiApp {
         close_on_exit: bool,
         new_pane_first: bool,
         cwd_override: Option<std::path::PathBuf>,
-    ) {
+    ) -> Option<PaneId> {
         let old_window_id = self.windows[self.active_window].window_id;
         let old_focus = self.windows[self.active_window].focused_pane;
         let Some(focused) = self.windows[self.active_window].focused_pane else {
-            return;
+            return None;
         };
 
         let cmd = if vertical {
@@ -372,7 +375,7 @@ impl PlexiApp {
             self.default_font_size,
         ) else {
             log::error!("Failed to create new terminal pane");
-            return;
+            return None;
         };
         pane.ephemeral = close_on_exit;
         self.windows[self.active_window]
@@ -443,6 +446,7 @@ impl PlexiApp {
         }
 
         ctx.navigate_to(new_tile);
+        Some(new_id)
     }
 
     pub(crate) fn new_tab(
@@ -834,6 +838,7 @@ impl PlexiApp {
         };
 
         // Phase 3: Remove tile and extract pane — defer drop so background apps can be parked.
+        let mut closed_pane_id = None;
         let removed_pane = {
             let ctx = &mut self.windows[ctx_idx];
             if let Some(parent_id) = ctx.tree.tiles.parent_of(tile_id) {
@@ -848,6 +853,7 @@ impl PlexiApp {
                     pane_id,
                     timestamp: crate::host::event_log::now_timestamp(),
                 });
+                closed_pane_id = Some(pane_id);
                 ctx.panes.remove(&pane_id)
             } else {
                 None
@@ -880,7 +886,15 @@ impl PlexiApp {
             removed
         };
 
-        // ctx borrow is released — park background WASM app runtimes; drop everything else.
+        // ctx borrow is released — reap any routine live-run record for this
+        // pane (the destroy half of the overlap guard's register/reap pair;
+        // without it a closed run would block its routine forever), then park
+        // background WASM app runtimes; drop everything else.
+        if let Some(pane_id) = closed_pane_id {
+            for name in self.scheduler.reap_pane(pane_id) {
+                log::info!("scheduler: routine '{name}' run ended — pane {pane_id} closed");
+            }
+        }
         match removed_pane {
             Some(Pane::App(app_pane)) => {
                 let pane_id = app_pane.id;

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -4101,3 +4101,453 @@ fn send_to_pane_never_routes_text_into_previous_panes_raw_focus_widget() {
         "pane B must consume its queued text once it owns input"
     );
 }
+
+// -- Routine firing path (stint 0575) ---------------------------------------
+//
+// Integration coverage for `tick_scheduler` / `fire_routine`: context
+// targeting, focus restore, ephemeral teardown, the missing-context skip,
+// the 0573 overlap guard, and the persisted-last_fire startup behavior.
+
+mod routine_firing {
+    use super::*;
+    use crate::host::context::{Context, Window};
+    use crate::host::pane::{AppPane, AppRuntime, Pane};
+    use crate::spatial::tiling::PaneId;
+
+    /// Write `routines.toml` into `root`'s workspace channel dir.
+    fn write_routines(root: &std::path::Path, body: &str) {
+        let dir = root.join(crate::config::workspace_channel_dir());
+        std::fs::create_dir_all(&dir).expect("create channel dir");
+        std::fs::write(dir.join("routines.toml"), body).expect("write routines.toml");
+    }
+
+    /// Point the harness's default context at `root` so `tick_scheduler`
+    /// loads routines from it, and give it a stable name.
+    fn root_default_context(h: &mut HostHarness, root: &std::path::Path) {
+        let ctx = h.app.router.get_mut(0);
+        ctx.root = Some(root.to_path_buf());
+        ctx.name = "main".to_string();
+    }
+
+    /// Insert a builtin app pane (rooted at `root`, never a real machine dir)
+    /// into `win_idx` and focus it, so `split_focused` has a split target.
+    fn add_focused_app_pane(h: &mut HostHarness, win_idx: usize, root: &std::path::Path) -> PaneId {
+        let pane_id = h.app.host.alloc_pane_id();
+        let pane = AppPane {
+            pip_status: None,
+            id: pane_id,
+            runtime: AppRuntime::Builtin(Box::new(crate::file_browser::FileBrowserApp::new(
+                root.to_path_buf(),
+            ))),
+            workspace_root: root.to_path_buf(),
+            permissions: crate::app::permissions::AppPermissions::builtin(),
+            manifest_id: "test".to_string(),
+            name: "Test App".to_string(),
+            pane_group: None,
+            linked_pane_id: None,
+            overlay_replaced: None,
+            hidden: false,
+            agent: None,
+            slots: std::collections::HashMap::new(),
+            semantic_state: Default::default(),
+        };
+        let win = &mut h.app.windows[win_idx];
+        win.panes.insert(pane_id, Pane::App(Box::new(pane)));
+        let tile_id = win.tree.tiles.insert_pane(pane_id);
+        if win.tree.root.is_none() {
+            win.tree.root = Some(tile_id);
+        }
+        win.focused_pane = Some(tile_id);
+        pane_id
+    }
+
+    /// Add a second context named `name` with its own window and a focused
+    /// pane, without going through the PTY-seeding production path. Returns
+    /// the new window's index.
+    fn add_secondary_context(h: &mut HostHarness, name: &str, root: &std::path::Path) -> usize {
+        let ctx_id = h.app.next_window_id;
+        h.app.next_window_id += 1;
+        let win_id = h.app.next_window_id;
+        h.app.next_window_id += 1;
+        h.app.windows.push(Window {
+            name: String::new(),
+            path: root.to_path_buf(),
+            tree: egui_tiles::Tree::empty("plexi"),
+            panes: std::collections::HashMap::new(),
+            focused_pane: None,
+            zoomed_pane: None,
+            grid_x: 1,
+            grid_y: 0,
+            window_id: win_id,
+            context_id: ctx_id,
+        });
+        let win_idx = h.app.windows.len() - 1;
+        add_focused_app_pane(h, win_idx, root);
+        h.app.router.push(Context {
+            name: name.to_string(),
+            path: root.to_path_buf(),
+            root: None, // no root: tick_scheduler must not load routines from here
+            description: None,
+            context_id: ctx_id,
+            parent_id: None,
+            depth: 0,
+            parked: false,
+        });
+        win_idx
+    }
+
+    fn terminal_pane_ids(h: &HostHarness, win_idx: usize) -> Vec<PaneId> {
+        h.app.windows[win_idx]
+            .panes
+            .iter()
+            .filter_map(|(id, p)| p.as_terminal().map(|_| *id))
+            .collect()
+    }
+
+    fn routine_notification_count(h: &HostHarness, needle: &str) -> usize {
+        h.app
+            .pending_notifications
+            .iter()
+            .filter(|n| n.title.contains(needle))
+            .count()
+    }
+
+    /// Rewind a routine's last_fire so it is due again without sleeping.
+    fn rewind_last_fire(h: &mut HostHarness, name: &str, hours: i64) {
+        for e in &mut h.app.scheduler.entries {
+            if e.routine.name == name {
+                e.last_fire = e
+                    .last_fire
+                    .map(|lf| lf - chrono::Duration::hours(hours))
+                    .or_else(|| Some(chrono::Local::now() - chrono::Duration::hours(hours)));
+            }
+        }
+    }
+
+    #[test]
+    fn routine_fires_into_named_context_and_restores_focus() {
+        let mut h = HostHarness::new();
+        let root = tempfile::tempdir().expect("tempdir");
+        root_default_context(&mut h, root.path());
+        add_focused_app_pane(&mut h, 0, root.path());
+        let work_root = tempfile::tempdir().expect("tempdir");
+        let work_win = add_secondary_context(&mut h, "work", work_root.path());
+
+        write_routines(
+            root.path(),
+            r#"
+            [[routine]]
+            name = "into-work"
+            command = "true"
+            schedule = "every 2 hours"
+            context = "work"
+        "#,
+        );
+
+        let active_ctx_before = h.app.router.active_idx();
+        let active_win_before = h.app.active_window;
+        let main_panes_before = h.app.windows[0].panes.len();
+        assert!(terminal_pane_ids(&h, work_win).is_empty());
+
+        h.app.tick_scheduler();
+
+        assert_eq!(
+            terminal_pane_ids(&h, work_win).len(),
+            1,
+            "routine pane must land in the named context's window"
+        );
+        assert_eq!(
+            h.app.windows[0].panes.len(),
+            main_panes_before,
+            "active context must not receive the pane"
+        );
+        assert_eq!(h.app.router.active_idx(), active_ctx_before);
+        assert_eq!(h.app.active_window, active_win_before);
+    }
+
+    #[test]
+    fn routine_empty_context_fires_into_active_context() {
+        let mut h = HostHarness::new();
+        let root = tempfile::tempdir().expect("tempdir");
+        root_default_context(&mut h, root.path());
+        add_focused_app_pane(&mut h, 0, root.path());
+
+        write_routines(
+            root.path(),
+            r#"
+            [[routine]]
+            name = "here"
+            command = "true"
+            schedule = "every 2 hours"
+        "#,
+        );
+
+        h.app.tick_scheduler();
+        assert_eq!(
+            terminal_pane_ids(&h, 0).len(),
+            1,
+            "empty context field fires into the active context"
+        );
+    }
+
+    #[test]
+    fn routine_missing_context_skips_notifies_once() {
+        let mut h = HostHarness::new();
+        h.app.notifications_enabled = true; // harness default is off
+        let root = tempfile::tempdir().expect("tempdir");
+        root_default_context(&mut h, root.path());
+        add_focused_app_pane(&mut h, 0, root.path());
+
+        write_routines(
+            root.path(),
+            r#"
+            [[routine]]
+            name = "ghost-run"
+            command = "true"
+            schedule = "every 2 hours"
+            context = "no-such-context"
+        "#,
+        );
+
+        h.app.tick_scheduler();
+        assert!(
+            terminal_pane_ids(&h, 0).is_empty(),
+            "missing context must not spawn a pane"
+        );
+        assert_eq!(
+            routine_notification_count(&h, "ghost-run"),
+            1,
+            "missing context surfaces one notification"
+        );
+
+        // Still-missing on the next due tick: no duplicate notification.
+        rewind_last_fire(&mut h, "ghost-run", 3);
+        h.app.tick_scheduler();
+        assert!(terminal_pane_ids(&h, 0).is_empty());
+        assert_eq!(
+            routine_notification_count(&h, "ghost-run"),
+            1,
+            "repeated observation of the same failure must not re-notify"
+        );
+    }
+
+    #[test]
+    fn startup_does_not_stampede_with_persisted_last_fire() {
+        let mut h = HostHarness::new();
+        let root = tempfile::tempdir().expect("tempdir");
+        root_default_context(&mut h, root.path());
+        add_focused_app_pane(&mut h, 0, root.path());
+
+        write_routines(
+            root.path(),
+            r#"
+            [[routine]]
+            name = "sync"
+            command = "true"
+            schedule = "every 2 hours"
+        "#,
+        );
+        let state = format!(
+            "[last_fire]\nsync = \"{}\"\n",
+            chrono::Local::now().to_rfc3339()
+        );
+        std::fs::write(
+            root.path()
+                .join(crate::config::workspace_channel_dir())
+                .join("routine-state.toml"),
+            state,
+        )
+        .expect("write state");
+
+        h.app.tick_scheduler();
+        assert!(
+            terminal_pane_ids(&h, 0).is_empty(),
+            "a last_fire inside the interval must suppress the startup fire"
+        );
+    }
+
+    #[test]
+    fn startup_fires_when_persisted_last_fire_is_stale_or_absent() {
+        // Stale persisted state → fires once.
+        let mut h = HostHarness::new();
+        let root = tempfile::tempdir().expect("tempdir");
+        root_default_context(&mut h, root.path());
+        add_focused_app_pane(&mut h, 0, root.path());
+        write_routines(
+            root.path(),
+            r#"
+            [[routine]]
+            name = "sync"
+            command = "true"
+            schedule = "every 2 hours"
+        "#,
+        );
+        let stale = chrono::Local::now() - chrono::Duration::hours(5);
+        std::fs::write(
+            root.path()
+                .join(crate::config::workspace_channel_dir())
+                .join("routine-state.toml"),
+            format!("[last_fire]\nsync = \"{}\"\n", stale.to_rfc3339()),
+        )
+        .expect("write state");
+        h.app.tick_scheduler();
+        assert_eq!(
+            terminal_pane_ids(&h, 0).len(),
+            1,
+            "an overdue routine fires once on launch"
+        );
+
+        // No state at all → fires (today's first-run behavior).
+        let mut h2 = HostHarness::new();
+        let root2 = tempfile::tempdir().expect("tempdir");
+        root_default_context(&mut h2, root2.path());
+        add_focused_app_pane(&mut h2, 0, root2.path());
+        write_routines(
+            root2.path(),
+            r#"
+            [[routine]]
+            name = "sync"
+            command = "true"
+            schedule = "every 2 hours"
+        "#,
+        );
+        h2.app.tick_scheduler();
+        assert_eq!(terminal_pane_ids(&h2, 0).len(), 1);
+    }
+
+    #[test]
+    fn overlap_guard_skips_streaks_and_reaps_on_close() {
+        let mut h = HostHarness::new();
+        h.app.notifications_enabled = true; // harness default is off
+        let root = tempfile::tempdir().expect("tempdir");
+        root_default_context(&mut h, root.path());
+        add_focused_app_pane(&mut h, 0, root.path());
+
+        write_routines(
+            root.path(),
+            r#"
+            [[routine]]
+            name = "long-job"
+            command = "true"
+            schedule = "every 2 hours"
+        "#,
+        );
+
+        h.app.tick_scheduler();
+        let run_panes = terminal_pane_ids(&h, 0);
+        assert_eq!(run_panes.len(), 1, "first tick fires");
+        let run_pane = run_panes[0];
+        assert_eq!(h.app.scheduler.live_run_count(), 1);
+
+        // Simulate the command still running (deterministic — no real pgrep
+        // timing): activity as sampled by tick_terminal_activity.
+        h.app.windows[0]
+            .panes
+            .get_mut(&run_pane)
+            .and_then(|p| p.as_terminal_mut())
+            .expect("terminal")
+            .activity = Some(crate::app_protocol::AgentState::Working);
+
+        let last_fire_before_skip = h.app.scheduler.entries[0].last_fire;
+        rewind_last_fire(&mut h, "long-job", 3);
+        let rewound = h.app.scheduler.entries[0].last_fire;
+        assert_ne!(last_fire_before_skip, rewound);
+
+        h.app.tick_scheduler();
+        assert_eq!(
+            terminal_pane_ids(&h, 0).len(),
+            1,
+            "overlapping run must be skipped, not stacked"
+        );
+        assert_eq!(
+            h.app.scheduler.entries[0].last_fire, rewound,
+            "a skipped tick must NOT stamp last_fire"
+        );
+        assert_eq!(
+            routine_notification_count(&h, "long-job"),
+            1,
+            "one notification per skip streak"
+        );
+
+        // Second skip in the same streak: no new notification.
+        h.app.tick_scheduler();
+        assert_eq!(routine_notification_count(&h, "long-job"), 1);
+
+        // Close the run's pane → the reap hook must free the routine.
+        h.app.close_pane_by_id(run_pane);
+        assert_eq!(
+            h.app.scheduler.live_run_count(),
+            0,
+            "closing the pane must reap the live-run record"
+        );
+
+        // Still due (last_fire untouched) → fires again on the next tick.
+        h.app.tick_scheduler();
+        assert_eq!(
+            terminal_pane_ids(&h, 0).len(),
+            1,
+            "routine fires again after the previous run is reaped"
+        );
+
+        // A new run means a new streak: a fresh skip notifies again.
+        let second_pane = terminal_pane_ids(&h, 0)[0];
+        h.app.windows[0]
+            .panes
+            .get_mut(&second_pane)
+            .and_then(|p| p.as_terminal_mut())
+            .expect("terminal")
+            .activity = Some(crate::app_protocol::AgentState::Working);
+        rewind_last_fire(&mut h, "long-job", 3);
+        h.app.tick_scheduler();
+        assert_eq!(
+            routine_notification_count(&h, "long-job"),
+            2,
+            "a new skip streak notifies once more"
+        );
+    }
+
+    #[test]
+    fn ephemeral_routine_pane_closes_on_exit_and_nonephemeral_stays() {
+        let mut h = HostHarness::new();
+        let root = tempfile::tempdir().expect("tempdir");
+        root_default_context(&mut h, root.path());
+        add_focused_app_pane(&mut h, 0, root.path());
+
+        write_routines(
+            root.path(),
+            r#"
+            [[routine]]
+            name = "flash"
+            command = "true"
+            schedule = "every 2 hours"
+            ephemeral = true
+
+            [[routine]]
+            name = "keeper"
+            command = "true"
+            schedule = "every 2 hours"
+        "#,
+        );
+
+        h.app.tick_scheduler();
+        assert_eq!(terminal_pane_ids(&h, 0).len(), 2, "both routines fire");
+
+        // The ephemeral pane closes when `true` exits; the other stays. PTY
+        // exit events are drained every frame, so pump frames until settled.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        while terminal_pane_ids(&h, 0).len() > 1 && std::time::Instant::now() < deadline {
+            h.run_frames(1);
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        assert_eq!(
+            terminal_pane_ids(&h, 0).len(),
+            1,
+            "ephemeral routine pane must close when its command exits"
+        );
+        // Closing the ephemeral pane also reaped its live-run record.
+        assert!(
+            h.app.scheduler.live_run_count() <= 1,
+            "ephemeral run must be reaped on close"
+        );
+    }
+}

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -4439,15 +4439,10 @@ mod routine_firing {
         let run_pane = run_panes[0];
         assert_eq!(h.app.scheduler.live_run_count(), 1);
 
-        // Simulate the command still running (deterministic — no real pgrep
-        // timing): activity as sampled by tick_terminal_activity.
-        h.app.windows[0]
-            .panes
-            .get_mut(&run_pane)
-            .and_then(|p| p.as_terminal_mut())
-            .expect("terminal")
-            .activity = Some(crate::app_protocol::AgentState::Working);
-
+        // No state is faked here: a freshly spawned pane whose PTY child has
+        // not exited IS a live run — liveness is pane-existence + !exited,
+        // never the `activity` sampler (tester13, PR #2508: sampling read
+        // exec-optimised ephemeral runs as finished and stacked panes).
         let last_fire_before_skip = h.app.scheduler.entries[0].last_fire;
         rewind_last_fire(&mut h, "long-job", 3);
         let rewound = h.app.scheduler.entries[0].last_fire;
@@ -4490,13 +4485,6 @@ mod routine_firing {
         );
 
         // A new run means a new streak: a fresh skip notifies again.
-        let second_pane = terminal_pane_ids(&h, 0)[0];
-        h.app.windows[0]
-            .panes
-            .get_mut(&second_pane)
-            .and_then(|p| p.as_terminal_mut())
-            .expect("terminal")
-            .activity = Some(crate::app_protocol::AgentState::Working);
         rewind_last_fire(&mut h, "long-job", 3);
         h.app.tick_scheduler();
         assert_eq!(
@@ -4504,6 +4492,108 @@ mod routine_firing {
             2,
             "a new skip streak notifies once more"
         );
+    }
+
+    /// Regression guard for tester13's Bug 1 on PR #2508, at the exact spawn
+    /// shape that escaped the original 0575 suite: `ephemeral = true` passes
+    /// the bare command to the shell, zsh exec-optimises `zsh -c "sleep 30"`
+    /// into the sleep itself (no children, fg pgid == shell pid), so the
+    /// `activity` sampler never leaves `None`. Liveness keyed on that sampler
+    /// read the run as finished and stacked a pane every tick. Liveness must
+    /// come from pane-existence + !exited, so this pane — activity untouched,
+    /// exactly as a real idle-sampled host would see it — blocks the refire.
+    #[test]
+    fn ephemeral_bare_command_run_blocks_refire_without_activity_sample() {
+        let mut h = HostHarness::new();
+        let root = tempfile::tempdir().expect("tempdir");
+        root_default_context(&mut h, root.path());
+        add_focused_app_pane(&mut h, 0, root.path());
+
+        write_routines(
+            root.path(),
+            r#"
+            [[routine]]
+            name = "eph"
+            command = "sleep 30"
+            schedule = "every 2 hours"
+            ephemeral = true
+        "#,
+        );
+
+        h.app.tick_scheduler();
+        let panes = terminal_pane_ids(&h, 0);
+        assert_eq!(panes.len(), 1, "first tick fires");
+        let run_pane = panes[0];
+        assert_eq!(
+            h.app.windows[0]
+                .panes
+                .get(&run_pane)
+                .and_then(|p| p.as_terminal())
+                .expect("terminal")
+                .activity,
+            None,
+            "precondition: the sampler has never seen this pane — the shape the bug lived in"
+        );
+
+        rewind_last_fire(&mut h, "eph", 3);
+        h.app.tick_scheduler();
+        assert_eq!(
+            terminal_pane_ids(&h, 0).len(),
+            1,
+            "a live ephemeral run with no activity sample must skip, not stack"
+        );
+        assert_eq!(h.app.scheduler.live_run_count(), 1);
+    }
+
+    /// A non-ephemeral pane whose PTY child exited (shows "[process exited]"
+    /// but stays open until a keypress) is a finished run: the next due tick
+    /// reaps it and fires a fresh pane alongside it.
+    #[test]
+    fn nonephemeral_exited_shell_reaps_and_refires() {
+        let mut h = HostHarness::new();
+        let root = tempfile::tempdir().expect("tempdir");
+        root_default_context(&mut h, root.path());
+        add_focused_app_pane(&mut h, 0, root.path());
+
+        write_routines(
+            root.path(),
+            r#"
+            [[routine]]
+            name = "keeper"
+            command = "true"
+            schedule = "every 2 hours"
+        "#,
+        );
+
+        h.app.tick_scheduler();
+        let panes = terminal_pane_ids(&h, 0);
+        assert_eq!(panes.len(), 1, "first tick fires");
+        let first_pane = panes[0];
+
+        // The field PtyEvent::Exit sets when the PTY child dies.
+        h.app.windows[0]
+            .panes
+            .get_mut(&first_pane)
+            .and_then(|p| p.as_terminal_mut())
+            .expect("terminal")
+            .exited = true;
+
+        rewind_last_fire(&mut h, "keeper", 3);
+        h.app.tick_scheduler();
+        let panes = terminal_pane_ids(&h, 0);
+        assert_eq!(
+            panes.len(),
+            2,
+            "an exited run must be reaped and the routine refired"
+        );
+        assert_eq!(h.app.scheduler.live_run_count(), 1, "only the new run is registered");
+        let new_run = h
+            .app
+            .scheduler
+            .live_run(root.path(), "keeper")
+            .expect("new live run")
+            .pane_id;
+        assert_ne!(new_run, first_pane, "the live run is the fresh pane");
     }
 
     #[test]

--- a/tools/gen_cli_docs/src/main.rs
+++ b/tools/gen_cli_docs/src/main.rs
@@ -59,14 +59,21 @@ fn emit_subcommand(cmd: &Command, parent_path: &str, depth: usize) {
 
     // Inject a hand-authored schedule reference block for `plexi routine`.
     if full_path == "plexi routine" {
-        println!("### Routine file format (`.plexi/routines.toml`)");
+        println!("### Routine file format (`{{workspace_channel_dir}}/routines.toml`)");
+        println!();
+        println!(
+            "The file lives in the workspace channel directory beside the rest of the \
+             workspace state — e.g. `.plexi-alpha/routines.toml` on the alpha channel."
+        );
         println!();
         println!("```toml");
         println!("[[routine]]");
         println!(r#"name      = "morning-sync""#);
         println!(r#"command   = "./scripts/sync.sh""#);
         println!(r#"schedule  = "daily at 09:00""#);
-        println!(r#"context   = "work"   # optional: only fires when this context is active"#);
+        println!(
+            r#"context   = "work"   # optional: fires into this context wherever it is; skipped if no context by that name exists"#
+        );
         println!(
             r#"ephemeral = true     # optional: close the spawned pane when the command exits"#
         );
@@ -76,13 +83,21 @@ fn emit_subcommand(cmd: &Command, parent_path: &str, depth: usize) {
         println!();
         println!("| Format | Example |");
         println!("|---|---|");
-        println!("| `every N seconds` | `every 30 seconds` |");
-        println!("| `every N minutes` | `every 5 minutes` |");
-        println!("| `every N hours`   | `every 2 hours` |");
+        println!("| `every N seconds` (or `Ns`) | `every 30 seconds` |");
+        println!("| `every N minutes` (or `Nm`) | `every 5 minutes` |");
+        println!("| `every N hours` (or `Nh`)   | `every 2 hours` |");
+        println!("| `every minute` / `every hour` | `every minute` |");
         println!("| `daily at HH:MM`  | `daily at 09:00` |");
+        println!("| `weekdays at HH:MM` | `weekdays at 09:00` |");
+        println!("| `weekends at HH:MM` | `weekends at 10:30am` |");
         println!("| `weekly on <day> at HH:MM` | `weekly on monday at 09:00` |");
         println!("| `monthly on N at HH:MM`    | `monthly on 1 at 08:00` |");
         println!("| 5-field cron `m h dom mon dow` | `0 9 * * 1-5` |");
+        println!();
+        println!(
+            "Singular unit names (`every 1 minute`) and am/pm times (`daily at 9am`) are \
+             accepted; day names take short or full spellings (`mon` / `monday`)."
+        );
         println!();
     }
 

--- a/tools/gen_cli_docs/src/main.rs
+++ b/tools/gen_cli_docs/src/main.rs
@@ -79,6 +79,15 @@ fn emit_subcommand(cmd: &Command, parent_path: &str, depth: usize) {
         );
         println!("```");
         println!();
+        println!(
+            "A routine never stacks panes: while the previous run's pane is still \
+             alive, due fires are skipped (with one notification per skip streak), \
+             and the routine fires again on the first tick after that run ends. \
+             Ephemeral panes close themselves when the command exits; a \
+             non-ephemeral pane holds its routine until its shell session ends or \
+             the pane is closed."
+        );
+        println!();
         println!("### Schedule formats");
         println!();
         println!("| Format | Example |");

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -127,6 +127,8 @@ context   = "work"   # optional: fires into this context wherever it is; skipped
 ephemeral = true     # optional: close the spawned pane when the command exits
 ```
 
+A routine never stacks panes: while the previous run's pane is still alive, due fires are skipped (with one notification per skip streak), and the routine fires again on the first tick after that run ends. Ephemeral panes close themselves when the command exits; a non-ephemeral pane holds its routine until its shell session ends or the pane is closed.
+
 ### Schedule formats
 
 | Format | Example |

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -110,18 +110,20 @@ Use --global to delete a globally-stored secret (one stored with `secret set --g
 
 Manage workspace routines — scheduled shell commands.
 
-Routines are declared in `.plexi/routines.toml` and run automatically on schedule. **Requires Plexi to be running** — there is no background daemon. Routines only fire while the host process is open.
+Routines are declared in `routines.toml` inside the workspace channel directory — `{workspace_channel_dir}/routines.toml`, e.g. `.plexi-alpha/routines.toml` on the alpha channel — and run automatically on schedule. **Requires Plexi to be running** — there is no background daemon. Routines only fire while the host process is open.
 
 Use `plexi routine list` to see configured routines, or `plexi routine run <name>` to fire one manually.
 
-### Routine file format (`.plexi/routines.toml`)
+### Routine file format (`{workspace_channel_dir}/routines.toml`)
+
+The file lives in the workspace channel directory beside the rest of the workspace state — e.g. `.plexi-alpha/routines.toml` on the alpha channel.
 
 ```toml
 [[routine]]
 name      = "morning-sync"
 command   = "./scripts/sync.sh"
 schedule  = "daily at 09:00"
-context   = "work"   # optional: only fires when this context is active
+context   = "work"   # optional: fires into this context wherever it is; skipped if no context by that name exists
 ephemeral = true     # optional: close the spawned pane when the command exits
 ```
 
@@ -129,26 +131,31 @@ ephemeral = true     # optional: close the spawned pane when the command exits
 
 | Format | Example |
 |---|---|
-| `every N seconds` | `every 30 seconds` |
-| `every N minutes` | `every 5 minutes` |
-| `every N hours`   | `every 2 hours` |
+| `every N seconds` (or `Ns`) | `every 30 seconds` |
+| `every N minutes` (or `Nm`) | `every 5 minutes` |
+| `every N hours` (or `Nh`)   | `every 2 hours` |
+| `every minute` / `every hour` | `every minute` |
 | `daily at HH:MM`  | `daily at 09:00` |
+| `weekdays at HH:MM` | `weekdays at 09:00` |
+| `weekends at HH:MM` | `weekends at 10:30am` |
 | `weekly on <day> at HH:MM` | `weekly on monday at 09:00` |
 | `monthly on N at HH:MM`    | `monthly on 1 at 08:00` |
 | 5-field cron `m h dom mon dow` | `0 9 * * 1-5` |
 
+Singular unit names (`every 1 minute`) and am/pm times (`daily at 9am`) are accepted; day names take short or full spellings (`mon` / `monday`).
+
 | Subcommand | Description |
 |---|---|
-| `list` | List routines defined in .plexi/routines.toml with their schedule and next fire time |
-| `run` | Manually trigger a named routine from .plexi/routines.toml |
+| `list` | List routines defined in the workspace channel dir's routines.toml with their schedule and next fire time |
+| `run` | Manually trigger a named routine from the workspace channel dir's routines.toml |
 
 ### `plexi routine list`
 
-List routines defined in .plexi/routines.toml with their schedule and next fire time
+List routines defined in the workspace channel dir's routines.toml with their schedule and next fire time
 
 ### `plexi routine run`
 
-Manually trigger a named routine from .plexi/routines.toml
+Manually trigger a named routine from the workspace channel dir's routines.toml
 
 | Flag / Arg | Type | Required | Description |
 |---|---|---|---|


### PR DESCRIPTION
## Summary

Implements stints 0571, 0573, 0575. No linked GitHub issues — stint is authoritative. All three are one subsystem (routines) and ship as one PR.

**Stint 0571 — schedule parser rejects its own documented syntax; stale routines path in docs**
- `parse_schedule` now accepts every row of the documented table: `every N second(s)/minute(s)/hour(s)` via unit-token parsing (the single-char `strip_suffix` that produced `"30 second"` is gone and cannot be reconstructed), plus new `weekly on <day> at HH:MM` (short and full day names) and `monthly on N at HH:MM` branches. Every previously accepted form keeps working; the undocumented `weekdays`/`weekends` forms are now documented instead of removed.
- Routines path corrected from `.plexi/routines.toml` to the channel-scoped `{workspace_channel_dir}/routines.toml` in `src/cli/args.rs` (upstream of the generated site), `tools/gen_cli_docs`, regenerated `website/src/content/docs/cli.md`, `skills/plexi-cli/SKILL.md` (canonical in-repo copy only — the public mirror is untouched; publishing happens only from release trees), and code comments in `scheduler.rs` / `run.rs`.
- The `context` key is now documented as a target (fires into that context wherever it is; skipped only if no context by that name exists), not a gate.

**Stint 0573 — lifecycle hardening: persist last_fire, overlap guard, surface silent skips**
- `last_fire` persists to `{workspace_channel_dir}/routine-state.toml` beside `routines.toml` (RFC 3339, atomic temp+rename, best-effort — a write failure is logged and never aborts the fire; missing/corrupt state degrades to today's behavior). Seeded on load; the in-memory value wins so a reload never rewinds an in-session fire. Interval routines no longer stampede at host startup.
- Overlap guard (decision of record: skip, not queue): live-run registry on `Scheduler` keyed `(source_root, name)`. A routine whose previous run is still going is skipped **without stamping `last_fire`** (fires on the next tick after the run ends), with one notification per skip streak. Reap is wired to the pane-close path (`close_tile`) — the register and reap sites are coupled — plus a liveness re-check at skip-decision time, so a pane destroyed via any path that bypasses `close_tile` can never permanently block its routine. `update_preamble` now samples terminal activity *before* the scheduler tick so a stale pre-spawn sample can't read as "finished" and stack a pane (found in review round 1).
- Every silent failure now emits a user-visible notification through the existing `enqueue_notification` choke point (#2506) — no second enqueue path, no `[notifications] sound` key touched anywhere. Covered: unreadable `routines.toml`, malformed TOML, unparseable schedule, missing context, spawn failure (observable now that `split_focused` returns the spawned pane id). Notifications are passive (priority 50, below the interrupt threshold — never auto-open, never trigger the audible cue), scoped to the context owning the routine's root (global fallback), and deduplicated per (routine, reason) — notify on transition into the failure state, not on every observation.

**Stint 0575 — integration coverage for the firing path**
- `HostHarness` tests for `tick_scheduler`/`fire_routine`: fire into a named context with active-context/window restore asserted, empty-context default, missing-context skip + notification dedup across ticks, startup no-stampede with persisted state (and fires-when-stale/absent), overlap skip → streak dedup → reap-on-close → refire, ephemeral pane teardown on command exit.
- Both unknowns flagged in the task body resolved: `tick_scheduler` runs from `App::logic` (`update_preamble`), so routines keep firing while the window is occluded — no bug to report; the 60s reload cache is bypassed in tests by writing `routines.toml` before the first tick plus a `#[cfg(test)] clear_reload_cache` for the scheduler unit tests.

## Done When

- 0571: every documented schedule row parses (unit tests for each row, both spellings where two exist, negative tests for malformed strings); docs corrected at all four sites; `weekdays`/`weekends` documented.
- 0573: `last_fire` survives a simulated restart; overlap guard skips while a run is live and fires after reap; each notification path fires exactly once across repeated ticks.
- 0575: firing-path integration tests as listed above, green in `cargo test --bin plexi`.

## Test Evidence

- `cargo test --bin plexi` (env-stripped): **1990 passed; 0 failed; 3 ignored** — full bin suite, includes the `skill_surface` gate over the edited SKILL.md.
- Scheduler unit tests: 18 (parser table + persistence + failure transitions + registry). Firing-path harness tests: 7.
- `gen_cli_docs` regenerated via the generator binary directly (not `just gen-cli-docs`); committed `cli.md` verified identical to a fresh generator run.
- Codex review vs alpha, 2 rounds: round 1 found the activity-sampling order race (fixed, see 0573 bullet); round 2 clean.
- PR install: required via `just pr-install <PR>` — host-runtime behavior (scheduler timing over real frames, PTY exit teardown, notification surfacing in the running host) exceeds what the headless harness proves. Tester owns the live smoke.