### PR TITLE
test: make timing gates load-aware (stint 0629)

### DIFF
--- a/scripts/daw-gate.sh
+++ b/scripts/daw-gate.sh
@@ -61,6 +61,27 @@ run_bounded() {
     return "$code"
 }
 
+# Screenshot collection is evidence, not a release condition. Under fleet load
+# the host can miss one client deadline while still being healthy, so retry a
+# bounded request with backoff and leave a load diagnostic for the tester.
+capture_screenshot_with_retry() {
+    local output="$1"
+    local log_file="$2"
+    local attempt
+    for attempt in 1 2 3; do
+        if run_bounded 20 "$plexi_bin" host screenshot --output "$output" >> "$log_file" 2>&1; then
+            return 0
+        fi
+        {
+            echo "daw-gate: screenshot attempt $attempt/3 failed; machine load diagnostic:"
+            uptime || true
+            sysctl -n vm.loadavg 2>/dev/null || true
+        } >> "$log_file"
+        [[ $attempt -lt 3 ]] && sleep "$attempt"
+    done
+    return 1
+}
+
 # Host log marker: the installed run's start/finish summary must reach the
 # channel's plexi.log, whose logger the host process owns. Bounded and
 # warn-only: a marker failure never changes the gate result.
@@ -171,10 +192,8 @@ for scene in "${scenes[@]}"; do
     # Best-effort pixel evidence. `plexi host screenshot` can silently stall
     # (pre-existing host bug, tracked separately) — bound it hard and never
     # let it affect the gate result.
-    if ! run_bounded 20 "$plexi_bin" host screenshot \
-        --output "$scene_out/host-after.png" \
-        > "$scene_out/screenshot.log" 2>&1; then
-        echo "daw-gate: warning: screenshot after scene $name failed or timed out (best-effort, gate unaffected)" \
+    if ! capture_screenshot_with_retry "$scene_out/host-after.png" "$scene_out/screenshot.log"; then
+        echo "daw-gate: warning: screenshot after scene $name failed after retries; see load diagnostics (best-effort, gate unaffected)" \
             | tee -a "$scene_out/screenshot.log" >&2
     fi
     [[ -n "$scene_entries" ]] && scene_entries+=","

--- a/scripts/editor-gate.sh
+++ b/scripts/editor-gate.sh
@@ -60,6 +60,27 @@ run_bounded() {
     return "$code"
 }
 
+# Screenshot collection is evidence, not a release condition. Under fleet load
+# the host can miss one client deadline while still being healthy, so retry a
+# bounded request with backoff and leave a load diagnostic for the tester.
+capture_screenshot_with_retry() {
+    local output="$1"
+    local log_file="$2"
+    local attempt
+    for attempt in 1 2 3; do
+        if run_bounded 20 "$plexi_bin" host screenshot --output "$output" >> "$log_file" 2>&1; then
+            return 0
+        fi
+        {
+            echo "editor-gate: screenshot attempt $attempt/3 failed; machine load diagnostic:"
+            uptime || true
+            sysctl -n vm.loadavg 2>/dev/null || true
+        } >> "$log_file"
+        [[ $attempt -lt 3 ]] && sleep "$attempt"
+    done
+    return 1
+}
+
 # Host log marker (FIX: the installed run's start/finish summary must reach
 # the channel's plexi.log, whose logger the host process owns). Bounded and
 # warn-only: a marker failure never changes the gate result.
@@ -140,10 +161,8 @@ for scene in "${scenes[@]}"; do
     # Best-effort pixel evidence. `plexi host screenshot` can silently stall
     # (pre-existing host bug, tracked separately) — bound it hard and never
     # let it affect the gate result.
