### PR TITLE
Editor and sidebar polish (stints 0561, 0563, 0564)

### DIFF
--- a/src/app/text_editor_app.rs
+++ b/src/app/text_editor_app.rs
@@ -481,7 +481,7 @@ impl TextEditorApp {
                     Some(i) => link.bytes.start + i + 2..link.bytes.end - 1,
                     None => link.bytes.clone(),
                 },
-                LinkKind::Autolink => link.bytes.clone(),
+                LinkKind::Autolink | LinkKind::BareUrl => link.bytes.clone(),
             };
             self.select_byte_range(&dest_range);
             log::info!("notes_editor: link edit — selected destination of {:?}", link.dest);
@@ -555,6 +555,7 @@ impl TextEditorApp {
         let kind = match link.kind {
             LinkKind::Markdown => "markdown",
             LinkKind::Autolink => "autolink",
+            LinkKind::BareUrl => "bare_url",
             LinkKind::Wiki => "wiki",
         };
         let (outcome, detail) = if link.dest.contains("://") {
@@ -1591,6 +1592,7 @@ impl App for TextEditorApp {
                     "kind": match l.kind {
                         LinkKind::Markdown => "markdown",
                         LinkKind::Autolink => "autolink",
+                        LinkKind::BareUrl => "bare_url",
                         LinkKind::Wiki => "wiki",
                     },
                     "target": l.dest,

--- a/src/editor/commands.rs
+++ b/src/editor/commands.rs
@@ -43,9 +43,15 @@ pub enum EditorCommand {
     InsertNewline,
     /// Delete selection, or one grapheme left of the caret.
     Backspace,
+    /// Delete selection, or every grapheme from the caret back to the start
+    /// of the current line. This is the macOS Cmd+Backspace behavior.
+    KillToLineStart,
     /// Delete selection, or one grapheme right of the caret.
     DeleteForward,
-    Move { movement: Movement, extend: bool },
+    Move {
+        movement: Movement,
+        extend: bool,
+    },
     /// Tab: indent every selected line (or insert one indent at the caret)
     /// as one undoable transaction.
     Indent,
@@ -180,6 +186,7 @@ impl Document {
             EditorCommand::InsertText(text) => self.insert_text(&text, true),
             EditorCommand::InsertNewline => self.insert_newline(),
             EditorCommand::Backspace => self.delete(true),
+            EditorCommand::KillToLineStart => self.kill_to_line_start(),
             EditorCommand::DeleteForward => self.delete(false),
             EditorCommand::Move { movement, extend } => self.do_move(movement, extend),
             EditorCommand::Indent => self.indent(),
@@ -369,6 +376,27 @@ impl Document {
             let b = movement::cursor_to_char(&self.buffer, caret);
             (a.min(b), a.max(b))
         };
+        if start_char == end_char {
+            return;
+        }
+        let ops = vec![EditOperation::Delete {
+            pos: start_char,
+            text: self.buffer.slice(start_char, end_char),
+        }];
+        self.commit(ops, selection_before, start_char, false);
+    }
+
+    /// Cmd+Backspace: delete the selection, or the current line prefix. At a
+    /// line start it is intentionally a no-op rather than joining lines.
+    fn kill_to_line_start(&mut self) {
+        if self.selection.is_range() {
+            self.delete(true);
+            return;
+        }
+        let selection_before = self.selection;
+        let caret = movement::clamp(&self.buffer, self.selection.head);
+        let start_char = self.buffer.line_to_char(caret.line);
+        let end_char = movement::cursor_to_char(&self.buffer, caret);
         if start_char == end_char {
             return;
         }
@@ -622,6 +650,26 @@ mod tests {
         d.apply(EditorCommand::Backspace);
         assert_eq!(d.text(), "abcd");
         assert_eq!(d.cursor(), Cursor::new(0, 2));
+    }
+
+    #[test]
+    fn kill_to_line_start_is_atomic_grapheme_safe_and_does_not_join_lines() {
+        let mut d = doc("first\npre café👨\u{200d}👩 tail");
+        d.apply(EditorCommand::SetCursor(Cursor::new(1, 12)));
+        d.apply(EditorCommand::KillToLineStart);
+        assert_eq!(d.text(), "first\ntail");
+        assert_eq!(d.cursor(), Cursor::new(1, 0));
+        d.apply(EditorCommand::Undo);
+        assert_eq!(d.text(), "first\npre café👨\u{200d}👩 tail");
+
+        d.apply(EditorCommand::SetCursor(Cursor::new(1, 0)));
+        d.apply(EditorCommand::KillToLineStart);
+        assert_eq!(d.text(), "first\npre café👨\u{200d}👩 tail");
+
+        d.apply(EditorCommand::SetCursor(Cursor::new(1, 4)));
+        d.apply(EditorCommand::ExtendTo(Cursor::new(1, 11)));
+        d.apply(EditorCommand::KillToLineStart);
+        assert_eq!(d.text(), "first\npre  tail");
     }
 
     #[test]
@@ -1026,7 +1074,11 @@ mod tests {
         let mut d = doc(text);
         d.apply(EditorCommand::SetCursor(Cursor::new(1, 12)));
         d.apply(EditorCommand::MarkdownNewline);
-        assert_eq!(d.text(), "```\n- not a list\n\n```", "plain newline in fence");
+        assert_eq!(
+            d.text(),
+            "```\n- not a list\n\n```",
+            "plain newline in fence"
+        );
 
         // Tab in a fence is a plain caret indent, not a line indent.
         let mut d = doc(text);

--- a/src/editor/preview.rs
+++ b/src/editor/preview.rs
@@ -80,6 +80,8 @@ pub enum LinkKind {
     Markdown,
     /// `<https://…>` or a bare autolink.
     Autolink,
+    /// A bare `http://` or `https://` URL detected only for live rendering.
+    BareUrl,
     /// `[[note name]]` wiki-style note link (not cmark syntax; scanned here).
     Wiki,
 }
@@ -141,7 +143,7 @@ pub struct StyleSpan {
 pub struct MarkdownLayout {
     pub blocks: Vec<Block>,
     pub inlines: Vec<InlineSpan>,
-    /// All links in source order (Markdown, autolink, wiki).
+    /// All links in source order (Markdown, autolink, bare URL, wiki).
     pub links: Vec<LinkTarget>,
     /// All inline image references in source order.
     pub images: Vec<ImageSpan>,
@@ -220,7 +222,9 @@ impl MarkdownLayout {
         if line_text.is_empty() {
             return Vec::new();
         }
-        let kind = self.block_at_line(line).map_or(BlockKind::Fallback, |b| b.kind);
+        let kind = self
+            .block_at_line(line)
+            .map_or(BlockKind::Fallback, |b| b.kind);
         let base = match kind {
             BlockKind::Heading(level) => MdStyle::Heading(level),
             BlockKind::CodeFence => MdStyle::Code,
@@ -248,8 +252,8 @@ impl MarkdownLayout {
         // Overlay inline emphasis intersecting this line, dimming the
         // delimiter bytes at the span edges. Skip inside code blocks.
         if kind != BlockKind::CodeFence {
-            let line_range = self.line_byte_start(line)
-                ..self.line_byte_start(line) + line_text.len();
+            let line_range =
+                self.line_byte_start(line)..self.line_byte_start(line) + line_text.len();
             for span in &self.inlines {
                 let start = span.bytes.start.max(line_range.start);
                 let end = span.bytes.end.min(line_range.end);
@@ -290,7 +294,11 @@ impl MarkdownLayout {
 fn compress_spans(text: &str, styles: &[MdStyle]) -> Vec<StyleSpan> {
     let mut spans: Vec<StyleSpan> = Vec::new();
     let mut start = 0usize;
-    for (i, _) in text.char_indices().skip(1).chain(std::iter::once((text.len(), ' '))) {
+    for (i, _) in text
+        .char_indices()
+        .skip(1)
+        .chain(std::iter::once((text.len(), ' ')))
+    {
         // A span breaks where the style of the char starting at `i` differs
         // from the style at `start`.
         if i == text.len() || styles[i] != styles[start] {
@@ -404,8 +412,9 @@ pub fn parse_markdown_layout(text: &str) -> MarkdownLayout {
             Event::Start(tag) => {
                 if depth == 0 {
                     match &tag {
-                        Tag::Heading { level, .. } => raw_blocks
-                            .push((BlockKind::Heading(*level as u8), range.clone())),
+                        Tag::Heading { level, .. } => {
+                            raw_blocks.push((BlockKind::Heading(*level as u8), range.clone()))
+                        }
                         Tag::Paragraph => {
                             raw_blocks.push((BlockKind::Paragraph, range.clone()));
                         }
@@ -534,6 +543,31 @@ pub fn parse_markdown_layout(text: &str) -> MarkdownLayout {
             kind: InlineKind::Link,
         });
     }
+    // Bare http(s) URLs are a render-time affordance: unlike Markdown links,
+    // they do not change the document. Skip parser-owned links and code so a
+    // URL is never double-styled or clickable inside literal source.
+    let mut excluded = excluded;
+    excluded.extend(links.iter().map(|link| link.bytes.clone()));
+    excluded.extend(images.iter().map(|image| image.bytes.clone()));
+    for range in scan_bare_http_urls(text) {
+        if excluded
+            .iter()
+            .any(|ex| range.start < ex.end && ex.start < range.end)
+        {
+            continue;
+        }
+        let url = text[range.clone()].to_string();
+        links.push(LinkTarget {
+            kind: LinkKind::BareUrl,
+            bytes: range.clone(),
+            dest: url.clone(),
+            display: url,
+        });
+        inlines.push(InlineSpan {
+            bytes: range,
+            kind: InlineKind::Link,
+        });
+    }
     links.sort_by_key(|l| l.bytes.start);
 
     if fallback_seen {
@@ -614,7 +648,60 @@ fn scan_wiki_links(text: &str) -> Vec<(Range<usize>, String)> {
     found
 }
 
-/// All links in `text` (Markdown, autolink, `[[wiki]]`), in source order.
+/// Finds bare http(s) URLs without consuming adjacent prose punctuation.
+/// Markdown/parser-owned ranges are filtered by the caller.
+fn scan_bare_http_urls(text: &str) -> Vec<Range<usize>> {
+    let mut found = Vec::new();
+    let mut offset = 0;
+    while offset < text.len() {
+        let tail = &text[offset..];
+        let start_rel = match (tail.find("http://"), tail.find("https://")) {
+            (Some(http), Some(https)) => http.min(https),
+            (Some(start), None) | (None, Some(start)) => start,
+            (None, None) => break,
+        };
+        let start = offset + start_rel;
+        let prefix_ok = start == 0
+            || !text[..start]
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '/'));
+        let mut end = text[start..]
+            .find(char::is_whitespace)
+            .map_or(text.len(), |end_rel| start + end_rel);
+        while end > start && trailing_url_punctuation(&text[start..end]) {
+            end -= text[..end]
+                .chars()
+                .next_back()
+                .expect("nonempty URL suffix")
+                .len_utf8();
+        }
+        if prefix_ok && end > start + "http://".len() {
+            found.push(start..end);
+        }
+        offset = (end.max(start + 1)).min(text.len());
+    }
+    found
+}
+
+fn trailing_url_punctuation(url: &str) -> bool {
+    match url.chars().next_back() {
+        Some('.' | ',' | '!' | '?' | ':' | ';' | ']' | '}' | '*' | '_' | '`' | '>') => true,
+        Some(')') => {
+            let opens = url.chars().filter(|&c| c == '(').count();
+            let closes = url.chars().filter(|&c| c == ')').count();
+            closes > opens
+        }
+        _ => false,
+    }
+}
+
+/// Whether `text` is exactly one pasteable bare http(s) URL.
+pub(crate) fn is_bare_http_url(text: &str) -> bool {
+    matches!(scan_bare_http_urls(text).as_slice(), [range] if range.start == 0 && range.end == text.len())
+}
+
+/// All links in `text` (Markdown, autolink, bare URL, `[[wiki]]`), in source order.
 /// Byte ranges are delimiter-inclusive.
 #[must_use]
 pub fn link_targets(text: &str) -> Vec<LinkTarget> {
@@ -719,7 +806,7 @@ mod tests {
         assert_eq!(layout.active_lines(0, 0), 0..1); // heading only
         assert_eq!(layout.active_lines(10, 10), 10..13); // whole fence
         assert_eq!(layout.active_lines(0, 2), 0..3); // heading → paragraph
-        // Reversed order works the same.
+                                                     // Reversed order works the same.
         assert_eq!(layout.active_lines(2, 0), 0..3);
     }
 
@@ -745,14 +832,32 @@ mod tests {
     fn heading_list_quote_markers_are_dimmed() {
         let layout = parse_markdown_layout(MIXED);
         let spans = layout.line_style_spans(0, "# Title");
-        assert_eq!(spans[0], StyleSpan { range: 0..2, style: MdStyle::Marker });
+        assert_eq!(
+            spans[0],
+            StyleSpan {
+                range: 0..2,
+                style: MdStyle::Marker
+            }
+        );
         assert_eq!(spans[1].style, MdStyle::Heading(1));
 
         let spans = layout.line_style_spans(5, "- [x] task done");
-        assert_eq!(spans[0], StyleSpan { range: 0..6, style: MdStyle::Marker });
+        assert_eq!(
+            spans[0],
+            StyleSpan {
+                range: 0..6,
+                style: MdStyle::Marker
+            }
+        );
 
         let spans = layout.line_style_spans(8, "> a quote line");
-        assert_eq!(spans[0], StyleSpan { range: 0..2, style: MdStyle::Marker });
+        assert_eq!(
+            spans[0],
+            StyleSpan {
+                range: 0..2,
+                style: MdStyle::Marker
+            }
+        );
         assert_eq!(spans[1].style, MdStyle::Quote);
     }
 
@@ -761,13 +866,7 @@ mod tests {
         let layout = parse_markdown_layout(MIXED);
         let line = "Some **bold** and *italic* text.";
         let spans = layout.line_style_spans(2, line);
-        let style_at = |pos: usize| {
-            spans
-                .iter()
-                .find(|s| s.range.contains(&pos))
-                .unwrap()
-                .style
-        };
+        let style_at = |pos: usize| spans.iter().find(|s| s.range.contains(&pos)).unwrap().style;
         let bold = line.find("bold").unwrap();
         let italic = line.find("italic").unwrap();
         assert_eq!(style_at(bold), MdStyle::Strong);
@@ -824,9 +923,15 @@ mod tests {
         let mut cache = MarkdownLayoutCache::default();
         let a = cache.layout_for(&TextBuffer::from_string("# a"), 1).clone();
         // Same revision: buffer is ignored, cached layout returned.
-        assert_eq!(cache.layout_for(&TextBuffer::from_string("# CHANGED"), 1), &a);
+        assert_eq!(
+            cache.layout_for(&TextBuffer::from_string("# CHANGED"), 1),
+            &a
+        );
         // New revision reparses.
-        assert_ne!(cache.layout_for(&TextBuffer::from_string("plain now"), 2), &a);
+        assert_ne!(
+            cache.layout_for(&TextBuffer::from_string("plain now"), 2),
+            &a
+        );
     }
 
     #[test]
@@ -853,13 +958,39 @@ mod tests {
     }
 
     #[test]
+    fn bare_urls_linkify_only_outside_code_and_trim_prose_punctuation() {
+        let text = "go https://example.test/a, then http://x.test/z. See https://example.test/Foo_(bar). **https://bold.test/path** `https://code.test` ![](https://image.test/p.png)\n```\nhttps://fence.test\n```";
+        let links = link_targets(text);
+        let bare: Vec<_> = links
+            .iter()
+            .filter(|link| link.kind == LinkKind::BareUrl)
+            .collect();
+        assert_eq!(bare.len(), 4);
+        assert_eq!(&text[bare[0].bytes.clone()], "https://example.test/a");
+        assert_eq!(&text[bare[1].bytes.clone()], "http://x.test/z");
+        assert_eq!(
+            &text[bare[2].bytes.clone()],
+            "https://example.test/Foo_(bar)"
+        );
+        assert_eq!(&text[bare[3].bytes.clone()], "https://bold.test/path");
+        let spans = parse_markdown_layout(text).line_style_spans(0, text.lines().next().unwrap());
+        assert_eq!(
+            spans
+                .iter()
+                .find(|span| span.range.contains(&text.find("https").unwrap()))
+                .unwrap()
+                .style,
+            MdStyle::Link
+        );
+        assert!(is_bare_http_url("https://example.test/a"));
+        assert!(!is_bare_http_url("https://example.test/a,"));
+    }
+
+    #[test]
     fn wiki_links_scan_with_exact_ranges_and_skip_code() {
         let text = "a [[trip ideas]] b `[[not this]]` c\n```\n[[nor this]]\n```\n[[second]]";
         let links = link_targets(text);
-        let wikis: Vec<_> = links
-            .iter()
-            .filter(|l| l.kind == LinkKind::Wiki)
-            .collect();
+        let wikis: Vec<_> = links.iter().filter(|l| l.kind == LinkKind::Wiki).collect();
         assert_eq!(wikis.len(), 2);
         assert_eq!(&text[wikis[0].bytes.clone()], "[[trip ideas]]");
         assert_eq!(wikis[0].dest, "trip ideas");
@@ -871,7 +1002,10 @@ mod tests {
         let text = "before\n\n![alt text](assets/pic.png)\n\n![](https://x.test/i.jpg)";
         let images = image_spans(text);
         assert_eq!(images.len(), 2);
-        assert_eq!(&text[images[0].bytes.clone()], "![alt text](assets/pic.png)");
+        assert_eq!(
+            &text[images[0].bytes.clone()],
+            "![alt text](assets/pic.png)"
+        );
         assert_eq!(images[0].dest, "assets/pic.png");
         assert_eq!(images[0].alt, "alt text");
         assert_eq!(images[1].dest, "https://x.test/i.jpg");
@@ -904,9 +1038,7 @@ mod tests {
         let text = "go [Plexi](https://plexiapp.com) and [[wiki page]] now";
         let layout = parse_markdown_layout(text);
         let spans = layout.line_style_spans(0, text);
-        let style_at = |pos: usize| {
-            spans.iter().find(|s| s.range.contains(&pos)).unwrap().style
-        };
+        let style_at = |pos: usize| spans.iter().find(|s| s.range.contains(&pos)).unwrap().style;
         assert_eq!(style_at(text.find("Plexi").unwrap()), MdStyle::Link);
         assert_eq!(style_at(text.find("wiki").unwrap()), MdStyle::Link);
         assert_eq!(style_at(0), MdStyle::Plain);

--- a/src/editor/widget.rs
+++ b/src/editor/widget.rs
@@ -16,7 +16,7 @@ use super::cursor::Cursor;
 use super::highlight::{SpanProvider, TokenKind};
 use super::mode::EditorMode;
 use super::movement::line_text;
-use super::preview::{LinkTarget, MarkdownLayoutCache, MdStyle};
+use super::preview::{is_bare_http_url, LinkTarget, MarkdownLayoutCache, MdStyle};
 use super::view::ViewState;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -434,7 +434,23 @@ impl<'a> EditorWidget<'a> {
             for event in &events {
                 match event {
                     Event::Text(text) => commands.push(EditorCommand::InsertText(text.clone())),
-                    Event::Paste(text) => commands.push(EditorCommand::InsertText(text.clone())),
+                    Event::Paste(text) => {
+                        let replacement = if self.mode.is_markdown()
+                            && self.doc.selection().is_range()
+                            && is_bare_http_url(text)
+                        {
+                            let label = self
+                                .doc
+                                .selected_text()
+                                .replace('\\', "\\\\")
+                                .replace('[', "\\[")
+                                .replace(']', "\\]");
+                            format!("[{label}]({text})")
+                        } else {
+                            text.clone()
+                        };
+                        commands.push(EditorCommand::InsertText(replacement));
+                    }
                     Event::Copy => copy_requested = true,
                     Event::Cut => cut_requested = true,
                     Event::Key {
@@ -443,6 +459,9 @@ impl<'a> EditorWidget<'a> {
                         modifiers,
                         ..
                     } => {
+                        if *key == Key::Backspace && modifiers.command {
+                            log::info!("editor: received Cmd+Backspace key event");
+                        }
                         if let Some(cmd) = translate_key(*key, *modifiers, page_rows, &self.mode) {
                             commands.push(cmd);
                         }
@@ -479,10 +498,7 @@ impl<'a> EditorWidget<'a> {
         let mut link_activation: Option<LinkTarget> = None;
         if let Some(pos) = response.interact_pointer_pos() {
             let cursor = self.hit_test(ui, &font_id, rect, gutter_width, pos);
-            if response.clicked()
-                && ui.input(|i| i.modifiers.command)
-                && self.mode.is_markdown()
-            {
+            if response.clicked() && ui.input(|i| i.modifiers.command) && self.mode.is_markdown() {
                 if let Some(cache) = self.md_cache.as_deref_mut() {
                     let layout = cache.layout_for(self.doc.buffer(), self.doc.revision());
                     let text = line_text(self.doc.buffer(), cursor.line);
@@ -547,8 +563,9 @@ impl<'a> EditorWidget<'a> {
             self.view.scroll_to_line(caret.line, line_count);
             // Keep the caret horizontally visible on unwrapped long lines.
             let text = line_text(self.doc.buffer(), caret.line);
-            let galley =
-                ui.fonts_mut(|f| f.layout_no_wrap(text.clone(), font_id.clone(), egui::Color32::WHITE));
+            let galley = ui.fonts_mut(|f| {
+                f.layout_no_wrap(text.clone(), font_id.clone(), egui::Color32::WHITE)
+            });
             let caret_x = galley
                 .pos_from_cursor(CCursor::new(caret.column.min(text.chars().count())))
                 .left();
@@ -691,7 +708,8 @@ impl<'a> EditorWidget<'a> {
         let y = pos.y - content_top + scroll_y;
         let line = self.view.line_at_y(y, line_count);
         let text = line_text(self.doc.buffer(), line);
-        let galley = ui.fonts_mut(|f| f.layout_no_wrap(text, font_id.clone(), egui::Color32::WHITE));
+        let galley =
+            ui.fonts_mut(|f| f.layout_no_wrap(text, font_id.clone(), egui::Color32::WHITE));
         let ccursor = galley.cursor_from_pos(Vec2::new(pos.x - content_left + scroll_x, 0.0));
         Cursor::new(line, ccursor.index)
     }
@@ -782,10 +800,8 @@ impl<'a> EditorWidget<'a> {
             .unwrap_or_else(|| CodeTheme::from_visuals(visuals));
         // Text clips at the gutter edge so horizontal scroll never paints
         // under the line numbers.
-        let text_rect = Rect::from_min_max(
-            egui::pos2(rect.left() + gutter_width, rect.top()),
-            rect.max,
-        );
+        let text_rect =
+            Rect::from_min_max(egui::pos2(rect.left() + gutter_width, rect.top()), rect.max);
         let painter = ui.painter_at(text_rect);
         let selection_color = visuals.selection.bg_fill.linear_multiply(0.5);
         let caret_color = visuals.selection.stroke.color;
@@ -835,9 +851,8 @@ impl<'a> EditorWidget<'a> {
                     font_id.clone(),
                     code_theme.gutter_text,
                 );
-                let number_pos =
-                    egui::pos2(content_left - GUTTER_PAD - number.size().x, top)
-                        .round_to_pixels(ppp);
+                let number_pos = egui::pos2(content_left - GUTTER_PAD - number.size().x, top)
+                    .round_to_pixels(ppp);
                 gutter_painter.galley(number_pos, number, code_theme.gutter_text);
             }
 
@@ -912,8 +927,7 @@ impl<'a> EditorWidget<'a> {
             let rendered = galley.text();
             if !rendered.is_empty() {
                 let node_id = egui::Id::new((widget_id, "editor_rendered_row", line));
-                let node_rect =
-                    Rect::from_min_size(egui::pos2(origin.x, top), galley.size());
+                let node_rect = Rect::from_min_size(egui::pos2(origin.x, top), galley.size());
                 ui.ctx().accesskit_node_builder(node_id, |node| {
                     node.set_role(egui::accesskit::Role::Paragraph);
                     node.set_value(rendered);
@@ -976,9 +990,9 @@ impl<'a> EditorWidget<'a> {
                     if extra <= 0.0 {
                         continue;
                     }
-                    let strip_top =
-                        content_top + self.view.line_top(*line) - scroll_y + self.view.line_height
-                            + IMAGE_PAD;
+                    let strip_top = content_top + self.view.line_top(*line) - scroll_y
+                        + self.view.line_height
+                        + IMAGE_PAD;
                     let height = extra - 2.0 * IMAGE_PAD;
                     let left = content_left + IMAGE_PAD - scroll_x;
                     match cache.get(ui.ctx(), base, dest) {
@@ -1016,8 +1030,7 @@ impl<'a> EditorWidget<'a> {
                                 egui::Stroke::new(1.0_f32, weak),
                                 egui::StrokeKind::Inside,
                             );
-                            let label_galley =
-                                painter.layout_no_wrap(label, font_id.clone(), weak);
+                            let label_galley = painter.layout_no_wrap(label, font_id.clone(), weak);
                             let label_pos = egui::pos2(
                                 strip_rect.left() + 8.0,
                                 strip_rect.center().y - label_galley.size().y / 2.0,
@@ -1067,9 +1080,7 @@ fn translate_key(
             Key::Tab if modifiers.shift => return Some(EditorCommand::MarkdownOutdent),
             Key::Tab if modifiers.is_none() => return Some(EditorCommand::MarkdownIndent),
             Key::Enter if modifiers.is_none() => return Some(EditorCommand::MarkdownNewline),
-            Key::Backspace if modifiers.is_none() => {
-                return Some(EditorCommand::MarkdownBackspace)
-            }
+            Key::Backspace if modifiers.is_none() => return Some(EditorCommand::MarkdownBackspace),
             _ => {}
         }
     }
@@ -1090,6 +1101,9 @@ fn translate_key(
         Key::ArrowDown => mv(Movement::Down),
         Key::Home => mv(Movement::LineStart),
         Key::End => mv(Movement::LineEnd),
+        Key::Backspace if modifiers.command && !modifiers.shift && !modifiers.alt => {
+            Some(EditorCommand::KillToLineStart)
+        }
         Key::Backspace => Some(EditorCommand::Backspace),
         Key::Delete => Some(EditorCommand::DeleteForward),
         Key::Enter => Some(EditorCommand::InsertNewline),
@@ -1243,8 +1257,8 @@ mod tests {
         };
         egui_kittest::Harness::new_ui_state(
             |ui, state: &mut ModeState| {
-                let mut widget = EditorWidget::new(&mut state.doc, &mut state.view)
-                    .mode(state.mode.clone());
+                let mut widget =
+                    EditorWidget::new(&mut state.doc, &mut state.view).mode(state.mode.clone());
                 if let Some(h) = &mut state.highlighter {
                     widget = widget.span_provider(h);
                 }
@@ -1301,7 +1315,9 @@ mod tests {
         // the document (text, selection, undo history, IME) may change.
         for mode in [
             EditorMode::PlainText,
-            EditorMode::Markdown { live_preview: false },
+            EditorMode::Markdown {
+                live_preview: false,
+            },
             EditorMode::Markdown { live_preview: true },
             EditorMode::Code {
                 language: "py".into(),
@@ -1329,7 +1345,10 @@ mod tests {
         let mode = EditorMode::Code {
             language: "not-a-language".into(),
         };
-        assert!(mode.language().and_then(crate::editor::SyntaxHighlighter::new).is_none());
+        assert!(mode
+            .language()
+            .and_then(crate::editor::SyntaxHighlighter::new)
+            .is_none());
         // The widget still renders and edits without a provider.
         let mut h = mode_harness("some text", mode);
         h.event(Event::Text("!".into()));
@@ -1380,7 +1399,10 @@ mod tests {
         // Undo through the shared history, unchanged by preview rendering.
         h.key_press_modifiers(Modifiers::COMMAND, Key::Z);
         h.step();
-        assert_eq!(h.state().doc.text(), "# Title\n\npara **bold** text\n\n- item");
+        assert_eq!(
+            h.state().doc.text(),
+            "# Title\n\npara **bold** text\n\n- item"
+        );
         // Cross-block select-all + copy path still sees the full source.
         h.key_press_modifiers(Modifiers::COMMAND, Key::A);
         h.step();
@@ -1420,6 +1442,49 @@ mod tests {
         h.event(Event::Paste("XY".into()));
         h.step();
         assert_eq!(semantic(&h).text, "aXYb");
+    }
+
+    #[test]
+    fn command_backspace_reaches_editor_and_kills_to_line_start() {
+        let mut h = harness("one\nsecond");
+        h.key_press_modifiers(Modifiers::COMMAND, Key::ArrowDown);
+        h.step();
+        h.key_press_modifiers(Modifiers::COMMAND, Key::Backspace);
+        h.step();
+        assert_eq!(semantic(&h).text, "one\n");
+        assert_eq!(
+            translate_key(
+                Key::Backspace,
+                Modifiers::COMMAND,
+                1,
+                &EditorMode::PlainText
+            ),
+            Some(EditorCommand::KillToLineStart)
+        );
+    }
+
+    #[test]
+    fn markdown_url_paste_over_selection_wraps_once_and_other_pastes_do_not() {
+        let mut h = preview_harness("Plexi");
+        h.key_press_modifiers(Modifiers::COMMAND, Key::A);
+        h.step();
+        h.event(Event::Paste("https://plexiapp.com".into()));
+        h.step();
+        assert_eq!(h.state().doc.text(), "[Plexi](https://plexiapp.com)");
+        h.state_mut().doc.apply(EditorCommand::Undo);
+        h.event(Event::Paste("not a URL".into()));
+        h.step();
+        assert_eq!(h.state().doc.text(), "not a URL");
+
+        let mut h = preview_harness("foo]bar\\baz");
+        h.key_press_modifiers(Modifiers::COMMAND, Key::A);
+        h.step();
+        h.event(Event::Paste("https://plexiapp.com".into()));
+        h.step();
+        assert_eq!(
+            h.state().doc.text(),
+            "[foo\\]bar\\\\baz](https://plexiapp.com)"
+        );
     }
 
     #[test]

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -1,6 +1,7 @@
 use crate::ui::list::{paint_selection, paint_text_centered};
 use crate::ui::style;
 use crate::ui::theme::Colors;
+use egui::emath::GuiRounding;
 use egui::{Align, Color32, CornerRadius, CursorIcon, Id, Layout, Rect, Sense, Vec2};
 
 pub const ACTION_ZONE_WIDTH: f32 = 30.0;
@@ -16,8 +17,8 @@ const ROW_PAD_V: f32 = 7.0;
 pub(crate) const PANE_DOT_RADIUS: f32 = 4.0;
 const PANE_DOT_SPACING: f32 = 11.0;
 const PANE_DOT_MAX: usize = 8;
-const WINDOW_GROUP_PAD_X: f32 = 3.0;
-const WINDOW_GROUP_PAD_Y: f32 = 3.0;
+const WINDOW_GROUP_PAD_X: f32 = 5.0;
+const WINDOW_GROUP_PAD_Y: f32 = 4.0;
 const WINDOW_GROUP_GAP: f32 = 5.0;
 const SIDEBAR_BADGE_W: f32 = 26.0;
 
@@ -138,13 +139,17 @@ fn draw_pips(
             .request_repaint_after(std::time::Duration::from_millis(100));
     }
     let painter = ui.painter();
-    let cy = rect.center().y;
+    let cy = rect
+        .center()
+        .y
+        .round_to_pixel_center(painter.pixels_per_point());
     let mut dot_centers = vec![0.0; capped];
     let mut group_rects = Vec::with_capacity(groups.len());
     let mut cursor_x = rect.min.x;
     if groups.is_empty() {
         for (dot_i, center) in dot_centers.iter_mut().enumerate() {
-            *center = cursor_x + WINDOW_GROUP_PAD_X + PANE_DOT_RADIUS;
+            *center = (cursor_x + WINDOW_GROUP_PAD_X + PANE_DOT_RADIUS)
+                .round_to_pixel_center(painter.pixels_per_point());
             cursor_x += PANE_DOT_SPACING;
             if dot_i + 1 == capped {
                 let group_rect = egui::Rect::from_min_max(
@@ -155,7 +160,8 @@ fn draw_pips(
                             + WINDOW_GROUP_PAD_X * 2.0,
                         cy + PANE_DOT_RADIUS + WINDOW_GROUP_PAD_Y,
                     ),
-                );
+                )
+                .round_to_pixels(painter.pixels_per_point());
                 painter.rect_filled(
                     group_rect,
                     egui::CornerRadius::same(4),
@@ -176,7 +182,8 @@ fn draw_pips(
                     group_width,
                     PANE_DOT_RADIUS * 2.0 + WINDOW_GROUP_PAD_Y * 2.0,
                 ),
-            );
+            )
+            .round_to_pixels(painter.pixels_per_point());
             let fill = if group.is_active {
                 with_alpha(colors.accent, 0.16 * row_alpha)
             } else {
@@ -189,7 +196,10 @@ fn draw_pips(
             } else if group.is_return_target {
                 egui::Stroke::new(
                     1.5_f32,
-                    with_alpha(colors.text_secondary(colors.bg_sidebar), row_alpha),
+                    // `border` is the theme's quiet structural outline; the
+                    // previous high-contrast text color made this capsule
+                    // compete with the context name and activity dots.
+                    with_alpha(colors.border, row_alpha),
                 )
             } else {
                 egui::Stroke::new(1.0_f32, with_alpha(colors.text_dim, 0.72 * row_alpha))
@@ -203,10 +213,11 @@ fn draw_pips(
             );
             group_rects.push((group, group_rect));
             for dot_i in start..end {
-                dot_centers[dot_i] = cursor_x
+                dot_centers[dot_i] = (cursor_x
                     + WINDOW_GROUP_PAD_X
                     + PANE_DOT_RADIUS
-                    + (dot_i - start) as f32 * PANE_DOT_SPACING;
+                    + (dot_i - start) as f32 * PANE_DOT_SPACING)
+                    .round_to_pixel_center(painter.pixels_per_point());
             }
             cursor_x += group_width;
             if group_i + 1 < groups.len() {
@@ -224,7 +235,7 @@ fn draw_pips(
         if is_dragging && agent_state.is_none() && !focused {
             color = color.gamma_multiply(0.4);
         }
-        let center = egui::pos2(cx, cy);
+        let center = egui::pos2(cx, cy).round_to_pixel_center(painter.pixels_per_point());
         if is_hidden {
             painter.circle_stroke(center, PANE_DOT_RADIUS, egui::Stroke::new(1.0_f32, color));
         } else {

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -2941,11 +2941,11 @@ mod tests {
 
     /// Stints 0528/0530 evidence: sidebar with seeded contexts (active +
     /// inactive names, path subtitles) and the spatial minimap overlay with a
-    /// workspace name, at ppp 2.0. Review: inactive context names must meet
-    /// the contrast floor, minimap name galley must sit on the pixel grid.
-    #[test]
-    fn screenshot_sidebar_and_minimap_typography_ppp2() {
-        let mut h = PlexiUiHarness::new_sized_ppp(1100.0, 700.0, 2.0);
+    /// workspace name, at 1x and 2x. Review: inactive context names must meet
+    /// the contrast floor, minimap name galley and status-dot capsules must
+    /// sit on the pixel grid.
+    fn render_sidebar_pane_dots_pixel_grid(ppp: f32, out: &str) {
+        let mut h = PlexiUiHarness::new_sized_ppp(1100.0, 700.0, ppp);
         h.step();
         add_focused_pane(&mut h);
         let inactive_ctx_id = h.with_app_mut(|app| {
@@ -3019,14 +3019,28 @@ mod tests {
         });
         // Index 2 is the inactive PLEXI context's only window: indexes 0 and
         // 1 are the active context's two spatial windows seeded above.
+        // The active context's first two windows each need a pane so its
+        // sidebar capsule draws the multi-window dot grouping this test
+        // exists to review.
+        add_focused_pane_to_window(&mut h, 1);
         add_focused_pane_to_window(&mut h, 2);
         h.with_app_mut(|app| {
             assert_eq!(app.windows[2].context_id, inactive_ctx_id);
         });
         h.run_steps(3);
-        h.save_screenshot("/tmp/plexi-0528-sidebar-minimap-ppp2.png")
+        h.save_screenshot(out)
             .expect("render failed");
-        println!("Screenshot saved to /tmp/plexi-0528-sidebar-minimap-ppp2.png");
+        println!("Screenshot saved to {out}");
+    }
+
+    #[test]
+    fn screenshot_sidebar_pane_dots_pixel_grid_ppp1() {
+        render_sidebar_pane_dots_pixel_grid(1.0, "/tmp/plexi-0564-sidebar-pips-ppp1.png");
+    }
+
+    #[test]
+    fn screenshot_sidebar_pane_dots_pixel_grid_ppp2() {
+        render_sidebar_pane_dots_pixel_grid(2.0, "/tmp/plexi-0564-sidebar-pips-ppp2.png");
     }
 
     /// Stint 0528 evidence: file browser rows + preview panel at ppp 2.0 —


### PR DESCRIPTION
## Summary

Implements stint 0561, stint 0563, and stint 0564. No linked GitHub issue — stint is authoritative.

- Adds Cmd+Backspace delete-to-line-start with atomic undo and a delivery regression.
- Linkifies bare HTTP(S) URLs safely and wraps a selected Markdown label when a URL is pasted.
- Snaps sidebar status-dot capsules to pixels, adds breathing room, and uses the theme border token for a quieter outline.

## Done When

- 0561: Cmd+Backspace deletes to the current line start, preserves selections, graphemes, and one-step undo.
- 0563: bare URLs render as clickable Markdown links outside code and existing links; URL paste over a Markdown selection creates one undoable link.
- 0564: sidebar multi-window dot capsules render crisply with increased padding and a subtle themed border at 1x and 2x.

**Test evidence (attempt 1):**
- cargo test: 2089 passed, 0 failed, 3 ignored — filters: full bin suite (env-stripped, RSS watched).
- PlexiUiHarness render: /tmp/plexi-0564-sidebar-pips-ppp1.png and /tmp/plexi-0564-sidebar-pips-ppp2.png — inspected seeded multi-window sidebar capsules and dots at 1x/2x; centers and outline are crisp and quiet. Review artifacts removed after inspection.
- Conclusion: binary install required — visible keyboard-capture and host UI behavior.