### PR TITLE
Harden agent lifecycle and CLI transport (stints 0618, 0619, 0620, 0621)

### DIFF
--- a/.agents/skills/drive-host/SKILL.md
+++ b/.agents/skills/drive-host/SKILL.md
@@ -83,11 +83,17 @@ Ground truth comes from the host, never from what you expect to have happened:
 
 ```bash
 plexi-pr-<N> pane state <pane-id>     # app panes: normalized semantic tree; terminals: status
-plexi-pr-<N> pane capture <pane-id> --lines 80
+CAPTURE_META=$(mktemp /tmp/plexi-capture-meta.XXXXXX)
+plexi-pr-<N> pane capture <pane-id> --lines 80 --plain 2>"$CAPTURE_META"
+CAPTURE_CURSOR=$(sed -n 's/^cursor=//p' "$CAPTURE_META")
+# Later: print only output/redraw deltas and advance the cursor again.
+NEXT_CAPTURE_META=$(mktemp /tmp/plexi-capture-meta.XXXXXX)
+plexi-pr-<N> pane capture <pane-id> --plain --from-cursor "$CAPTURE_CURSOR" \
+  2>"$NEXT_CAPTURE_META"
 tail -100 ~/.plexi-pr-<N>/plexi.log
 ```
 
-`pane state` exposes the last committed normalized semantic tree for process, native builtin, and WASM app panes — assert against `semantic.nodes`, not against a screenshot you eyeballed. Process panes also retain their compatible `frame` field. `pane capture` returns terminal output as a JSON array; use `--from-cursor <n>` to read only lines written since a prior capture. The channel log (`~/.plexi-pr-<N>/plexi.log`) is the source for anything the drive commands can't surface — every feature ships an `info` trace, so grep it for the behavior you seeded.
+`pane state` exposes the last committed normalized semantic tree for process, native builtin, and WASM app panes — assert against `semantic.nodes`, not against a screenshot you eyeballed. Process panes also retain their compatible `frame` field. `pane capture --plain` keeps stdout byte-clean for terminal assertions and writes `cursor=<N>` to stderr; feed that cursor to `--from-cursor` for the next changed-row delta. The channel log (`~/.plexi-pr-<N>/plexi.log`) is the source for anything the drive commands can't surface — every feature ships an `info` trace, so grep it for the behavior you seeded.
 
 ### 4. Teardown
 

--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: plexi-cli
 description: Operating inside Plexi — spawn/name panes, focus, launch apps, manage contexts, surface notifications. Use when working in a Plexi pane or orchestrating other panes.
-skill_version: "4.4.1"
+skill_version: "4.4.2"
 plexi_version: "0.2.0"
-last_verified: "2026-07-28"
+last_verified: "2026-07-29"
 ---
 
 # Plexi CLI
@@ -11,6 +11,8 @@ last_verified: "2026-07-28"
 You are running inside a Plexi pane. `PLEXI_SOCKET` is set automatically -- every `plexi` command routes to the correct running instance.
 
 **Before using any subcommand**, run `plexi <noun> --help` to confirm it exists and check its flags. Subcommands change across releases -- never assume.
