### PR TITLE
Restore keyboard input in fullscreen terminal panes (stint 0627)

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -93,9 +93,10 @@ impl PlexiApp {
     /// If the focused pane in the active window is a terminal and no overlay
     /// owns keyboard input, take this frame's input-intent events out of `ctx`
     /// and return them for the focused terminal (stint 0387). The caller threads
-    /// the result into `render_panels` → the tiling behavior → the focused
-    /// `TerminalView`, so the events reach the terminal without egui's
-    /// render-time widget machinery getting a chance to consume them first.
+    /// the result into `render_panels`, where whichever pane path is active
+    /// (tiled or zoomed) passes it to the focused `TerminalView`, so the events
+    /// reach the terminal without egui's render-time widget machinery getting
+    /// a chance to consume them first.
     ///
     /// Returns `None` (leaving `ctx` untouched) unless the frame's derived
     /// [`crate::app::input_owner::InputOwner`] is a terminal pane. The single

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -147,8 +147,8 @@ impl PlexiApp {
         focused_terminal_input: Option<crate::render::terminal_pane::TerminalInput>,
     ) {
         let ctx = ui.ctx().clone();
-        // Taken by the CentralPanel's tiling behavior below; rebind as `mut`
-        // so it can be `.take()`n into the behavior for the focused terminal.
+        // Taken exactly once by whichever production path renders the focused
+        // terminal this frame: the tiling behavior or the zoom overlay.
         let mut focused_terminal_input = focused_terminal_input;
         // Toolbar
         egui::Panel::top("toolbar")
@@ -464,6 +464,15 @@ impl PlexiApp {
                 ctx.assert_focus_invariants();
 
                 let zoomed_pane = ctx.zoomed_pane;
+                // The tiled tree intentionally paints only placeholders while
+                // zoomed, so retain the ownership-transferred keyboard buffer
+                // for the overlay's direct TerminalView instead of handing it
+                // to a behavior that cannot consume it.
+                let mut zoomed_terminal_input = if zoomed_pane.is_some() {
+                    focused_terminal_input.take()
+                } else {
+                    None
+                };
                 let tab_info = ctx.compute_tab_info();
                 let pane_names: HashMap<PaneId, String> = ctx
                     .panes
@@ -898,6 +907,16 @@ impl PlexiApp {
                                                     crate::ui::focus::SurfaceKey::Pane(pane_id),
                                                     egui_term::terminal_widget_id(pane_id),
                                                 );
+                                                let terminal_input =
+                                                    zoomed_terminal_input.take().unwrap_or_else(
+                                                        || {
+                                                            crate::render::terminal_pane::TerminalInput {
+                                                                keyboard_events: Vec::new(),
+                                                                modifiers: ui
+                                                                    .input(|input| input.modifiers),
+                                                            }
+                                                        },
+                                                    );
                                                 let terminal = TerminalView::new(ui, &mut t.backend)
                                                     .set_focus(owner_pane == Some(pane_id))
                                                     .set_theme(self.theme.clone())
@@ -905,7 +924,11 @@ impl PlexiApp {
                                                     .set_size(Vec2::new(
                                                         ui.available_width(),
                                                         ui.available_height(),
-                                                    ));
+                                                    ))
+                                                    .with_input(
+                                                        terminal_input.keyboard_events,
+                                                        terminal_input.modifiers,
+                                                    );
                                                 ui.add(terminal);
                                                 log::debug!("[DRAG] zoom overlay: TerminalView render done");
                                             }

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -3810,6 +3810,91 @@ fn note_semantics(h: &HostHarness, pane_id: PaneId) -> serde_json::Value {
         .expect("notes semantics")
 }
 
+// -- stint 0627: fullscreen terminal input -----------------------------------
+
+fn zoom_focused_pane_through_shortcut(h: &mut HostHarness, pane_id: PaneId) {
+    h.focus_pane(pane_id);
+    h.run_frames(2);
+    h.press_key(egui::Key::Enter, egui::Modifiers::COMMAND);
+    h.run_frames(2);
+
+    let tile = h.app.windows[0]
+        .tree
+        .tiles
+        .find_pane(&pane_id)
+        .expect("focused pane must have a tile");
+    assert_eq!(
+        h.app.windows[0].zoomed_pane,
+        Some(tile),
+        "Cmd+Enter must fullscreen the focused pane through ToggleZoom"
+    );
+}
+
+fn type_x_through_raw_input(h: &mut HostHarness) {
+    let input =
+        crate::app::key_str_to_egui_raw_input("x").expect("printable key must map to RawInput");
+    h.frame(input);
+}
+
+/// Passing control for stint 0627: physical printable-key input reaches a
+/// focused terminal while it remains in the ordinary tiled layout.
+#[test]
+fn fullscreen_input_conjunction_tiled_terminal_reaches_pty() {
+    let mut h = HostHarness::new();
+    let terminal = h.add_focused_terminal();
+    assert!(
+        h.app.windows[0].zoomed_pane.is_none(),
+        "control must remain tiled"
+    );
+
+    h.terminal_backend(terminal).enable_input_tap();
+    type_x_through_raw_input(&mut h);
+
+    assert_eq!(
+        h.terminal_backend(terminal).take_input_tap(),
+        b"x",
+        "tiled terminal must receive printable-key bytes"
+    );
+}
+
+/// Failing repro for stint 0627: the same physical printable-key input and
+/// terminal backend used by the tiled control must still reach the PTY after
+/// production Cmd+Enter fullscreening.
+#[test]
+fn fullscreen_input_conjunction_fullscreen_terminal_reaches_pty() {
+    let mut h = HostHarness::new();
+    let terminal = h.add_focused_terminal();
+    zoom_focused_pane_through_shortcut(&mut h, terminal);
+
+    h.terminal_backend(terminal).enable_input_tap();
+    type_x_through_raw_input(&mut h);
+
+    assert_eq!(
+        h.terminal_backend(terminal).take_input_tap(),
+        b"x",
+        "fullscreen terminal must receive the same printable-key bytes as tiled"
+    );
+}
+
+/// Passing control for stint 0627: fullscreen itself does not suppress input;
+/// a fullscreened editor receives the identical production RawInput and
+/// updates its observable document semantics.
+#[test]
+fn fullscreen_input_conjunction_fullscreen_editor_updates_body() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    let editor = open_focused_note(&mut h, tmp.path(), "");
+    zoom_focused_pane_through_shortcut(&mut h, editor);
+
+    type_x_through_raw_input(&mut h);
+
+    assert_eq!(
+        note_semantics(&h, editor)["source_text"],
+        "x",
+        "fullscreen editor must consume the same printable-key RawInput"
+    );
+}
+
 /// A fresh scratch editor opened while the host is occluded still owns input
 /// once it becomes visible: pane text waits for the editor's first focusable
 /// render instead of being discarded by that render's preamble.


