### PR TITLE
Notification lifecycle controls (stints 0608, 0610, 0611)

### DIFF
--- a/.agents/skills/babysitter/RUN_STATE.md
+++ b/.agents/skills/babysitter/RUN_STATE.md
@@ -10,13 +10,16 @@ batch7 (0629) -> #2520 as 955c9b2f, MERGED 14:17:51Z, stint 0629 verified done 1
 batch7 = brief 14:45Z -> merge 14:18Z (~2h35m across 3 tester rounds, 2 fix rounds).
 active: none. worker-7 (477) still open pending the follow-up stint; testers 478/479/480 closed.
 
-RUN BLOCKED ON DISK — read before briefing anything:
-/System/Volumes/Data at 423 MiB free of 926 GiB (100%). pr-install is a multi-GB Rust build,
-so NO tester round can run and batch8 CANNOT start. I reaped ~19 GB of agent scratch
-checkouts under /tmp and the free figure did not move, so the pressure is not only ours.
-Known large: PLEXI/target 33G, ~/Library/Caches 27G, ~/.cargo 2.6G, 12 stale ~/.plexi-pr-*
-profiles (oldest 16 Jun). Those are Ian's call, not an agent's. Surfaced to Ian 10:16 local
-with a recommendation to cargo clean the 33G target first. DO NOT RESUME until he clears it.
+DISK INCIDENT — RESOLVED 2026-07-29 ~11:00 local. Do not re-hold on it.
+Hit 423 MiB free of 926 GiB mid-batch7 (a tester died on ENOSPC). Cleared in three steps:
+head reaped ~19 GB of /tmp agent scratch checkouts, operator deleted ~13 GB of worktree
+build caches, then cargo clean in the PLEXI root freed 46 GB (57644 files). NOW 41 GiB free.
+CONSEQUENCE: the next worker faces a FULL cold Rust rebuild — its first gate will be much
+slower than the ~75s steady-state runs; that is expected, not a hang.
+Two reporting traps proven here: (1) APFS free-space reporting lags deletes by minutes — never
+conclude a delete failed from an immediate df; (2) do not hold on a free-space THRESHOLD
+guess, hold only on an actual ENOSPC failure. Still deferred to Ian: ~/Library/Caches 27G,
+12 stale ~/.plexi-pr-* profiles (oldest 16 Jun). Machine-level cleanup is his call.
 
 CAUSE + standing rule change: the "never rm -rf, leave scratch behind" clause in every brief
 is what filled the disk (four agent scratch checkouts alone = 19 GB). That clause exists to

--- a/.agents/skills/babysitter/RUN_STATE.md
+++ b/.agents/skills/babysitter/RUN_STATE.md
@@ -1,52 +1,71 @@
 # Babysitter run state — overwritten at each merge boundary
 
-updated: 2026-07-29T14:30Z (babysitter-19, Claude cm, pane 473)
-mode: stints 0629 0608 0610 0611 0607 0605 0600 0604 0630 0615 0616 0617 0577
+updated: 2026-07-29T17:35Z (babysitter-20, Claude cm, pane 476)
+mode: stints 0608 0610 0611 0607 0605 0600 0604 0630 0615 0616 0617 0577
 auto_merge: yes (RUN_CONFIG [authorization].auto_merge = true)
 
-merged: batch1 (0561+0563+0564) -> PR #2514. batch2 (0562) -> #2515. batch3 (0632) -> #2516.
-batch4 (0618+0619+0620+0621) -> #2517 as e89b796d. batch5 (0627) -> #2518 as 5c67bc5b. batch6 (0624) -> #2519 as ef8f4905,
-MERGED 12:26Z; 0624 verified done. batch6 = brief 13:05Z -> merge 12:26Z UTC (~55m),
-1 tester round, 0 fix rounds, no human check needed (all 7 scope items driven LIVE).
-batch5 (0627) merged 11:42Z, 1 tester round. Chore commit dcd525d9. Stint 0634 filed.
-active: none. worker-6 (474) and tester-11 (475) closed. Tree clean at ef8f4905.
+merged: batch1 (0561+0563+0564) -> #2514. batch2 (0562) -> #2515. batch3 (0632) -> #2516.
+batch4 (0618-0621) -> #2517. batch5 (0627) -> #2518. batch6 (0624) -> #2519.
+batch7 (0629) -> #2520 as 955c9b2f, MERGED 14:17:51Z, stint 0629 verified done 14:18:16Z.
+batch7 = brief 14:45Z -> merge 14:18Z (~2h35m across 3 tester rounds, 2 fix rounds).
+active: none. worker-7 (477) still open pending the follow-up stint; testers 478/479/480 closed.
 
