### PR TITLE
feat(routines): write-side CLI verbs, single schema, routine run context parity (stints 0572, 0574)

### DIFF
--- a/sdk/protocol/pgap.schema.json
+++ b/sdk/protocol/pgap.schema.json
@@ -902,6 +902,13 @@
               },
               "type": "array"
             },
+            "context_name": {
+              "description": "When set, spawn the terminal into the context with this name,\nwherever it is — the host resolves the name and errors back when no\nsuch context exists. Sent by `plexi routine run` for routines that\ndeclare a `context`, matching the scheduler's fire targeting\n(stint 0574). Terminal spawns only.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "cwd": {
               "type": [
                 "string",

--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -135,8 +135,13 @@ search for; keep `--detail` to the active tool.
 ```
 workspace init           Set up .plexi/ in current dir. NEVER run from ~.
 run [COMMAND]            Run a named command from .plexi/commands.toml. Omit to list.
-routine list             Show routines from the workspace channel dir's routines.toml with schedule/next fire.
-routine run NAME         Manually trigger a routine.
+routine list             Show the workspace's routines with schedule/next fire. Resolves routines.toml from the workspace root (works from any subdirectory).
+routine run NAME         Manually trigger a routine. Fires into its configured context like a scheduled run; --force fires a disabled routine.
+routine add NAME --command CMD --schedule SPEC [--context CTX] [--ephemeral]
+                         Append a routine. Schedule is validated by the scheduler's own parser; comments in the file are preserved.
+routine remove NAME      Delete a routine from routines.toml.
+routine enable NAME      Re-enable a disabled routine (removes enabled = false).
+routine disable NAME     Keep the routine but never fire it (sets enabled = false).
 ```
 
 ### ai, config, doctor, notes, demo, update, uninstall

--- a/src/app/assistant_host_tools.rs
+++ b/src/app/assistant_host_tools.rs
@@ -670,6 +670,7 @@ impl PlexiApp {
             path: None,
             workspace_root: None,
             target_context: None,
+            context_name: None,
             name: None,
         });
         let result = if let Some(created) = self

--- a/src/app/launch_spec.rs
+++ b/src/app/launch_spec.rs
@@ -21,6 +21,7 @@ pub(crate) struct PaneLaunchSpec {
     pub(crate) no_focus: bool,
     pub(crate) workspace_root: Option<PathBuf>,
     pub(crate) target_context: Option<u64>,
+    pub(crate) context_name: Option<String>,
     pub(crate) name: Option<String>,
 }
 
@@ -41,6 +42,7 @@ impl PaneLaunchSpec {
             no_focus: false,
             workspace_root: None,
             target_context: None,
+            context_name: None,
             name: None,
         })
     }
@@ -58,12 +60,17 @@ impl PaneLaunchSpec {
             path,
             workspace_root,
             target_context,
+            context_name,
             name,
             ..
         } = request
         else {
             return Err("expected spawn_pane request".to_string());
         };
+
+        if context_name.as_deref().is_some_and(|c| !c.is_empty()) && type_id != "terminal" {
+            return Err("context_name is only supported for terminal spawns".to_string());
+        }
 
         let target = match (type_id.as_str(), path.as_deref()) {
             ("terminal", None) => PaneLaunchTarget::Terminal,
@@ -90,6 +97,7 @@ impl PaneLaunchSpec {
             no_focus: *no_focus,
             workspace_root: workspace_root.as_deref().map(PathBuf::from),
             target_context: *target_context,
+            context_name: context_name.clone(),
             name: name.clone(),
         })
     }
@@ -134,6 +142,7 @@ impl PaneLaunchSpec {
                 .as_ref()
                 .map(|p| p.to_string_lossy().into_owned()),
             target_context: self.target_context,
+            context_name: self.context_name.clone(),
             name: self.name.clone(),
         }
     }
@@ -166,6 +175,7 @@ mod tests {
             path: path.map(str::to_string),
             workspace_root: None,
             target_context: None,
+            context_name: None,
             name: None,
         }
     }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -848,6 +848,72 @@ impl PlexiApp {
                 ) {
                     let layout_str = spec.layout.as_deref().unwrap_or("split_h");
                     let initial_cmd = super::cmd_from_args(&spec.args);
+                    // Named-context targeting (stint 0574): `plexi routine run`
+                    // fires a routine into its configured context by name,
+                    // matching the scheduler's fire path. The context is a hard
+                    // target — a missing name errors back to the caller, and
+                    // the spawn never touches active_window or focus state.
+                    if let Some(ctx_name) = spec.context_name.as_deref().filter(|c| !c.is_empty()) {
+                        if layout_str == "new_window" || layout_str == "tab" {
+                            let msg = format!(
+                                "context_name does not support layout '{layout_str}' — use a split layout"
+                            );
+                            log::warn!("pane_ipc: spawn_pane rejected: {msg}");
+                            if let Some(rf) = &spec.response_file {
+                                write_json_response(rf, serde_json::json!({ "error": msg }));
+                            }
+                            return;
+                        }
+                        let Some(target_ctx_id) = self
+                            .router
+                            .iter()
+                            .find(|c| c.name == ctx_name)
+                            .map(|c| c.context_id)
+                        else {
+                            let msg = format!("context '{ctx_name}' does not exist");
+                            log::warn!("pane_ipc: spawn_pane: {msg}");
+                            if let Some(rf) = &spec.response_file {
+                                write_json_response(rf, serde_json::json!({ "error": msg }));
+                            }
+                            return;
+                        };
+                        let Some((target_win, target_tile)) =
+                            self.context_spawn_target(target_ctx_id)
+                        else {
+                            let msg = format!("context '{ctx_name}' has no pane to spawn beside");
+                            log::warn!("pane_ipc: spawn_pane: {msg}");
+                            if let Some(rf) = &spec.response_file {
+                                write_json_response(rf, serde_json::json!({ "error": msg }));
+                            }
+                            return;
+                        };
+                        let vertical =
+                            matches!(layout_str, "split_h" | "split_right" | "split_left");
+                        let new_pane_first = matches!(layout_str, "split_above" | "split_left");
+                        log::info!(
+                            "pane_ipc: spawn_pane terminal context_name='{ctx_name}' context_id={target_ctx_id} target_win={target_win} layout={layout_str} initial_cmd={initial_cmd:?} ephemeral={}",
+                            spec.ephemeral
+                        );
+                        response_pane_id = self.spawn_terminal_pane_at(
+                            target_win,
+                            target_tile,
+                            vertical,
+                            new_pane_first,
+                            initial_cmd.as_deref(),
+                            spec.ephemeral,
+                            cwd_override,
+                            spec.no_focus,
+                        );
+                        if let Some(ref pane_name) = spec.name {
+                            if !pane_name.is_empty() {
+                                self.apply_inline_pane_name(response_pane_id, pane_name);
+                            }
+                        }
+                        if let Some(rf) = &spec.response_file {
+                            write_response(rf, format!("{{\"pane_id\":{response_pane_id}}}").as_bytes());
+                        }
+                        return;
+                    }
                     if layout_str == "new_window" {
                         // Derive context from the calling pane's window; fall back to active.
                         let target_win_idx = spec
@@ -2851,6 +2917,25 @@ impl PlexiApp {
         log::info!("scheduler: routine notification queued={queued} title='{title}' body='{body}'");
     }
 
+    /// The pane a context-targeted terminal spawn splits beside: the first
+    /// window of `context_id`, and that window's focused pane (or tree root).
+    /// `None` when the context has no window or the window has no pane —
+    /// nothing to split, so the spawn fails rather than landing elsewhere.
+    /// Shared by the scheduler's `fire_routine` and the `context_name` spawn
+    /// path (`plexi routine run`), so both doors target identically.
+    pub(crate) fn context_spawn_target(
+        &self,
+        context_id: u64,
+    ) -> Option<(usize, egui_tiles::TileId)> {
+        let win_idx = self
+            .windows
+            .iter()
+            .position(|w| w.context_id == context_id)?;
+        let win = &self.windows[win_idx];
+        let tile = win.focused_pane.or(win.tree.root)?;
+        Some((win_idx, tile))
+    }
+
     /// Fire a routine into its target context. Returns the spawned pane id,
     /// or `None` when the routine could not run (missing context, spawn
     /// failure) — both surfaced as notifications on transition into the
@@ -2899,30 +2984,16 @@ impl PlexiApp {
             }
         };
 
-        let original_ctx_idx = self.router.active_idx();
-        let original_active_win = self.active_window;
-
-        // Temporarily switch to target context's window if different from current
-        if target_ctx_idx != original_ctx_idx {
-            self.router.set_active(target_ctx_idx);
-            let target_ctx_id = self.router.get(target_ctx_idx).context_id;
-            if let Some(win_idx) = self
-                .windows
-                .iter()
-                .position(|w| w.context_id == target_ctx_id)
-            {
-                self.active_window = win_idx;
-            }
-        }
-
+        // Explicit-target spawn: never steer through router.set_active /
+        // active_window — the target is a parameter, not ambient focus state
+        // (stint 0574; "Don't switch global state to thread data" trap).
+        let target_ctx_id = self.router.get(target_ctx_idx).context_id;
         let cwd = self.router.get(target_ctx_idx).root.clone();
-        let spawned = self.split_focused(false, Some(command), ephemeral, false, cwd);
-
-        // Restore original context
-        if target_ctx_idx != original_ctx_idx {
-            self.router.set_active(original_ctx_idx);
-            self.active_window = original_active_win;
-        }
+        let spawned = self.context_spawn_target(target_ctx_id).map(|(win, tile)| {
+            // vertical=true → side-by-side, matching the previous
+            // split_focused(false, ..) behavior (its LinearDir is inverted).
+            self.spawn_terminal_pane_at(win, tile, true, false, Some(command), ephemeral, cwd, false)
+        });
 
         if spawned.is_none() {
             log::warn!("scheduler: routine '{name}' — failed to spawn a pane");
@@ -2982,6 +3053,7 @@ impl PlexiApp {
                 path: path_target,
                 workspace_root: val["workspace_root"].as_str().map(str::to_string),
                 target_context: val["target_context"].as_u64(),
+                context_name: val["context_name"].as_str().map(str::to_string),
                 name: val["name"].as_str().map(str::to_string),
             };
             let Ok(spec) = crate::app::launch_spec::PaneLaunchSpec::from_spawn_pane(&request)

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -485,6 +485,7 @@ fn spawn_pane_new_window_uses_caller_context_not_active() {
         path: None,
         workspace_root: None,
         target_context: None,
+        context_name: None,
         name: None,
     });
     app.drain_pane_cmd_channel();
@@ -566,6 +567,7 @@ fn spawn_pane_tab_anchors_to_from_pane_window_not_active() {
         path: None,
         workspace_root: None,
         target_context: None,
+        context_name: None,
         name: None,
     });
     app.drain_pane_cmd_channel();
