### PR TITLE
fix(sdk): unify packaged Python SDK version (stint 0576)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -246,6 +246,7 @@ rm -rf "$profile_dir/sdk/plexi_sdk.tmp" "$profile_dir/sdk/plexi_sdk.old"
 cp -R sdk/python/plexi_sdk "$profile_dir/sdk/plexi_sdk.tmp"
 mv "$profile_dir/sdk/plexi_sdk" "$profile_dir/sdk/plexi_sdk.old" 2>/dev/null || true
 mv "$profile_dir/sdk/plexi_sdk.tmp" "$profile_dir/sdk/plexi_sdk"
+cp sdk/python/pyproject.toml "$profile_dir/sdk/pyproject.toml"
 rm -rf "$profile_dir/sdk/plexi_sdk.old" "$profile_dir/sdk/plexi_sdk.py"
 find "$profile_dir/sdk/plexi_sdk" -name '__pycache__' -type d -exec rm -rf {} + 2>/dev/null || true
 # App-seeding policy is channel-gated (see scripts/AGENTS.md). packs/core.toml

--- a/sdk/python/SDK_V3.md
+++ b/sdk/python/SDK_V3.md
@@ -802,7 +802,9 @@ plexi_sdk/
 - `plexi_sdk/_state.py`
 - legacy widget modules replaced by `ui.py` primitives
 
-**`pyproject.toml` version:** `3.0.0`. Python requirement remains repo-standard `>=3.11`.
+`pyproject.toml` is copied beside the host-installed package and is the sole
+package-version source. Missing SDK metadata is an installation error, not a
+defaulted version. Python requirement remains repo-standard `>=3.11`.
 
 ---
 

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -14,7 +14,8 @@ is no ambient process access to escape to. See `docs/wasm-runtime.md`
 § Security Model for the full boundary.
 """
 
-__version__ = "3.0.0"
+from ._version import __version__
+
 SDK_ID = f"plexi-sdk-py/{__version__}"
 
 from ._v3_state import StateSnapshot, log, state

--- a/sdk/python/plexi_sdk/_version.py
+++ b/sdk/python/plexi_sdk/_version.py
@@ -1,40 +1,36 @@
 """Single source of truth for the SDK version.
 
 The version lives in ``pyproject.toml`` (the ``[project].version`` field).
-At runtime it is read via ``importlib.metadata`` when the package is installed.
-When running from an uninstalled source checkout (no dist metadata), it is read
-directly from the sibling ``pyproject.toml``. Both paths return the same string;
-they never diverge because there is exactly one place the number is written.
+The host copies that metadata beside the package at runtime. Missing or malformed
+metadata is an installation error: returning a default would make the SDK claim
+a version that was never declared.
 """
 
 from __future__ import annotations
 
 import tomllib
-from importlib.metadata import PackageNotFoundError, version as _dist_version
 from pathlib import Path
 
-_DISTRIBUTION_NAME = "plexi-sdk"
-
-
-_FALLBACK_VERSION = "0.1.13"
-
-
-def _read_from_pyproject() -> str | None:
+def _read_from_pyproject() -> str:
     pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
     if not pyproject.is_file():
-        return None
+        raise RuntimeError(
+            f"Plexi SDK metadata is missing: expected {pyproject}. "
+            "Reinstall Plexi to restore the bundled SDK."
+        )
     with pyproject.open("rb") as f:
         data = tomllib.load(f)
-    return str(data.get("project", {}).get("version", _FALLBACK_VERSION))
-
-
-def _resolve_version() -> str:
-    if source_version := _read_from_pyproject():
-        return source_version
     try:
-        return _dist_version(_DISTRIBUTION_NAME)
-    except PackageNotFoundError:
-        return _FALLBACK_VERSION
+        version = data["project"]["version"]
+    except KeyError as e:
+        raise RuntimeError(
+            f"Plexi SDK metadata is invalid: {pyproject} has no project.version."
+        ) from e
+    if not isinstance(version, str) or not version:
+        raise RuntimeError(
+            f"Plexi SDK metadata is invalid: {pyproject} has an empty project.version."
+        )
+    return version
 
 
-__version__ = _resolve_version()
+__version__ = _read_from_pyproject()

--- a/sdk/python/plexi_sdk/_version.py
+++ b/sdk/python/plexi_sdk/_version.py
@@ -1,36 +1,65 @@
 """Single source of truth for the SDK version.
 
