### PR TITLE
refactor(release): split just promote and just release

### DIFF
--- a/justfile
+++ b/justfile
@@ -409,18 +409,24 @@ changelog:
 bump bump="patch":
     bash scripts/release-version.sh "{{bump}}"
 
-# Promote to the next channel. Run `just bump` first if cutting a new version.
-# Flags (order-independent after `to`): install, release
+# Promote to the next channel. Code only — never tags or publishes.
+# Run `just bump` first if cutting a new version; run `just release` after,
+# once you're ready to make the promoted commit live for that channel.
+# Flags (order-independent after `to`): install
 #   just promote              — auto-detect alpha→beta or beta→main, prompt
-#   just promote beta         — promote alpha→beta (code only)
-#   just promote main         — promote beta→main (code only)
+#   just promote beta         — promote alpha→beta
+#   just promote main         — promote beta→main
 #   just promote beta install — promote + install beta
 #   just promote main install — promote + install main
-#   just promote beta release — promote + cut vX.Y.Z-beta.N tag + trigger CI
-#   just promote main release — promote + cut vX.Y.Z tag + trigger CI
-#   just promote main install release — promote + install + tag + trigger CI
 promote to="" *flags="":
     bash scripts/promote.sh "{{to}}" {{flags}}
+
+# Cut and publish the source-build release tag for a channel already
+# promoted to its target branch. Never moves code — that's `just promote`.
+#   just release beta — cut vX.Y.Z-beta.N at beta HEAD, publish, trigger CI
+#   just release main — cut/retag vX.Y.Z at main HEAD, publish, trigger CI
+release channel="":
+    bash scripts/release-tag.sh "{{channel}}"
 
 # Remove a Plexi channel and its profile dir, app bundle, and CLI binary.
 # Defaults to removing all channels plus shell integration and completions.

--- a/scripts/RELEASE_CHANNELS.md
+++ b/scripts/RELEASE_CHANNELS.md
@@ -133,26 +133,33 @@ Preview unreleased commits without committing anything:
 just changelog
 ```
 
+`just promote` moves code between branches; `just release` cuts and publishes
+the tag. They're deliberately separate: moving code to beta or main is
+reversible and local, publishing a tag is not — other machines on that
+channel auto-update to it. Never bundled into one command.
+
 Standard release batch:
 
 ```sh
 just bump                          # bump Cargo.toml, write CHANGELOG, commit + tag locally
-just promote beta release          # alpha→beta + publish vX.Y.Z-beta.N source-build tag
-just promote main release          # beta→main + publish vX.Y.Z source-build tag
+just promote beta                  # alpha→beta
+just release beta                  # publish vX.Y.Z-beta.N source-build tag, trigger CI
+just promote main                  # beta→main
+just release main                  # publish vX.Y.Z source-build tag, trigger CI
 ```
 
-Promote code only (no CI tag, test locally first):
+Promote code only and stop there (test locally before publishing):
 
 ```sh
 just promote beta                  # alpha→beta, no tag
 just promote main                  # beta→main, no tag
 ```
 
-Add `install` anywhere to build and install that channel after promoting:
+Add `install` to `promote` to build and install that channel after promoting:
 
 ```sh