-next: batch7 = 0629 SOLO. Then
-0608+0610+0611 (0609 may join ONLY if that worker proves it separable and it does not
-widen the batch). Then 0607. Then 0605+0600+0604+0630 (0630 = pane id badge missing when
-a window has only one pane, p2/S, repro-first). Then 0615+0616+0617. Then 0577.
+RUN BLOCKED ON DISK — read before briefing anything:
+/System/Volumes/Data at 423 MiB free of 926 GiB (100%). pr-install is a multi-GB Rust build,
+so NO tester round can run and batch8 CANNOT start. I reaped ~19 GB of agent scratch
+checkouts under /tmp and the free figure did not move, so the pressure is not only ours.
+Known large: PLEXI/target 33G, ~/Library/Caches 27G, ~/.cargo 2.6G, 12 stale ~/.plexi-pr-*
+profiles (oldest 16 Jun). Those are Ian's call, not an agent's. Surfaced to Ian 10:16 local
+with a recommendation to cargo clean the 33G target first. DO NOT RESUME until he clears it.
+
+CAUSE + standing rule change: the "never rm -rf, leave scratch behind" clause in every brief
+is what filled the disk (four agent scratch checkouts alone = 19 GB). That clause exists to
+stop Codex permission stalls and must NOT be dropped. Instead THE HEAD now reaps: at every
+merge boundary, after reading the verdicts, delete this batch's /tmp/plexi-* scratch dirs
+yourself. Agents still never rm -rf.
+
+next: batch8 = 0608+0610+0611 (0609 may join ONLY if that worker proves it separable and it
+does not widen the batch). Then 0607. Then 0605+0600+0604+0630 (0630 = pane id badge missing
+when a window has only one pane, p2/S, repro-first). Then 0615+0616+0617. Then 0577.
 excluded: 0601 0439 0602 0596 0598 0622
-exceptions: Park any batch at 3 fix rounds with a follow-up stint and move on. For 0577:
+exceptions: park any batch at 3 fix rounds with a follow-up stint and move on. For 0577:
 implement, gate, open a green PR, then park UNMERGED for Ian's attended review regardless
 of auto_merge.
 
 run_hazard: scene-live compiles again (0632) but its live backend still skips the optional
 screenshot and plexi host screenshot times out against an occluded host, so visual gates
-still cannot emit a PNG. Filed as stint 0633. Until it lands, testers log a missing visual
-gate as a documented HUMAN_CHECKS.md carve-out, never a product FAIL.
-run_hazard_2 (NEW, batch5): NO CLI VERB can fullscreen/zoom a pane, and `pane key <id>
-cmd+enter` writes literal PTY bytes rather than triggering the host shortcut. Any
-fullscreen-conjunction behavior is therefore harness-only-testable — brief testers
-accordingly and route it to HUMAN_CHECKS.md instead of demanding a live drive. Stint 0634.
-standing_rule: timing/wall-clock/perf failures under fleet load are a known class (stint
-0629) — one quiet-baseline rerun before chasing; if it passes quiet, cite 0629 and move on.
+cannot emit a PNG. Stint 0633. Until it lands, testers log a missing visual gate as a
+documented HUMAN_CHECKS.md carve-out, never a product FAIL.
+run_hazard_2: NO CLI VERB can fullscreen/zoom a pane, and pane key <id> cmd+enter writes
+literal PTY bytes rather than triggering the host shortcut. Fullscreen behavior is
+harness-only-testable — route it to HUMAN_CHECKS.md, never demand a live drive. Stint 0634.
+standing_rule: timing/perf failures under fleet load are a known class (0629, now landed) —
+one quiet-baseline rerun before chasing; if it passes quiet, cite 0629 and move on.
 