-The version lives in ``pyproject.toml`` (the ``[project].version`` field).
-The host copies that metadata beside the package at runtime. Missing or malformed
-metadata is an installation error: returning a default would make the SDK claim
-a version that was never declared.
+The version is declared once, in ``pyproject.toml`` (``[project].version``), and
+reaches the running package by one of two routes:
+
+- **Host / source layout** — the host copies ``pyproject.toml`` beside the
+  package directory, so it is read from there.
+- **Installed distribution** — a wheel carries that same declared value in its
+  ``dist-info`` metadata, so it is read via ``importlib.metadata``.
+
+Both routes resolve the same declaration. There is deliberately no literal
+default: a missing version is an installation error, and returning a made-up one
+would make the SDK claim a version that was never declared.
 """
 
 from __future__ import annotations
 
 import tomllib
+from importlib.metadata import PackageNotFoundError, version as _distribution_version
 from pathlib import Path
 
-def _read_from_pyproject() -> str:
+_DISTRIBUTION_NAME = "plexi-sdk"
+
+
+def _from_pyproject() -> str | None:
+    """Read the version from ``pyproject.toml`` beside the package, if present."""
     pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
     if not pyproject.is_file():
-        raise RuntimeError(
-            f"Plexi SDK metadata is missing: expected {pyproject}. "
-            "Reinstall Plexi to restore the bundled SDK."
-        )
+        return None
     with pyproject.open("rb") as f:
         data = tomllib.load(f)
     try:
-        version = data["project"]["version"]
+        declared = data["project"]["version"]
     except KeyError as e:
         raise RuntimeError(
             f"Plexi SDK metadata is invalid: {pyproject} has no project.version."
         ) from e
-    if not isinstance(version, str) or not version:
+    if not isinstance(declared, str) or not declared:
         raise RuntimeError(
             f"Plexi SDK metadata is invalid: {pyproject} has an empty project.version."
         )
-    return version
+    return declared
 
 
-__version__ = _read_from_pyproject()
+def _from_distribution() -> str | None:
+    """Read the version from installed distribution metadata, if installed."""
+    try:
+        return _distribution_version(_DISTRIBUTION_NAME)
+    except PackageNotFoundError:
+        return None
+
+
+def _resolve_version() -> str:
+    resolved = _from_pyproject() or _from_distribution()
+    if resolved is None:
+        package_dir = Path(__file__).resolve().parent
+        raise RuntimeError(
+            "Plexi SDK metadata is missing: no pyproject.toml beside "
+            f"{package_dir} and no installed '{_DISTRIBUTION_NAME}' distribution. "
+            "Reinstall Plexi to restore the bundled SDK."
+        )
+    return resolved
+
+
+__version__ = _resolve_version()

--- a/sdk/python/tests/test_version_unification.py
+++ b/sdk/python/tests/test_version_unification.py
@@ -7,7 +7,11 @@ If anyone reintroduces a hardcoded version constant, these tests fail loudly.
 from __future__ import annotations
 
 import tomllib
+import os
 from pathlib import Path
+import shutil
+import subprocess
+import sys
 
 import plexi_sdk
 
@@ -25,6 +29,25 @@ def test_dunder_version_matches_pyproject():
 
 def test_sdk_id_embeds_version():
     assert plexi_sdk.SDK_ID == f"plexi-sdk-py/{plexi_sdk.__version__}"
+
+
+def test_version_resolves_from_host_sdk_layout(tmp_path: Path):
+    """The host ships the package and metadata side by side under ``sdk/``."""
+    package_dir = Path(plexi_sdk.__file__).resolve().parent
+    sdk_dir = tmp_path / "sdk"
+    shutil.copytree(package_dir, sdk_dir / "plexi_sdk")
+    shutil.copy2(package_dir.parent / "pyproject.toml", sdk_dir / "pyproject.toml")
+
+    env = os.environ | {"PYTHONPATH": str(sdk_dir)}
+    result = subprocess.run(
+        [sys.executable, "-S", "-c", "import plexi_sdk; print(plexi_sdk.SDK_ID)"],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.stdout.strip() == f"plexi-sdk-py/{_pyproject_version()}"
 
 
 def test_no_stale_sdk_version_constant():

--- a/sdk/python/tests/test_version_unification.py
+++ b/sdk/python/tests/test_version_unification.py
@@ -31,23 +31,40 @@ def test_sdk_id_embeds_version():
     assert plexi_sdk.SDK_ID == f"plexi-sdk-py/{plexi_sdk.__version__}"
 
 
-def test_version_resolves_from_host_sdk_layout(tmp_path: Path):
-    """The host ships the package and metadata side by side under ``sdk/``."""
+def _host_sdk_layout(tmp_path: Path) -> Path:
     package_dir = Path(plexi_sdk.__file__).resolve().parent
     sdk_dir = tmp_path / "sdk"
     shutil.copytree(package_dir, sdk_dir / "plexi_sdk")
     shutil.copy2(package_dir.parent / "pyproject.toml", sdk_dir / "pyproject.toml")
+    return sdk_dir
 
+
+def _import_host_sdk(sdk_dir: Path) -> subprocess.CompletedProcess[str]:
     env = os.environ | {"PYTHONPATH": str(sdk_dir)}
-    result = subprocess.run(
+    return subprocess.run(
         [sys.executable, "-S", "-c", "import plexi_sdk; print(plexi_sdk.SDK_ID)"],
-        check=True,
         capture_output=True,
         env=env,
         text=True,
     )
 
+
+def test_version_resolves_from_host_sdk_layout(tmp_path: Path):
+    """The host ships the package and metadata side by side under ``sdk/``."""
+    result = _import_host_sdk(_host_sdk_layout(tmp_path))
+
+    assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == f"plexi-sdk-py/{_pyproject_version()}"
+
+
+def test_missing_host_sdk_metadata_fails_loudly(tmp_path: Path):
+    sdk_dir = _host_sdk_layout(tmp_path)
+    (sdk_dir / "pyproject.toml").unlink()
+
+    result = _import_host_sdk(sdk_dir)
+
+    assert result.returncode != 0
+    assert "Plexi SDK metadata is missing" in result.stderr
 
 
 def test_no_stale_sdk_version_constant():

--- a/sdk/python/tests/test_version_unification.py
+++ b/sdk/python/tests/test_version_unification.py
@@ -7,7 +7,6 @@ If anyone reintroduces a hardcoded version constant, these tests fail loudly.
 from __future__ import annotations
 
 import tomllib
-import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -40,11 +39,20 @@ def _host_sdk_layout(tmp_path: Path) -> Path:
 
 
 def _import_host_sdk(sdk_dir: Path) -> subprocess.CompletedProcess[str]:
-    env = os.environ | {"PYTHONPATH": str(sdk_dir)}
+    """Import the copied SDK with ``sdk_dir`` as the only non-stdlib path.
+
+    ``-I`` drops the cwd and ``PYTHONPATH``; ``-S`` drops site-packages. Without
+    both, the probe silently resolves the real source tree or the editable
+    install instead of the layout under test.
+    """
+    code = (
+        f"import sys; sys.path.insert(0, {str(sdk_dir)!r}); "
+        "import plexi_sdk; print(plexi_sdk.SDK_ID)"
+    )
     return subprocess.run(
-        [sys.executable, "-S", "-c", "import plexi_sdk; print(plexi_sdk.SDK_ID)"],
+        [sys.executable, "-I", "-S", "-c", code],
         capture_output=True,
-        env=env,
+        cwd=sdk_dir.parent,
         text=True,
     )
 
@@ -58,6 +66,7 @@ def test_version_resolves_from_host_sdk_layout(tmp_path: Path):
 
 
 def test_missing_host_sdk_metadata_fails_loudly(tmp_path: Path):
+    """No pyproject.toml and no installed distribution: refuse to guess a version."""
     sdk_dir = _host_sdk_layout(tmp_path)
     (sdk_dir / "pyproject.toml").unlink()
 
@@ -65,6 +74,22 @@ def test_missing_host_sdk_metadata_fails_loudly(tmp_path: Path):
 
     assert result.returncode != 0
     assert "Plexi SDK metadata is missing" in result.stderr
+
+
+def test_version_resolves_from_installed_distribution_metadata(tmp_path: Path):
+    """Wheel layout: the package ships without pyproject.toml, dist-info carries it."""
+    sdk_dir = _host_sdk_layout(tmp_path)
+    (sdk_dir / "pyproject.toml").unlink()
+    dist_info = sdk_dir / "plexi_sdk-9.9.9.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: plexi-sdk\nVersion: 9.9.9\n"
+    )
+
+    result = _import_host_sdk(sdk_dir)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "plexi-sdk-py/9.9.9"
 
 
 def test_no_stale_sdk_version_constant():

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "plexi-sdk"
-version = "0.2.0"
+version = "0.2.2"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -892,6 +892,7 @@ pub fn ensure_profile_initialized() -> bool {
     let stamp_path = sdk_dir.join(".sdk_version");
     let current_version = env!("CARGO_PKG_VERSION");
     let needs_extract = !sdk_dest.exists()
+        || !sdk_dir.join("pyproject.toml").is_file()
         || std::fs::read_to_string(&stamp_path)
             .map(|v| v.trim() != current_version)
             .unwrap_or(true);
@@ -907,11 +908,18 @@ pub fn ensure_profile_initialized() -> bool {
                 eprintln!("profile init: failed to seed SDK: {e}");
             } else {
                 let _ = std::fs::create_dir_all(&sdk_dir);
-                let _ = std::fs::write(&stamp_path, current_version);
-                log::info!(
-                    "profile init: seeded SDK v{current_version} to {}",
-                    sdk_dest.display()
-                );
+                if let Err(e) = std::fs::write(
+                    sdk_dir.join("pyproject.toml"),
+                    include_str!("../../sdk/python/pyproject.toml"),
+                ) {
+                    eprintln!("profile init: failed to seed SDK metadata: {e}");
+                } else {
+                    let _ = std::fs::write(&stamp_path, current_version);
+                    log::info!(
+                        "profile init: seeded SDK v{current_version} to {}",
+                        sdk_dest.display()
+                    );
+                }
             }
         }
     } else {


### PR DESCRIPTION
## Summary

Implements stint 0576. No linked GitHub issue; stint is authoritative.

- Re-export the SDK package version from the single authoritative `pyproject.toml` metadata file.
- Seed that metadata beside `plexi_sdk` for both host extraction and `install.sh`.
- Treat missing or malformed SDK metadata as an installation error; never invent a fallback version.
- Cover both the valid host layout and the hidden-metadata failure path.

## Root cause

`_version.py` had a stale hardcoded fallback, so a damaged host SDK install could silently report a version unrelated to its package metadata.

## Done When

- `plexi_sdk.__version__` and `SDK_ID` derive from `sdk/python/pyproject.toml`.
- The SDK packaged under `sdk/plexi_sdk` resolves the same version without installed distribution metadata.
- Missing packaged metadata fails loudly rather than reporting a default version.

## Test evidence

- `pytest sdk/python/tests/test_version_unification.py -q`: 5 passed, including the hidden-metadata error case.
- `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py`: Success: no issues found in 27 source files.
- `just check-sdk-docs`: SDK docs are up to date.
- `cargo build`: passed (linker compact-unwind warning only).
- Env-stripped `cargo test --bin plexi`: 2120 passed, 2 pre-existing/unrelated failures (`headless_frame_fails_fast_when_the_guest_dies_at_import`, `pane_send_submit_unconfirmed_reports_observed_input_line`); the full scene suite passed and no RSS watchdog hit.

## Validation handoff

Automated/headless worker validation only. A separate tester owns any live host validation.