@@ -654,6 +656,7 @@ fn spawn_pane_seeds_root_in_empty_window() {
         path: None,
         workspace_root: None,
         target_context: None,
+        context_name: None,
         name: Some("seeded".to_string()),
     });
     app.drain_pane_cmd_channel();

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1468,11 +1468,54 @@ pub fn normalize_config_scope_aliases(args: Vec<String>) -> Vec<String> {
 
 #[derive(Subcommand)]
 pub enum RoutineCmd {
-    /// List routines defined in the workspace channel dir's routines.toml with their schedule and next fire time.
+    /// List routines defined in the workspace's routines.toml with their schedule and next fire time.
     List,
-    /// Manually trigger a named routine from the workspace channel dir's routines.toml.
+    /// Manually trigger a named routine from the workspace's routines.toml.
+    ///
+    /// The routine fires exactly like a scheduled run: into its configured context
+    /// when one is named (erroring if that context does not exist), otherwise into
+    /// the caller's context.
     Run {
         /// Name of the routine to run
+        name: String,
+        /// Fire the routine even when it is disabled
+        #[arg(long)]
+        force: bool,
+    },
+    /// Add a routine to the workspace's routines.toml.
+    ///
+    /// The schedule is validated against the same parser the scheduler uses, so an
+    /// accepted routine is guaranteed to fire. Hand-written comments elsewhere in
+    /// the file are preserved.
+    Add {
+        /// Unique name for the routine
+        name: String,
+        /// Shell command the routine runs
+        #[arg(long)]
+        command: String,
+        /// When to run — e.g. "every 30m", "daily at 09:00", "0 9 * * 1-5"
+        #[arg(long)]
+        schedule: String,
+        /// Context to fire into (default: the active context at fire time)
+        #[arg(long)]
+        context: Option<String>,
+        /// Close the spawned pane when the command exits
+        #[arg(long)]
+        ephemeral: bool,
+    },
+    /// Remove a routine from the workspace's routines.toml.
+    Remove {
+        /// Name of the routine to remove
+        name: String,
+    },
+    /// Re-enable a disabled routine (removes its `enabled = false` key).
+    Enable {
+        /// Name of the routine to enable
+        name: String,
+    },
+    /// Disable a routine without deleting it (sets `enabled = false`; it never fires until re-enabled).
+    Disable {
+        /// Name of the routine to disable
         name: String,
     },
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -626,7 +626,7 @@ pub use pane::{
     pane_set_title_cli, pane_slot_delete_cli, pane_slot_list_cli, pane_slot_read_cli,
     pane_slot_write_cli, pane_state_cli,
 };
-pub use routine::{routine_list, routine_run};
+pub use routine::{routine_add, routine_list, routine_remove, routine_run, routine_set_enabled};
 pub use run::{run_command, run_list_commands};
 pub use validate::validate_cli;
 pub use workspace::{

--- a/src/cli/open.rs
+++ b/src/cli/open.rs
@@ -27,6 +27,9 @@ pub(super) fn wait_for_response(response_file: &str) -> i32 {
 }
 
 /// Unified pane spawning. All CLI spawn paths funnel through here.
+/// `context_name` targets the named context wherever it is (terminal spawns
+/// only — the host resolves the name and errors back when it does not exist);
+/// `None` keeps the caller-derived targeting.
 pub fn pane_new_cli(
     cmd: Option<&str>,
     name: Option<&str>,
@@ -38,6 +41,7 @@ pub fn pane_new_cli(
     app: Option<&str>,
     mcp: &[String],
     extra_args: &[String],
+    context_name: Option<&str>,
 ) -> i32 {
     // Determine mode: app or terminal
     let is_app = app.is_some() || !mcp.is_empty();
@@ -95,7 +99,10 @@ pub fn pane_new_cli(
         if let Some(n) = name {
             payload["name"] = serde_json::Value::String(n.to_string());
         }
-        log::info!("pane_new:cli: sending via socket type_id={type_id} name={name:?} ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} response_file={response_file:?}");
+        if let Some(ctx) = context_name {
+            payload["context_name"] = serde_json::Value::String(ctx.to_string());
+        }
+        log::info!("pane_new:cli: sending via socket type_id={type_id} name={name:?} ephemeral={ephemeral} no_focus={no_focus} from_pane_id={from_pane_id:?} cwd={cwd:?} context_name={context_name:?} response_file={response_file:?}");
         let code = send_to_socket(payload);
         if code != 0 {
             return code;
@@ -144,6 +151,9 @@ pub fn pane_new_cli(
     }
     if let Some(n) = name {
         queue_payload["name"] = serde_json::Value::String(n.to_string());
+    }
+    if let Some(ctx) = context_name {
+        queue_payload["context_name"] = serde_json::Value::String(ctx.to_string());
     }
     let file = queue_dir.join(format!("{id}.json"));
     if let Err(e) = std::fs::write(&file, queue_payload.to_string()) {
@@ -257,6 +267,7 @@ fn open_descriptor_in_renderer(
         Some("cli-renderer"),
         &[],
         &[path],
+        None,
     )
 }
 
@@ -312,6 +323,7 @@ pub fn open_mcp_by_name(
                 Some("mcp-renderer"),
                 &entry.command,
                 &[],
+                None,
             )
         }
         None => {
@@ -571,6 +583,7 @@ pub fn open_cli(
         Some(type_id),
         &[],
         args,
+        None,
     )
 }
 

--- a/src/cli/routine.rs
+++ b/src/cli/routine.rs
@@ -1,23 +1,103 @@
 use super::open::pane_new_cli;
-use super::run::{routines_file, RoutinesCliConfig};
+use crate::host::scheduler::{parse_schedule, routines_file, RoutinesConfig};
+use std::path::{Path, PathBuf};
+
+/// Accepted `--schedule` grammar, printed whenever a schedule fails to parse.
+/// Mirrors `crate::host::scheduler::parse_schedule` — the same parser the
+/// scheduler fires on, so a written schedule can never be silently dropped.
+const SCHEDULE_FORMS_HELP: &str = "Accepted schedule forms:
+  every N seconds|minutes|hours    (every 30s / every 5 minutes / every 2 hours)
+  every minute / every hour
+  daily at HH:MM                   (daily at 09:00 / daily at 9am)
+  weekdays at HH:MM                (weekdays at 09:00)
+  weekends at HH:MM                (weekends at 10:30am)
+  weekly on <day> at HH:MM         (weekly on monday at 09:00)
+  monthly on N at HH:MM            (monthly on 1 at 08:00)
+  5-field cron: m h dom mon dow    (0 9 * * 1-5)";
+
+/// A failure while reading or mutating `routines.toml`. Wrapped by the CLI
+/// verbs into user-facing messages; kept typed so tests can assert the cause.
+#[derive(Debug)]
+enum RoutineFileError {
+    /// The schedule string is not accepted by `parse_schedule`.
+    BadSchedule(String),
+    /// `routine add` with a name that already exists in the file.
+    DuplicateName(String),
+    /// A mutating verb named a routine that is not in the file.
+    UnknownName { name: String, available: Vec<String> },
+    /// I/O or parse failure — message names the path and the operation.
+    Io(String),
+}
+
+impl std::fmt::Display for RoutineFileError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RoutineFileError::BadSchedule(s) => {
+                write!(f, "schedule '{s}' is not a recognized format")
+            }
+            RoutineFileError::DuplicateName(name) => {
+                write!(f, "a routine named '{name}' already exists")
+            }
+            RoutineFileError::UnknownName { name, available } => {
+                if available.is_empty() {
+                    write!(f, "routine '{name}' not found (no routines defined)")
+                } else {
+                    write!(
+                        f,
+                        "routine '{name}' not found. Available routines: {}",
+                        available.join(", ")
+                    )
+                }
+            }
+            RoutineFileError::Io(msg) => write!(f, "{msg}"),
+        }
+    }
+}
+
+/// Resolve the workspace root that owns `routines.toml`, walking up from the
+/// current directory like every other workspace-scoped CLI resolution
+/// (stint 0574). `None` means no workspace was found.
+fn workspace_root() -> Option<PathBuf> {
+    crate::config::active_workspace_root()
+}
+
+fn print_no_workspace_error() {
+    eprintln!("error: no workspace found from the current directory");
+    eprintln!("Run `plexi workspace init` in your project root first.");
+}
+
+/// Parse `routines.toml` at `path` into the scheduler-owned config type.
+fn load_config(path: &Path) -> Result<RoutinesConfig, String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|e| format!("could not read {}: {e}", path.display()))?;
+    toml::from_str(&contents).map_err(|e| format!("failed to parse {}: {e}", path.display()))
+}
 
 pub fn routine_list() -> i32 {
     log::info!("cli: routine list");
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("error: could not determine current directory: {e}");
-            return 1;
-        }
-    };
     let rf = routines_file();