### PR DESCRIPTION
## Summary

Implements stint 0627. No linked GitHub issue — stint is authoritative.

- Routes the ownership-transferred terminal input buffer to the fullscreen terminal renderer as well as the tiled renderer.
- Adds a failing-first HostHarness conjunction guard: tiled terminal passes, fullscreen editor passes, and fullscreen terminal now passes after the fix.
- Confirms the regression originated in the July 14 input-routing refactor, not the recent sidebar or background-host changes.

## Done When

- A fullscreen terminal pane receives physical keyboard input through the production RawInput and PTY path.
- The same terminal remains functional while tiled.
- A fullscreen editor continues receiving identical input.
- Headless binary tests are green; live GUI validation remains owned by the separate tester.

## Test evidence

**Attempt 1:**
- Failing-first repro: 2 passed, 1 failed — only `fullscreen_input_conjunction_fullscreen_terminal_reaches_pty` failed; PTY received `[]` instead of `x`.
- Targeted after fix: 3 passed, 0 failed — filter `fullscreen_input_conjunction`.
- `cargo build`: finished successfully in 39.32s; existing linker compact-unwind warning only.
- `cargo test --bin plexi`: 2112 passed, 0 failed, 3 ignored; finished in 72.95s.
- Pre-push Codex review: clean.
- Conclusion: binary install required — this changes PTY and keyboard-capture behavior.
- PR install: required via `just pr-install <PR>` by the separate tester; worker did not boot or drive a GUI host.