### PR TITLE
fix: stamp pane context env explicitly (stint 0607)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1762,8 +1762,9 @@ impl PlexiApp {
         // workspace path returns earlier and is untouched. The welcome screen
         // still renders for any genuinely-empty window elsewhere.
         let seed_cwd = app.windows[0].path.clone();
+        let seed_context = app.pane_context_env_for_window(0);
         if app
-            .seed_window_root_pane(0, seed_cwd, None, false)
+            .seed_window_root_pane(0, &seed_context, seed_cwd, None, false)
             .is_some()
         {
             log::info!("first boot: seeded base root pane in context 1");

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -1148,6 +1148,42 @@ fn new_context_creates_top_level_empty_context() {
     );
 }
 
+/// Regression for stint 0607: a top-level context's root PTY must receive the
+/// new context identity, even though the previously active context remains
+/// selected while the new window is being seeded.
+#[test]
+fn new_context_root_pty_env_uses_its_own_context_identity() {
+    let mut h = crate::testing::HostHarness::new();
+    let previous_context_id = h.app.router.active().context_id;
+
+    h.app.new_context();
+
+    let new_context = h.app.router.active().clone();
+    if new_context.context_id == previous_context_id {
+        return; // PTY unavailable in this test environment.
+    }
+    let window = h
+        .app
+        .windows
+        .iter()
+        .find(|window| window.context_id == new_context.context_id)
+        .expect("new context window");
+    let terminal = window
+        .panes
+        .values()
+        .find_map(|pane| pane.as_terminal())
+        .expect("new context root terminal");
+
+    assert_eq!(
+        terminal.spawn_env.get("PLEXI_CONTEXT_ID"),
+        Some(&new_context.context_id.to_string())
+    );
+    assert_eq!(
+        terminal.spawn_env.get("PLEXI_CONTEXT_NAME"),
+        Some(&new_context.name)
+    );
+}
+
 /// Issue #2029: closing a sub-context portal that is the sole pane on a window must
 /// delete that window. Previously the window survived empty, showing the welcome screen.
 #[test]

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -669,6 +669,9 @@ pub struct TerminalPane {
     /// redraw (Claude Code, Codex) never advances that counter, so it would
     /// report a busy pane as idle.
     pub last_pty_output_at: Option<std::time::Instant>,
+    /// Test-only copy of the environment handed to the PTY constructor.
+    #[cfg(test)]
+    pub spawn_env: HashMap<String, String>,
 }
 
 impl TerminalPane {
@@ -679,6 +682,8 @@ impl TerminalPane {
         settings: BackendSettings,
         default_font_size: f32,
     ) -> Option<Self> {
+        #[cfg(test)]
+        let spawn_env = settings.env.clone();
         let backend = match TerminalBackend::new(id, ctx, tx, settings) {
             Ok(b) => b,
             Err(e) => {
@@ -705,6 +710,8 @@ impl TerminalPane {
             activity: None,
             slots: HashMap::new(),
             last_pty_output_at: None,
+            #[cfg(test)]
+            spawn_env,
         })
     }
 }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -183,6 +183,26 @@ pub(crate) fn restore_assistant_pane(
 }
 
 impl PlexiApp {
+    /// Resolve the environment identity for a pane owned by `win_idx`.
+    ///
+    /// The caller supplies the target window explicitly; this must never use
+    /// `active_window` or `router.active()`, since a command can create panes
+    /// outside the currently visible context.
+    pub(crate) fn pane_context_env_for_window(&self, win_idx: usize) -> PaneContextEnv {
+        let context_id = self.windows[win_idx].context_id;
+        self.pane_context_env_for_context(context_id)
+    }
+
+    /// Resolve a registered context's identity for a pane about to spawn.
+    pub(crate) fn pane_context_env_for_context(&self, context_id: u64) -> PaneContextEnv {
+        PaneContextEnv {
+            context_id,
+            name: self.context_name_for(context_id),
+            description: self.context_description_for(context_id),
+            root: self.context_root_for(context_id),
+            depth: self.context_depth_for(context_id),
+        }
+    }
     /// Convert a manifest-declared share fraction (0.0..1.0 exclusive) to a `ShareRatio`.
     /// Validates the range and falls back to 0.5 (1:1) on invalid input, logging a warning.
     fn share_ratio_from_fraction(app_id: &str, fraction: Option<f32>) -> ShareRatio {
@@ -920,30 +940,21 @@ impl PlexiApp {
 
     pub(super) fn create_single_pane_tree(
         &mut self,
+        context: &PaneContextEnv,
         cwd: Option<PathBuf>,
         initial_cmd: Option<&str>,
         close_on_exit: bool,
     ) -> Option<(Tree<PaneId>, HashMap<PaneId, Pane>, TileId)> {
         let new_id = self.host.alloc_pane_id();
-
-        let ctx_id = self
-            .windows
-            .get(self.active_window)
-            .map(|w| w.context_id)
-            .unwrap_or(0);
-        let ctx_name = self.context_name_for(ctx_id);
-        let ctx_desc = self.context_description_for(ctx_id);
-        let ctx_root = self.context_root_for(ctx_id);
-        let ctx_depth = self.context_depth_for(ctx_id);
         let mut settings = Self::make_backend_settings(
             new_id,
             cwd,
             &self.colors,
-            ctx_id,
-            &ctx_name,
-            &ctx_desc,
-            ctx_root.as_ref(),
-            ctx_depth,
+            context.context_id,
+            &context.name,
+            &context.description,
+            context.root.as_ref(),
+            context.depth,
         );
         if let Some(cmd) = initial_cmd {
             log::info!(
@@ -986,11 +997,7 @@ impl PlexiApp {
         keep_focus: bool,
     ) -> crate::spatial::tiling::PaneId {
         let new_id = self.host.alloc_pane_id();
-        let ctx_id = self.windows[win_idx].context_id;
-        let ctx_name = self.context_name_for(ctx_id);
-        let ctx_desc = self.context_description_for(ctx_id);
-        let ctx_root = self.context_root_for(ctx_id);
-        let ctx_depth = self.context_depth_for(ctx_id);
+        let context = self.pane_context_env_for_window(win_idx);
         let cwd = cwd_override.or_else(|| self.windows[win_idx].get_focused_pane_cwd(target_tile));
         log::info!(
             "spawn_terminal_pane_at: win_idx={win_idx} target_tile={target_tile:?} new_id={new_id} \
@@ -1000,11 +1007,11 @@ impl PlexiApp {
             new_id,
             cwd,
             &self.colors,
-            ctx_id,
-            &ctx_name,
-            &ctx_desc,
-            ctx_root.as_ref(),
-            ctx_depth,
+            context.context_id,
+            &context.name,
+            &context.description,
+            context.root.as_ref(),
+            context.depth,
         );
         if let Some(cmd) = initial_cmd {
             super::apply_initial_cmd(&mut settings, cmd, close_on_exit);

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -233,8 +233,9 @@ impl PlexiApp {
             // the tree. If it has panes but none focused (rare), drop into the
             // standard terminal split path which will no-op for now.
             if self.windows[active].panes.is_empty() {
+                let context = self.pane_context_env_for_window(active);
                 if let Some((tree, panes, root_tile)) =
-                    self.create_single_pane_tree(None, None, false)
+                    self.create_single_pane_tree(&context, None, None, false)
                 {
                     self.windows[active].tree = tree;
                     self.windows[active].panes = panes;

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -675,9 +675,17 @@ impl PlexiApp {
         let win_id = self.next_window_id;
         self.next_window_id += 1;
 
-        // Push an empty window, then seed its base root pane in place through the
-        // shared installer. `active_window` still points at the previous window
-        // here, preserving `create_single_pane_tree`'s historical env context.
+        let ctx_name = format!("Context {}", self.router.len() + 1);
+        let context_env = super::create::PaneContextEnv {
+            context_id: ctx_id,
+            name: ctx_name.clone(),
+            description: String::new(),
+            root: Some(cwd.clone()),
+            depth: 0,
+        };
+
+        // Push an empty window, then seed its base root pane with the new
+        // context's identity before it is registered in the router.
         self.windows.push(Window {
             name: String::new(),
             path: cwd.clone(),
@@ -692,7 +700,7 @@ impl PlexiApp {
         });
         let new_idx = self.windows.len() - 1;
         if self
-            .seed_window_root_pane(new_idx, cwd.clone(), None, false)
+            .seed_window_root_pane(new_idx, &context_env, cwd.clone(), None, false)
             .is_none()
         {
             log::error!("new_context_empty: failed to seed root pane — aborting new context");
@@ -700,7 +708,6 @@ impl PlexiApp {
             return;
         }
 
-        let ctx_name = format!("Context {}", self.router.len() + 1);
         self.router.push(crate::host::context::Context {
             name: ctx_name,
             path: cwd.clone(),
@@ -743,34 +750,8 @@ impl PlexiApp {
         let win_id = self.next_window_id;
         self.next_window_id += 1;
 
-        // Push an empty window, then seed its base root pane in place through the
-        // shared installer (see `new_context_empty` for the active_window note).
-        self.windows.push(Window {
-            name: String::new(),
-            path: path.clone(),
-            tree: egui_tiles::Tree::empty("plexi"),
-            panes: HashMap::new(),
-            focused_pane: None,
-            zoomed_pane: None,
-            grid_x: 0,
-            grid_y: 0,
-            window_id: win_id,
-            context_id: ctx_id,
-        });
-        let new_idx = self.windows.len() - 1;
-        if self
-            .seed_window_root_pane(new_idx, path.clone(), None, false)
-            .is_none()
-        {
-            log::error!(
-                "new_context_at_path: failed to seed root pane for {} — aborting new context",
-                path.display()
-            );
-            self.windows.pop();
-            return;
-        }
-
-        // Check for anchor defaults from .plexi/workspace.toml [context] section.
+        // Resolve the identity before spawning: the root pane starts before this
+        // context is registered in the router.
         let anchor = crate::host::anchor::Anchor::detect(&path);
         let (ctx_name, ctx_description) =
             match anchor.as_ref().and_then(|a| a.context_defaults.as_ref()) {
@@ -795,6 +776,40 @@ impl PlexiApp {
                     (name, None)
                 }
             };
+        let context_env = super::create::PaneContextEnv {
+            context_id: ctx_id,
+            name: ctx_name.clone(),
+            description: ctx_description.clone().unwrap_or_default(),
+            root: Some(path.clone()),
+            depth: 0,
+        };
+
+        // Push an empty window, then seed its base root pane in place with the
+        // context identity resolved above.
+        self.windows.push(Window {
+            name: String::new(),
+            path: path.clone(),
+            tree: egui_tiles::Tree::empty("plexi"),
+            panes: HashMap::new(),
+            focused_pane: None,
+            zoomed_pane: None,
+            grid_x: 0,
+            grid_y: 0,
+            window_id: win_id,
+            context_id: ctx_id,
+        });
+        let new_idx = self.windows.len() - 1;
+        if self
+            .seed_window_root_pane(new_idx, &context_env, path.clone(), None, false)
+            .is_none()
+        {
+            log::error!(
+                "new_context_at_path: failed to seed root pane for {} — aborting new context",
+                path.display()
+            );
+            self.windows.pop();
+            return;
+        }
 
         self.router.push(crate::host::context::Context {
             name: ctx_name,
@@ -855,9 +870,13 @@ impl PlexiApp {
             "create_page_at({grid_x},{grid_y}): cwd={} context_id={context_id} initial_cmd={initial_cmd:?} close_on_exit={close_on_exit}",
             cwd.display()
         );
-        let Some((tree, panes, root_tile)) =
-            self.create_single_pane_tree(Some(cwd.clone()), initial_cmd, close_on_exit)
-        else {
+        let context_env = self.pane_context_env_for_context(context_id);
+        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(
+            &context_env,
+            Some(cwd.clone()),
+            initial_cmd,
+            close_on_exit,
+        ) else {
             log::error!("Failed to create terminal for new page at ({grid_x}, {grid_y})");
             return;
         };
@@ -903,12 +922,13 @@ impl PlexiApp {
     pub(crate) fn seed_window_root_pane(
         &mut self,
         win_idx: usize,
+        context: &super::create::PaneContextEnv,
         cwd: PathBuf,
         initial_cmd: Option<&str>,
         close_on_exit: bool,
     ) -> Option<(PaneId, egui_tiles::TileId)> {
         let (tree, panes, root_tile) =
-            self.create_single_pane_tree(Some(cwd), initial_cmd, close_on_exit)?;
+            self.create_single_pane_tree(context, Some(cwd), initial_cmd, close_on_exit)?;
         let pane_id = *panes
             .keys()
             .next()
@@ -944,8 +964,9 @@ impl PlexiApp {
             .filter(|p| p != &PathBuf::from("/"))
             .unwrap_or(home);
         let active = self.active_window;
+        let context = self.pane_context_env_for_window(active);
         let Some((pane_id, _root_tile)) =
-            self.seed_window_root_pane(active, cwd, initial_cmd, close_on_exit)
+            self.seed_window_root_pane(active, &context, cwd, initial_cmd, close_on_exit)
         else {
             log::error!("seed_root_pane: failed to create terminal for empty active window");
             return None;
@@ -964,7 +985,9 @@ impl PlexiApp {
             cwd.display(),
             self.router.active().root
         );
-        let Some((tree, panes, root_tile)) = self.create_single_pane_tree(Some(cwd), None, false)
+        let context = self.pane_context_env_for_window(self.active_window);
+        let Some((tree, panes, root_tile)) =
+            self.create_single_pane_tree(&context, Some(cwd), None, false)
         else {
             log::error!("Failed to create terminal for reset context");
             return;

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -3185,7 +3185,11 @@ fn first_boot_seam_seeds_base_root_pane() {
     );
 
     let cwd = std::env::temp_dir();
-    if h.app.seed_window_root_pane(0, cwd, None, false).is_none() {
+    let context = h.app.pane_context_env_for_window(0);
+    if h.app
+        .seed_window_root_pane(0, &context, cwd, None, false)
+        .is_none()
+    {
         // No PTY in this env — the installer degrades to the welcome screen,
         // matching first boot's documented fallback. Nothing more to assert.
         return;
@@ -3211,7 +3215,11 @@ fn first_boot_seam_seeds_base_root_pane() {
 fn first_boot_shape_matches_new_context() {
     let mut h = HostHarness::new();
     let cwd = std::env::temp_dir();
-    if h.app.seed_window_root_pane(0, cwd, None, false).is_none() {
+    let context = h.app.pane_context_env_for_window(0);
+    if h.app
+        .seed_window_root_pane(0, &context, cwd, None, false)
+        .is_none()
+    {
         return; // no PTY in this env
     }
     let boot_pane_count = h.app.windows[0].panes.len();


### PR DESCRIPTION
## Summary

Implements stint 0607. No linked GitHub issue — stint is authoritative.

- Pass `PaneContextEnv` explicitly through root-pane, page, and terminal spawn seams.
- Resolve top-level context identity before its PTY is spawned, including path-backed contexts.
- Add a harness regression that inspects the environment handed to the PTY spawn.

## Done When

Pane environment is stamped from the pane's resolved context rather than `router.active()` or `active_window`; context creation and pane-spawn paths carry explicit identity. Existing panes are not re-stamped after moves.

**Test evidence (attempt 1):**
- cargo test: 2123 passed, 0 failed, 5 ignored — full bin suite; targeted `app::tests::context_tests::new_context_root_pty_env_uses_its_own_context_identity` also passed.
- Conclusion: install skippable — full headless harness coverage of the PTY-spawn environment contract.