### PR TITLE
chore(babysitter): prewarm release build in worker postgate

### DIFF
--- a/.agents/skills/babysitter/RUN_CONFIG.toml
+++ b/.agents/skills/babysitter/RUN_CONFIG.toml
@@ -56,3 +56,11 @@ style = "file-form, no slash commands for codex"
 # Either engine: relay early when context feels heavy — baton to a fresh head.
 check_interval_seconds = 900
 codex_head_clock = "external-heartbeat"  # operator loop prompts 'cycle'
+
+[worker-postgate]
+# After gates pass and before reporting impl:done, the worker runs
+# `cargo build --release` in its own worktree. Cost: minutes it was going to
+# spend idle anyway. Effect: the tester's pr-install in the same worktree
+# becomes an incremental build — the single biggest cycle-time cut available
+# (Ian spotted it 2026-07-29). Provenance contract unchanged.
+prewarm_release_build = true


### PR DESCRIPTION
## Summary
- babysitter workers now run \`cargo build --release\` in their own worktree after gates pass, before reporting impl:done — spends idle wait time productively so the tester's pr-install becomes an incremental build instead of cold. Biggest cycle-time cut available in the pipeline (spotted 2026-07-29).

## Test plan
- [ ] Next babysitter run: confirm worker-postgate build fires and tester pr-install picks up the incremental cache