-    if ! run_bounded 20 "$plexi_bin" host screenshot \
-        --output "$scene_out/host-after.png" \
-        > "$scene_out/screenshot.log" 2>&1; then
-        echo "editor-gate: warning: screenshot after scene $name failed or timed out (best-effort, gate unaffected)" \
+    if ! capture_screenshot_with_retry "$scene_out/host-after.png" "$scene_out/screenshot.log"; then
+        echo "editor-gate: warning: screenshot after scene $name failed after retries; see load diagnostics (best-effort, gate unaffected)" \
             | tee -a "$scene_out/screenshot.log" >&2
     fi
     [[ -n "$scene_entries" ]] && scene_entries+=","

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -125,8 +125,8 @@ mod tests {
     use std::fs;
     use tempfile::tempdir;
 
-    fn poll_for_signal(rx: &MailboxReceiver<()>, timeout: Duration) -> bool {
-        let deadline = Instant::now() + timeout;
+    fn poll_for_signal(rx: &MailboxReceiver<()>, base_timeout: Duration) -> bool {
+        let deadline = Instant::now() + crate::testing::load_aware_timeout(base_timeout);
         while Instant::now() < deadline {
             if rx.try_recv().is_ok() {
                 return true;
@@ -144,7 +144,9 @@ mod tests {
 
         let wake = Arc::new(RecordingWake::new());
         let (watcher, rx) = start(config.clone(), wake.clone()).expect("watcher should start");
-        thread::sleep(Duration::from_millis(150));
+        thread::sleep(crate::testing::load_aware_timeout(Duration::from_millis(
+            150,
+        )));
 
         fs::write(&config, "# v2\n").unwrap();
         assert!(
@@ -167,7 +169,9 @@ mod tests {
         let (watcher, rx) =
             start(config, Arc::new(RecordingWake::new())).expect("watcher should start");
         // Drain any initial FSEvents from the config.toml creation above.
-        thread::sleep(Duration::from_millis(500));
+        thread::sleep(crate::testing::load_aware_timeout(Duration::from_millis(
+            500,
+        )));
         while rx.try_recv().is_ok() {}
 
         fs::write(dir.path().join("other.txt"), "noise\n").unwrap();
@@ -186,7 +190,9 @@ mod tests {
 
         let (_watcher, rx) =
             start(config.clone(), Arc::new(RecordingWake::new())).expect("watcher should start");
-        thread::sleep(Duration::from_millis(150));
+        thread::sleep(crate::testing::load_aware_timeout(Duration::from_millis(
+            150,
+        )));
 
         for i in 0..5 {
             fs::write(&config, format!("# v{i}\n")).unwrap();
@@ -196,7 +202,8 @@ mod tests {
         assert!(poll_for_signal(&rx, Duration::from_secs(3)));
 
         let mut extras = 0;
-        let deadline = Instant::now() + Duration::from_millis(500);
+        let deadline =
+            Instant::now() + crate::testing::load_aware_timeout(Duration::from_millis(500));
         while Instant::now() < deadline {
             if rx.try_recv().is_ok() {
                 extras += 1;

--- a/src/host/hot_reload.rs
+++ b/src/host/hot_reload.rs
@@ -240,9 +240,9 @@ mod tests {
 
     fn poll_for_reload(
         rx: &MailboxReceiver<ReloadRequest>,
-        timeout: Duration,
+        base_timeout: Duration,
     ) -> Option<ReloadRequest> {
-        let deadline = Instant::now() + timeout;
+        let deadline = Instant::now() + crate::testing::load_aware_timeout(base_timeout);
         while Instant::now() < deadline {
             if let Ok(req) = rx.try_recv() {
                 return Some(req);
@@ -263,7 +263,9 @@ mod tests {
         watcher.watch(42, dir.path());
 
         // Give FSEvents a moment to arm before mutating.
-        thread::sleep(Duration::from_millis(150));
+        thread::sleep(crate::testing::load_aware_timeout(Duration::from_millis(
+            150,
+        )));
         fs::write(&file, "print('v2')\n").unwrap();
 
         let got = poll_for_reload(&rx, Duration::from_secs(3));
@@ -286,7 +288,9 @@ mod tests {
 
         let (mut watcher, rx) = HotReloadWatcher::new(Arc::new(RecordingWake::new()));
         watcher.watch(7, dir.path());
-        thread::sleep(Duration::from_millis(150));
+        thread::sleep(crate::testing::load_aware_timeout(Duration::from_millis(
+            150,
+        )));
 
         // Fire a tight burst — every write within ~10ms.
         for i in 0..6 {
@@ -302,7 +306,8 @@ mod tests {
         // debounce the burst should coalesce — at most one extra is OK
         // (FSEvents occasionally splits a burst across two windows).
         let mut extras = 0;
-        let deadline = Instant::now() + Duration::from_millis(600);
+        let deadline =
+            Instant::now() + crate::testing::load_aware_timeout(Duration::from_millis(600));
         while Instant::now() < deadline {
             if rx.try_recv().is_ok() {
                 extras += 1;
@@ -324,11 +329,15 @@ mod tests {
 
         let (mut watcher, rx) = HotReloadWatcher::new(Arc::new(RecordingWake::new()));
         watcher.watch(11, dir.path());
-        thread::sleep(Duration::from_millis(150));
+        thread::sleep(crate::testing::load_aware_timeout(Duration::from_millis(
+            150,
+        )));
 
         watcher.unwatch(11);
         // Drain any in-flight event from before the unwatch.
-        thread::sleep(Duration::from_millis(400));
+        thread::sleep(crate::testing::load_aware_timeout(Duration::from_millis(
+            400,
+        )));
         while rx.try_recv().is_ok() {}
 
         // Subsequent edits should never produce a ReloadRequest.

--- a/src/host/wasm_app.rs
+++ b/src/host/wasm_app.rs
@@ -1084,6 +1084,7 @@ fn fs_main() -> @location(0) vec4<f32> { return u.color; }
     }
 
     #[test]
+    #[ignore = "perf-gate: run explicitly on a quiet machine"]
     fn g11_gpu_render_pass_executes_on_device() -> Result<(), String> {
         use gpu::Host;
         let mut ctx = gpu_ctx();
@@ -1151,6 +1152,63 @@ fn fs_main() -> @location(0) vec4<f32> { return u.color; }
             "warmed render pass submit should be < 5ms, was {elapsed:?}"
         );
 
+        let img = ctx.gpu.as_ref().unwrap().read_texture(surface)?;
+        let px = img.get_pixel(32, 32);
+        assert!(
+            px[0] < 40 && px[1] > 200 && px[2] < 40,
+            "surface should be the uniform green, got {px:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn g11_gpu_render_pass_renders_uniform_color() -> Result<(), String> {
+        use gpu::Host;
+        let mut ctx = gpu_ctx();
+
+        let surface = ctx.gpu.as_mut().unwrap().alloc_surface(64, 64);
+        let view = ctx.create_surface_view(surface)?;
+        let ubuf = ctx.create_buffer(
+            "color".to_string(),
+            16,
+            gpu::BufferUsage::UNIFORM | gpu::BufferUsage::COPY_DST,
+        )?;
+        let green: [f32; 4] = [0.0, 1.0, 0.0, 1.0];
+        let green_bytes: Vec<u8> = green.iter().flat_map(|f| f.to_le_bytes()).collect();
+        ctx.write_buffer(ubuf, 0, green_bytes)?;
+        let pipeline = ctx.create_render_pipeline(
+            "uniform".to_string(),
+            UNIFORM_WGSL.to_string(),
+            gpu::RenderPipelineDesc {
+                vs_entry: "vs_main".to_string(),
+                fs_entry: "fs_main".to_string(),
+                vertex_stride: 0,
+                attrs: vec![],
+                output_format: gpu::TextureFormat::Rgba8Unorm,
+                blend_alpha: false,
+            },
+        )?;
+        let bind = ctx.create_bind_group(
+            pipeline,
+            vec![gpu::BindingEntry {
+                binding: 0,
+                resource_ref: gpu::BindingResource::Buffer(ubuf),
+            }],
+        )?;
+        ctx.submit_render_pass(gpu::RenderPassDesc {
+            target: view,
+            clear_color: Some((0.0, 0.0, 0.0, 1.0)),
+            pipeline,
+            vertex_buffer: None,
+            index_buffer: None,
+            bind_groups: vec![(0, bind)],
+            draws: vec![gpu::DrawCall {
+                vertices: 3,
+                instances: 1,
+                first_vertex: 0,
+                first_instance: 0,
+            }],
+        })?;
         let img = ctx.gpu.as_ref().unwrap().read_texture(surface)?;
         let px = img.get_pixel(32, 32);
         assert!(

--- a/src/host/wasm_app.rs
+++ b/src/host/wasm_app.rs
@@ -1085,7 +1085,7 @@ fn fs_main() -> @location(0) vec4<f32> { return u.color; }
 
     #[test]
     #[ignore = "perf-gate: run explicitly on a quiet machine"]
-    fn g11_gpu_render_pass_executes_on_device() -> Result<(), String> {
+    fn perf_gate_gpu_render_pass_executes_on_device() -> Result<(), String> {
         use gpu::Host;
         let mut ctx = gpu_ctx();
 

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -3957,6 +3957,32 @@ mod tests {
     // default 480x360 size so a regression back to synchronous readback gets
     // caught before it lands.
     #[test]
+    fn async_readback_arrives_with_load_aware_budget() -> wasmtime::Result<()> {
+        let mut p = pong_pane();
+        p.init(&StateSnapshot { entries: vec![] }, (480.0, 360.0), 0, &[])?;
+        let (w, h) = p.surface_size().expect("surface allocated after init");
+        let deadline = Instant::now()
+            + crate::testing::load_aware_timeout(std::time::Duration::from_secs(5));
+
+        p.request_surface_readback()
+            .expect("queue async surface readback");
+        let img = loop {
+            if let Some(result) = p.take_surface_readback() {
+                break result.expect("async surface readback succeeds");
+            }
+            assert!(
+                Instant::now() < deadline,
+                "async surface readback did not arrive by {deadline:?} at {w}x{h}"
+            );
+            std::thread::yield_now();
+        };
+        assert_eq!(img.width(), w);
+        assert_eq!(img.height(), h);
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "perf-gate: run explicitly on a quiet machine"]
     fn perf_gate_async_readback_within_budget() -> wasmtime::Result<()> {
         let mut p = pong_pane();
         p.init(&StateSnapshot { entries: vec![] }, (480.0, 360.0), 0, &[])?;

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -4481,7 +4481,8 @@ mod tests {
             .send(&json!({"type": "render", "frame_id": 1}))
             .expect("send render");
 
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let deadline = std::time::Instant::now()
+            + crate::testing::load_aware_timeout(std::time::Duration::from_secs(30));
         let mut messages = Vec::new();
         while std::time::Instant::now() < deadline {
             messages.extend(runtime.drain_messages().expect("valid runtime JSON"));

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -131,13 +131,22 @@ fn poll_until<T>(
 fn poll_live_until<T>(
     base_timeout: Duration,
     interval: Duration,
-    observe: impl FnMut() -> Option<T>,
+    mut observe: impl FnMut(Duration) -> Result<Option<T>, SceneError>,
 ) -> Result<T, SceneError> {
-    poll_until(
-        crate::testing::load_aware_timeout(base_timeout),
-        interval,
-        observe,
-    )
+    let started = Instant::now();
+    let deadline = started + crate::testing::load_aware_timeout(base_timeout);
+    loop {
+        if let Some(value) = observe(started.elapsed())? {
+            return Ok(value);
+        }
+        if Instant::now() >= deadline {
+            return Err(SceneError::new(
+                "eventual_timeout",
+                "eventual assertion did not pass before timeout",
+            ));
+        }
+        std::thread::sleep(interval);
+    }
 }
 
 fn live_context_count(contexts: Option<&serde_json::Value>, panes: &[serde_json::Value]) -> usize {
@@ -1179,10 +1188,11 @@ impl LiveBackend {
                 )
             })?;
         }
-        poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
-            self.json(&["host", "status", "--json"])
+        poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, |_| {
+            Ok(self
+                .json(&["host", "status", "--json"])
                 .ok()
-                .filter(|status| host_seed_ready(status, 1))
+                .filter(|status| host_seed_ready(status, 1)))
         })
         .map_err(|_| {
             SceneError::new(
@@ -1214,11 +1224,12 @@ impl LiveBackend {
         }
         self.teardown.attempted = true;
         let stopped = self.command(&["host".into(), "stop".into()], false).is_ok();
-        let gone = poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
-            self.command(&["host".into(), "status".into(), "--json".into()], false)
+        let gone = poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, |_| {
+            Ok(self
+                .command(&["host".into(), "status".into(), "--json".into()], false)
                 .ok()
                 .and_then(|out| serde_json::from_slice::<serde_json::Value>(&out.stdout).ok())
-                .filter(|status| classify_host_status(status) == HostStatusClass::Stopped)
+                .filter(|status| classify_host_status(status) == HostStatusClass::Stopped))
         })
         .is_ok();
         self.teardown.ok = stopped && gone;
@@ -1251,14 +1262,14 @@ impl LiveBackend {
         timeout: Duration,
     ) -> Result<serde_json::Value, SceneError> {
         let mut previous = None;
-        poll_live_until(timeout, LIVE_POLL_INTERVAL, || {
+        poll_live_until(timeout, LIVE_POLL_INTERVAL, |_| {
             if let Ok(state) = self.pane_state(pane_id) {
                 if previous.as_ref() == Some(&state) {
-                    return Some(state);
+                    return Ok(Some(state));
                 }
                 previous = Some(state);
             }
-            None
+            Ok(None)
         })
     }
 
@@ -1425,15 +1436,15 @@ impl LiveBackend {
             Step::Focus { focus } => {
                 let pane_id = self.handles.resolve(focus)?;
                 self.command(&["pane".into(), "focus".into(), pane_id.to_string()], true)?;
-                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
-                    self.json(&["pane", "list"]).ok().and_then(|value| {
+                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, |_| {
+                    Ok(self.json(&["pane", "list"]).ok().and_then(|value| {
                         value.as_array()?.iter().find_map(|pane| {
                             (pane.get("id").and_then(serde_json::Value::as_u64) == Some(pane_id)
                                 && pane.get("focused").and_then(serde_json::Value::as_bool)
                                     == Some(true))
                             .then_some(())
                         })
-                    })
+                    }))
                 })?;
                 log::info!(
                     "scene_live: step=focus channel={} handle={} pane_id={pane_id}",
@@ -1447,8 +1458,8 @@ impl LiveBackend {
             Step::Close { close } => {
                 let pane_id = self.handles.resolve(close)?;
                 self.command(&["pane".into(), "close".into(), pane_id.to_string()], true)?;
-                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
-                    self.json(&["pane", "list"]).ok().and_then(|value| {
+                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, |_| {
+                    Ok(self.json(&["pane", "list"]).ok().and_then(|value| {
                         value
                             .as_array()?
                             .iter()
@@ -1456,7 +1467,7 @@ impl LiveBackend {
                                 pane.get("id").and_then(serde_json::Value::as_u64) != Some(pane_id)
                             })
                             .then_some(())
-                    })
+                    }))
                 })?;
                 log::info!(
                     "scene_live: step=close channel={} handle={} pane_id={pane_id}",
@@ -1485,8 +1496,7 @@ impl LiveBackend {
                     &assert_label.target,
                     "semantic label assertion",
                 )?;
-                let deadline = Instant::now() + Duration::from_secs(5);
-                loop {
+                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, |_| {
                     let state = self.pane_state(pane_id)?;
                     let matched = state
                         .pointer("/semantic/nodes")
@@ -1500,23 +1510,27 @@ impl LiveBackend {
                             })
                         });
                     if matched {
-                        return Ok(Some(StepDetail::LabelMatched {
+                        return Ok(Some(Some(StepDetail::LabelMatched {
                             target: assert_label.target.clone(),
                             pane_id: Some(pane_id),
                             label: assert_label.label.clone(),
-                        }));
+                        })));
                     }
-                    if Instant::now() >= deadline {
-                        return Err(SceneError::new(
+                    Ok(None)
+                })
+                .map_err(|error| {
+                    if error.code == "eventual_timeout" {
+                        SceneError::new(
                             "label_not_found",
                             format!(
                                 "assert_label: {:?} not found in live pane {}",
                                 assert_label.label, pane_id
                             ),
-                        ));
+                        )
+                    } else {
+                        error
                     }
-                    std::thread::sleep(LIVE_POLL_INTERVAL);
-                }
+                })
             }
             Step::Assert { assert } => self.check_eventually(assert).map(|()| None),
             Step::Expect { expect } => self.expect(expect),
@@ -1548,8 +1562,8 @@ impl LiveBackend {
                     &["context".into(), "zoom".into(), context_id.to_string()],
                     true,
                 )?;
-                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
-                    self.json(&["context", "list"]).ok().and_then(|value| {
+                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, |_| {
+                    Ok(self.json(&["context", "list"]).ok().and_then(|value| {
                         value
                             .as_array()?
                             .iter()
@@ -1561,7 +1575,7 @@ impl LiveBackend {
                                 entry.get("is_active").and_then(serde_json::Value::as_bool)
                             })
                             .filter(|active| *active)
-                    })
+                    }))
                 })?;
                 Ok(None)
             }
@@ -1587,10 +1601,11 @@ impl LiveBackend {
                     ],
                     true,
                 )?;
-                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
-                    self.json(&["context", "list"])
+                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, |_| {
+                    Ok(self
+                        .json(&["context", "list"])
                         .ok()
-                        .and_then(|value| (value.as_array()?.len() > before).then_some(()))
+                        .and_then(|value| (value.as_array()?.len() > before).then_some(())))
                 })?;
                 Ok(None)
             }
@@ -1761,11 +1776,8 @@ impl LiveBackend {
     }
 
     fn check_eventually(&self, spec: &AssertSpec) -> Result<(), SceneError> {
-        poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
-            match self.check(spec) {
-                Ok(()) => Some(()),
-                Err(_) => None,
-            }
+        poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, |_| {
+            Ok(self.check(spec).ok())
         })
     }
 
@@ -1801,43 +1813,46 @@ impl LiveBackend {
                 true,
             )?;
         }
-        let started = Instant::now();
-        let deadline = started + Duration::from_secs_f32(spec.timeout_s);
         let mut history = Vec::new();
-        loop {
-            let state = self.pane_state(pane_id)?;
-            history.push(PollSample {
-                timestamp_ms: started.elapsed().as_millis(),
-                observed: state.clone(),
-            });
-            let changed = spec
-                .node_changes
-                .as_ref()
-                .is_none_or(|needle| state.to_string().contains(needle) && state != before);
-            let contains = spec
-                .tree_contains
-                .as_ref()
-                .is_none_or(|needle| state.to_string().contains(needle));
-            if changed && contains && notes_expectations_match(spec, &state) {
-                break;
-            }
-            if Instant::now() >= deadline {
-                return Err(SceneError::new(
-                    if spec.after_key.is_some() || spec.after_text.is_some() {
-                        "input_no_effect"
-                    } else {
-                        "eventual_timeout"
-                    },
-                    format!(
-                        "expect target '{}' did not satisfy semantic predicate; before={before}",
-                        spec.target
-                    ),
-                )
-                .with_poll_history(history));
-            }
-            std::thread::sleep(LIVE_POLL_INTERVAL);
+        let result = poll_live_until(
+            Duration::from_secs_f32(spec.timeout_s),
+            LIVE_POLL_INTERVAL,
+            |elapsed| {
+                let state = self.pane_state(pane_id)?;
+                history.push(PollSample {
+                    timestamp_ms: elapsed.as_millis(),
+                    observed: state.clone(),
+                });
+                let changed = spec
+                    .node_changes
+                    .as_ref()
+                    .is_none_or(|needle| state.to_string().contains(needle) && state != before);
+                let contains = spec
+                    .tree_contains
+                    .as_ref()
+                    .is_none_or(|needle| state.to_string().contains(needle));
+                if changed && contains && notes_expectations_match(spec, &state) {
+                    return Ok(Some(()));
+                }
+                Ok(None)
+            },
+        );
+        match result {
+            Ok(()) => Ok(None),
+            Err(error) if error.code == "eventual_timeout" => Err(SceneError::new(
+                if spec.after_key.is_some() || spec.after_text.is_some() {
+                    "input_no_effect"
+                } else {
+                    "eventual_timeout"
+                },
+                format!(
+                    "expect target '{}' did not satisfy semantic predicate; before={before}",
+                    spec.target
+                ),
+            )
+            .with_poll_history(history)),
+            Err(error) => Err(error),
         }
-        Ok(None)
     }
 }
 
@@ -3141,6 +3156,32 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error.code, "eventual_timeout");
+    }
+
+    #[test]
+    fn live_backend_real_host_polls_use_the_central_boundary() {
+        let source = include_str!("scenes.rs");
+        let start = source
+            .find("impl LiveBackend {")
+            .expect("LiveBackend implementation exists");
+        let end = source[start..]
+            .find("\n}\n\nfn geometry_failures")
+            .map(|offset| start + offset)
+            .expect("LiveBackend implementation has a stable end marker");
+        let live_backend = &source[start..end];
+
+        assert!(
+            !live_backend.contains("Instant::now"),
+            "LiveBackend host polling must use poll_live_until, never a raw deadline"
+        );
+        assert!(
+            !live_backend.contains("poll_until("),
+            "LiveBackend host polling must use load-aware poll_live_until"
+        );
+        assert!(
+            !live_backend.contains("std::thread::sleep(LIVE_POLL_INTERVAL)"),
+            "LiveBackend host polling must let poll_live_until own poll cadence"
+        );
     }
 
     #[test]

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -125,6 +125,21 @@ fn poll_until<T>(
     }
 }
 
+/// Polls an installed host response with a correctness budget. Live scenes
+/// exercise a real host and CLI transport, so their timeout is a liveness
+/// bound rather than an idle-machine performance claim.
+fn poll_live_until<T>(
+    base_timeout: Duration,
+    interval: Duration,
+    observe: impl FnMut() -> Option<T>,
+) -> Result<T, SceneError> {
+    poll_until(
+        crate::testing::load_aware_timeout(base_timeout),
+        interval,
+        observe,
+    )
+}
+
 fn live_context_count(contexts: Option<&serde_json::Value>, panes: &[serde_json::Value]) -> usize {
     contexts
         .and_then(serde_json::Value::as_array)
@@ -1164,7 +1179,7 @@ impl LiveBackend {
                 )
             })?;
         }
-        poll_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
+        poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
             self.json(&["host", "status", "--json"])
                 .ok()
                 .filter(|status| host_seed_ready(status, 1))
@@ -1199,7 +1214,7 @@ impl LiveBackend {
         }
         self.teardown.attempted = true;
         let stopped = self.command(&["host".into(), "stop".into()], false).is_ok();
-        let gone = poll_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
+        let gone = poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
             self.command(&["host".into(), "status".into(), "--json".into()], false)
                 .ok()
                 .and_then(|out| serde_json::from_slice::<serde_json::Value>(&out.stdout).ok())
@@ -1236,7 +1251,7 @@ impl LiveBackend {
         timeout: Duration,
     ) -> Result<serde_json::Value, SceneError> {
         let mut previous = None;
-        poll_until(timeout, LIVE_POLL_INTERVAL, || {
+        poll_live_until(timeout, LIVE_POLL_INTERVAL, || {
             if let Ok(state) = self.pane_state(pane_id) {
                 if previous.as_ref() == Some(&state) {
                     return Some(state);
@@ -1410,7 +1425,7 @@ impl LiveBackend {
             Step::Focus { focus } => {
                 let pane_id = self.handles.resolve(focus)?;
                 self.command(&["pane".into(), "focus".into(), pane_id.to_string()], true)?;
-                poll_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
+                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
                     self.json(&["pane", "list"]).ok().and_then(|value| {
                         value.as_array()?.iter().find_map(|pane| {
                             (pane.get("id").and_then(serde_json::Value::as_u64) == Some(pane_id)
@@ -1432,7 +1447,7 @@ impl LiveBackend {
             Step::Close { close } => {
                 let pane_id = self.handles.resolve(close)?;
                 self.command(&["pane".into(), "close".into(), pane_id.to_string()], true)?;
-                poll_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
+                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
                     self.json(&["pane", "list"]).ok().and_then(|value| {
                         value
                             .as_array()?
@@ -1533,7 +1548,7 @@ impl LiveBackend {
                     &["context".into(), "zoom".into(), context_id.to_string()],
                     true,
                 )?;
-                poll_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
+                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
                     self.json(&["context", "list"]).ok().and_then(|value| {
                         value
                             .as_array()?
@@ -1572,7 +1587,7 @@ impl LiveBackend {
                     ],
                     true,
                 )?;
-                poll_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
+                poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
                     self.json(&["context", "list"])
                         .ok()
                         .and_then(|value| (value.as_array()?.len() > before).then_some(()))
@@ -1746,7 +1761,7 @@ impl LiveBackend {
     }
 
     fn check_eventually(&self, spec: &AssertSpec) -> Result<(), SceneError> {
-        poll_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
+        poll_live_until(Duration::from_secs(5), LIVE_POLL_INTERVAL, || {
             match self.check(spec) {
                 Ok(()) => Some(()),
                 Err(_) => None,
@@ -3119,16 +3134,13 @@ mod tests {
     }
 
     #[test]
-    fn bounded_eventual_timeout_is_fast_and_structured() {
-        let started = Instant::now();
-
+    fn bounded_eventual_timeout_is_structured() {
         let error = poll_until(Duration::from_millis(3), Duration::from_millis(1), || {
             None::<()>
         })
         .unwrap_err();
 
         assert_eq!(error.code, "eventual_timeout");
-        assert!(started.elapsed() < Duration::from_millis(100));
     }
 
     #[test]

--- a/src/testing/TESTING.md
+++ b/src/testing/TESTING.md
@@ -6,6 +6,18 @@ How Plexi is tested, which layer owns what, and how to add coverage.
 
 **If you'd assert on observable state (pane tree, app UI, pixels) → write a TOML scene. If you'd assert on a return value or internal invariant → write a Rust test.** Two layers, no overlap.
 
+## Wall-clock budgets
+
+Default `cargo test --bin plexi` proves correctness, not idle-machine speed.
+Any test that waits for a real subprocess, GPU readback, or host response must
+use `crate::testing::load_aware_timeout`: it scales the one-minute load average
+against available CPUs and caps the multiplier, so fleet contention does not
+look like a product failure while a genuine hang remains bounded. Tests that
+assert a frame-time or throughput ceiling are performance gates: name them
+`perf_gate_*`, mark them `#[ignore = "perf-gate: ..."]`, and run them explicitly
+on a quiet machine. Keep a non-ignored correctness counterpart that proves the
+operation eventually completes.
+
 | Layer | Tool | Lives in | Runs |
 |---|---|---|---|
 | Pure logic | `#[test]` unit tests | next to the code | `cargo test --bin plexi` |

--- a/src/testing/TESTING.md
+++ b/src/testing/TESTING.md
@@ -9,14 +9,22 @@ How Plexi is tested, which layer owns what, and how to add coverage.
 ## Wall-clock budgets
 
 Default `cargo test --bin plexi` proves correctness, not idle-machine speed.
-Any test that waits for a real subprocess, GPU readback, or host response must
-use `crate::testing::load_aware_timeout`: it scales the one-minute load average
-against available CPUs and caps the multiplier, so fleet contention does not
-look like a product failure while a genuine hang remains bounded. Tests that
-assert a frame-time or throughput ceiling are performance gates: name them
-`perf_gate_*`, mark them `#[ignore = "perf-gate: ..."]`, and run them explicitly
-on a quiet machine. Keep a non-ignored correctness counterpart that proves the
-operation eventually completes.
+Any test that waits for a real subprocess, filesystem watcher, GPU readback, or
+host response must route its bound through `crate::testing::load_aware_timeout`.
+It scales the one-minute load average against available CPUs and caps the
+multiplier, so fleet contention does not look like a product failure while a
+genuine hang remains bounded. This does not apply to a deliberately tiny timeout
+that is an input to a pure unit test; assert its returned error, not how quickly
+the scheduler ran it. Tests that assert a frame-time or throughput ceiling are
+performance gates: name them `perf_gate_*`, mark them
+`#[ignore = "perf-gate: ..."]`, and run only those gates on a quiet machine:
+
+```bash
+cargo test --bin plexi perf_gate_ -- --ignored
+```
+
+Keep a non-ignored correctness counterpart that proves the operation eventually
+completes.
 
 | Layer | Tool | Lives in | Runs |
 |---|---|---|---|

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -1979,7 +1979,7 @@ fn click_pane_delivers_canvas_space_coordinate_through_fit_contain_transform() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "canvas-click-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2058,7 +2058,7 @@ fn click_pane_delivers_canvas_space_coordinate_through_fit_contain_transform() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "app did not report the click's canvas-space coordinate in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2113,7 +2113,7 @@ fn drag_pane_delivers_press_moves_release_through_canvas_transform() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "canvas-click-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2186,7 +2186,7 @@ fn drag_pane_delivers_press_moves_release_through_canvas_transform() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "app did not report a completed drag in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2242,7 +2242,7 @@ fn drag_pane_node_endpoints_fail_loudly_without_bounds() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "canvas-click-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2314,7 +2314,7 @@ fn emitted_app_event_is_recorded_and_awaitable() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "event-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2335,7 +2335,7 @@ fn emitted_app_event_is_recorded_and_awaitable() {
         .wait_for_app_event(
             "probe.tick",
             Some("\"count\":1"),
-            std::time::Duration::from_secs(30),
+            crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
         )
         .expect("probe.tick event recorded on the timeline");
     assert_eq!(record.event, "probe.tick");
@@ -2389,7 +2389,7 @@ fn click_pane_node_activates_button_and_mutates_guest_view() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "node-click-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2484,7 +2484,7 @@ fn click_pane_node_activates_button_and_mutates_guest_view() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "app did not reflect the node-targeted click's mutation in time (last seen: {observed_count:?})"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2630,7 +2630,7 @@ fn key_pane_delivers_key_event_and_mutates_guest_view() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "key-event-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2681,7 +2681,7 @@ fn key_pane_delivers_key_event_and_mutates_guest_view() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "app did not reflect the key event's mutation in time (last seen: {observed_count:?})"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2726,7 +2726,7 @@ fn bare_escape_closes_focused_python_wasm_pane() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "key-event-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2810,7 +2810,7 @@ fn queued_node_click_survives_a_hot_reload_relaunch_race() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "node-click-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2875,7 +2875,7 @@ fn queued_node_click_survives_a_hot_reload_relaunch_race() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "click queued before a hot-reload relaunch must still land once the \
              relaunched pane is ready again (last seen count: {observed_count:?})"
         );
@@ -3285,7 +3285,7 @@ fn wait_for_text_label(h: &mut HostHarness, pane_id: PaneId, prefix: &str, expec
             return;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "timed out waiting for label '{expected}' (last seen: {seen:?})"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -3330,7 +3330,7 @@ fn focused_text_input_receives_typing_and_enter_submits() {
             break;
         }
         assert!(
-            start.elapsed() < std::time::Duration::from_secs(30),
+            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "text-input-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -5277,7 +5277,8 @@ mod routine_firing {
 
         // The ephemeral pane closes when `true` exits; the other stays. PTY
         // exit events are drained every frame, so pump frames until settled.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        let deadline = std::time::Instant::now()
+            + crate::testing::load_aware_timeout(std::time::Duration::from_secs(15));
         while terminal_pane_ids(&h, 0).len() > 1 && std::time::Instant::now() < deadline {
             h.run_frames(1);
             std::thread::sleep(std::time::Duration::from_millis(50));
@@ -5629,7 +5630,8 @@ mod agent_boot {
     /// generously — the observed path needs real seconds: shell boot, the
     /// typed command, a full settle window, and a 1 Hz detector tick.
     fn pump_until_response(h: &mut HostHarness, response: &str, hidden: bool) {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        let deadline = std::time::Instant::now()
+            + crate::testing::load_aware_timeout(std::time::Duration::from_secs(20));
         while !std::path::Path::new(response).exists() && std::time::Instant::now() < deadline {
             std::thread::sleep(std::time::Duration::from_millis(50));
             if hidden {
@@ -5878,7 +5880,9 @@ mod pane_send_submit_tests {
     /// How long a test will wait for a submit to resolve. Comfortably above the
     /// host's own ceiling (settle + two confirm windows) so a failure here means
     /// the host never answered, not that the test was impatient.
-    const RESOLVE_TIMEOUT: Duration = Duration::from_secs(25);
+    fn resolve_timeout() -> Duration {
+        crate::testing::load_aware_timeout(Duration::from_secs(25))
+    }
 
     fn last_pty_output_at(h: &HostHarness, pane: PaneId) -> Option<Instant> {
         h.app.windows[0]
@@ -5898,7 +5902,7 @@ mod pane_send_submit_tests {
     /// a shell that never wrote anything is already as settled as it gets.
     fn settle_terminal(h: &mut HostHarness, pane: PaneId) {
         let started = Instant::now();
-        while started.elapsed() < Duration::from_secs(10) {
+        while started.elapsed() < crate::testing::load_aware_timeout(Duration::from_secs(10)) {
             h.run_frames(1);
             match last_pty_output_at(h, pane) {
                 Some(at) if at.elapsed() >= Duration::from_millis(600) => return,
@@ -5913,7 +5917,7 @@ mod pane_send_submit_tests {
     /// Pump frames until the pane's tail contains `needle`.
     fn wait_for_output(h: &mut HostHarness, pane: PaneId, needle: &str) {
         let started = Instant::now();
-        while started.elapsed() < Duration::from_secs(10) {
+        while started.elapsed() < crate::testing::load_aware_timeout(Duration::from_secs(10)) {
             h.run_frames(1);
             if tail(h, pane).iter().any(|line| line.contains(needle)) {
                 return;
@@ -5932,7 +5936,8 @@ mod pane_send_submit_tests {
     /// logic-only passes, the ones an occluded host is limited to.
     fn resolve(h: &mut HostHarness, path: &str, hidden: bool) -> serde_json::Value {
         let started = Instant::now();
-        while started.elapsed() < RESOLVE_TIMEOUT {
+        let timeout = resolve_timeout();
+        while started.elapsed() < timeout {
             if hidden {
                 h.run_hidden_frames(1);
             } else {
@@ -5944,7 +5949,7 @@ mod pane_send_submit_tests {
             }
             std::thread::sleep(Duration::from_millis(10));
         }
-        panic!("submit at {path} was never answered within {RESOLVE_TIMEOUT:?}");
+        panic!("submit at {path} was never answered within {timeout:?}");
     }
 
     fn submit(h: &HostHarness, pane: PaneId, text: &str, response_file: Option<String>) {

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -61,6 +61,44 @@ use crate::spatial::tiling::PaneId;
 use egui::RawInput;
 use std::collections::HashMap;
 use std::sync::{atomic::AtomicU64, Arc};
+use std::time::Duration;
+
+/// Returns a correctness timeout scaled for the machine's current one-minute
+/// load average. Wall-clock budgets prove that an asynchronous operation
+/// eventually completes; they are not performance claims, so a busy fleet
+/// must not turn them into false failures. The multiplier is capped to keep a
+/// genuine hang bounded even when the host is severely overloaded.
+pub(crate) fn load_aware_timeout(base: Duration) -> Duration {
+    let cores = std::thread::available_parallelism()
+        .map(|count| count.get() as f64)
+        .unwrap_or(1.0);
+    let mut load = [0.0; 3];
+    let samples = unsafe { libc::getloadavg(load.as_mut_ptr(), load.len() as i32) };
+    let multiplier = if samples > 0 {
+        load_multiplier(load[0], cores)
+    } else {
+        1
+    };
+    base.saturating_mul(multiplier)
+}
+
+fn load_multiplier(load: f64, cores: f64) -> u32 {
+    const MAX_MULTIPLIER: u32 = 4;
+    (load / cores).ceil().clamp(1.0, MAX_MULTIPLIER as f64) as u32
+}
+
+#[cfg(test)]
+mod load_aware_timeout_tests {
+    use super::*;
+
+    #[test]
+    fn correctness_budget_scales_with_load_and_stops_at_the_cap() {
+        let base = Duration::from_secs(10);
+        assert_eq!(base.saturating_mul(load_multiplier(0.5, 4.0)), base);
+        assert_eq!(base.saturating_mul(load_multiplier(7.0, 4.0)), Duration::from_secs(20));
+        assert_eq!(base.saturating_mul(load_multiplier(100.0, 4.0)), Duration::from_secs(40));
+    }
+}
 
 // ─── HostSnapshot ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Implements stint 0629. No linked GitHub issue — stint is authoritative.

- Separate the GPU/readback wall-clock performance gates from default correctness coverage.
- Scale harness correctness deadlines from the one-minute load average, capped at 4x.
- Retry best-effort live-gate screenshots with backoff and machine-load diagnostics.

## Done When

- Default `cargo test --bin plexi` excludes explicit performance gates while preserving correctness assertions.
- Timing-dependent correctness waits share a capped, load-aware budget helper.
- Screenshot collection reports retries and load diagnostics instead of a bare timeout.

## Test evidence

- `cargo test --bin plexi`: 2117 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out.
- Focused helper and async-readback tests: passed.
- `cargo build --bin plexi`, `bash -n scripts/editor-gate.sh scripts/daw-gate.sh`, and staged diff check: passed.
- Headless-only validation; no PR install or live host run.
- Codex pre-push review: no findings.