-head_lessons: SKILL.md, HUMAN_CHECKS.md, RUN_STATE.md are TRACKED — commit them BEFORE
-briefing the next worker (Worker Mode preflight hard-stops on a dirty root) and before any
-merge (the sync step destroys uncommitted edits). LOG.md is gitignored. Never chain a pane
-close behind file writes in one bash call. Before merging, check that the ONE behavior the
-stint is about appears BY NAME in the tester's LIVE evidence list — a PASS summary can
-silently substitute harness evidence for the live evidence the brief demanded (caught live
-on #2518 with one clarifying question; that question is not a fix round).
-lessons: live beta lacks pane send --submit, pane new --agent, pane status, AND pane slot
-wait — use the compatibility fallback. A fallback-spawned pane does NOT get the alias
-bypass, so brief every pane to never use rm -rf (fresh unique scratch dirs instead). After
-a fallback-form brief send, press enter and CONFIRM "esc to interrupt" appears — the first
-enter often only settles the paste. A head bash loop that waits for pane-idle trips on the
-momentary idle between Codex tool calls; require idle twice ~20s apart, or use the slot.
+head_lessons (batch7, NEW):
+- THE COMMIT-FIRST STEP IS NOT OPTIONAL AND WORKERS SKIP IT. I told worker-7 to commit
+  RUN_STATE.md before just merge-pr; it went straight to the merge and the sync step
+  silently reverted my whole baton to the batch6 version. Next time: verify the
+  chore(babysitter) commit EXISTS in git log before authorizing the merge command.
+- I caused a false FAIL. My fix-round brief asked for a STRUCTURAL/type-enforced boundary as
+  an aspiration; tester-14 turned that into a pass criterion and failed the PR for it, though
+  it was never in 0629's Done-When. Aspirational language in a fix brief becomes a gate.
+  State the real criterion explicitly, or say "if cheap, consider X — not a gate."
+  Overruled on the record and merged; follow-up stint for capability-token enforcement.
+- A tester hit "No space left on device" mid-round and reported it instead of guessing.
+  Trust that immediately as infrastructure, never treat it as a product finding.
+- Reading a 6-line pane tail made a working pane look idle for a cycle. Read ~20 lines
+  before concluding a send did not land.
+- codex /model <name> echoes but the footer keeps the old model — mid-run escalation is
+  unverifiable. Pick the tier at spawn; do not thrash on /model.
+
+lessons (carried): live beta lacks pane send --submit, pane new --agent, pane status, AND
+pane slot wait — use the compatibility fallback. Fallback-spawned panes do NOT get the alias
+bypass. After a fallback-form brief send, press enter and CONFIRM "esc to interrupt" appears;
+the first enter often only settles the paste. A head bash loop waiting for pane-idle trips on
+the momentary idle between Codex tool calls — require idle twice ~20s apart, or use the slot.
 Codex rejects slash-form skill invocation; worker briefs name the Worker Mode contract in
 prose. The codex footer's "medium" is reasoning effort, NOT model tier — col IS large.
-new_capability: 0624 landed on alpha (ef8f4905) — `plexi pane heartbeat <id> --every <dur>
---text "cycle"` is host-owned and idle-gated. NOT yet in the live beta binary; usable once
-beta rebuilds. It replaces the operator-as-clock half of RUN_CONFIG [cadence].
-quota: 88% of weekly Claude limit used as of 09:43Z, resets Jul 30 2pm America/Detroit.
+new_capability: 0624 (ef8f4905) — plexi pane heartbeat <id> --every <dur> --text "cycle",
+host-owned and idle-gated. Not in the live beta binary yet; usable once beta rebuilds.
+quota: 88% of weekly Claude limit used as of 09:43Z Jul 29, resets Jul 30 2pm America/Detroit.

--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plexi-cli
 description: Operating inside Plexi — spawn/name panes, focus, launch apps, manage contexts, surface notifications. Use when working in a Plexi pane or orchestrating other panes.
-skill_version: "4.4.2"
+skill_version: "4.4.3"
 plexi_version: "0.2.0"
 last_verified: "2026-07-29"
 ---
@@ -127,7 +127,10 @@ notify --title TEXT      Required. --body TEXT, --level info|warn|error,
                          never the currently active one. Outside a pane there is no
                          sending context: --scope context|window errors, and an
                          unscoped notify escalates to global.
-                         --choice "key:Label" (repeatable, blocks until chosen).
+                         Prints a notification id; use `notify dismiss ID` from the
+                         posting pane to remove it. --choice "key:Label" (repeatable,
+                         blocks until chosen). --wait-timeout SECS bounds only that choice wait
+                         (0 = wait indefinitely); --timeout always controls display lifetime.
                          --host-action "key:action_type:arg" (runs even after caller exits).
 ```
 

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -2295,6 +2295,7 @@ impl PlexiApp {
                 write_response(response_file, json_str.as_bytes());
             }
             crate::app_protocol::AppRequest::Notify {
+                notify_id,
                 level,
                 title,
                 body,
@@ -2313,13 +2314,15 @@ impl PlexiApp {
                 source_pane_id,
                 ..
             } => {
-                let internal_id = format!(
-                    "__host__:{}",
-                    std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_nanos())
-                        .unwrap_or(0)
-                );
+                let internal_id = notify_id.clone().unwrap_or_else(|| {
+                    format!(
+                        "__host__:{}",
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_nanos())
+                            .unwrap_or(0)
+                    )
+                });
                 log::info!(
                     "pane_ipc: kind=notify title={:?} choices={} scope={:?} source_context_id={:?} source_pane_id={:?} response_file={:?}",
                     title,
@@ -2422,6 +2425,28 @@ impl PlexiApp {
                         deliver_after: None,
                     },
                 );
+            }
+            crate::app_protocol::AppRequest::DismissNotification {
+                notify_id,
+                source_context_id,
+                source_pane_id,
+                response_file,
+            } => {
+                let result = match (source_context_id, source_pane_id) {
+                    (Some(_), Some(pane_id)) => self
+                        .dismiss_notification_from_sender(notify_id, *pane_id)
+                        .map(|()| "dismissed"),
+                    _ => Err("notify dismiss requires caller pane and context"),
+                };
+                match result {
+                    Ok(message) => {
+                        write_response(response_file, message.as_bytes());
+                    }
+                    Err(message) => {
+                        log::warn!("pane_ipc: notify dismiss id={notify_id:?}: {message}");
+                        write_response(response_file, message.as_bytes());
+                    }
+                }
             }
             crate::app_protocol::AppRequest::CreateContext {
                 root,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3550,13 +3550,8 @@ impl eframe::App for PlexiApp {
                     timeout_secs,
                     on_dismiss,
                 } => {
-                    let notif_source_win_id: u64 = if sender_pane_id != 0 {
-                        self.find_pane_in_any_window(sender_pane_id)
-                            .map(|(idx, _)| self.windows[idx].window_id)
-                            .unwrap_or_else(|| self.windows[self.active_window].window_id)
-                    } else {
-                        self.windows[self.active_window].window_id
-                    };
+                    let (scope, notif_source_win_id) =
+                        self.resolve_app_notification_provenance(sender_pane_id, scope);
                     // Strip any per-option shortcut that conflicts with navigation keys.
                     let options: Vec<crate::app_protocol::NotifyOption> = options.into_iter().map(|mut opt| {
                         if let Some(ref sc) = opt.shortcut.clone() {

--- a/src/app/notifications.rs
+++ b/src/app/notifications.rs
@@ -222,6 +222,69 @@ impl NotifySource {
 }
 
 impl PlexiApp {
+    /// Resolve app-notification provenance without consulting focus. A live
+    /// sender pane supplies its window; a parked or gone sender has only the
+    /// context stamped on the command, so window visibility narrows to that
+    /// context rather than borrowing the currently active window.
+    pub(crate) fn resolve_app_notification_provenance(
+        &self,
+        sender_pane_id: u64,
+        scope: crate::app_protocol::NotifyScope,
+    ) -> (crate::app_protocol::NotifyScope, u64) {
+        if let Some((window_index, _)) = (sender_pane_id != 0)
+            .then(|| self.find_pane_in_any_window(sender_pane_id))
+            .flatten()
+        {
+            return (scope, self.windows[window_index].window_id);
+        }
+        if scope == crate::app_protocol::NotifyScope::Window {
+            log::info!(
+                "notify: app sender pane_id={} has no live window — narrowing window scope to context",
+                sender_pane_id
+            );
+            return (crate::app_protocol::NotifyScope::Context, 0);
+        }
+        (scope, 0)
+    }
+
+    /// Remove a CLI notification only when the caller owns its stamped pane.
+    /// This is deliberately a queue mutation rather than
+    /// a UI-only close so sticky entries cannot survive a CLI dismissal.
+    pub(crate) fn dismiss_notification_from_sender(
+        &mut self,
+        notify_id: &str,
+        source_pane_id: u64,
+    ) -> Result<(), &'static str> {
+        let expected_owner = notify_id
+            .strip_prefix("cli:")
+            .and_then(|rest| rest.split_once(':'))
+            .and_then(|(pane_id, _)| pane_id.parse::<u64>().ok());
+        if expected_owner != Some(source_pane_id) {
+            return Err("notification not found or not owned by caller");
+        }
+        let Some(position) = self
+            .pending_notifications
+            .iter()
+            .position(|n| n.notify_id == notify_id)
+        else {
+            return Err("notification not found or not owned by caller");
+        };
+        self.pending_notifications.remove(position);
+        if self.current_notify_id.as_deref() == Some(notify_id) {
+            self.current_notify_id = None;
+        }
+        if self.pending_notifications.is_empty() {
+            self.show_notification_modal = false;
+        }
+        self.save_notifications();
+        log::info!(
+            "notify: dismissed id={} source_pane_id={}",
+            notify_id,
+            source_pane_id
+        );
+        Ok(())
+    }
+
     /// The single choke point for every notification entering the host.
     ///
     /// Owns, in one place, the policy that used to be re-decided at each of the

--- a/src/app/tests/notification_tests.rs
+++ b/src/app/tests/notification_tests.rs
@@ -817,6 +817,121 @@ fn cli_notify_request(
     }
 }
 
+/// 0608: a parked app has no sender window. Window-scoped delivery must stay
+/// in its stamped context rather than inheriting whatever window is active at
+/// dispatch.
+#[test]
+fn parked_app_window_notification_narrows_without_active_window_provenance() {
+    let mut h = HostHarness::new();
+    h.app.notifications_enabled = true;
+    let context_id = h.app.router.active().context_id;
+    let (scope, source_window_id) = h
+        .app
+        .resolve_app_notification_provenance(0, crate::app_protocol::NotifyScope::Window);
+    h.app.enqueue_notification(
+        crate::app::notifications::NotifySource::App,
+        PendingNotification {
+            notify_id: "parked-window-scope".into(),
+            sender_pane_id: 0,
+            source_context_id: context_id,
+            source_window_id,
+            level: "info".into(),
+            title: "Parked".into(),
+            body: "body".into(),
+            kind: crate::app_protocol::NotifyKind::Message,
+            options: vec![],
+            input_prompt: None,
+            required: false,
+            priority: 50,
+            scope,
+            image_inline: None,
+            image_pipe_id: None,
+            response_file: None,
+            timeout_secs: None,
+            on_dismiss: None,
+            enqueued_at: std::time::Instant::now(),
+            tombstoned: false,
+            deliver_after: None,
+        },
+    );
+
+    let notification = &h.app.pending_notifications[0];
+    assert_eq!(
+        notification.scope,
+        crate::app_protocol::NotifyScope::Context
+    );
+    assert_eq!(notification.source_window_id, 0);
+    assert_eq!(notification.source_context_id, context_id);
+}
+
+/// 0610/0611: the CLI's display timeout reaches the host payload, while a
+/// sticky CLI notification can be removed only by its posting pane.
+#[test]
+fn cli_notification_timeout_and_sender_scoped_dismissal() {
+    let mut h = HostHarness::new();
+    h.app.notifications_enabled = true;
+    let owner_pane_id = h.add_test_pane();
+    let foreign_pane_id = h.add_test_pane();
+    let context_id = h.app.router.active().context_id;
+    let response_dir = tempfile::tempdir().expect("tempdir");
+    let response_file = response_dir.path().join("dismiss-response");
+
+    h.inject_ipc(crate::app_protocol::AppRequest::Notify {
+        level: "info".into(),
+        title: "sticky".into(),
+        body: "body".into(),
+        kind: crate::app_protocol::NotifyKind::Message,
+        options: vec![],
+        input_prompt: None,
+        required: false,
+        actions: vec![],
+        notify_id: Some(format!("cli:{owner_pane_id}:sticky")),
+        priority: 50,
+        image_inline: None,
+        image_pipe_id: None,
+        timeout_secs: Some(30),
+        on_dismiss: None,
+        response_file: None,
+        scope: None,
+        source_context_id: Some(context_id),
+        source_pane_id: Some(owner_pane_id),
+    });
+    h.run_frames(2);
+
+    let posted = &h.app.pending_notifications[0];
+    assert_eq!(posted.notify_id, format!("cli:{owner_pane_id}:sticky"));
+    assert_eq!(posted.timeout_secs, Some(30));
+    assert_eq!(
+        posted.sender_pane_id, 0,
+        "CLI notifications must not auto-dismiss with their focused terminal"
+    );
+
+    h.inject_ipc(crate::app_protocol::AppRequest::DismissNotification {
+        notify_id: format!("cli:{owner_pane_id}:sticky"),
+        source_context_id: Some(context_id),
+        source_pane_id: Some(foreign_pane_id),
+        response_file: response_file.to_string_lossy().into_owned(),
+    });
+    h.run_frames(2);
+    assert_eq!(
+        h.app.pending_notifications.len(),
+        1,
+        "foreign pane must not dismiss"
+    );
+
+    h.inject_ipc(crate::app_protocol::AppRequest::DismissNotification {
+        notify_id: format!("cli:{owner_pane_id}:sticky"),
+        source_context_id: Some(context_id),
+        source_pane_id: Some(owner_pane_id),
+        response_file: response_file.to_string_lossy().into_owned(),
+    });
+    h.run_frames(2);
+    assert!(
+        h.app.pending_notifications.is_empty(),
+        "owner dismissal removes sticky notification"
+    );
+}
+
 /// 0569: an unscoped `plexi notify` from inside a pane is context-local, not
 /// global. Drives the real CLI surface end to end through pane_ipc, carrying
 /// the caller identity the CLI stamps from `PLEXI_CONTEXT_ID`.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -1,7 +1,7 @@
 use clap::{
-    Args, Parser, Subcommand,
-    builder::ValueHint,
     builder::styling::{AnsiColor, Effects, Styles},
+    builder::ValueHint,
+    Args, Parser, Subcommand,
 };
 
 fn plexi_styles() -> Styles {
@@ -143,34 +143,10 @@ pub enum Commands {
     },
     /// Send a notification to the Plexi UI.
     Notify {
-        /// Notification title (required)
-        #[arg(long)]
-        title: String,
-        /// Notification body text
-        #[arg(long, default_value = "")]
-        body: String,
-        /// Severity level: info, warn, or error
-        #[arg(long, default_value = "info", value_parser = ["info", "warn", "error"])]
-        level: String,
-        /// Add a clickable button to the notification. Format: `key:Label` (returns key when clicked) or
-        /// `Label:pane_focus:<pane_id>` (switches focus to that pane when clicked).
-        /// Repeatable.
-        #[arg(long = "choice")]
-        choices: Vec<String>,
-        /// Action to perform on the host when a button is clicked. Format: `key:action_type:action_arg`.
-        /// Repeatable. The host runs this even after the process that sent the notification has exited.
-        #[arg(long = "host-action")]
-        host_actions: Vec<String>,
-        /// Queue choice buttons without waiting for a selected value
-        #[arg(long)]
-        no_wait: bool,
-        /// How many seconds before the notification disappears (0 = stays until dismissed)
-        #[arg(long, default_value = "0")]
-        timeout: u64,
-        /// Which panes see this notification: window, context, or global
-        /// (default: context — the notification stays in the context that sent it)
-        #[arg(long, value_name = "SCOPE", value_parser = ["window", "context", "global"])]
-        scope: Option<String>,
+        #[command(subcommand)]
+        cmd: Option<NotifyCmd>,
+        #[command(flatten)]
+        post: NotifyPostArgs,
     },
 
     // ── AI ────────────────────────────────────────────────────────────────────
@@ -279,6 +255,50 @@ pub enum Commands {
     /// List run completions (hidden, used by shell completions)
     #[command(hide = true, name = "_complete-run")]
     CompleteRun,
+}
+
+#[derive(Subcommand)]
+pub enum NotifyCmd {
+    /// Remove a notification previously posted by this pane.
+    Dismiss {
+        /// Notification id printed by `plexi notify`.
+        notify_id: String,
+    },
+}
+
+#[derive(Args)]
+pub struct NotifyPostArgs {
+    /// Notification title (required when posting)
+    #[arg(long)]
+    pub title: Option<String>,
+    /// Notification body text
+    #[arg(long, default_value = "")]
+    pub body: String,
+    /// Severity level: info, warn, or error
+    #[arg(long, default_value = "info", value_parser = ["info", "warn", "error"])]
+    pub level: String,
+    /// Add a clickable button to the notification. Format: `key:Label` (returns key when clicked) or
+    /// `Label:pane_focus:<pane_id>` (switches focus to that pane when clicked).
+    /// Repeatable.
+    #[arg(long = "choice")]
+    pub choices: Vec<String>,
+    /// Action to perform on the host when a button is clicked. Format: `key:action_type:action_arg`.
+    /// Repeatable. The host runs this even after the process that sent the notification has exited.
+    #[arg(long = "host-action")]
+    pub host_actions: Vec<String>,
+    /// Queue choice buttons without waiting for a selected value
+    #[arg(long)]
+    pub no_wait: bool,
+    /// How many seconds before the notification disappears (0 = stays until dismissed)
+    #[arg(long, default_value = "0")]
+    pub timeout: u64,
+    /// How many seconds to wait for a choice response (0 = wait indefinitely)
+    #[arg(long, default_value = "0")]
+    pub wait_timeout: u64,
+    /// Which panes see this notification: window, context, or global
+    /// (default: context — the notification stays in the context that sent it)
+    #[arg(long, value_name = "SCOPE", value_parser = ["window", "context", "global"])]
+    pub scope: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -1768,9 +1788,32 @@ pub enum AiCmd {
 #[cfg(test)]
 mod tests {
     use super::{
-        AppCmd, Cli, Commands, ConfigCmd, ConfigScope, SecretCmd, normalize_config_scope_aliases,
+        normalize_config_scope_aliases, AppCmd, Cli, Commands, ConfigCmd, ConfigScope, NotifyCmd,
+        SecretCmd,
     };
     use clap::Parser;
+
+    #[test]
+    fn notify_preserves_post_flags_and_exposes_dismiss_subcommand() {
+        let post = Cli::try_parse_from(["plexi", "notify", "--title", "Done", "--timeout", "30"])
+            .expect("notify post parses");
+        let Some(Commands::Notify { cmd: None, post }) = post.command else {
+            panic!("expected notify post");
+        };
+        assert_eq!(post.title.as_deref(), Some("Done"));
+        assert_eq!(post.timeout, 30);
+
+        let dismiss = Cli::try_parse_from(["plexi", "notify", "dismiss", "cli:42:abc"])
+            .expect("notify dismiss parses");
+        let Some(Commands::Notify {
+            cmd: Some(NotifyCmd::Dismiss { notify_id }),
+            ..
+        }) = dismiss.command
+        else {
+            panic!("expected notify dismiss");
+        };
+        assert_eq!(notify_id, "cli:42:abc");
+    }
 
     #[test]
     fn host_start_accepts_ephemeral_flag() {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -979,7 +979,7 @@ pub use install::{
 pub use list::{freeze_cli, parse_notify_choice};
 pub use marketplace::{app_browse_cli, app_publish_cli, app_search_cli};
 pub use notes::{notes_list_cli, notes_open_cli};
-pub use notify::{notify_cli, parse_notify_scope};
+pub use notify::{dismiss_notify_cli, notify_cli, parse_notify_scope};
 pub use open::{
     app_trust_cli, mcp_pane_title, open_cli, open_cli_by_name, open_mcp_by_name, pane_new_cli,
     parse_prefix, AgentBootRequest, OpenPrefix,

--- a/src/cli/notify.rs
+++ b/src/cli/notify.rs
@@ -24,7 +24,8 @@ pub fn notify_cli(
     level: &str,
     choices: &[(String, String, Option<String>)],
     wait_for_response: bool,
-    timeout_secs: u64,
+    display_timeout_secs: u64,
+    wait_timeout_secs: u64,
     scope: Option<crate::app_protocol::NotifyScope>,
     source_context_id: Option<u64>,
     source_pane_id: Option<u64>,
@@ -79,8 +80,14 @@ pub fn notify_cli(
         None
     };
 
+    let notify_id = format!(
+        "cli:{}:{}",
+        source_pane_id.unwrap_or(0),
+        uuid::Uuid::new_v4()
+    );
     let mut payload = serde_json::json!({
         "type": "notify",
+        "notify_id": notify_id,
         "level": level,
         "title": title,
         "body": body,
@@ -88,6 +95,9 @@ pub fn notify_cli(
         "options": options_json,
         "priority": 50,
     });
+    if display_timeout_secs > 0 {
+        payload["timeout_secs"] = serde_json::Value::from(display_timeout_secs);
+    }
     if let Some(ref rf) = response_file_str {
         payload["response_file"] = serde_json::Value::String(rf.clone());
     }
@@ -140,17 +150,13 @@ pub fn notify_cli(
 
     // Fire-and-forget path — command is delivered, nothing to wait for.
     let Some(response_file) = response_file_str else {
-        if timeout_secs > 0 {
-            eprintln!(
-                "warning: --timeout only limits waiting for a choice response; notification queued"
-            );
-        }
-        println!("notification queued");
+        println!("{notify_id}");
         return 0;
     };
     log::info!("notify:cli: polling for response at {response_file:?}");
 
-    let timeout = (timeout_secs > 0).then(|| std::time::Duration::from_secs(timeout_secs));
+    let timeout =
+        (wait_timeout_secs > 0).then(|| std::time::Duration::from_secs(wait_timeout_secs));
     match crate::rpc::poll_string(&response_file, timeout) {
         Ok(key) => {
             log::info!("notify:cli: response received {:?}", key.trim());
@@ -158,12 +164,60 @@ pub fn notify_cli(
             0
         }
         Err(crate::rpc::PollError::TimedOut) => {
-            log::info!("notify:cli: timed out after {timeout_secs}s");
+            log::info!("notify:cli: choice wait timed out after {wait_timeout_secs}s");
             2
         }
         Err(e) => {
             log::warn!("notify:cli: {e}");
             eprintln!("error: {e}");
+            1
+        }
+    }
+}
+
+pub fn dismiss_notify_cli(
+    notify_id: &str,
+    source_context_id: Option<u64>,
+    source_pane_id: Option<u64>,
+) -> i32 {
+    let (Some(source_context_id), Some(source_pane_id)) = (source_context_id, source_pane_id)
+    else {
+        eprintln!("error: notify dismiss requires a caller pane and context");
+        return 1;
+    };
+    let Some(socket_path) = super::resolve_command_socket() else {
+        eprintln!("error: PLEXI_SOCKET is not set — run this inside a Plexi terminal pane");
+        return 1;
+    };
+    let response_file = crate::rpc::response_file("notify-dismiss", "txt");
+    let payload = serde_json::json!({
+        "type": "dismiss_notification",
+        "notify_id": notify_id,
+        "source_context_id": source_context_id,
+        "source_pane_id": source_pane_id,
+        "response_file": response_file,
+    });
+    use std::io::Write;
+    use std::os::unix::net::UnixStream;
+    let mut stream = match UnixStream::connect(&socket_path) {
+        Ok(stream) => stream,
+        Err(e) => {
+            eprintln!("error: could not connect to PLEXI_SOCKET {socket_path:?}: {e}");
+            return 1;
+        }
+    };
+    if let Err(e) = stream.write_all(format!("{payload}\n").as_bytes()) {
+        eprintln!("error: could not write to socket: {e}");
+        return 1;
+    }
+    match crate::rpc::poll_string(&response_file, Some(std::time::Duration::from_secs(30))) {
+        Ok(result) if result.trim() == "dismissed" => 0,
+        Ok(result) => {
+            eprintln!("error: {}", result.trim());
+            1
+        }
+        Err(e) => {
+            eprintln!("error: notify dismiss: {e}");
             1
         }
     }
@@ -221,6 +275,7 @@ mod notify_tests {
             &[],
             true,
             0,
+            0,
             None,
             None,
             None,
@@ -245,6 +300,7 @@ mod notify_tests {
                 &choices,
                 false,
                 0,
+                0,
                 None,
                 None,
                 None,
@@ -262,6 +318,31 @@ mod notify_tests {
         assert_eq!(payload["options"][0]["host_action"], "pane_focus:188");
     }
 
+    #[test]
+    fn notify_cli_timeout_is_sent_as_display_lifetime() {
+        let env = socket_env_guard();
+        let (code, payload) = capture_notify_payload(&env, || {
+            notify_cli(
+                "Expiry",
+                "body",
+                "info",
+                &[],
+                false,
+                30,
+                0,
+                None,
+                None,
+                None,
+            )
+        });
+
+        assert_eq!(code, 0);
+        assert_eq!(payload["timeout_secs"], 30);
+        assert!(payload["notify_id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("cli:0:")));
+    }
+
     /// The stint 0536 leak fix: a blocking choice that times out must exit 2
     /// and must not leave a response file behind in the profile's rpc/ dir.
     #[test]
@@ -276,6 +357,7 @@ mod notify_tests {
                 "info",
                 &choices,
                 true,
+                1,
                 1,
                 None,
                 None,
@@ -334,6 +416,7 @@ mod notify_tests {
             &choices,
             true,
             1,
+            1,
             None,
             None,
             None,
@@ -387,7 +470,7 @@ mod notify_tests {
     fn notify_cli_sends_caller_identity() {
         let env = socket_env_guard();
         let (code, payload) = capture_notify_payload(&env, || {
-            notify_cli("T", "B", "info", &[], false, 0, None, Some(7), Some(42))
+            notify_cli("T", "B", "info", &[], false, 0, 0, None, Some(7), Some(42))
         });
         assert_eq!(code, 0);
         assert_eq!(payload["source_context_id"], 7);
@@ -400,7 +483,7 @@ mod notify_tests {
     fn notify_cli_omits_identity_when_absent() {
         let env = socket_env_guard();
         let (code, payload) = capture_notify_payload(&env, || {
-            notify_cli("T", "B", "info", &[], false, 0, None, None, None)
+            notify_cli("T", "B", "info", &[], false, 0, 0, None, None, None)
         });
         assert_eq!(code, 0);
         assert!(payload.get("source_context_id").is_none());
@@ -418,7 +501,7 @@ mod notify_tests {
             crate::app_protocol::NotifyScope::Context,
             crate::app_protocol::NotifyScope::Window,
         ] {
-            let code = notify_cli("T", "B", "info", &[], false, 0, Some(scope), None, None);
+            let code = notify_cli("T", "B", "info", &[], false, 0, 0, Some(scope), None, None);
             assert_eq!(code, 1, "{scope:?} without a caller context must error");
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -229,8 +229,8 @@ fn main() -> eframe::Result {
         .collect();
     use crate::cli::args::{
         AccountCmd, AgentCmd, AiCmd, AppCmd, Cli, Commands, ConfigCmd, ContextCmd, DescriptorCmd,
-        EventsCmd, HookAction, HostCmd, NotesCmd, PaneCmd, PaneSlotCmd, RegistryCmd, RoutineCmd,
-        SecretCmd, UpdateCmd, WorkspaceCmd,
+        EventsCmd, HookAction, HostCmd, NotesCmd, NotifyCmd, PaneCmd, PaneSlotCmd, RegistryCmd,
+        RoutineCmd, SecretCmd, UpdateCmd, WorkspaceCmd,
     };
     use clap::Parser;
     let args = cli::args::normalize_config_scope_aliases(args);
@@ -664,16 +664,41 @@ fn main() -> eframe::Result {
                             std::process::exit(cli::host_screenshot_cli(pane, output.as_deref()))
                         }
                     },
-                    Commands::Notify {
-                        title,
-                        body,
-                        level,
-                        choices,
-                        host_actions,
-                        no_wait,
-                        timeout,
-                        scope,
-                    } => {
+                    Commands::Notify { cmd, post } => {
+                        // The caller's own identity, stamped by the pane env.
+                        // A set-but-garbled value is corrupt state, not an
+                        // outside-pane caller — fail loudly, never reinterpret.
+                        let caller_env_id = |key: &str| match std::env::var(key) {
+                            Ok(s) => match s.parse::<u64>() {
+                                Ok(id) => Some(id),
+                                Err(_) => {
+                                    eprintln!("error: {key} is not a valid number: {s}");
+                                    std::process::exit(1);
+                                }
+                            },
+                            Err(_) => None,
+                        };
+                        let source_context_id = caller_env_id("PLEXI_CONTEXT_ID");
+                        let source_pane_id = caller_env_id("PLEXI_PANE_ID");
+                        if let Some(NotifyCmd::Dismiss { notify_id }) = cmd {
+                            std::process::exit(cli::dismiss_notify_cli(
+                                &notify_id,
+                                source_context_id,
+                                source_pane_id,
+                            ));
+                        }
+                        let Some(title) = post.title else {
+                            eprintln!("error: --title is required when posting a notification");
+                            std::process::exit(1);
+                        };
+                        let body = post.body;
+                        let level = post.level;
+                        let choices = post.choices;
+                        let host_actions = post.host_actions;
+                        let no_wait = post.no_wait;
+                        let timeout = post.timeout;
+                        let wait_timeout = post.wait_timeout;
+                        let scope = post.scope;
                         // Parse --host-action flags into a key → "action_type:action_arg" map.
                         let mut host_action_map: std::collections::HashMap<String, String> =
                             std::collections::HashMap::new();
@@ -738,21 +763,6 @@ fn main() -> eframe::Result {
                             "notify:cli: host_actions={} merged into choices",
                             host_actions.len()
                         );
-                        // The caller's own identity, stamped by the pane env.
-                        // A set-but-garbled value is corrupt state, not an
-                        // outside-pane caller — fail loudly, never reinterpret.
-                        let caller_env_id = |key: &str| match std::env::var(key) {
-                            Ok(s) => match s.parse::<u64>() {
-                                Ok(id) => Some(id),
-                                Err(_) => {
-                                    eprintln!("error: {key} is not a valid number: {s}");
-                                    std::process::exit(1);
-                                }
-                            },
-                            Err(_) => None,
-                        };
-                        let source_context_id = caller_env_id("PLEXI_CONTEXT_ID");
-                        let source_pane_id = caller_env_id("PLEXI_PANE_ID");
                         std::process::exit(cli::notify_cli(
                             &title,
                             &body,
@@ -760,6 +770,7 @@ fn main() -> eframe::Result {
                             &parsed_choices,
                             !no_wait,
                             timeout,
+                            wait_timeout,
                             parsed_scope,
                             source_context_id,
                             source_pane_id,

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -179,6 +179,16 @@ pub enum AppRequest {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source_pane_id: Option<u64>,
     },
+    /// Remove a notification posted by the caller. The host verifies the
+    /// caller identity against the notification's stamped provenance.
+    DismissNotification {
+        notify_id: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source_context_id: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        source_pane_id: Option<u64>,
+        response_file: String,
+    },
     /// Report agent state for a pane. Called by hook scripts via `plexi agent report`.
     SetAgentState {
         pane_id: u64,

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -1121,16 +1121,17 @@ Emits a `mcpServers` JSON block pointing at this instance's host MCP server (rea
 
 Send a notification to the Plexi UI
 
+| Subcommand | Description |
+|---|---|
+| `dismiss` | Remove a notification previously posted by this pane |
+
+### `plexi notify dismiss`
+
+Remove a notification previously posted by this pane
+
 | Flag / Arg | Type | Required | Description |
 |---|---|---|---|
-| `--title` | string | yes | Notification title (required) |
-| `--body` | string | no | Notification body text |
-| `--level` | string | no | Severity level: info, warn, or error Default: `info`. |
-| `--choice` | string (repeatable) | no | Add a clickable button to the notification. Format: `key:Label` (returns key when clicked) or `Label:pane_focus:<pane_id>` (switches focus to that pane when clicked). Repeatable |
-| `--host-action` | string (repeatable) | no | Action to perform on the host when a button is clicked. Format: `key:action_type:action_arg`. Repeatable. The host runs this even after the process that sent the notification has exited |
-| `--no-wait` | flag | no | Queue choice buttons without waiting for a selected value |
-| `--timeout` | string | no | How many seconds before the notification disappears (0 = stays until dismissed) Default: `0`. |
-| `--scope` | string | no | Which panes see this notification: window, context, or global (default: context — the notification stays in the context that sent it) |
+| `<notify_id>` | string | yes | Notification id printed by `plexi notify` |
 
 ## `plexi ai`
 


### PR DESCRIPTION
## Summary

Implements stints 0608, 0610, and 0611. No linked GitHub issue — stint is authoritative.

- Preserve app notification provenance: parked or gone senders narrow window scope to their stamped context instead of borrowing the active window.
- Make `plexi notify --timeout` the display lifetime, add `--wait-timeout` for choice-response waits, and print the notification id.
- Add sender-scoped `plexi notify dismiss ID` for sticky notifications, with host-side foreign-dismiss rejection.

## Done When

- 0608: parked app window-scoped notifications do not attach to the active window.
- 0610: help, payload, and runtime agree that `--timeout` controls display lifetime; choice wait has its own timeout.
- 0611: posting pane can dismiss its sticky notification; a foreign pane cannot; CLI skill documents the surface.

**Test evidence:**
- cargo test: 2122 passed, 0 failed, 5 ignored — filters: full bin suite (env-stripped, RSS watchdog).
- Conclusion: install skippable — full HostHarness and CLI contract coverage; separate tester owns live validation.