-    let config_path = cwd.join(&rf);
-    let contents = match std::fs::read_to_string(&config_path) {
-        Ok(c) => c,
+    let Some(root) = workspace_root() else {
+        println!("No workspace found — routines live in {rf} at a workspace root.");
+        println!("Run `plexi workspace init` in your project root first.");
+        return 0;
+    };
+    let config_path = root.join(&rf);
+    let config = match std::fs::read_to_string(&config_path) {
+        Ok(contents) => match toml::from_str::<RoutinesConfig>(&contents) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("error: failed to parse {}: {e}", config_path.display());
+                return 1;
+            }
+        },
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             println!("No routines configured.");
             println!();
-            println!("To set up routines, create {} in your project:", rf);
+            println!(
+                "To set up routines, run `plexi routine add`, or create {} in workspace {}:",
+                rf,
+                root.display()
+            );
             println!("  [[routine]]");
             println!("  name = \"morning-sync\"");
             println!("  command = \"./scripts/morning.sh\"");
@@ -30,20 +110,13 @@ pub fn routine_list() -> i32 {
             return 1;
         }
     };
-    let config: RoutinesCliConfig = match toml::from_str(&contents) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("error: failed to parse {rf}: {e}");
-            return 1;
-        }
-    };
     if config.routine.is_empty() {
         println!("No routines defined in {rf}.");
         return 0;
     }
     println!("Routines:");
     for r in &config.routine {
-        let next = match crate::host::scheduler::parse_schedule(&r.schedule) {
+        let next = match parse_schedule(&r.schedule) {
             Some(s) => crate::host::scheduler::next_fire_description(&s, None),
             None => "invalid schedule".to_string(),
         };
@@ -53,41 +126,28 @@ pub fn routine_list() -> i32 {
             r.context.clone()
         };
         let ephemeral_label = if r.ephemeral { " [ephemeral]" } else { "" };
+        let disabled_label = if r.enabled { "" } else { " [disabled]" };
         println!(
-            "  {:20} {:<30} next: {}  context: {}{}",
-            r.name, r.schedule, next, ctx_label, ephemeral_label
+            "  {:20} {:<30} next: {}  context: {}{}{}",
+            r.name, r.schedule, next, ctx_label, ephemeral_label, disabled_label
         );
     }
     0
 }
 
 /// `plexi routine run <name>` — manually fire a routine
