### PR TITLE
docs: describe the source installer honestly (stint 0650)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,17 @@ If you run into any issues, don't hesitate to reach out directly: adhdisntreal@g
 
 ### One-liner
 
+Plexi needs Git and a Rust toolchain. If Rust is missing, the installer offers
+to install it with rustup. A cold build takes several minutes.
+
 ```bash
 curl -fsSL https://plexiapp.com/install | sh
 ```
 
-Downloads the latest release, installs to `/Applications`, sets up the `plexi` CLI, and wires ZSH integration. Restart your terminal when done.
+The installer clones Plexi into `~/.plexi-src`, builds it on your Mac, copies
+Plexi.app to `/Applications`, installs the `plexi` CLI, and adds shell
+completions. It may ask for your password to write the CLI to `/usr/local/bin`.
+Restart your terminal when done.
 
 First run:
 
@@ -57,13 +63,6 @@ curl -fsSL https://plexiapp.com/install | bash -s -- --channel alpha
 **First launch (unsigned app):** macOS may block it on first open.
 - **macOS 15+:** System Settings → Privacy & Security → "Open Anyway".
 - **Or:** `xattr -cr /Applications/Plexi.app && open /Applications/Plexi.app`
-
-### Manual
-
-1. Download the latest `Plexi-vX.Y.Z.zip` from [Releases](https://github.com/ianjamesburke/PLEXI/releases).
-2. Unzip and move `Plexi.app` to `/Applications`.
-3. Run `xattr -cr /Applications/Plexi.app` if macOS blocks it.
-4. On first launch, click **Install CLI** in the setup prompt to add `plexi` to your PATH.
 
 ### Build from source
 

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -8,15 +8,23 @@ Plexi runs on macOS (Apple Silicon or Intel, macOS 12 Monterey or later).
 
 ## Install
 
+Plexi needs Git and a Rust toolchain. If Rust is missing, the installer first
+asks whether to install it with rustup. A cold build takes several minutes.
+
 Open Terminal and run:
 
 ```sh
 curl -fsSL https://plexiapp.com/install | sh
 ```
 
-You'll be asked for your password. The script installs Plexi.app to /Applications, sets up the `plexi` CLI in /usr/local/bin, and adds shell completions. Launch Plexi from Applications or Spotlight.
+The installer clones Plexi into `~/.plexi-src`, builds it on your Mac, copies
+Plexi.app to `/Applications`, installs the `plexi` CLI in `/usr/local/bin`, and
+adds shell completions. It may ask for your password to write the CLI. Launch
+Plexi from Applications or Spotlight.
 
-On first launch, Plexi will request Accessibility permission. This is required for context-aware features.
+Plexi does not request Accessibility permission on first launch. Its app bundle
+declares camera and microphone permissions for video rooms, which macOS requests
+only when a feature uses them.
 
 ## Teach Your Agent
 


### PR DESCRIPTION
## Summary

Implements stint 0650. No linked GitHub issue. Stint is authoritative.

- Corrects the README and getting-started guide to describe the source-build installer.
- States the Git and Rust requirements, Rust installation prompt, local source directory, build time, CLI setup, and possible admin prompt.
- Removes the nonexistent Accessibility prompt and documents the declared camera and microphone permissions.

## Done When

- README describes the installer as a local source build and removes the stale manual release instructions.
- Getting Started explains prerequisites, the first Rust prompt, and the local build path.
- Documentation no longer claims Plexi requests Accessibility permission.

## Test evidence

- docs-only: no application suites apply.
- `just check-docs-coverage`: passed.
- No install, host launch, or GUI validation was run. A separate tester pane owns live validation.