-just promote beta install release
-just promote main install release
+just promote beta install
+just promote main install
 ```
 
 ## Channel Update Policy

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Plexi channel promotion pipeline.
-# Usage: promote.sh [beta|main] [install] [release]
+# Plexi channel promotion pipeline. Moves code between branches — never cuts
+# or publishes a release tag. For that, run `just release beta|main` once
+# you're satisfied with what landed here.
+# Usage: promote.sh [beta|main] [install]
 #   No argument: auto-detects current branch and prompts for confirmation.
 #   install: build and install the target channel after promoting.
-#   release: cut and push a prerelease tag (beta) or stable tag (main) for source-build updates.
 #
 # Run `just bump` on alpha before promoting if you haven't already.
 set -euo pipefail
@@ -75,12 +76,10 @@ check_pushed() {
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 to="${1:-}"
 do_install=""
-do_release=""
 for arg in "${@:2}"; do
     case "$arg" in
         install) do_install="install" ;;
-        release) do_release="release" ;;
-        *) die "unknown flag '$arg' — valid flags: install, release" ;;
+        *) die "unknown flag '$arg' — valid flags: install" ;;
     esac
 done
 
@@ -131,28 +130,14 @@ if [[ "$to" == "beta" ]]; then
 
     version=$(grep '^version' "$ALPHA_TREE/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
 
-    if [[ "$do_release" == "release" || "$do_release" == "true" ]]; then
-        base=$(echo "$version" | sed 's/-.*//')
-        git -C "$ALPHA_TREE" fetch origin --tags --quiet 2>/dev/null || true
-        highest=$(git -C "$ALPHA_TREE" tag -l "v${base}-beta.*" --sort=-v:refname | head -1)
-        if [[ -n "$highest" ]]; then
-            n=$(echo "$highest" | sed 's/.*-beta\.//')
-            next=$((n + 1))
-        else
-            next=1
-        fi
-        tag="v${base}-beta.${next}"
-        echo "Cutting $tag on alpha..."
-        git -C "$ALPHA_TREE" tag "$tag"
-        git -C "$ALPHA_TREE" push origin "$tag"
-        echo "Published $tag for source-build updates."
-    fi
-
-    if [[ "$do_install" == "install" || "$do_install" == "true" ]]; then
+    if [[ "$do_install" == "install" ]]; then
         echo ""
         echo "Installing beta (v$version)..."
         (cd "$BETA_TREE" && just install)
     fi
+
+    echo ""
+    echo "Code promoted to beta. Run 'just release beta' to publish its source-build tag."
     exit 0
 fi
 
@@ -186,33 +171,11 @@ git push origin beta:main
 echo "Syncing main worktree..."
 git -C "$MAIN_TREE" pull origin main
 
-if [[ "$do_release" == "release" || "$do_release" == "true" ]]; then
-    main_commit=$(git -C "$MAIN_TREE" rev-parse HEAD)
-    if git -C "$MAIN_TREE" tag -l "v$version" | grep -q "v$version"; then
-        tagged_commit=$(git -C "$MAIN_TREE" rev-list -n 1 "v$version")
-        if [[ "$tagged_commit" != "$main_commit" ]]; then
-            echo "info: tag v$version points at an older commit — re-tagging at main HEAD..."
-            git -C "$MAIN_TREE" tag -f "v$version" "$main_commit"
-        fi
-    else
-        echo "Creating tag v$version at main HEAD..."
-        git -C "$MAIN_TREE" tag "v$version"
-    fi
-    echo "Publishing tag v$version for source-build updates..."
-    git -C "$MAIN_TREE" push origin "v$version" --force
-    echo ""
-    echo "REMINDER: republish the agent-skill mirror from this release tree —"
-    echo "          copy $MAIN_TREE/skills/plexi-cli/SKILL.md to ianjamesburke/plexi-skills,"
-    echo "          push main, tag v$version. Steps: skills/AGENTS.md."
-else
-    echo "Code promoted to main. Run 'just promote main release' to publish its source-build tag."
-fi
-
-if [[ "$do_install" == "install" || "$do_install" == "true" ]]; then
+if [[ "$do_install" == "install" ]]; then
     echo ""
     echo "Installing main (v$version)..."
     (cd "$MAIN_TREE" && just install)
 fi
 
 echo ""
-echo "v$version is on main."
+echo "v$version is on main. Run 'just release main' to publish its source-build tag."

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -1,66 +1,83 @@
 #!/usr/bin/env bash
-# Push a version tag for source-build updates.
-# Internal helper used by scripts/promote.sh — do not call directly.
-# Use: just promote beta release  OR  just promote main release
+# Cut and publish a source-build release tag for a channel. Never moves code
+# between branches — that's `just promote`. Run this only after
+# `just promote beta|main` has landed on the target branch and you're ready
+# to make the result live for that channel's auto-updaters.
+# Usage: release-tag.sh [beta|main]
 set -euo pipefail
 
 REPO_ROOT=$(dirname "$(git rev-parse --git-common-dir)")
-ALPHA_TREE="$REPO_ROOT"
+BETA_TREE="$REPO_ROOT/worktrees/beta"
 MAIN_TREE="$REPO_ROOT/worktrees/main"
 
 die() { echo "error: $*" >&2; exit 1; }
 
-push_tag() {
-    local tree="$1" tag="$2"
-    remote_tag=$(git ls-remote --tags origin "refs/tags/$tag" | awk '{print $1}')
-    if [[ -n "$remote_tag" ]]; then
-        echo "Tag $tag is already published for source-build updates."
-    else
-        echo "Pushing tag $tag to origin..."
-        git -C "$tree" push origin "$tag"
-        echo "Published $tag for source-build updates."
-    fi
-}
+channel="${1:-}"
+case "$channel" in
+    beta|main) ;;
+    *) die "usage: release-tag.sh [beta|main]" ;;
+esac
 
-# ── prerelease flow: newest alpha/beta tag on alpha ───────────────────────────
-
-base=$(grep '^version' "$ALPHA_TREE/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/' | sed 's/-.*//')
-pre_tag=$(git -C "$ALPHA_TREE" tag -l "v${base}-alpha.*" "v${base}-beta.*" --sort=-v:refname | head -1)
-
-if [[ -n "$pre_tag" ]]; then
-    tagged_commit=$(git -C "$ALPHA_TREE" rev-list -n 1 "$pre_tag")
-    head_commit=$(git -C "$ALPHA_TREE" rev-parse HEAD)
-    remote_tag=$(git ls-remote --tags origin "refs/tags/$pre_tag" | awk '{print $1}')
-    if [[ -z "$remote_tag" ]]; then
-        [[ "$tagged_commit" == "$head_commit" ]] \
-            || die "$pre_tag points at $tagged_commit, not alpha HEAD $head_commit — re-cut the prerelease"
-        push_tag "$ALPHA_TREE" "$pre_tag"
-        exit 0
-    fi
-fi
-
-# ── stable flow: vX.Y.Z from the main worktree ────────────────────────────────
-
-[[ $(git -C "$MAIN_TREE" rev-parse --abbrev-ref HEAD) == "main" ]] \
-    || die "main worktree is not on 'main' branch"
-
-git -C "$MAIN_TREE" fetch origin main
-local_main=$(git -C "$MAIN_TREE" rev-parse HEAD)
-remote_main=$(git -C "$MAIN_TREE" rev-parse origin/main)
-[[ "$local_main" == "$remote_main" ]] \
-    || die "main worktree is not in sync with origin/main — run 'just promote main' first"
-
-version=$(grep '^version' "$MAIN_TREE/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
-
-if git -C "$MAIN_TREE" tag -l "v$version" | grep -q "v$version"; then
-    tagged_commit=$(git -C "$MAIN_TREE" rev-list -n 1 "v$version")
-    if [[ "$tagged_commit" != "$local_main" ]]; then
-        die "tag v$version points at $tagged_commit, not main HEAD $local_main — run 'just bump' on alpha first"
-    fi
-    echo "Tag v$version already exists at main HEAD."
+if [[ "$channel" == "beta" ]]; then
+    tree="$BETA_TREE"
+    branch="beta"
 else
-    echo "Creating tag v$version at main HEAD..."
-    git -C "$MAIN_TREE" tag "v$version"
+    tree="$MAIN_TREE"
+    branch="main"
 fi
 
-push_tag "$MAIN_TREE" "v$version"
+git -C "$tree" diff --quiet && git -C "$tree" diff --cached --quiet \
+    || die "$branch worktree has uncommitted changes — commit or restore first"
+
+[[ $(git -C "$tree" rev-parse --abbrev-ref HEAD) == "$branch" ]] \
+    || die "$tree worktree is not on '$branch'"
+
+# The tag must pin the exact commit that was promoted — refuse to tag a
+# worktree that's stale or has drifted from origin, since either means this
+# isn't the commit `just promote $branch` actually landed.
+git -C "$tree" fetch origin "$branch" --quiet
+
+local_head=$(git -C "$tree" rev-parse HEAD)
+remote_head=$(git -C "$tree" rev-parse "origin/$branch")
+[[ "$local_head" == "$remote_head" ]] \
+    || die "$branch worktree ($local_head) does not match origin/$branch ($remote_head) — run 'just promote $branch' first, or pull"
+
+version=$(grep '^version' "$tree/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')
+
+if [[ "$channel" == "beta" ]]; then
+    base=$(echo "$version" | sed 's/-.*//')
+    git -C "$tree" fetch origin --tags --quiet 2>/dev/null || true
+    highest=$(git -C "$tree" tag -l "v${base}-beta.*" --sort=-v:refname | head -1)
+    if [[ -n "$highest" ]]; then
+        n=$(echo "$highest" | sed 's/.*-beta\.//')
+        next=$((n + 1))
+    else
+        next=1
+    fi
+    tag="v${base}-beta.${next}"
+    echo "Cutting $tag on beta ($local_head)..."
+    git -C "$tree" tag "$tag" "$local_head"
+    git -C "$tree" push origin "$tag"
+    echo ""
+    echo "Published $tag for source-build updates."
+else
+    tag="v$version"
+    if git -C "$tree" tag -l "$tag" | grep -q "$tag"; then
+        tagged_commit=$(git -C "$tree" rev-list -n 1 "$tag")
+        if [[ "$tagged_commit" != "$local_head" ]]; then
+            echo "info: tag $tag points at an older commit — re-tagging at main HEAD..."
+            git -C "$tree" tag -f "$tag" "$local_head"
+        fi
+    else
+        echo "Creating tag $tag at main HEAD..."
+        git -C "$tree" tag "$tag" "$local_head"
+    fi
+    echo "Publishing tag $tag for source-build updates..."
+    git -C "$tree" push origin "$tag" --force
+    echo ""
+    echo "REMINDER: republish the agent-skill mirror from this release tree —"
+    echo "          copy $tree/skills/plexi-cli/SKILL.md to ianjamesburke/plexi-skills,"
+    echo "          push main, tag $tag. Steps: skills/AGENTS.md."
+fi
+
+echo "$tag is live."

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -2,7 +2,7 @@
 # Bump version, regenerate CHANGELOG via git-cliff, commit, and tag the release commit.
 # Usage: scripts/release-version.sh [patch|minor|major]   — called by `just bump`
 # Default: patch
-# After bumping: just promote beta release → just promote main release
+# After bumping: just promote beta → just release beta → just promote main → just release main
 set -euo pipefail
 
 REPO_ROOT=$(dirname "$(git rev-parse --git-common-dir)")
@@ -47,7 +47,7 @@ if [[ -n "$prekind" ]]; then
     git -C "$TREE" tag "$tag"
     echo ""
     echo "$tag tagged locally on alpha."
-    echo "Next: just promote beta release"
+    echo "Next: just promote beta (then just release beta)"
     exit 0
 fi
 
@@ -128,4 +128,4 @@ git -C "$TREE" tag "$tag"
 
 echo ""
 echo "$tag committed and tagged locally on alpha."
-echo "Next: just promote beta release"
+echo "Next: just promote beta (then just release beta)"

--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -42,7 +42,7 @@ by construction. Publishing the alpha copy mid-cycle is forbidden: it would
 document unreleased surface under the released version number, which is exactly
 the failure this contract exists to prevent.
 
-Publish flow (manual; `promote.sh main release` prints this reminder):
+Publish flow (manual; `just release main` prints this reminder):
 
 1. From the release tree, copy `skills/plexi-cli/SKILL.md` — that single file,
    never a directory glob — into the mirror repo at


### PR DESCRIPTION
## Summary
- \`just promote\` and \`just release\` were one command (\`promote.sh\`, gated by a `release` flag) despite very different risk tiers: promoting is a local, reversible branch move; releasing publishes a tag that live machines on that channel auto-update to.
- Splits them: \`promote.sh\` no longer accepts \`release\` at all — it only ever moves code. Tagging moves to \`just release beta|main\`, which requires the target worktree to exactly match its origin branch before it will tag, so it can't publish a stale or wrong commit.
- \`scripts/release-tag.sh\` already existed but was dead — orphaned by a June refactor that inlined tagging into promote.sh and never deleted it. Repurposed it (it was wired to the unused RC-prerelease flow) instead of adding a parallel script.
- Updated scripts/RELEASE_CHANNELS.md, skills/AGENTS.md, and the promote/bump script comments to match.

## Test plan
- [x] \`bash -n\` on all three touched scripts
- [x] \`just --list\` shows both \`promote\` and new \`release\` recipes correctly
- [ ] Run \`just promote beta\` then \`just release beta\` for real once ready to cut the next release, confirm tag lands on beta HEAD and CI triggers