-pub fn routine_run(name: &str) -> i32 {
-    log::info!("cli: routine run '{name}'");
-    let cwd = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(e) => {
-            eprintln!("error: could not determine current directory: {e}");
-            return 1;
-        }
-    };
+pub fn routine_run(name: &str, force: bool) -> i32 {
+    log::info!("cli: routine run '{name}' force={force}");
     let rf = routines_file();
-    let config_path = cwd.join(&rf);
-    let contents = match std::fs::read_to_string(&config_path) {
-        Ok(c) => c,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            eprintln!("error: no {rf} found in {}", cwd.display());
-            return 1;
-        }
-        Err(e) => {
-            eprintln!("error: could not read {}: {e}", config_path.display());
-            return 1;
-        }
+    let Some(root) = workspace_root() else {
+        print_no_workspace_error();
+        return 1;
     };
-    let config: RoutinesCliConfig = match toml::from_str(&contents) {
+    let config_path = root.join(&rf);
+    let config = match load_config(&config_path) {
         Ok(c) => c,
-        Err(e) => {
-            eprintln!("error: failed to parse {rf}: {e}");
+        Err(msg) => {
+            eprintln!("error: {msg}");
             return 1;
         }
     };
@@ -102,11 +162,21 @@ pub fn routine_run(name: &str) -> i32 {
             return 1;
         }
     };
+    if !routine.enabled && !force {
+        eprintln!(
+            "error: routine '{name}' is disabled — run `plexi routine enable {name}` first, or pass --force to fire it anyway"
+        );
+        return 1;
+    }
 
     // Spawn via socket (when inside a Plexi pane) with spawn-queue fallback.
-    // pane_new_cli implements the socket-first pattern used by all other spawn paths.
+    // pane_new_cli implements the socket-first pattern used by all other spawn
+    // paths. A named context is passed through so the host fires the routine
+    // into it — the same targeting the scheduler's fire path uses (stint 0574);
+    // the host errors back when the context does not exist.
+    let context = Some(routine.context.as_str()).filter(|c| !c.is_empty());
     log::info!(
-        "cli: routine run '{name}' — dispatching command: {}",
+        "cli: routine run '{name}' — dispatching command: {} context={context:?}",
         routine.command
     );
     pane_new_cli(
@@ -120,5 +190,375 @@ pub fn routine_run(name: &str) -> i32 {
         None,
         &[],
         &[],
+        context,
     )
+}
+
+/// `plexi routine add` — append a `[[routine]]` table to routines.toml.
+pub fn routine_add(
+    name: &str,
+    command: &str,
+    schedule: &str,
+    context: Option<&str>,
+    ephemeral: bool,
+) -> i32 {
+    let Some(root) = workspace_root() else {
+        print_no_workspace_error();
+        return 1;
+    };
+    let channel_dir = root.join(crate::config::workspace_channel_dir());
+    if !channel_dir.is_dir() {
+        eprintln!(
+            "error: workspace channel directory {} does not exist",
+            channel_dir.display()
+        );
+        eprintln!("Run `plexi workspace init` in {} first.", root.display());
+        return 1;
+    }
+    let path = root.join(routines_file());
+    match add_routine_to_file(&path, name, command, schedule, context, ephemeral) {
+        Ok(()) => {
+            log::info!("cli: routine add '{name}' -> {}", path.display());
+            println!("Added routine '{name}' ({schedule}) to {}", path.display());
+            0
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            if matches!(e, RoutineFileError::BadSchedule(_)) {
+                eprintln!("{SCHEDULE_FORMS_HELP}");
+            }
+            1
+        }
+    }
+}
+
+/// `plexi routine remove <name>` — delete the entry from routines.toml.
+pub fn routine_remove(name: &str) -> i32 {
+    let Some(root) = workspace_root() else {
+        print_no_workspace_error();
+        return 1;
+    };
+    let path = root.join(routines_file());
+    match remove_routine_from_file(&path, name) {
+        Ok(()) => {
+            log::info!("cli: routine remove '{name}' -> {}", path.display());
+            println!("Removed routine '{name}' from {}", path.display());
+            0
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            1
+        }
+    }
+}
+
+/// `plexi routine enable <name>` / `plexi routine disable <name>`.
+pub fn routine_set_enabled(name: &str, enabled: bool) -> i32 {
+    let verb = if enabled { "enable" } else { "disable" };
+    let Some(root) = workspace_root() else {
+        print_no_workspace_error();
+        return 1;
+    };
+    let path = root.join(routines_file());
+    match set_routine_enabled_in_file(&path, name, enabled) {
+        Ok(()) => {
+            log::info!("cli: routine {verb} '{name}' -> {}", path.display());
+            println!("Routine '{name}' {verb}d.");
+            0
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            1
+        }
+    }
+}
+
+// ── format-preserving file mutations (toml_edit) ─────────────────────────────
+//
+// All writes round-trip through `toml_edit` so hand-written comments and key
+// ordering survive untouched, and land atomically (temp file in the same
+// directory, then rename) so a crash mid-write can never truncate the file.
+
+/// Write `content` to `path` atomically: temp file in the same directory,
+/// then rename over the destination. The temp name is pid-unique so two
+/// concurrent CLI invocations can never clobber each other's staged content.
+fn atomic_write(path: &Path, content: &str) -> Result<(), RoutineFileError> {
+    let tmp = path.with_extension(format!("toml.cli-tmp-{}", std::process::id()));
+    std::fs::write(&tmp, content)
+        .and_then(|_| std::fs::rename(&tmp, path))
+        .map_err(|e| RoutineFileError::Io(format!("could not write {}: {e}", path.display())))
+}
+
+/// Parse an existing routines.toml into an editable document. `missing_ok`
+/// controls whether an absent file yields an empty document (`routine add`)
+/// or an error (every other verb).
+fn read_doc(path: &Path, missing_ok: bool) -> Result<toml_edit::DocumentMut, RoutineFileError> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => contents.parse().map_err(|e| {
+            RoutineFileError::Io(format!("failed to parse {}: {e}", path.display()))
+        }),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound && missing_ok => {
+            Ok(toml_edit::DocumentMut::new())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(RoutineFileError::Io(format!(
+            "no {} found — nothing to modify. Run `plexi routine add` first.",
+            path.display()
+        ))),
+        Err(e) => Err(RoutineFileError::Io(format!(
+            "could not read {}: {e}",
+            path.display()
+        ))),
+    }
+}
+
+/// The `[[routine]]` array of tables in `doc`, or an error naming the problem.
+fn routine_tables_mut<'a>(
+    doc: &'a mut toml_edit::DocumentMut,
+    path: &Path,
+) -> Result<&'a mut toml_edit::ArrayOfTables, RoutineFileError> {
+    doc.entry("routine")
+        .or_insert(toml_edit::Item::ArrayOfTables(
+            toml_edit::ArrayOfTables::new(),
+        ))
+        .as_array_of_tables_mut()
+        .ok_or_else(|| {
+            RoutineFileError::Io(format!(
+                "'routine' in {} is not an array of tables ([[routine]])",
+                path.display()
+            ))
+        })
+}
+
+fn table_name(table: &toml_edit::Table) -> Option<&str> {
+    table.get("name").and_then(|v| v.as_str())
+}
+
+fn names_of(tables: &toml_edit::ArrayOfTables) -> Vec<String> {
+    tables
+        .iter()
+        .filter_map(|t| table_name(t).map(str::to_string))
+        .collect()
+}
+
+fn add_routine_to_file(
+    path: &Path,
+    name: &str,
+    command: &str,
+    schedule: &str,
+    context: Option<&str>,
+    ephemeral: bool,
+) -> Result<(), RoutineFileError> {
+    // Validate through the same parser the scheduler fires on — never write a
+    // routine the scheduler would silently drop (stint 0572).
+    if parse_schedule(schedule).is_none() {
+        return Err(RoutineFileError::BadSchedule(schedule.to_string()));
+    }
+    let mut doc = read_doc(path, true)?;
+    let tables = routine_tables_mut(&mut doc, path)?;
+    if tables.iter().any(|t| table_name(t) == Some(name)) {
+        return Err(RoutineFileError::DuplicateName(name.to_string()));
+    }
+    let mut table = toml_edit::Table::new();
+    table["name"] = toml_edit::value(name);
+    table["command"] = toml_edit::value(command);
+    table["schedule"] = toml_edit::value(schedule);
+    if let Some(ctx) = context.filter(|c| !c.is_empty()) {
+        table["context"] = toml_edit::value(ctx);
+    }
+    if ephemeral {
+        table["ephemeral"] = toml_edit::value(true);
+    }
+    tables.push(table);
+    atomic_write(path, &doc.to_string())
+}
+
+fn remove_routine_from_file(path: &Path, name: &str) -> Result<(), RoutineFileError> {
+    let mut doc = read_doc(path, false)?;
+    let tables = routine_tables_mut(&mut doc, path)?;
+    let Some(idx) = tables.iter().position(|t| table_name(t) == Some(name)) else {
+        return Err(RoutineFileError::UnknownName {
+            name: name.to_string(),
+            available: names_of(tables),
+        });
+    };
+    tables.remove(idx);
+    atomic_write(path, &doc.to_string())
+}
+
+fn set_routine_enabled_in_file(
+    path: &Path,
+    name: &str,
+    enabled: bool,
+) -> Result<(), RoutineFileError> {
+    let mut doc = read_doc(path, false)?;
+    let tables = routine_tables_mut(&mut doc, path)?;
+    let Some(table) = tables.iter_mut().find(|t| table_name(t) == Some(name)) else {
+        return Err(RoutineFileError::UnknownName {
+            name: name.to_string(),
+            available: names_of(tables),
+        });
+    };
+    if enabled {
+        // Enabled is the default — drop the key so the file returns to its
+        // untouched shape rather than accumulating `enabled = true` lines.
+        table.remove("enabled");
+    } else {
+        table["enabled"] = toml_edit::value(false);
+    }
+    atomic_write(path, &doc.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn routines_path(dir: &Path) -> PathBuf {
+        dir.join("routines.toml")
+    }
+
+    #[test]
+    fn add_writes_a_file_the_scheduler_parses() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = routines_path(tmp.path());
+        add_routine_to_file(
+            &path,
+            "sync",
+            "./sync.sh",
+            "daily at 09:00",
+            Some("work"),
+            true,
+        )
+        .expect("add succeeds");
+
+        // Host and CLI read the same struct — the written file must parse
+        // through the scheduler-owned RoutinesConfig (stint 0574).
+        let config: RoutinesConfig =
+            toml::from_str(&std::fs::read_to_string(&path).expect("read")).expect("parses");
+        assert_eq!(config.routine.len(), 1);
+        let r = &config.routine[0];
+        assert_eq!(r.name, "sync");
+        assert_eq!(r.command, "./sync.sh");
+        assert_eq!(r.schedule, "daily at 09:00");
+        assert_eq!(r.context, "work");
+        assert!(r.ephemeral);
+        assert!(r.enabled, "enabled defaults to true");
+    }
+
+    #[test]
+    fn add_rejects_duplicate_name() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = routines_path(tmp.path());
+        add_routine_to_file(&path, "sync", "true", "every 2 hours", None, false)
+            .expect("first add succeeds");
+        let err = add_routine_to_file(&path, "sync", "false", "every 1 hour", None, false)
+            .expect_err("duplicate must be rejected");
+        assert!(matches!(err, RoutineFileError::DuplicateName(_)), "{err}");
+        assert!(err.to_string().contains("sync"), "{err}");
+    }
+
+    #[test]
+    fn add_rejects_unparseable_schedule() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = routines_path(tmp.path());
+        let err = add_routine_to_file(&path, "sync", "true", "every fortnight", None, false)
+            .expect_err("bad schedule must be rejected");
+        assert!(matches!(err, RoutineFileError::BadSchedule(_)), "{err}");
+        assert!(!path.exists(), "no file may be written on rejection");
+    }
+
+    #[test]
+    fn disable_then_scheduler_load_skips_the_entry() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let dir = root.join(crate::config::workspace_channel_dir());
+        std::fs::create_dir_all(&dir).expect("create channel dir");
+        let path = dir.join("routines.toml");
+        add_routine_to_file(&path, "sync", "true", "every 2 hours", None, false)
+            .expect("add succeeds");
+
+        let mut s = crate::host::scheduler::Scheduler::new();
+        s.load_from_root(root);
+        assert_eq!(s.entries.len(), 1, "enabled routine loads");
+
+        set_routine_enabled_in_file(&path, "sync", false).expect("disable succeeds");
+        let mut s = crate::host::scheduler::Scheduler::new();
+        assert!(
+            s.load_from_root(root).is_empty(),
+            "a disabled routine is not a load failure"
+        );
+        assert!(
+            s.entries.is_empty(),
+            "disabled routine must never become a SchedulerEntry"
+        );
+
+        set_routine_enabled_in_file(&path, "sync", true).expect("enable succeeds");
+        let mut s = crate::host::scheduler::Scheduler::new();
+        s.load_from_root(root);
+        assert_eq!(s.entries.len(), 1, "re-enabled routine loads again");
+    }
+
+    #[test]
+    fn comments_survive_disable_round_trip() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = routines_path(tmp.path());
+        let original = "# my routines — do not touch\n\n[[routine]]\n# fires every morning\nname = \"sync\" # the important one\ncommand = \"./sync.sh\"\nschedule = \"daily at 09:00\"\n";
+        std::fs::write(&path, original).expect("write");
+
+        set_routine_enabled_in_file(&path, "sync", false).expect("disable succeeds");
+        let disabled = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(
+            disabled,
+            format!("{original}enabled = false\n"),
+            "disable must only add the enabled key"
+        );
+
+        set_routine_enabled_in_file(&path, "sync", true).expect("enable succeeds");
+        let enabled = std::fs::read_to_string(&path).expect("read");
+        assert_eq!(
+            enabled, original,
+            "enable must restore the file byte-for-byte"
+        );
+    }
+
+    #[test]
+    fn remove_unknown_name_lists_available() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = routines_path(tmp.path());
+        add_routine_to_file(&path, "sync", "true", "every 2 hours", None, false)
+            .expect("add succeeds");
+        let err = remove_routine_from_file(&path, "ghost").expect_err("unknown name errors");
+        match &err {
+            RoutineFileError::UnknownName { available, .. } => {
+                assert_eq!(available, &vec!["sync".to_string()]);
+            }
+            other => panic!("expected UnknownName, got {other:?}"),
+        }
+        assert!(err.to_string().contains("sync"), "{err}");
+    }
+
+    #[test]
+    fn remove_deletes_only_the_named_entry() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = routines_path(tmp.path());
+        add_routine_to_file(&path, "a", "true", "every 2 hours", None, false).expect("add a");
+        add_routine_to_file(&path, "b", "true", "every 1 hour", None, false).expect("add b");
+        remove_routine_from_file(&path, "a").expect("remove a");
+        let config: RoutinesConfig =
+            toml::from_str(&std::fs::read_to_string(&path).expect("read")).expect("parses");
+        assert_eq!(config.routine.len(), 1);
+        assert_eq!(config.routine[0].name, "b");
+    }
+
+    #[test]
+    fn workspace_resolution_walks_up_from_subdirectory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        std::fs::create_dir_all(root.join(crate::config::workspace_channel_dir()))
+            .expect("create channel dir");
+        let nested = root.join("a").join("b");
+        std::fs::create_dir_all(&nested).expect("create nested dirs");
+        let resolved = crate::app::registry::resolve_workspace_root(&nested)
+            .expect("nested subdirectory must resolve to the workspace root");
+        assert_eq!(resolved, root);
+    }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -285,31 +285,6 @@ pub fn run_command(command_name: &str, extra_args: &[String]) -> i32 {
     }
 }
 