+
+Socket transport failures explicitly reported as an incomplete frame were not dispatched and are safe to retry. A host response timeout happens after transport success and does not prove non-delivery; do not retry it blindly.
 
 ## Env Vars (set automatically in every pane)
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -2885,11 +2885,10 @@ impl PlexiApp {
     ///
     /// The same pass synthesizes the host-observed half of the agent detector
     /// (`TerminalPane::observed_agent`): when a known agent binary is the PTY
-    /// foreground-group leader and no lifecycle hook has reported yet, the
-    /// pane's agent identity comes from the process name and its state from
-    /// the PTY output settle. This is what makes a freshly booted Codex —
-    /// whose hooks stay silent until the first prompt submission — visible to
-    /// `pane list` and to the `pane new --agent` boot wait.
+    /// foreground-group leader, the pane's agent identity comes from the
+    /// process name (or an interpreter's script argv) and its state from the
+    /// PTY output settle. This covers both a hook-silent boot and a stale hook
+    /// Idle that contradicts sustained fresh PTY activity.
     pub(super) fn tick_terminal_activity(&mut self) {
         use crate::app_protocol::AgentState;
         for window in self.windows.iter_mut() {
@@ -2922,14 +2921,19 @@ impl PlexiApp {
                     t.activity = new;
                 }
 
-                let observed = if t.agent.is_some() || t.exited {
-                    // A hook has reported (or the shell died): hooks own the
-                    // pane's agent state from the first report onward.
+                let observed = if t.exited {
                     None
                 } else {
                     fg.filter(|fg| *fg != shell_pid as i32)
-                        .and_then(|fg| crate::host::shell::get_pid_name(fg as u32))
-                        .and_then(|name| crate::host::shell::known_agent_process(&name))
+                        .and_then(
+                            |fg| match crate::host::shell::get_pid_agent_probe(fg as u32) {
+                                crate::host::shell::AgentProcessProbe::Known(agent) => Some(agent),
+                                crate::host::shell::AgentProcessProbe::UnsupportedInterpreter {
+                                    ..
+                                }
+                                | crate::host::shell::AgentProcessProbe::Unknown => None,
+                            },
+                        )
                         .map(|agent| {
                             // A TUI that has stopped redrawing is sitting at its
                             // prompt; one that is still streaming (banner draw,
@@ -2951,6 +2955,24 @@ impl PlexiApp {
                             }
                         })
                 };
+                let was_stale_idle_fallback = t.agent.as_ref().is_some_and(|hook| {
+                    hook.state == AgentState::Idle
+                        && t.agent_reported_at.is_some_and(|reported| {
+                            reported.elapsed() >= crate::host::pane::HOOK_AGENT_FRESHNESS
+                        })
+                        && t.observed_agent.as_ref().is_some_and(|observed| {
+                            observed.agent == hook.agent && observed.state == AgentState::Working
+                        })
+                });
+                let is_stale_idle_fallback = t.agent.as_ref().is_some_and(|hook| {
+                    hook.state == AgentState::Idle
+                        && t.agent_reported_at.is_some_and(|reported| {
+                            reported.elapsed() >= crate::host::pane::HOOK_AGENT_FRESHNESS
+                        })
+                        && observed.as_ref().is_some_and(|observed| {
+                            observed.agent == hook.agent && observed.state == AgentState::Working
+                        })
+                });
                 let changed = match (&t.observed_agent, &observed) {
                     (None, None) => false,
                     (Some(a), Some(b)) => a.agent != b.agent || a.state != b.state,
@@ -2964,6 +2986,15 @@ impl PlexiApp {
                         observed.as_ref().map(|a| (&a.agent, &a.state)),
                         fg
                     );
+                    if is_stale_idle_fallback && !was_stale_idle_fallback {
+                        log::info!(
+                            "observed agent: pane {pane_id} stale hook idle yielded to corroborated working"
+                        );
+                    } else if was_stale_idle_fallback && !is_stale_idle_fallback {
+                        log::info!(
+                            "observed agent: pane {pane_id} corroborated working settled; returning to hook idle"
+                        );
+                    }
                     t.observed_agent = observed;
                 }
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -513,6 +513,28 @@ fn handle_socket_line(line: &str, mailbox: &ui_mailbox::UiMailbox<crate::app_pro
     }
 }
 
+/// Read one complete newline-delimited request frame. EOF without a newline is
+/// an incomplete transport write, even when its bytes happen to form valid
+/// JSON, and must never be dispatched.
+fn read_socket_frame(reader: &mut impl std::io::BufRead) -> std::io::Result<Option<String>> {
+    let mut line = String::new();
+    let bytes = reader.read_line(&mut line)?;
+    if bytes == 0 {
+        return Ok(None);
+    }
+    if !line.ends_with('\n') {
+        log::warn!(
+            "pane_ipc: discarded EOF-terminated partial frame bytes={bytes}; request was not dispatched"
+        );
+        return Ok(None);
+    }
+    line.pop();
+    if line.ends_with('\r') {
+        line.pop();
+    }
+    Ok(Some(line))
+}
+
 fn spawn_socket_listener(
     mailbox: ui_mailbox::UiMailbox<crate::app_protocol::AppRequest>,
     subscribe_mailbox: ui_mailbox::UiMailbox<crate::host::event_subscriptions::HostSubscribeRequest>,
@@ -570,10 +592,14 @@ fn handle_socket_connection(
             return;
         }
     };
-    let reader = BufReader::new(stream);
-    let mut lines = reader.lines();
-    let Some(Ok(first)) = lines.next() else {
-        return;
+    let mut reader = BufReader::new(stream);
+    let first = match read_socket_frame(&mut reader) {
+        Ok(Some(first)) => first,
+        Ok(None) => return,
+        Err(error) => {
+            log::warn!("pane_ipc: socket read failed: {error}");
+            return;
+        }
     };
     let first = first.trim().to_owned();
     if first.is_empty() {
@@ -585,7 +611,7 @@ fn handle_socket_connection(
     if let Ok(val) = serde_json::from_str::<serde_json::Value>(&first) {
         match val.get("type").and_then(|t| t.as_str()) {
             Some("events_subscribe") => {
-                handle_events_subscribe(write_half, lines, val, &subscribe_mailbox);
+                handle_events_subscribe(write_half, reader.lines(), val, &subscribe_mailbox);
                 return;
             }
             Some("events_list") => {
@@ -601,8 +627,15 @@ fn handle_socket_connection(
     }
     // Normal path: first line plus any remaining lines as AppRequests.
     handle_socket_line(&first, &mailbox);
-    for line in lines {
-        let Ok(line) = line else { break };
+    loop {
+        let line = match read_socket_frame(&mut reader) {
+            Ok(Some(line)) => line,
+            Ok(None) => break,
+            Err(error) => {
+                log::warn!("pane_ipc: socket read failed: {error}");
+                break;
+            }
+        };
         let line = line.trim().to_owned();
         if line.is_empty() {
             continue;

--- a/src/app/pane_wait.rs
+++ b/src/app/pane_wait.rs
@@ -82,6 +82,7 @@ const SUBMIT_SERVICE_INTERVAL: Duration = Duration::from_millis(50);
 /// only when frames run, so the boot service keeps frames coming at half that
 /// period rather than sleeping until the timeout deadline.
 const AGENT_BOOT_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const AGENT_BOOT_INTERPRETER_STABLE: Duration = Duration::from_secs(1);
 
 /// The single collapsed-paste retry, spent by moving it out of the
 /// [`PendingSubmit`].
@@ -316,6 +317,46 @@ impl PlexiApp {
             .is_some_and(|agent| agent.state == AgentState::Idle)
     }
 
+    fn unsupported_interpreter_boot(
+        &self,
+        pane_id: u64,
+        agent_cmd: &str,
+    ) -> Option<(String, Option<String>)> {
+        let requested = agent_cmd.split_whitespace().next()?;
+        let requested_name = std::path::Path::new(requested)
+            .file_name()
+            .and_then(|name| name.to_str())?;
+        // An unknown custom command may still have a valid lifecycle hook.
+        // Fail fast only when the caller explicitly requested a built-in
+        // known agent identity but the stable interpreter argv contradicts
+        // our ability to observe that identity.
+        crate::host::shell::known_agent_process(requested_name)?;
+        let terminal = self
+            .windows
+            .iter()
+            .find_map(|window| window.panes.get(&pane_id))
+            .and_then(crate::host::pane::Pane::as_terminal)?;
+        if !terminal
+            .last_pty_output_at
+            .is_some_and(|at| at.elapsed() >= AGENT_BOOT_INTERPRETER_STABLE)
+        {
+            return None;
+        }
+        let shell_pid = terminal.backend.child_pid();
+        let foreground = terminal
+            .backend
+            .foreground_pid()
+            .filter(|pid| *pid != shell_pid as i32)?;
+        match crate::host::shell::get_pid_agent_probe(foreground as u32) {
+            crate::host::shell::AgentProcessProbe::UnsupportedInterpreter {
+                interpreter,
+                script,
+            } => Some((interpreter, script)),
+            crate::host::shell::AgentProcessProbe::Known(_)
+            | crate::host::shell::AgentProcessProbe::Unknown => None,
+        }
+    }
+
     /// Fail every parked boot whose pane is gone, expire the overdue ones, and
     /// keep frames coming until the next deadline.
     ///
@@ -337,6 +378,48 @@ impl PlexiApp {
         parked.dedup();
         for pane_id in parked {
             self.complete_agent_boots(pane_id);
+        }
+        if self.pending_agent_boots.is_empty() {
+            return;
+        }
+        let unsupported: Vec<_> = self
+            .pending_agent_boots
+            .iter()
+            .filter_map(|boot| {
+                self.unsupported_interpreter_boot(boot.pane_id, &boot.agent_cmd)
+                    .map(|reason| (boot.pane_id, reason))
+            })
+            .collect();
+        for (pane_id, (interpreter, script)) in unsupported {
+            let (failed, live): (Vec<_>, Vec<_>) = std::mem::take(&mut self.pending_agent_boots)
+                .into_iter()
+                .partition(|boot| boot.pane_id == pane_id);
+            self.pending_agent_boots = live;
+            for boot in failed {
+                let script_detail = script
+                    .as_deref()
+                    .map(|path| format!(" script {path:?}"))
+                    .unwrap_or_else(|| " an unreadable script argv".to_string());
+                let error = format!(
+                    "`{}` is running under interpreter `{interpreter}` with{script_detail}, which does not identify a known agent; readiness cannot be observed at boot",
+                    boot.agent_cmd
+                );
+                log::warn!(
+                    "pane_agent_boot: pane_id={} agent_cmd={:?} fail-fast unsupported interpreter={interpreter:?} script={script:?}",
+                    boot.pane_id,
+                    boot.agent_cmd
+                );
+                crate::rpc::write_json_response(
+                    &boot.response_file,
+                    serde_json::json!({
+                        "ok": false,
+                        "timeout": false,
+                        "unsupported_interpreter": true,
+                        "pane_id": boot.pane_id,
+                        "error": error,
+                    }),
+                );
+            }
         }
         if self.pending_agent_boots.is_empty() {
             return;

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -216,6 +216,55 @@ fn socket_line_parse_error_queues_nothing() {
     );
 }
 
+fn run_socket_connection(
+    payload: &[u8],
+) -> crate::app::ui_mailbox::MailboxReceiver<crate::app_protocol::AppRequest> {
+    use std::io::Write as _;
+
+    let ctx = egui::Context::default();
+    let wake = std::sync::Arc::new(crate::app::ui_mailbox::EguiWake::new(ctx));
+    let (mailbox, rx) =
+        crate::app::ui_mailbox::UiMailbox::<crate::app_protocol::AppRequest>::channel(
+            wake.clone(),
+            "pane_ipc",
+        );
+    let (subscribe_mailbox, _subscribe_rx) = crate::app::ui_mailbox::UiMailbox::<
+        crate::host::event_subscriptions::HostSubscribeRequest,
+    >::channel(wake.clone(), "event_subscribe");
+    let (publish_mailbox, _publish_rx) = crate::app::ui_mailbox::UiMailbox::<
+        crate::host::event_subscriptions::HostPublishRequest,
+    >::channel(wake, "event_publish");
+    let (server, mut client) = std::os::unix::net::UnixStream::pair().expect("socket pair");
+    client.write_all(payload).expect("write payload");
+    client
+        .shutdown(std::net::Shutdown::Write)
+        .expect("close write half");
+    handle_socket_connection(server, mailbox, subscribe_mailbox, publish_mailbox);
+    rx
+}
+
+#[test]
+fn socket_connection_discards_valid_json_without_newline_frame() {
+    let rx = run_socket_connection(br#"{"type":"wake"}"#);
+    assert!(
+        rx.try_recv().is_err(),
+        "EOF-terminated JSON without a newline is an incomplete frame"
+    );
+}
+
+#[test]
+fn socket_connection_dispatches_newline_framed_json_once() {
+    let rx = run_socket_connection(b"{\"type\":\"wake\"}\n");
+    assert!(matches!(
+        rx.try_recv(),
+        Ok(crate::app_protocol::AppRequest::Wake)
+    ));
+    assert!(
+        rx.try_recv().is_err(),
+        "one complete frame must dispatch exactly once"
+    );
+}
+
 /// `AppRequest::Wake` through the host handler is a pure no-op: no panic,
 /// no window/pane state change.
 #[test]

--- a/src/cli/AGENTS.md
+++ b/src/cli/AGENTS.md
@@ -15,6 +15,8 @@ Every CLI command and feature must work identically on alpha, beta, main, and PR
 
 **Socket rule:** A channel-suffixed binary always sends commands to its own profile's `notify.sock`, even when it inherits a different `PLEXI_SOCKET`. The bare `plexi` binary honors `PLEXI_SOCKET`. Route new command dispatch through `resolve_command_socket()`.
 
+**Transport completion is newline-framed.** The CLI reports socket success only after the complete newline-delimited JSON frame is accepted. The host discards EOF-terminated partial frames, even when the partial bytes form valid JSON. An explicitly reported incomplete-frame transport failure was not dispatched and is safe to retry; a later host response timeout is not proof of non-delivery.
+
 **Completion testing on PR builds:** `just pr-install` skips completion install. To test, manually run `plexi-pr-<N> completions zsh > <path>` and restore after.
 
 ## CLI Design Rules

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -517,6 +517,217 @@ pub(super) fn resolve_command_socket() -> Option<std::path::PathBuf> {
     socket
 }
 
+const SOCKET_TRANSPORT_DEADLINE: std::time::Duration = std::time::Duration::from_secs(2);
+
+#[derive(Debug)]
+enum SocketTransportError {
+    ConnectTimeout,
+    Connect(std::io::Error),
+    WriteTimeout { bytes_written: usize },
+    Write {
+        source: std::io::Error,
+        bytes_written: usize,
+    },
+}
+
+fn wait_for_socket(
+    fd: std::os::fd::RawFd,
+    events: libc::c_short,
+    deadline: std::time::Instant,
+) -> std::io::Result<bool> {
+    loop {
+        let now = std::time::Instant::now();
+        if now >= deadline {
+            return Ok(false);
+        }
+        let remaining = deadline.saturating_duration_since(now);
+        let timeout_ms = remaining.as_millis().max(1).min(i32::MAX as u128) as i32;
+        let mut poll_fd = libc::pollfd {
+            fd,
+            events,
+            revents: 0,
+        };
+        let rc = unsafe { libc::poll(&mut poll_fd, 1, timeout_ms) };
+        if rc > 0 {
+            return Ok(true);
+        }
+        if rc == 0 {
+            return Ok(false);
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() != std::io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+fn classify_connect_wait(
+    result: std::io::Result<bool>,
+) -> Result<(), SocketTransportError> {
+    match result {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(SocketTransportError::ConnectTimeout),
+        Err(error) => Err(SocketTransportError::Connect(error)),
+    }
+}
+
+fn connect_unix_deadline(
+    socket_path: &std::path::Path,
+    deadline: std::time::Instant,
+) -> Result<std::os::fd::OwnedFd, SocketTransportError> {
+    use std::os::fd::FromRawFd as _;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let path = socket_path.as_os_str().as_bytes();
+    let mut addr: libc::sockaddr_un = unsafe { std::mem::zeroed() };
+    if path.len() >= addr.sun_path.len() {
+        return Err(SocketTransportError::Connect(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Unix socket path is too long",
+        )));
+    }
+    addr.sun_family = libc::AF_UNIX as libc::sa_family_t;
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "openbsd",
+        target_os = "netbsd",
+        target_os = "dragonfly"
+    ))]
+    {
+        addr.sun_len =
+            (std::mem::offset_of!(libc::sockaddr_un, sun_path) + path.len() + 1) as u8;
+    }
+    for (dst, src) in addr.sun_path.iter_mut().zip(path.iter().copied()) {
+        *dst = src as libc::c_char;
+    }
+
+    let raw_fd = unsafe { libc::socket(libc::AF_UNIX, libc::SOCK_STREAM, 0) };
+    if raw_fd < 0 {
+        return Err(SocketTransportError::Connect(
+            std::io::Error::last_os_error(),
+        ));
+    }
+    let fd = unsafe { std::os::fd::OwnedFd::from_raw_fd(raw_fd) };
+    let flags = unsafe { libc::fcntl(raw_fd, libc::F_GETFL) };
+    if flags < 0 || unsafe { libc::fcntl(raw_fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(SocketTransportError::Connect(
+            std::io::Error::last_os_error(),
+        ));
+    }
+
+    let addr_len =
+        (std::mem::offset_of!(libc::sockaddr_un, sun_path) + path.len() + 1) as libc::socklen_t;
+    let rc = unsafe {
+        libc::connect(
+            raw_fd,
+            &addr as *const libc::sockaddr_un as *const libc::sockaddr,
+            addr_len,
+        )
+    };
+    if rc == 0 {
+        return Ok(fd);
+    }
+    let error = std::io::Error::last_os_error();
+    if !error.raw_os_error().is_some_and(|code| {
+        code == libc::EINPROGRESS || code == libc::EAGAIN || code == libc::EWOULDBLOCK
+    }) {
+        return Err(SocketTransportError::Connect(error));
+    }
+    classify_connect_wait(wait_for_socket(raw_fd, libc::POLLOUT, deadline))?;
+    let mut socket_error: libc::c_int = 0;
+    let mut socket_error_len = std::mem::size_of_val(&socket_error) as libc::socklen_t;
+    let rc = unsafe {
+        libc::getsockopt(
+            raw_fd,
+            libc::SOL_SOCKET,
+            libc::SO_ERROR,
+            &mut socket_error as *mut _ as *mut libc::c_void,
+            &mut socket_error_len,
+        )
+    };
+    if rc < 0 {
+        return Err(SocketTransportError::Connect(
+            std::io::Error::last_os_error(),
+        ));
+    }
+    if socket_error != 0 {
+        return Err(SocketTransportError::Connect(
+            std::io::Error::from_raw_os_error(socket_error),
+        ));
+    }
+    Ok(fd)
+}
+
+fn send_line_to_socket(
+    socket_path: &std::path::Path,
+    line: &[u8],
+    timeout: std::time::Duration,
+) -> Result<(), SocketTransportError> {
+    use std::os::fd::AsRawFd as _;
+
+    let deadline = std::time::Instant::now() + timeout;
+    let fd = connect_unix_deadline(socket_path, deadline)?;
+    let raw_fd = fd.as_raw_fd();
+    let mut written = 0;
+    while written < line.len() {
+        if std::time::Instant::now() >= deadline {
+            return Err(SocketTransportError::WriteTimeout {
+                bytes_written: written,
+            });
+        }
+        let rc = unsafe {
+            libc::write(
+                raw_fd,
+                line[written..].as_ptr() as *const libc::c_void,
+                line.len() - written,
+            )
+        };
+        if rc > 0 {
+            written += rc as usize;
+            continue;
+        }
+        if rc == 0 {
+            return Err(SocketTransportError::Write {
+                source: std::io::Error::new(
+                    std::io::ErrorKind::WriteZero,
+                    "socket accepted zero bytes",
+                ),
+                bytes_written: written,
+            });
+        }
+        let error = std::io::Error::last_os_error();
+        if error.kind() == std::io::ErrorKind::Interrupted {
+            continue;
+        }
+        if error
+            .raw_os_error()
+            .is_some_and(|code| code == libc::EAGAIN || code == libc::EWOULDBLOCK)
+        {
+            match wait_for_socket(raw_fd, libc::POLLOUT, deadline) {
+                Ok(true) => continue,
+                Ok(false) => {
+                    return Err(SocketTransportError::WriteTimeout {
+                        bytes_written: written,
+                    });
+                }
+                Err(source) => {
+                    return Err(SocketTransportError::Write {
+                        source,
+                        bytes_written: written,
+                    });
+                }
+            }
+        }
+        return Err(SocketTransportError::Write {
+            source: error,
+            bytes_written: written,
+        });
+    }
+    Ok(())
+}
+
 pub(super) fn send_to_socket(payload: serde_json::Value) -> i32 {
     let socket_path = match resolve_command_socket() {
         Some(path) => path,
@@ -525,26 +736,179 @@ pub(super) fn send_to_socket(payload: serde_json::Value) -> i32 {
             return 1;
         }
     };
-    use std::io::Write;
-    use std::os::unix::net::UnixStream;
-    let mut stream = match UnixStream::connect(&socket_path) {
-        Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+    let line = format!("{}\n", payload);
+    let started = std::time::Instant::now();
+    match send_line_to_socket(
+        &socket_path,
+        line.as_bytes(),
+        SOCKET_TRANSPORT_DEADLINE,
+    ) {
+        Ok(()) => {
+            log::info!(
+                "cli: socket transport complete path={socket_path:?} bytes={} elapsed_ms={}",
+                line.len(),
+                started.elapsed().as_millis()
+            );
+            0
+        }
+        Err(SocketTransportError::Connect(e))
+            if e.kind() == std::io::ErrorKind::ConnectionRefused =>
+        {
             let _ = std::fs::remove_file(&socket_path);
             eprintln!("error: Plexi is not responding (stale socket removed). Is Plexi running?");
-            return 1;
+            1
         }
-        Err(e) => {
+        Err(SocketTransportError::ConnectTimeout) => {
+            log::warn!(
+                "cli: socket connect timed out path={socket_path:?} deadline_ms={}",
+                SOCKET_TRANSPORT_DEADLINE.as_millis()
+            );
+            eprintln!(
+                "error: timed out connecting to PLEXI_SOCKET {socket_path:?}; request was not delivered"
+            );
+            1
+        }
+        Err(SocketTransportError::Connect(e)) => {
+            log::warn!("cli: socket connect failed path={socket_path:?}: {e}");
             eprintln!("error: could not connect to PLEXI_SOCKET {socket_path:?}: {e}");
-            return 1;
+            1
         }
-    };
-    let line = format!("{}\n", payload);
-    if let Err(e) = stream.write_all(line.as_bytes()) {
-        eprintln!("error: could not write to socket: {e}");
-        return 1;
+        Err(SocketTransportError::WriteTimeout { bytes_written }) => {
+            log::warn!(
+                "cli: socket write timed out path={socket_path:?} bytes_written={bytes_written} payload_bytes={} deadline_ms={}",
+                line.len(),
+                SOCKET_TRANSPORT_DEADLINE.as_millis()
+            );
+            if bytes_written == 0 {
+                eprintln!(
+                    "error: timed out writing request to PLEXI_SOCKET {socket_path:?}; the incomplete frame was not delivered and is safe to retry"
+                );
+            } else {
+                eprintln!(
+                    "error: timed out writing request to PLEXI_SOCKET {socket_path:?} after {bytes_written}/{} bytes; the incomplete frame was not delivered and is safe to retry",
+                    line.len()
+                );
+            }
+            1
+        }
+        Err(SocketTransportError::Write {
+            source,
+            bytes_written,
+        }) => {
+            log::warn!(
+                "cli: socket write failed path={socket_path:?} bytes_written={bytes_written} payload_bytes={}: {source}",
+                line.len()
+            );
+            if bytes_written == 0 {
+                eprintln!("error: could not write request to socket: {source}");
+            } else {
+                eprintln!(
+                    "error: socket write failed after {bytes_written}/{} bytes: {source}; the incomplete frame was not delivered and is safe to retry",
+                    line.len()
+                );
+            }
+            1
+        }
     }
-    0
+}
+
+#[cfg(test)]
+mod transport_deadline_tests {
+    use super::{
+        connect_unix_deadline, send_line_to_socket, SocketTransportError,
+    };
+    use std::io::{BufRead as _, BufReader};
+    use std::os::unix::net::UnixListener;
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+    fn unique_socket_dir(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "pxt-{label}-{}-{:x}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+                & 0xffff_ffff
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        dir
+    }
+
+    #[test]
+    fn stalled_write_returns_with_phase_and_partial_byte_count() {
+        let dir = unique_socket_dir("write");
+        let socket = dir.join("notify.sock");
+        let listener = UnixListener::bind(&socket).expect("bind");
+        let peer = std::thread::spawn(move || {
+            let (_stream, _) = listener.accept().expect("accept");
+            std::thread::sleep(Duration::from_millis(500));
+        });
+
+        let started = Instant::now();
+        let line = vec![b'x'; 32 * 1024 * 1024];
+        let error = send_line_to_socket(&socket, &line, Duration::from_millis(100))
+            .expect_err("stalled write must time out");
+        let elapsed = started.elapsed();
+        peer.join().expect("peer");
+
+        assert!(matches!(
+            error,
+            SocketTransportError::WriteTimeout { bytes_written } if bytes_written > 0
+        ));
+        assert!(
+            elapsed < Duration::from_millis(300),
+            "write exceeded strict deadline: {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn saturated_listener_returns_connect_phase_within_deadline() {
+        let dir = unique_socket_dir("connect");
+        let socket = dir.join("notify.sock");
+        let _listener = UnixListener::bind(&socket).expect("bind");
+        let mut queued = Vec::new();
+        let started = Instant::now();
+        let error = loop {
+            match connect_unix_deadline(&socket, Instant::now() + Duration::from_millis(25)) {
+                Ok(fd) => queued.push(fd),
+                Err(error) => break error,
+            }
+            assert!(queued.len() < 512, "listener backlog did not saturate");
+        };
+        assert!(matches!(
+            error,
+            SocketTransportError::ConnectTimeout | SocketTransportError::Connect(_)
+        ));
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "connect saturation probe exceeded bound"
+        );
+    }
+
+    #[test]
+    fn connect_poll_expiry_is_typed_as_connect_timeout() {
+        let error = super::classify_connect_wait(Ok(false)).expect_err("timeout");
+        assert!(matches!(error, SocketTransportError::ConnectTimeout));
+    }
+
+    #[test]
+    fn normal_listener_receives_exact_payload_once() {
+        let dir = unique_socket_dir("exact");
+        let socket = dir.join("notify.sock");
+        let listener = UnixListener::bind(&socket).expect("bind");
+        let handle = std::thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("accept");
+            let mut line = String::new();
+            BufReader::new(stream)
+                .read_line(&mut line)
+                .expect("read request");
+            line
+        });
+        let payload = b"{\"type\":\"transport_exactly_once\"}\n";
+        send_line_to_socket(&socket, payload, Duration::from_secs(1)).expect("send");
+        assert_eq!(handle.join().expect("listener"), String::from_utf8_lossy(payload));
+    }
 }
 
 /// Best-effort wake of a running instance after a spawn-queue file write.

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -400,6 +400,35 @@ pub enum Pane {
     Portal(Box<PortalPane>),
 }
 
+/// A hook report owns the state unconditionally for this long. Afterward,
+/// host-observed Working may corroborate activity that contradicts a stale
+/// hook Idle; fresh hook reports and hook Working always remain authoritative.
+pub(crate) const HOOK_AGENT_FRESHNESS: std::time::Duration = std::time::Duration::from_secs(3);
+
+fn select_terminal_agent<'a>(
+    hook: Option<&'a crate::app_protocol::PaneAgentState>,
+    hook_reported_at: Option<std::time::Instant>,
+    observed: Option<&'a crate::app_protocol::PaneAgentState>,
+    now: std::time::Instant,
+) -> Option<&'a crate::app_protocol::PaneAgentState> {
+    let Some(hook) = hook else {
+        return observed;
+    };
+    if hook.state != crate::app_protocol::AgentState::Idle {
+        return Some(hook);
+    }
+    let hook_is_stale = hook_reported_at
+        .is_some_and(|reported| now.saturating_duration_since(reported) >= HOOK_AGENT_FRESHNESS);
+    let contradicts_idle = observed.is_some_and(|observed| {
+        observed.agent == hook.agent && observed.state == crate::app_protocol::AgentState::Working
+    });
+    if hook_is_stale && contradicts_idle {
+        observed
+    } else {
+        Some(hook)
+    }
+}
+
 /// A portal pane points at a child context and caches its rolled-up state.
 pub struct PortalPane {
     pub pane_id: PaneId,
@@ -477,14 +506,21 @@ impl Pane {
     }
 
     /// The pane's agent state, from the shared detector's two signal sources:
-    /// hook-reported state (`SetAgentState`, authoritative) when any hook has
-    /// fired, else the host-observed synthesis from `tick_terminal_activity`
-    /// (known agent process in the PTY foreground + output-settle state).
+    /// hook-reported state (`SetAgentState`, authoritative while fresh and
+    /// whenever Working) plus the host-observed synthesis from
+    /// `tick_terminal_activity` (known agent process in the PTY foreground +
+    /// output-settle state). A stale hook Idle may yield to corroborated
+    /// observed Working until the output settles again.
     /// Every consumer — `pane list`, `pane state`, the `pane new --agent`
     /// boot predicate — reads through here, so they stay correct together.
     pub fn agent(&self) -> Option<&crate::app_protocol::PaneAgentState> {
         match self {
-            Pane::Terminal(t) => t.agent.as_ref().or(t.observed_agent.as_ref()),
+            Pane::Terminal(t) => select_terminal_agent(
+                t.agent.as_ref(),
+                t.agent_reported_at,
+                t.observed_agent.as_ref(),
+                std::time::Instant::now(),
+            ),
             Pane::App(a) => a
                 .agent
                 .as_ref()
@@ -528,6 +564,7 @@ impl Pane {
     pub fn set_agent(&mut self, agent: Option<crate::app_protocol::PaneAgentState>) -> bool {
         match self {
             Pane::Terminal(t) => {
+                t.agent_reported_at = agent.as_ref().map(|_| std::time::Instant::now());
                 t.agent = agent;
                 true
             }
@@ -611,14 +648,14 @@ pub struct TerminalPane {
     /// When true, the pane is visually deprioritized (outline dot, dimmed tab title).
     pub hidden: bool,
     pub agent: Option<crate::app_protocol::PaneAgentState>,
+    /// Receipt time of the latest lifecycle hook report. Used only to bound
+    /// how long hook Idle suppresses contradictory host-observed Working.
+    pub(crate) agent_reported_at: Option<std::time::Instant>,
     /// Host-observed agent state, synthesized in `tick_terminal_activity`
-    /// when a known agent binary holds the PTY foreground and no hook has
-    /// reported yet: identity from the foreground process name, state from
-    /// the PTY output settle (`last_pty_output_at`). Covers the boot window
-    /// for agents whose lifecycle hooks stay silent until first interaction
-    /// (Codex defers `session_start` to the first prompt submission). Cleared
-    /// permanently for the pane once `agent` is set — hook reports are the
-    /// authoritative source and never compete with the synthesis.
+    /// when a known agent binary holds the PTY foreground: identity from the
+    /// foreground process name or interpreter script argv, state from the PTY
+    /// output settle (`last_pty_output_at`). Covers both the pre-hook boot
+    /// window and stale hook-Idle gaps.
     pub observed_agent: Option<crate::app_protocol::PaneAgentState>,
     /// Host-observed terminal activity (foreground process running, exited),
     /// polled via `tcgetpgrp` in `tick_terminal_activity`. Separate from
@@ -663,11 +700,76 @@ impl TerminalPane {
             outside_workspace_root: None,
             hidden: false,
             agent: None,
+            agent_reported_at: None,
             observed_agent: None,
             activity: None,
             slots: HashMap::new(),
             last_pty_output_at: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod agent_source_tests {
+    use super::*;
+    use crate::app_protocol::{AgentState, PaneAgentState};
+    use std::time::{Duration, Instant};
+
+    fn state(state: AgentState) -> PaneAgentState {
+        PaneAgentState {
+            pane_id: 7,
+            state,
+            agent: "codex".to_string(),
+            detail: None,
+            session_id: None,
+        }
+    }
+
+    #[test]
+    fn fresh_hook_idle_remains_authoritative_over_observed_working() {
+        let now = Instant::now();
+        let hook = state(AgentState::Idle);
+        let observed = state(AgentState::Working);
+        let selected = select_terminal_agent(
+            Some(&hook),
+            Some(now - Duration::from_millis(100)),
+            Some(&observed),
+            now,
+        )
+        .expect("agent");
+        assert_eq!(selected.state, AgentState::Idle);
+    }
+
+    #[test]
+    fn stale_hook_idle_yields_to_observed_working_then_returns_idle() {
+        let now = Instant::now();
+        let hook = state(AgentState::Idle);
+        let working = state(AgentState::Working);
+        let idle = state(AgentState::Idle);
+        let stale_at = now - HOOK_AGENT_FRESHNESS - Duration::from_millis(1);
+
+        let selected =
+            select_terminal_agent(Some(&hook), Some(stale_at), Some(&working), now).expect("agent");
+        assert_eq!(selected.state, AgentState::Working);
+
+        let selected =
+            select_terminal_agent(Some(&hook), Some(stale_at), Some(&idle), now).expect("agent");
+        assert_eq!(selected.state, AgentState::Idle);
+    }
+
+    #[test]
+    fn hook_working_is_never_overridden() {
+        let now = Instant::now();
+        let hook = state(AgentState::Working);
+        let observed = state(AgentState::Idle);
+        let selected = select_terminal_agent(
+            Some(&hook),
+            Some(now - HOOK_AGENT_FRESHNESS - Duration::from_secs(1)),
+            Some(&observed),
+            now,
+        )
+        .expect("agent");
+        assert_eq!(selected.state, AgentState::Working);
     }
 }
 

--- a/src/host/shell.rs
+++ b/src/host/shell.rs
@@ -462,8 +462,8 @@ fn invoked_exec_basename(pid: u32) -> Option<String> {
 /// agent detector: hooks are authoritative once they fire, but not every
 /// agent CLI emits a hook at boot (Codex defers `session_start` to the first
 /// prompt submission), so the host also recognizes the agent by its process
-/// name. Best-effort by design — a wrapper script that hides the agent binary
-/// behind another name is simply not observed until its hooks report.
+/// name. Interpreter-launched agents are resolved by [`get_pid_agent_probe`],
+/// which applies this same table to their script argv.
 pub fn known_agent_process(name: &str) -> Option<&'static str> {
     match name {
         "claude" => Some("claude-code"),
@@ -471,6 +471,149 @@ pub fn known_agent_process(name: &str) -> Option<&'static str> {
         "pi" => Some("pi"),
         _ => None,
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AgentProcessProbe {
+    Known(&'static str),
+    UnsupportedInterpreter {
+        interpreter: String,
+        script: Option<String>,
+    },
+    Unknown,
+}
+
+pub fn get_pid_agent_probe(pid: u32) -> AgentProcessProbe {
+    let Some(process_name) = get_pid_name(pid) else {
+        return AgentProcessProbe::Unknown;
+    };
+    if let Some(agent) = known_agent_process(&process_name) {
+        return AgentProcessProbe::Known(agent);
+    }
+    if !known_agent_interpreter(&process_name) {
+        return AgentProcessProbe::Unknown;
+    }
+    let args = get_pid_argv(pid).unwrap_or_default();
+    let script = args
+        .iter()
+        .find(|arg| {
+            let base = std::path::Path::new(arg)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or(arg);
+            !arg.starts_with('-')
+                && base != process_name
+                && !known_agent_interpreter(base)
+                && base != "env"
+        })
+        .cloned();
+    if let Some(agent) = script.as_deref().and_then(known_agent_script) {
+        return AgentProcessProbe::Known(agent);
+    }
+    AgentProcessProbe::UnsupportedInterpreter {
+        interpreter: process_name,
+        script,
+    }
+}
+
+fn known_agent_interpreter(name: &str) -> bool {
+    let name = name.to_ascii_lowercase();
+    matches!(name.as_str(), "node" | "nodejs" | "python" | "python3")
+        || name
+            .strip_prefix("python")
+            .is_some_and(|suffix| suffix.starts_with(|c: char| c.is_ascii_digit()))
+}
+
+fn known_agent_script(script: &str) -> Option<&'static str> {
+    let path = std::path::Path::new(script);
+    let base = path.file_stem()?.to_str()?;
+    if let Some(agent) = known_agent_process(base) {
+        return Some(agent);
+    }
+    let normalized = script.replace('\\', "/");
+    if normalized.contains("/pi-coding-agent/") {
+        Some("pi")
+    } else if normalized.contains("/claude-code/") || normalized.contains("/@anthropic-ai/") {
+        Some("claude-code")
+    } else if normalized.contains("/@openai/codex/") {
+        Some("codex")
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn get_pid_argv(pid: u32) -> Option<Vec<String>> {
+    let mut argmax: libc::c_int = 0;
+    let mut size = std::mem::size_of::<libc::c_int>();
+    let mut mib = [libc::CTL_KERN, libc::KERN_ARGMAX];
+    if unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            2,
+            &mut argmax as *mut _ as *mut libc::c_void,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    } != 0
+        || argmax <= 0
+    {
+        return None;
+    }
+    let mut buf = vec![0u8; argmax as usize];
+    let mut len = buf.len();
+    let mut mib = [libc::CTL_KERN, libc::KERN_PROCARGS2, pid as libc::c_int];
+    if unsafe {
+        libc::sysctl(
+            mib.as_mut_ptr(),
+            3,
+            buf.as_mut_ptr() as *mut libc::c_void,
+            &mut len,
+            std::ptr::null_mut(),
+            0,
+        )
+    } != 0
+        || len <= std::mem::size_of::<libc::c_int>()
+    {
+        return None;
+    }
+    let argc =
+        libc::c_int::from_ne_bytes(buf[..std::mem::size_of::<libc::c_int>()].try_into().ok()?);
+    if argc <= 0 {
+        return None;
+    }
+    let bytes = &buf[std::mem::size_of::<libc::c_int>()..len];
+    let exec_end = bytes.iter().position(|byte| *byte == 0)?;
+    let mut cursor = exec_end + 1;
+    while cursor < bytes.len() && bytes[cursor] == 0 {
+        cursor += 1;
+    }
+    let mut args = Vec::with_capacity(argc as usize);
+    while args.len() < argc as usize && cursor < bytes.len() {
+        let end = bytes[cursor..].iter().position(|byte| *byte == 0)? + cursor;
+        args.push(String::from_utf8_lossy(&bytes[cursor..end]).into_owned());
+        cursor = end + 1;
+    }
+    Some(args)
+}
+
+#[cfg(target_os = "linux")]
+fn get_pid_argv(pid: u32) -> Option<Vec<String>> {
+    let bytes = std::fs::read(format!("/proc/{pid}/cmdline")).ok()?;
+    Some(
+        bytes
+            .split(|byte| *byte == 0)
+            .filter(|arg| !arg.is_empty())
+            .map(|arg| String::from_utf8_lossy(arg).into_owned())
+            .collect(),
+    )
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn get_pid_argv(pid: u32) -> Option<Vec<String>> {
+    let _ = pid;
+    None
 }
 
 /// True when `pid` has at least one live child process. Used as one of the
@@ -711,6 +854,48 @@ mod tests {
         // normalizing a symlinked install back to its invoked basename, so
         // a resolved payload name must never reach (or match) this table.
         assert_eq!(known_agent_process("codex-aarch64-apple-darwin"), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn interpreter_script_argv_identifies_agent_through_shebang_symlink() {
+        let dir = std::env::temp_dir().join(format!(
+            "plexi-interpreter-agent-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let script = dir.join("cli.py");
+        std::fs::write(
+            &script,
+            "#!/usr/bin/env python3\nimport time\ntime.sleep(30)\n",
+        )
+        .expect("write script");
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+        let alias = dir.join("pi");
+        std::os::unix::fs::symlink(&script, &alias).expect("symlink");
+
+        let mut child = std::process::Command::new(&alias)
+            .spawn()
+            .expect("spawn interpreter-shaped agent");
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let probe = get_pid_agent_probe(child.id());
+        let process_name = get_pid_name(child.id());
+        let argv = get_pid_argv(child.id());
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert_eq!(
+            probe,
+            AgentProcessProbe::Known("pi"),
+            "process_name={process_name:?} argv={argv:?}"
+        );
     }
 
     #[test]

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -5343,6 +5343,55 @@ mod agent_boot {
         format!("{} 60", link.display())
     }
 
+    fn persistent_agent_dir(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "plexi-{label}-{}-{:x}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+                & 0xffff_ffff
+        ));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        dir
+    }
+
+    fn interpreter_script_alias(dir: &std::path::Path, alias: &str) -> String {
+        let script = dir.join("cli.py");
+        std::fs::write(
+            &script,
+            "#!/usr/bin/env python3\nimport time\ntime.sleep(60)\n",
+        )
+        .expect("write script");
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+        let link = dir.join(alias);
+        std::os::unix::fs::symlink(&script, &link).expect("symlink");
+        link.to_string_lossy().into_owned()
+    }
+
+    fn unmapped_interpreter_agent(dir: &std::path::Path) -> String {
+        let worker = dir.join("worker.py");
+        std::fs::write(&worker, "import time\ntime.sleep(60)\n").expect("write worker");
+        let launcher = dir.join("pi");
+        std::fs::write(
+            &launcher,
+            format!(
+                "#!/bin/sh\nexec /usr/bin/env python3 '{}'\n",
+                worker.display()
+            ),
+        )
+        .expect("write launcher");
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut perms = std::fs::metadata(&launcher).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&launcher, perms).unwrap();
+        launcher.to_string_lossy().into_owned()
+    }
+
     fn pane_info(h: &mut HostHarness, dir: &std::path::Path, pane_id: u64) -> serde_json::Value {
         let response = temp_response(dir, "agent-info");
         h.inject_ipc(AppRequest::GetPaneInfo {
@@ -5404,6 +5453,54 @@ mod agent_boot {
         );
     }
 
+    #[test]
+    fn agent_spawn_completes_from_interpreter_script_identity() {
+        let dir = persistent_agent_dir("interpreter-agent");
+        let mut h = HostHarness::new();
+        h.app.set_context_root(dir.clone(), None);
+        h.add_test_pane();
+
+        let command = interpreter_script_alias(&dir, "pi");
+        let response = spawn_agent_pane(&mut h, &dir, &command, Some(120.0));
+        h.run_frames(1);
+        let pane_id = spawned_terminal(&h);
+
+        pump_until_response(&mut h, &response, false);
+        let reply = read_json_response(&response);
+        assert_eq!(
+            reply["pane_id"].as_u64(),
+            Some(pane_id),
+            "interpreter script argv must feed the shared detector: {reply}"
+        );
+        let info = pane_info(&mut h, &dir, pane_id);
+        assert_eq!(info["agent"]["agent"].as_str(), Some("pi"));
+        assert_eq!(info["agent"]["state"].as_str(), Some("idle"));
+    }
+
+    #[test]
+    fn agent_spawn_fails_fast_for_unmapped_interpreter_script() {
+        let dir = persistent_agent_dir("interpreter-unsupported");
+        let mut h = HostHarness::new();
+        h.app.set_context_root(dir.clone(), None);
+        h.add_test_pane();
+
+        let command = unmapped_interpreter_agent(&dir);
+        let response = spawn_agent_pane(&mut h, &dir, &command, Some(120.0));
+        h.run_frames(1);
+        let pane_id = spawned_terminal(&h);
+
+        pump_until_response(&mut h, &response, false);
+        let reply = read_json_response(&response);
+        assert_eq!(reply["ok"].as_bool(), Some(false));
+        assert_eq!(reply["timeout"].as_bool(), Some(false));
+        assert_eq!(reply["unsupported_interpreter"].as_bool(), Some(true));
+        assert_eq!(reply["pane_id"].as_u64(), Some(pane_id));
+        assert!(
+            reply["error"].as_str().expect("error").contains(&command),
+            "fail-fast reason must name requested agent command: {reply}"
+        );
+    }
+
     /// The observed path lives in `App::logic` end to end (activity tick,
     /// boot service) — an occluded host must still complete the boot.
     #[test]
@@ -5458,8 +5555,7 @@ mod agent_boot {
         h.run_frames(1);
     }
 
-    /// Hook reports are authoritative: once one lands, it both overrides the
-    /// observed state and permanently disables synthesis for the pane.
+    /// Hook Working is authoritative even while the observed process settles.
     #[test]
     fn hook_report_overrides_observed_agent() {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -5480,8 +5576,7 @@ mod agent_boot {
         assert_eq!(info["agent"]["state"].as_str(), Some("working"));
 
         // Ride past the next detector ticks: the settled fake codex is still
-        // in the foreground, but synthesis must stay off once hooks own the
-        // pane — the hook state must not flap back to observed idle.
+        // in the foreground, but a hook Working must not flap to observed idle.
         for _ in 0..30 {
             std::thread::sleep(std::time::Duration::from_millis(50));
             h.run_frames(1);
@@ -5493,6 +5588,56 @@ mod agent_boot {
             "a hook report must permanently supersede the observed agent: {info}"
         );
         assert_eq!(info["agent"]["state"].as_str(), Some("working"));
+    }
+
+    #[test]
+    fn stale_hook_idle_yields_to_observed_working_and_settles_back() {
+        let dir = persistent_agent_dir("stale-hook");
+        let mut h = HostHarness::new();
+        h.app.set_context_root(dir.clone(), None);
+        h.add_test_pane();
+        let command = fake_idle_codex(&dir);
+        let response = spawn_agent_pane(&mut h, &dir, &command, Some(120.0));
+        h.run_frames(1);
+        let pane_id = spawned_terminal(&h);
+        pump_until_response(&mut h, &response, false);
+
+        let terminal = h.app.windows[0]
+            .panes
+            .get_mut(&pane_id)
+            .and_then(|pane| pane.as_terminal_mut())
+            .expect("terminal");
+        terminal.agent = Some(crate::app_protocol::PaneAgentState {
+            pane_id,
+            state: AgentState::Idle,
+            agent: "codex".to_string(),
+            detail: None,
+            session_id: None,
+        });
+        terminal.agent_reported_at =
+            Some(std::time::Instant::now() - crate::host::pane::HOOK_AGENT_FRESHNESS);
+        terminal.observed_agent = Some(crate::app_protocol::PaneAgentState {
+            pane_id,
+            state: AgentState::Working,
+            agent: "codex".to_string(),
+            detail: None,
+            session_id: None,
+        });
+
+        let info = pane_info(&mut h, &dir, pane_id);
+        assert_eq!(info["agent"]["state"].as_str(), Some("working"));
+
+        h.app.windows[0]
+            .panes
+            .get_mut(&pane_id)
+            .and_then(|pane| pane.as_terminal_mut())
+            .expect("terminal")
+            .observed_agent
+            .as_mut()
+            .expect("observed")
+            .state = AgentState::Idle;
+        let info = pane_info(&mut h, &dir, pane_id);
+        assert_eq!(info["agent"]["state"].as_str(), Some("idle"));
     }
 }
 


### PR DESCRIPTION
## Summary

Implements stints 0618, 0619, 0620, and 0621. No linked GitHub issue — stint is authoritative.

- 0618: keeps fresh hook reports authoritative while allowing sustained host-observed working activity to override a stale hook-idle gap, then settle back to idle.
- 0619: identifies interpreter-launched agents from script argv and fails known-but-unobservable interpreter boots promptly with a typed reason.
- 0620: adds phase-typed connect/write deadlines, complete-frame-only delivery, and exact-once framing tests for CLI Unix-socket transport.
- 0621: updates `drive-host` to use byte-clean `pane capture --plain` output and cursor deltas.

## Done When

- 0618 has a deterministic stale-idle regression without changing boot-window detection.
- 0619 covers a real shebang-plus-symlink agent and the typed fail-fast path.
- 0620 distinguishes connect and write failures, bounds stalled transport, rejects incomplete EOF frames, and delivers a normal payload exactly once.
- 0621 documents the current alpha capture command surface.

## Review

- Pre-push Codex review: clean after two passes.

**Test evidence (attempt 1):**
- focused detector, interpreter boot/fail-fast, transport, framing, and skill-surface tests: green
- cargo build: passed
- cargo test: 2109 passed, 0 failed, 3 ignored — filters: full bin suite
- Conclusion: binary install required — PTY agent lifecycle and orchestration behavior need the separate installed-build tester round
- PR install: required via `just pr-install <PR>` by the validator; not run by this Worker Mode implementation
