### PR TITLE
fix(release): refuse empty just bump

### DIFF
--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -59,6 +59,17 @@ command -v git-cliff >/dev/null 2>&1 || die "git-cliff not found — brew instal
 
 current=$(grep '^version' "$TREE/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
 base=$(echo "$current" | sed 's/-.*//')
+
+# ── refuse an empty bump ──────────────────────────────────────────────────────
+# Cargo.toml's current version is the last release commit's tag. If nothing has
+# landed on alpha since that tag, bumping again produces a version + changelog
+# entry with no changes (see v0.2.2).
+
+if git -C "$TREE" rev-parse -q --verify "refs/tags/v$current" >/dev/null; then
+    unreleased=$(git -C "$TREE" log "v$current..HEAD" --oneline | wc -l | tr -d ' ')
+    [[ "$unreleased" -gt 0 ]] || die "no commits since v$current — nothing to release"
+fi
+
 IFS='.' read -r major minor patch <<< "$base"
 
 case "$bump" in


### PR DESCRIPTION
## Summary
- \`just bump\` (scripts/release-version.sh) had no guard against running with zero commits since the last stable tag — it always bumped Cargo.toml/SDK/skill version and wrote a changelog section, even an empty one.
- This produced v0.2.2: bumped straight after v0.2.1 with no intervening commits, no changelog content.
- Adds a check right after reading the current version: if refs/tags/v\$current exists, require at least one commit since that tag, else abort with a clear error.

## Test plan
- [x] Verified locally: \`git log v0.2.2..HEAD --oneline\` returns 0 commits at current alpha HEAD — guard condition reproduces the exact failure case.
- [ ] Confirm \`just bump\` proceeds normally once real commits land on alpha.