-// ── plexi routine subcommands ─────────────────────────────────────────────────
-
-pub(super) fn routines_file() -> String {
-    format!("{}/routines.toml", crate::config::workspace_channel_dir())
-}
-
-/// Parsed `{workspace_channel_dir}/routines.toml` for CLI use
-#[derive(serde::Deserialize)]
-pub(super) struct RoutinesCliConfig {
-    #[serde(default)]
-    pub(super) routine: Vec<RoutineCliDef>,
-}
-
-#[derive(serde::Deserialize)]
-pub(super) struct RoutineCliDef {
-    pub(super) name: String,
-    pub(super) command: String,
-    pub(super) schedule: String,
-    #[serde(default)]
-    pub(super) context: String,
-    #[serde(default)]
-    pub(super) ephemeral: bool,
-}
-
-/// `plexi routine list` — list routines from the workspace channel dir's routines.toml
 #[cfg(test)]
 mod command_parse_tests {
     use crate::cli::{CommandEntry, PlexiCommands};

--- a/src/host/scheduler.rs
+++ b/src/host/scheduler.rs
@@ -2,7 +2,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-fn routines_file() -> String {
+/// Workspace-relative path of the routines file. Single owner — the CLI
+/// (`plexi routine`) and the scheduler must always resolve the same file.
+pub(crate) fn routines_file() -> String {
     format!("{}/routines.toml", crate::config::workspace_channel_dir())
 }
 
@@ -41,6 +43,14 @@ pub(crate) struct Routine {
     pub context: String,
     #[serde(default)]
     pub ephemeral: bool,
+    /// Disabled routines stay in the file but never fire. Defaults to true so
+    /// the key only appears once a routine has been disabled (stint 0572).
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+fn default_enabled() -> bool {
+    true
 }
 
 #[derive(Clone)]
@@ -184,6 +194,15 @@ impl Scheduler {
         let count = config.routine.len();
         let mut new_failures = Vec::new();
         for routine in config.routine {
+            // Disabled routines are fully inert: no SchedulerEntry, no schedule
+            // validation, no failure notifications (stint 0572).
+            if !routine.enabled {
+                log::info!(
+                    "scheduler: routine '{}' is disabled, skipping",
+                    routine.name
+                );
+                continue;
+            }
             // A schedule edit resolves the routine's previous bad-schedule
             // state whether or not the new string parses; a *different* bad
             // string is a new failure and notifies again.
@@ -511,6 +530,11 @@ pub(crate) fn parse_schedule(s: &str) -> Option<ParsedSchedule> {
         };
         let n: u64 = n_str.parse().ok()?;
         let secs = n.checked_mul(interval_unit_secs(unit)?)?;
+        // A zero-length interval would be due on every tick — an uncontrolled
+        // fire loop, never a meaningful schedule.
+        if secs == 0 {
+            return None;
+        }
         return Some(ParsedSchedule::Interval { secs });
     }
 
@@ -859,6 +883,8 @@ mod tests {
         assert!(parse_schedule("garbage schedule").is_none());
         assert!(parse_schedule("").is_none());
         assert!(parse_schedule("every 30 parsecs").is_none());
+        assert!(parse_schedule("every 0 seconds").is_none());
+        assert!(parse_schedule("every 0m").is_none());
         assert!(parse_schedule("every fast").is_none());
         assert!(parse_schedule("weekly on funday at 9am").is_none());
         assert!(parse_schedule("weekly on monday").is_none());

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,7 +255,31 @@ fn main() -> eframe::Result {
                     },
                     Commands::Routine { cmd } => match cmd {
                         RoutineCmd::List => std::process::exit(cli::routine_list()),
-                        RoutineCmd::Run { name } => std::process::exit(cli::routine_run(&name)),
+                        RoutineCmd::Run { name, force } => {
+                            std::process::exit(cli::routine_run(&name, force))
+                        }
+                        RoutineCmd::Add {
+                            name,
+                            command,
+                            schedule,
+                            context,
+                            ephemeral,
+                        } => std::process::exit(cli::routine_add(
+                            &name,
+                            &command,
+                            &schedule,
+                            context.as_deref(),
+                            ephemeral,
+                        )),
+                        RoutineCmd::Remove { name } => {
+                            std::process::exit(cli::routine_remove(&name))
+                        }
+                        RoutineCmd::Enable { name } => {
+                            std::process::exit(cli::routine_set_enabled(&name, true))
+                        }
+                        RoutineCmd::Disable { name } => {
+                            std::process::exit(cli::routine_set_enabled(&name, false))
+                        }
                     },
                     Commands::Agent { cmd } => match cmd {
                         AgentCmd::Init { name, from } => {
@@ -435,6 +459,7 @@ fn main() -> eframe::Result {
                                         Some("mcp-renderer"),
                                         &mcp,
                                         &[],
+                                        None,
                                     ));
                                 } else {
                                     let binary = cli_flag.unwrap();
@@ -951,6 +976,7 @@ fn main() -> eframe::Result {
                                 None,
                                 &[],
                                 &[],
+                                None,
                             ));
                         }
                     },

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -317,6 +317,13 @@ pub enum AppRequest {
         /// a descendant of the requesting app's context (#1518).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         target_context: Option<u64>,
+        /// When set, spawn the terminal into the context with this name,
+        /// wherever it is — the host resolves the name and errors back when no
+        /// such context exists. Sent by `plexi routine run` for routines that
+        /// declare a `context`, matching the scheduler's fire targeting
+        /// (stint 0574). Terminal spawns only.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        context_name: Option<String>,
         /// Inline pane name — applied immediately after spawn so the pane
         /// starts with a human-readable label instead of the default shell title.
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -2573,6 +2580,40 @@ mod tests {
         assert!(
             !serialised_absent.contains("name"),
             "name should be omitted when None: {serialised_absent}"
+        );
+    }
+
+    #[test]
+    fn spawn_pane_context_name_round_trips_serde() {
+        let json = r#"{"type":"spawn_pane","type_id":"terminal","context_name":"work"}"#;
+        let cmd: AppRequest = serde_json::from_str(json).expect("deserialise");
+        match &cmd {
+            AppRequest::SpawnPane { context_name, .. } => {
+                assert_eq!(context_name.as_deref(), Some("work"));
+            }
+            other => panic!("expected SpawnPane, got {other:?}"),
+        }
+        let serialised = serde_json::to_string(&cmd).expect("serialise");
+        assert!(
+            serialised.contains(r#""context_name":"work""#),
+            "context_name missing: {serialised}"
+        );
+
+        let json_absent = r#"{"type":"spawn_pane","type_id":"terminal"}"#;
+        let cmd_absent: AppRequest = serde_json::from_str(json_absent).expect("deserialise absent");
+        match &cmd_absent {
+            AppRequest::SpawnPane { context_name, .. } => {
+                assert!(
+                    context_name.is_none(),
+                    "absent context_name must deserialise to None"
+                );
+            }
+            other => panic!("expected SpawnPane, got {other:?}"),
+        }
+        let serialised_absent = serde_json::to_string(&cmd_absent).expect("serialise absent");
+        assert!(
+            !serialised_absent.contains("context_name"),
+            "context_name should be omitted when None: {serialised_absent}"
         );
     }
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -3499,6 +3499,7 @@ fn blank_text_editor_open_acquires_input_focus() {
         path: None,
         workspace_root: None,
         target_context: None,
+        context_name: None,
         name: None,
     });
     // R3 moved IPC draining into logic so the editor can be opened while eframe
@@ -4263,6 +4264,94 @@ mod routine_firing {
         );
         assert_eq!(h.app.router.active_idx(), active_ctx_before);
         assert_eq!(h.app.active_window, active_win_before);
+    }
+
+    /// `plexi routine run` parity (stint 0574): a spawn_pane request carrying
+    /// `context_name` lands in that context's window without touching the
+    /// active window — the same targeting `fire_routine` uses.
+    #[test]
+    fn spawn_pane_context_name_lands_in_named_context() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut h = HostHarness::new();
+        let root = tempfile::tempdir().expect("tempdir");
+        root_default_context(&mut h, root.path());
+        add_focused_app_pane(&mut h, 0, root.path());
+        let work_root = tempfile::tempdir().expect("tempdir");
+        let work_win = add_secondary_context(&mut h, "work", work_root.path());
+
+        let active_win_before = h.app.active_window;
+        let main_panes_before = h.app.windows[0].panes.len();
+        let response = temp_response(tmp.path(), "ctx-name-spawn");
+        h.app
+            .handle_pane_ipc_request(AppRequest::SpawnPane {
+                type_id: "terminal".to_string(),
+                layout: Some("split_h".to_string()),
+                args: vec!["true".to_string()],
+                from_pane_id: None,
+                request_id: None,
+                response_file: Some(response.clone()),
+                ephemeral: false,
+                cwd: None,
+                no_focus: false,
+                path: None,
+                workspace_root: None,
+                target_context: None,
+                context_name: Some("work".to_string()),
+                name: None,
+            });
+
+        let reply = read_json_response(&response);
+        let pane_id = reply["pane_id"].as_u64().expect("spawn must return pane_id");
+        assert!(
+            h.app.windows[work_win].panes.contains_key(&pane_id),
+            "pane must land in the named context's window"
+        );
+        assert_eq!(
+            h.app.windows[0].panes.len(),
+            main_panes_before,
+            "active context must not receive the pane"
+        );
+        assert_eq!(h.app.active_window, active_win_before);
+    }
+
+    /// A `context_name` naming no live context is a hard error back to the
+    /// caller — never a silent fallback into the active context.
+    #[test]
+    fn spawn_pane_unknown_context_name_errors() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mut h = HostHarness::new();
+        let root = tempfile::tempdir().expect("tempdir");
+        root_default_context(&mut h, root.path());
+        add_focused_app_pane(&mut h, 0, root.path());
+        let panes_before = h.app.windows[0].panes.len();
+
+        let response = temp_response(tmp.path(), "ctx-name-missing");
+        h.app
+            .handle_pane_ipc_request(AppRequest::SpawnPane {
+                type_id: "terminal".to_string(),
+                layout: Some("split_h".to_string()),
+                args: vec!["true".to_string()],
+                from_pane_id: None,
+                request_id: None,
+                response_file: Some(response.clone()),
+                ephemeral: false,
+                cwd: None,
+                no_focus: false,
+                path: None,
+                workspace_root: None,
+                target_context: None,
+                context_name: Some("ghost".to_string()),
+                name: None,
+            });
+
+        let reply = read_json_response(&response);
+        let err = reply["error"].as_str().expect("must reply with an error");
+        assert!(err.contains("ghost"), "error must name the context: {err}");
+        assert_eq!(
+            h.app.windows[0].panes.len(),
+            panes_before,
+            "no pane may be spawned anywhere on a missing context"
+        );
     }
 
     #[test]

--- a/tools/gen_cli_docs/src/main.rs
+++ b/tools/gen_cli_docs/src/main.rs
@@ -77,7 +77,16 @@ fn emit_subcommand(cmd: &Command, parent_path: &str, depth: usize) {
         println!(
             r#"ephemeral = true     # optional: close the spawned pane when the command exits"#
         );
+        println!(
+            r#"enabled   = false    # optional: keep the routine but never fire it (`plexi routine disable`)"#
+        );
         println!("```");
+        println!();
+        println!(
+            "`plexi routine add` / `remove` / `enable` / `disable` edit this file for \
+             you, validating the schedule against the same parser the scheduler uses \
+             and preserving hand-written comments."
+        );
         println!();
         println!(
             "A routine never stacks panes: while the previous run's pane is still \

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -125,7 +125,10 @@ command   = "./scripts/sync.sh"
 schedule  = "daily at 09:00"
 context   = "work"   # optional: fires into this context wherever it is; skipped if no context by that name exists
 ephemeral = true     # optional: close the spawned pane when the command exits
+enabled   = false    # optional: keep the routine but never fire it (`plexi routine disable`)
 ```
+
+`plexi routine add` / `remove` / `enable` / `disable` edit this file for you, validating the schedule against the same parser the scheduler uses and preserving hand-written comments.
 
 A routine never stacks panes: while the previous run's pane is still alive, due fires are skipped (with one notification per skip streak), and the routine fires again on the first tick after that run ends. Ephemeral panes close themselves when the command exits; a non-ephemeral pane holds its routine until its shell session ends or the pane is closed.
 
@@ -148,20 +151,65 @@ Singular unit names (`every 1 minute`) and am/pm times (`daily at 9am`) are acce
 
 | Subcommand | Description |
 |---|---|
-| `list` | List routines defined in the workspace channel dir's routines.toml with their schedule and next fire time |
-| `run` | Manually trigger a named routine from the workspace channel dir's routines.toml |
+| `list` | List routines defined in the workspace's routines.toml with their schedule and next fire time |
+| `run` | Manually trigger a named routine from the workspace's routines.toml |
+| `add` | Add a routine to the workspace's routines.toml |
+| `remove` | Remove a routine from the workspace's routines.toml |
+| `enable` | Re-enable a disabled routine (removes its `enabled = false` key) |
+| `disable` | Disable a routine without deleting it (sets `enabled = false`; it never fires until re-enabled) |
 
 ### `plexi routine list`
 
-List routines defined in the workspace channel dir's routines.toml with their schedule and next fire time
+List routines defined in the workspace's routines.toml with their schedule and next fire time
 
 ### `plexi routine run`
 
-Manually trigger a named routine from the workspace channel dir's routines.toml
+Manually trigger a named routine from the workspace's routines.toml.
+
+The routine fires exactly like a scheduled run: into its configured context when one is named (erroring if that context does not exist), otherwise into the caller's context.
 
 | Flag / Arg | Type | Required | Description |
 |---|---|---|---|
 | `<name>` | string | yes | Name of the routine to run |
+| `--force` | flag | no | Fire the routine even when it is disabled |
+
+### `plexi routine add`
+
+Add a routine to the workspace's routines.toml.
+
+The schedule is validated against the same parser the scheduler uses, so an accepted routine is guaranteed to fire. Hand-written comments elsewhere in the file are preserved.
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<name>` | string | yes | Unique name for the routine |
+| `--command` | string | yes | Shell command the routine runs |
+| `--schedule` | string | yes | When to run — e.g. "every 30m", "daily at 09:00", "0 9 * * 1-5" |
+| `--context` | string | no | Context to fire into (default: the active context at fire time) |
+| `--ephemeral` | flag | no | Close the spawned pane when the command exits |
+
+### `plexi routine remove`
+
+Remove a routine from the workspace's routines.toml
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<name>` | string | yes | Name of the routine to remove |
+
+### `plexi routine enable`
+
+Re-enable a disabled routine (removes its `enabled = false` key)
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<name>` | string | yes | Name of the routine to enable |
+
+### `plexi routine disable`
+
+Disable a routine without deleting it (sets `enabled = false`; it never fires until re-enabled)
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<name>` | string | yes | Name of the routine to disable |
 
 ## `plexi agent`
 

--- a/website/src/content/docs/pgap.md
+++ b/website/src/content/docs/pgap.md
@@ -243,6 +243,7 @@ Unified pane spawn primitive (#592). Supersedes SpawnApp for new apps. Requires 
 | Field | Type | Required |
 |-------|------|----------|
 | `args` | `string[]` | no |
+| `context_name` | `string?` | no |
 | `cwd` | `string?` | no |
 | `ephemeral` | `boolean` | no |
 | `from_pane_id` | `integer?` | no |


### PR DESCRIPTION
## Summary

Implements stint 0572, stint 0574. No linked GitHub issue — stint is authoritative.

**stint 0572 — `plexi routine add/remove/enable/disable`**
- Four new write verbs on `RoutineCmd` (plus `run --force`); shell completions are clap-generated and verified (`completions zsh | grep`).
- `--schedule` is validated through the scheduler's own `parse_schedule` — the single parser, no second pre-check — and an unparseable spec is a hard error listing every accepted form. `parse_schedule` itself now rejects zero-length intervals (`every 0 seconds`), protecting hand-edited files from a fire-per-tick loop too.
- Writes round-trip through `toml_edit` (repo already depends on it via `config_cli.rs`): hand-written comments survive `routine disable` byte-for-byte apart from the `enabled` key (regression-tested). Writes are atomic — pid-unique temp file in the same directory, then rename.
- New `enabled` key on `Routine`: serde-defaults to `true` so existing files are untouched and the key only appears once disabled. `Scheduler::load_from_root` skips disabled entries at parse time (no `SchedulerEntry`, no schedule validation, no notifications); `routine run` refuses a disabled routine unless `--force`; `routine list` renders a `[disabled]` marker.
- Every mutating verb logs `info` with the routine name and resolved file path.

**stint 0574 — schema dedupe + run parity**
- `RoutineCliDef` / `RoutinesCliConfig` deleted outright; `src/host/scheduler.rs`'s `Routine` / `RoutinesConfig` is the single schema (no alias, no re-export shim). `routines_file()` likewise has one owner (scheduler).
- `routine list` / `routine run` resolve `routines.toml` from the workspace root via `active_workspace_root()` (walk-up), not the literal cwd; the no-workspace message points at `plexi workspace init`.
- `routine run` honors `routine.context`: new `context_name` field on `SpawnPane` (terminal spawns only, rejected otherwise in `from_spawn_pane`), resolved host-side. Named context that exists → fires into it; missing → hard error back to the CLI, exit 1; empty → caller's context, unchanged.
- `fire_routine` no longer mutates `router.set_active` / `active_window` as a calling convention. A shared `context_spawn_target(context_id)` helper + the existing explicit-target `spawn_terminal_pane_at` serve both the scheduler fire path and the CLI `context_name` path, so both doors target identically. All five pre-existing firing-path harness tests (stint 0575) pass unchanged. The conversion fit inside this PR — no follow-up stint needed.
- Regenerated: `website/src/content/docs/cli.md` (via `gen_cli_docs`, run directly — hand-authored routine block updated with `enabled`), `sdk/protocol/pgap.schema.json`, `_protocol.py` (no diff). `skills/plexi-cli/SKILL.md` routine section updated via the real `skills/` path.

## Behavior notes (deliberate)

- `routine enable` **removes** the `enabled` key rather than writing `enabled = true` — the file returns to its untouched shape (decision of record: the key only appears once disabled).
- A running host picks up `routine enable/disable` on its existing reload cadence (`load_from_root` caches per root for 60s) — same latency as any hand-edit of `routines.toml` today. Immediate invalidation would need a new host IPC and is further gated by the known idle-host tick gap (stint 0615), so it is intentionally out of scope here.
- `fire_routine` previously spawned into the **original** active window when the target context existed but had no window (the active_window switch silently failed); with explicit targeting this is now an honest spawn failure with the existing "Routine failed" notification.

## Done When — stint 0572

- `routine add` rejects duplicate names (exit 1, names the existing entry) and unparseable schedules (hard error listing accepted forms) — unit-tested
- creates `routines.toml` if absent when the workspace channel dir exists; errors pointing at `plexi workspace init` otherwise
- `routine remove` unknown name: exit 1 listing available names — unit-tested
- disable → `load_from_root` skips the entry — unit-tested; comments survive disable byte-for-byte — unit-tested
- docs (cli.md routine table + plexi-cli SKILL.md) and completions updated

## Done When — stint 0574

- one `Routine`/`RoutinesConfig` pair, CLI types deleted — deserialization round-trip test proves the written file parses through the scheduler struct
- `routine run` into a named context lands in that context (harness test `spawn_pane_context_name_lands_in_named_context`); missing context is a hard error (harness test `spawn_pane_unknown_context_name_errors`)
- `routine list`/`run` resolve from the workspace root — walk-up unit test `workspace_resolution_walks_up_from_subdirectory`
- `fire_routine` focus-state mutation removed — pre-existing test `routine_fires_into_named_context_and_restores_focus` still green

## Test evidence

- `cargo test --bin plexi` (env-stripped, memory-watchdogged): **2010 passed, 0 failed, 3 ignored** — full bin suite
- `just check-cli-docs`: "CLI docs are up to date."
- `mypy sdk/python/plexi_sdk/` (SDK gate): "Success: no issues found in 27 source files"
- Codex review (2 runs): round 1 finding (shared temp filename) fixed with pid-unique temp; round 2 finding (zero-interval schedule) fixed in `parse_schedule`; round 2's reload-latency note documented above as deliberate scope.
- Conclusion: binary install required for live validation of the new verbs against a real workspace — validator should use `just pr-install <PR>` and drive `plexi-pr-<PR> routine ...`; headless coverage above is complete for host logic.