### PR TITLE
fix(host): attribute tracebacks and quarantine pre-v3 apps (stints 0643, 0642)

### DIFF
--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -88,6 +88,7 @@ app install [SPEC]       Install from path, github:owner/repo, or --pack core.
                          No args = install from .plexi/apps.toml. --version SEMVER to pin.
 app uninstall ID         Remove an installed app.
 app list                 Show all installed apps with versions.
+app prune --dry-run      Report retired first-party pre-v3 installs that launch reconciliation removes.
 app info ID              Show app details: id, name, version, tools.
 app render APP           Render an app (installed id or local path, e.g. ".") without a
                          running host. Default output is the JSON UI tree; --png for an

--- a/src/cli/AGENTS.md
+++ b/src/cli/AGENTS.md
@@ -43,6 +43,7 @@ Any change to a CLI verb, flag, or agent-facing behavior updates this file **and
 ## Traps
 
 - **Path-based app commands must not resolve a workspace.** `app validate <path>`, `app install <path>`, `app run <path>` operate on an explicit filesystem path. Never call `resolve_workspace_root` for that argument. Use `std::fs::canonicalize` directly. `resolve_workspace_root` is only legitimate in `AppRegistry::load` and `app init`.
+- **Profile reconciliation is narrowly scoped.** `app prune --dry-run` reports only positively identified retired first-party pre-v3 installs; never infer deletability from absence from the current core pack, because user and marketplace apps also live in the global profile.
 - **Building a `-c` command string:** use `cmd_from_args` (in `src/app/mod.rs`), not `shell_join` directly. A single-arg array is already a shell expression; `shell_join(["echo hello"])` yields `'echo hello'`.
 - **Shell suffix construction:** when appending a stay-alive or exec suffix to a user command string, use the absolute shell path from `settings.shell` (already resolved), not `$SHELL`. `trim_end_matches([';', ' '])` the user command before appending to prevent `;;` syntax errors.
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1419,6 +1419,35 @@ pub fn app_list() -> i32 {
     super::list::list_cli()
 }
 
+/// `plexi app prune --dry-run` reports precisely the legacy installs that a
+/// normal launch will reconcile. The no-flag form performs the same safe,
+/// positively-identified reconciliation for users repairing a stopped profile.
+pub fn app_prune_cli(dry_run: bool) -> i32 {
+    let apps_dir = crate::app::registry::apps_dir();
+    let candidates = crate::cli::install_host::orphaned_pre_v3_first_party_apps(&apps_dir);
+    log::info!(
+        "app_prune: {} candidate(s) at {} dry_run={dry_run}",
+        candidates.len(),
+        apps_dir.display()
+    );
+    if dry_run {
+        for candidate in candidates {
+            println!("would quarantine {}", candidate.display());
+        }
+        return 0;
+    }
+    let removed = crate::cli::install_host::reconcile_orphaned_pre_v3_first_party_apps(&apps_dir);
+    let all_removed = removed.len() == candidates.len();
+    for path in removed {
+        println!("quarantined {}", path.display());
+    }
+    if !all_removed {
+        eprintln!("error: one or more orphaned pre-v3 apps could not be quarantined");
+        return 1;
+    }
+    0
+}
+
 /// `plexi app render <app> --size WxH [--state state.json] [--output path] [--png]`
 /// Renders an app headlessly. `app` may be an installed app ID or a local directory path.
 /// Default output: JSON frame tree. With --png: PNG image.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -590,6 +590,12 @@ pub enum AppCmd {
     },
     /// Show all installed apps with their versions.
     List,
+    /// Report obsolete first-party pre-v3 apps that launch-time reseeding quarantines.
+    Prune {
+        /// Show candidates without removing anything.
+        #[arg(long)]
+        dry_run: bool,
+    },
     /// Render an app headlessly (JSON frame tree by default, or PNG with --png).
     Render {
         /// App id or local path to render (e.g. "calc" or "./my-app")

--- a/src/cli/install_host.rs
+++ b/src/cli/install_host.rs
@@ -822,6 +822,119 @@ pub fn core_pack_ids() -> std::collections::HashSet<String> {
         .unwrap_or_default()
 }
 
+/// First-party apps deliberately retired before the v3 SDK migration. An app
+/// is a quarantine candidate only when its stable former-first-party id is in
+/// this set *and* its source still imports the removed v2 App/RenderContext
+/// surface. The intersection is intentional: a user or marketplace app with
+/// an unfamiliar id is never removed merely because it is not in core.
+const RETIRED_PRE_V3_FIRST_PARTY_APP_IDS: &[&str] = &[
+    "assistant",
+    "audio-recorder",
+    "bluesky",
+    "calendar",
+    "chess",
+    "context-notifier-poc",
+    "descriptor-renderer",
+    "dev-here",
+    "gh-projects",
+    "github-tree",
+    "image-loader",
+    "image-render-poc",
+    "image-url-poc",
+    "input-inspector",
+    "layout-demo",
+    "mcp-demo",
+    "mind-map",
+    "node-canvas",
+    "notification-tester",
+    "permission-test",
+    "quick-note",
+    "screen-time",
+    "secrets-routing-tester",
+    "snake-race",
+    "timer",
+    "typing-tutor",
+    "ui-playground",
+    "workspace",
+];
+
+/// Return app directories identified as former first-party pre-v3 installs.
+/// This is side-effect free so `plexi app prune --dry-run` can report exactly
+/// what a launch-time reconciliation would remove.
+pub fn orphaned_pre_v3_first_party_apps(target_root: &Path) -> Vec<PathBuf> {
+    let core_ids = core_pack_ids();
+    let mut candidates = Vec::new();
+    let Ok(entries) = std::fs::read_dir(target_root) else {
+        return candidates;
+    };
+    for entry in entries.flatten() {
+        let app_dir = entry.path();
+        if !app_dir.is_dir() {
+            continue;
+        }
+        let Some(id) = app_dir.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if core_ids.contains(id) || !RETIRED_PRE_V3_FIRST_PARTY_APP_IDS.contains(&id) {
+            continue;
+        }
+        if has_pre_v3_app_imports(&app_dir) {
+            candidates.push(app_dir);
+        }
+    }
+    candidates.sort();
+    candidates
+}
+
+/// Quarantine only candidates returned by [`orphaned_pre_v3_first_party_apps`].
+/// The hidden profile directory keeps ambiguous legacy content recoverable while
+/// removing it from normal app discovery. Re-running is a no-op.
+pub fn reconcile_orphaned_pre_v3_first_party_apps(target_root: &Path) -> Vec<PathBuf> {
+    let candidates = orphaned_pre_v3_first_party_apps(target_root);
+    let quarantine = target_root.join(".plexi-quarantine-pre-v3");
+    for path in &candidates {
+        let Some(name) = path.file_name() else { continue };
+        let destination = quarantine.join(name);
+        match std::fs::create_dir_all(&quarantine).and_then(|()| std::fs::rename(path, &destination)) {
+            Ok(()) => log::info!("install: quarantined orphaned pre-v3 app {}", path.display()),
+            Err(error) => log::warn!(
+                "install: could not quarantine orphaned pre-v3 app {}: {error}",
+                path.display()
+            ),
+        }
+    }
+    candidates
+        .into_iter()
+        .filter(|path| !path.exists())
+        .collect()
+}
+
+fn has_pre_v3_app_imports(app_dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(app_dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            return false;
+        };
+        if file_type.is_symlink() {
+            return false;
+        }
+        if file_type.is_dir() {
+            return has_pre_v3_app_imports(&path);
+        }
+        if !file_type.is_file() || path.extension().is_none_or(|extension| extension != "py") {
+            return false;
+        }
+        std::fs::read_to_string(path).is_ok_and(|source| {
+            source.contains("from plexi_sdk import")
+                && source.contains("App")
+                && source.contains("RenderContext")
+        })
+    })
+}
+
 /// Returns the set of app IDs defined in the bundled examples pack.
 pub fn examples_pack_ids() -> std::collections::HashSet<String> {
     Pack::from_toml_str(EXAMPLES_PACK_TOML)
@@ -1389,6 +1502,72 @@ mod pack_export_tests {
 mod core_pack_tests {
     use super::test_support::MockCloner;
     use super::*;
+
+    fn plant_python_app(root: &Path, id: &str, source: &str) -> PathBuf {
+        let app_dir = root.join(id);
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(
+            app_dir.join("manifest.toml"),
+            format!(
+                "schema_version = 1\n\n[app]\nid = \"{id}\"\ntype = \"app\"\nname = \"{id}\"\nversion = \"0.1.0\"\nentry = \"main.py\"\n"
+            ),
+        )
+        .unwrap();
+        std::fs::write(app_dir.join("main.py"), source).unwrap();
+        app_dir
+    }
+
+    #[test]
+    fn reconcile_quarantines_only_identified_orphaned_pre_v3_first_party_apps() {
+        let target = tempfile::tempdir().unwrap();
+        let legacy = "from plexi_sdk import App, RenderContext\nclass Old(App): pass\n";
+        let stale_quick_note = plant_python_app(target.path(), "quick-note", legacy);
+        let stale_timer = plant_python_app(target.path(), "timer", legacy);
+        let live_core = plant_python_app(target.path(), "balls", legacy);
+        let user_app = plant_python_app(target.path(), "my-private-app", legacy);
+        let marketplace_app = plant_python_app(target.path(), "marketplace-legacy", legacy);
+        let current_v3 = plant_python_app(
+            target.path(),
+            "calendar",
+            "from plexi_sdk import log, state\nstate.get('today')\n",
+        );
+
+        let candidates = orphaned_pre_v3_first_party_apps(target.path());
+        assert_eq!(
+            candidates,
+            vec![stale_quick_note.clone(), stale_timer.clone()]
+        );
+        let removed = reconcile_orphaned_pre_v3_first_party_apps(target.path());
+        assert_eq!(removed, vec![stale_quick_note.clone(), stale_timer.clone()]);
+        assert!(!stale_quick_note.exists());
+        assert!(!stale_timer.exists());
+        assert!(target.path().join(".plexi-quarantine-pre-v3/quick-note").exists());
+        assert!(target.path().join(".plexi-quarantine-pre-v3/timer").exists());
+        for preserved in [&live_core, &user_app, &marketplace_app, &current_v3] {
+            assert!(preserved.exists(), "must preserve {}", preserved.display());
+        }
+        assert!(
+            reconcile_orphaned_pre_v3_first_party_apps(target.path()).is_empty(),
+            "a second reconcile must be idempotent"
+        );
+    }
+
+    #[test]
+    fn orphaned_pre_v3_dry_run_candidates_leave_directories_unchanged() {
+        let target = tempfile::tempdir().unwrap();
+        let stale = plant_python_app(
+            target.path(),
+            "quick-note",
+            "from plexi_sdk import App, RenderContext\nclass Old(App): pass\n",
+        );
+        let candidates = orphaned_pre_v3_first_party_apps(target.path());
+        assert_eq!(candidates, vec![stale.clone()]);
+        assert!(
+            stale.exists(),
+            "candidate discovery must not delete anything"
+        );
+        assert!(stale.join("main.py").exists());
+    }
 
     #[test]
     fn core_pack_always_installs_missing_apps() {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -952,8 +952,8 @@ pub use agent::{
 pub use ai::{ai_doctor_cli, ai_onboard_cli, ai_setup_cli};
 pub use app::{
     app_action_cli, app_info, app_init, app_inspect_cli, app_install_package, app_install_with_pin,
-    app_list, app_package_cli, app_render, app_test_cli, app_uninstall, app_update_cli,
-    InstallConfirm,
+    app_list, app_package_cli, app_prune_cli, app_render, app_test_cli, app_uninstall,
+    app_update_cli, InstallConfirm,
 };
 pub use app_check::app_check_cli;
 pub use completions::{complete_open_cli, complete_run_cli, completions_cli};

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -1554,19 +1554,21 @@ impl LivePythonPane {
             }
         }
         let stderr = self.runtime.drain_stderr();
-        if !stderr.trim().is_empty() {
-            if is_benign_cpython_wasi_stderr(&stderr) {
-                log::debug!(
+        for record in guest_stderr_records(&stderr) {
+            match record.kind {
+                GuestStderrKind::BenignWasiStartup => log::debug!(
                     "app::{} CPython WASM stderr (benign WASI startup noise): {}",
                     self.app_id,
-                    stderr.trim()
-                );
-            } else {
-                log::error!(
-                    "app::{} CPython WASM stderr: {}",
+                    record.line
+                ),
+                GuestStderrKind::Payload => {
+                    log::error!("app::{} CPython WASM stderr: {}", self.app_id, record.line)
+                }
+                GuestStderrKind::TracebackException => log::error!(
+                    "app::{} CPython WASM stderr exception: {}",
                     self.app_id,
-                    stderr.trim()
-                );
+                    record.line
+                ),
             }
         }
     }
@@ -2193,6 +2195,7 @@ fn python_semantic_state(tree: Option<&PythonUiTree>) -> crate::host::pane::Sema
 /// agents and humans to ignore real guest tracebacks in the same stream.
 /// Returns true only when *every* non-empty line matches a known-benign
 /// pattern; any unrecognized line (a real traceback) keeps the ERROR level.
+#[cfg(test)]
 fn is_benign_cpython_wasi_stderr(stderr: &str) -> bool {
     const BENIGN_SUBSTRINGS: &[&str] = &["Could not find platform dependent libraries"];
     stderr
@@ -2200,6 +2203,56 @@ fn is_benign_cpython_wasi_stderr(stderr: &str) -> bool {
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .all(|line| BENIGN_SUBSTRINGS.iter().any(|needle| line.contains(needle)))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GuestStderrKind {
+    BenignWasiStartup,
+    Payload,
+    TracebackException,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GuestStderrRecord<'a> {
+    kind: GuestStderrKind,
+    line: &'a str,
+}
+
+/// Turn guest stderr into one host log record per physical non-empty line.
+/// A traceback's final line is singled out because it contains the exception
+/// type and message a reader needs to find first. This deliberately returns
+/// records rather than a formatted blob: logging a blob gives continuation
+/// lines no host prefix and makes them impossible to attribute or grep.
+fn guest_stderr_records(stderr: &str) -> Vec<GuestStderrRecord<'_>> {
+    const BENIGN_SUBSTRINGS: &[&str] = &["Could not find platform dependent libraries"];
+    let mut records: Vec<_> = stderr
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(|line| GuestStderrRecord {
+            kind: if BENIGN_SUBSTRINGS.iter().any(|needle| line.contains(needle)) {
+                GuestStderrKind::BenignWasiStartup
+            } else {
+                GuestStderrKind::Payload
+            },
+            line,
+        })
+        .collect();
+    if records.iter().any(|record| {
+        record.kind == GuestStderrKind::Payload
+            && record
+                .line
+                .starts_with("Traceback (most recent call last):")
+    }) {
+        if let Some(last_payload) = records
+            .iter_mut()
+            .rev()
+            .find(|record| record.kind == GuestStderrKind::Payload)
+        {
+            last_payload.kind = GuestStderrKind::TracebackException;
+        }
+    }
+    records
 }
 
 fn python_key_name(key: egui::Key) -> String {
@@ -4020,6 +4073,47 @@ mod tests {
             "Could not find platform dependent libraries <exec_prefix>\n\
              Traceback (most recent call last):\n  ZeroDivisionError"
         ));
+    }
+
+    #[test]
+    fn guest_stderr_records_split_noise_and_prefixable_traceback_lines() {
+        let records = guest_stderr_records(
+            "Could not find platform dependent libraries <exec_prefix>\n\
+             Traceback (most recent call last):\n\
+               File \"main.py\", line 4, in <module>\n\
+             ImportError: cannot import name 'App' from 'plexi_sdk'\n",
+        );
+        assert_eq!(
+            records,
+            vec![
+                GuestStderrRecord {
+                    kind: GuestStderrKind::BenignWasiStartup,
+                    line: "Could not find platform dependent libraries <exec_prefix>",
+                },
+                GuestStderrRecord {
+                    kind: GuestStderrKind::Payload,
+                    line: "Traceback (most recent call last):",
+                },
+                GuestStderrRecord {
+                    kind: GuestStderrKind::Payload,
+                    line: "File \"main.py\", line 4, in <module>",
+                },
+                GuestStderrRecord {
+                    kind: GuestStderrKind::TracebackException,
+                    line: "ImportError: cannot import name 'App' from 'plexi_sdk'",
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn guest_stderr_records_never_preserve_raw_continuations() {
+        let records = guest_stderr_records("warning one\nwarning two\n");
+        assert_eq!(records.len(), 2);
+        assert!(records.iter().all(|record| !record.line.contains('\n')));
+        assert!(records
+            .iter()
+            .all(|record| record.kind == GuestStderrKind::Payload));
     }
 
     #[test]

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -736,6 +736,10 @@ pub struct LivePythonPane {
     /// instead of discarding it, so it survives to the next frame that
     /// actually reaches the render call.
     pending_click_carry: Option<crate::host::pane::PendingPaneClick>,
+    /// Line-buffered, traceback-aware classifier over this guest's stderr.
+    /// Lives on the pane because a traceback spans several `drain_stderr`
+    /// calls and its state must survive between them.
+    stderr_classifier: GuestStderrClassifier,
 }
 
 #[derive(Debug, Clone)]
@@ -1246,6 +1250,7 @@ impl LivePythonPane {
             granted_fs_roots: Vec::new(),
             pending_commands: Vec::new(),
             pending_click_carry: None,
+            stderr_classifier: GuestStderrClassifier::new(),
         })
     }
 
@@ -1554,21 +1559,41 @@ impl LivePythonPane {
             }
         }
         let stderr = self.runtime.drain_stderr();
-        for record in guest_stderr_records(&stderr) {
-            match record.kind {
-                GuestStderrKind::BenignWasiStartup => log::debug!(
-                    "app::{} CPython WASM stderr (benign WASI startup noise): {}",
-                    self.app_id,
-                    record.line
-                ),
-                GuestStderrKind::Payload => {
-                    log::error!("app::{} CPython WASM stderr: {}", self.app_id, record.line)
-                }
-                GuestStderrKind::TracebackException => log::error!(
-                    "app::{} CPython WASM stderr exception: {}",
-                    self.app_id,
-                    record.line
-                ),
+        let mut records = self.stderr_classifier.push(&stderr);
+        if self.runtime.is_finished() {
+            // Nothing more will terminate a half-line, so report it now
+            // rather than losing the last line of a crash.
+            records.extend(self.stderr_classifier.flush());
+        }
+        for record in records {
+            self.log_guest_stderr(&record);
+        }
+    }
+
+    /// One host record per guest stderr line, each carrying the `app::<id>`
+    /// prefix so the whole traceback is greppable by app (stint 0643).
+    fn log_guest_stderr(&self, record: &GuestStderrRecord) {
+        match record.kind {
+            GuestStderrKind::BenignWasiStartup => log::debug!(
+                "app::{} CPython WASM stderr (benign WASI startup noise): {}",
+                self.app_id,
+                record.line
+            ),
+            GuestStderrKind::TracebackException => log::error!(
+                "app::{} CPython WASM stderr exception: {}",
+                self.app_id,
+                record.line
+            ),
+            GuestStderrKind::TracebackExceptionDetail => log::error!(
+                "app::{} CPython WASM stderr exception (cont): {}",
+                self.app_id,
+                record.line
+            ),
+            GuestStderrKind::Payload
+            | GuestStderrKind::TracebackHeader
+            | GuestStderrKind::TracebackFrame
+            | GuestStderrKind::TracebackChainSeparator => {
+                log::error!("app::{} CPython WASM stderr: {}", self.app_id, record.line)
             }
         }
     }
@@ -2139,6 +2164,10 @@ impl LivePythonPane {
         self.timers.clear();
         self.pending_timer_events.clear();
         self.viewport_size = None;
+        // A fresh runtime is a fresh stderr stream: carrying the old guest's
+        // half-line or traceback state into it would misclassify the new
+        // guest's first lines.
+        self.stderr_classifier = GuestStderrClassifier::new();
         if let Some(dropped) = self.pending_click_carry.take() {
             // A node-targeted click's arena id belongs to the tree it was
             // resolved against — that tree is gone after relaunch, so
@@ -2192,67 +2221,163 @@ fn python_semantic_state(tree: Option<&PythonUiTree>) -> crate::host::pane::Sema
 /// libraries <exec_prefix>` to stderr on every guest boot even when the
 /// runtime starts and runs fine — WASI has no real filesystem layout for
 /// CPython's `sysconfig` probe to find. Logging that line at ERROR trains
-/// agents and humans to ignore real guest tracebacks in the same stream.
-/// Returns true only when *every* non-empty line matches a known-benign
-/// pattern; any unrecognized line (a real traceback) keeps the ERROR level.
-#[cfg(test)]
-fn is_benign_cpython_wasi_stderr(stderr: &str) -> bool {
-    const BENIGN_SUBSTRINGS: &[&str] = &["Could not find platform dependent libraries"];
-    stderr
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .all(|line| BENIGN_SUBSTRINGS.iter().any(|needle| line.contains(needle)))
-}
+/// agents and humans to ignore real guest tracebacks in the same stream, so
+/// it is demoted to DEBUG per line.
+const BENIGN_WASI_STARTUP_SUBSTRINGS: &[&str] = &["Could not find platform dependent libraries"];
+const TRACEBACK_HEADER: &str = "Traceback (most recent call last):";
+/// The two sentences CPython prints between a chained pair of tracebacks.
+/// Each is followed by a fresh `Traceback` header, so they close the block
+/// they follow rather than continuing it.
+const TRACEBACK_CHAIN_SEPARATORS: &[&str] = &[
+    "During handling of the above exception, another exception occurred:",
+    "The above exception was the direct cause of the following exception:",
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GuestStderrKind {
     BenignWasiStartup,
     Payload,
+    TracebackHeader,
+    TracebackFrame,
+    TracebackChainSeparator,
+    /// The line carrying the exception type and message — what a reader is
+    /// actually looking for, and the only kind that gets the `exception:`
+    /// marker in the log.
     TracebackException,
+    /// Continuation lines of a multi-line exception message. Attributed to
+    /// the exception but deliberately not marked as one: an exception has
+    /// exactly one `exception:` line, however many lines its message spans.
+    TracebackExceptionDetail,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct GuestStderrRecord<'a> {
+struct GuestStderrRecord {
     kind: GuestStderrKind,
-    line: &'a str,
+    line: String,
 }
 
-/// Turn guest stderr into one host log record per physical non-empty line.
-/// A traceback's final line is singled out because it contains the exception
-/// type and message a reader needs to find first. This deliberately returns
-/// records rather than a formatted blob: logging a blob gives continuation
-/// lines no host prefix and makes them impossible to attribute or grep.
-fn guest_stderr_records(stderr: &str) -> Vec<GuestStderrRecord<'_>> {
-    const BENIGN_SUBSTRINGS: &[&str] = &["Could not find platform dependent libraries"];
-    let mut records: Vec<_> = stderr
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .map(|line| GuestStderrRecord {
-            kind: if BENIGN_SUBSTRINGS.iter().any(|needle| line.contains(needle)) {
-                GuestStderrKind::BenignWasiStartup
-            } else {
-                GuestStderrKind::Payload
-            },
-            line,
-        })
-        .collect();
-    if records.iter().any(|record| {
-        record.kind == GuestStderrKind::Payload
-            && record
-                .line
-                .starts_with("Traceback (most recent call last):")
-    }) {
-        if let Some(last_payload) = records
-            .iter_mut()
-            .rev()
-            .find(|record| record.kind == GuestStderrKind::Payload)
-        {
-            last_payload.kind = GuestStderrKind::TracebackException;
+/// Longest unterminated stderr fragment held back waiting for its newline.
+const MAX_BUFFERED_STDERR_LINE: usize = 64 * 1024;
+
+/// Where the stderr stream currently sits inside a CPython traceback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TracebackState {
+    Outside,
+    /// Inside the indented frame block that follows a `Traceback` header.
+    Frames,
+    /// Past the exception line, consuming the rest of its message.
+    ExceptionMessage,
+}
+
+/// Classifies a guest's stderr into one host log record per line.
+///
+/// Streaming and stateful on purpose. `drain_stderr` hands back whatever bytes
+/// happen to have arrived, so a single traceback routinely spans several
+/// drains and a drain can even split a line mid-way. Any rule that reads a
+/// drain as a self-contained block — "the exception is the last line I can
+/// see" — therefore marks whichever frame line ended the *chunk*, and the real
+/// exception arrives later unmarked. Roles are decided from each line's own
+/// shape against carried-over state instead: a frame line is indented, an
+/// exception line is not, which is what structurally distinguishes them.
+struct GuestStderrClassifier {
+    /// Bytes after the last newline, held until the rest of the line arrives.
+    partial: String,
+    state: TracebackState,
+}
+
+impl GuestStderrClassifier {
+    fn new() -> Self {
+        Self {
+            partial: String::new(),
+            state: TracebackState::Outside,
         }
     }
-    records
+
+    /// Classify every complete line in `chunk`, holding back a trailing
+    /// unterminated one for the next drain.
+    fn push(&mut self, chunk: &str) -> Vec<GuestStderrRecord> {
+        self.partial.push_str(chunk);
+        let mut records = Vec::new();
+        while let Some(newline) = self.partial.find('\n') {
+            let line: String = self.partial.drain(..=newline).collect();
+            if let Some(record) = self.classify(line.trim_end()) {
+                records.push(record);
+            }
+        }
+        // A guest writing without newlines must not buffer forever: flush the
+        // oversized fragment as its own record rather than holding the log
+        // hostage to a line that never terminates.
+        if self.partial.len() > MAX_BUFFERED_STDERR_LINE {
+            records.extend(self.flush());
+        }
+        records
+    }
+
+    /// Emit the buffered unterminated line. Called once the guest is gone, so
+    /// a crash whose last line lacks a trailing newline is still reported.
+    fn flush(&mut self) -> Option<GuestStderrRecord> {
+        let line = std::mem::take(&mut self.partial);
+        self.classify(line.trim_end())
+    }
+
+    fn classify(&mut self, line: &str) -> Option<GuestStderrRecord> {
+        if line.trim().is_empty() {
+            // A blank line closes a traceback block — CPython separates a
+            // chained traceback from the next with one. It carries nothing a
+            // reader needs, so it steers state and is never logged.
+            if self.state == TracebackState::ExceptionMessage {
+                self.state = TracebackState::Outside;
+            }
+            return None;
+        }
+        let trimmed = line.trim();
+        let indented = line.starts_with([' ', '\t']);
+        let kind = if BENIGN_WASI_STARTUP_SUBSTRINGS
+            .iter()
+            .any(|needle| trimmed.contains(needle))
+        {
+            GuestStderrKind::BenignWasiStartup
+        } else if trimmed == TRACEBACK_HEADER {
+            self.state = TracebackState::Frames;
+            GuestStderrKind::TracebackHeader
+        } else if TRACEBACK_CHAIN_SEPARATORS.contains(&trimmed) {
+            self.state = TracebackState::Outside;
+            GuestStderrKind::TracebackChainSeparator
+        } else {
+            match self.state {
+                // The frame block ends at the first line that is not indented,
+                // and in CPython's format that line is the exception. Shape,
+                // not position: `File "x.py", line 1, in f` and the source and
+                // caret lines under it are indented, `RuntimeError: boom` is
+                // not — which also lands a bare `KeyboardInterrupt` correctly.
+                TracebackState::Frames if !indented => {
+                    self.state = TracebackState::ExceptionMessage;
+                    GuestStderrKind::TracebackException
+                }
+                TracebackState::Frames => GuestStderrKind::TracebackFrame,
+                TracebackState::ExceptionMessage => GuestStderrKind::TracebackExceptionDetail,
+                // A compile-time `SyntaxError` has no `Traceback` header at
+                // all: it opens straight into an indented `File` line. Keying
+                // on the frame shape picks that up, and picks a traceback up
+                // mid-stream if its header was already consumed.
+                TracebackState::Outside if indented && is_traceback_frame_line(trimmed) => {
+                    self.state = TracebackState::Frames;
+                    GuestStderrKind::TracebackFrame
+                }
+                TracebackState::Outside => GuestStderrKind::Payload,
+            }
+        };
+        Some(GuestStderrRecord {
+            kind,
+            line: trimmed.to_string(),
+        })
+    }
+}
+
+/// `File "<path>", line <n>[, in <name>]` — the one shape every CPython
+/// traceback frame opens with, quoted path or angle-bracketed frozen module.
+fn is_traceback_frame_line(trimmed: &str) -> bool {
+    trimmed.starts_with("File ") && trimmed.contains(", line ")
 }
 
 fn python_key_name(key: egui::Key) -> String {
@@ -4046,71 +4171,217 @@ mod tests {
         );
     }
 
-    /// Stint 0417: the benign CPython WASI startup line must classify as
-    /// non-error so it doesn't drown real guest tracebacks in the log.
+    /// Feed stderr through one classifier the way the pane does — one call
+    /// per `drain_stderr` — then flush the trailing partial line.
+    fn classify_stderr(chunks: &[&str]) -> Vec<GuestStderrRecord> {
+        let mut classifier = GuestStderrClassifier::new();
+        let mut records: Vec<_> = chunks
+            .iter()
+            .flat_map(|chunk| classifier.push(chunk))
+            .collect();
+        records.extend(classifier.flush());
+        records
+    }
+
+    fn exception_lines(records: &[GuestStderrRecord]) -> Vec<&str> {
+        records
+            .iter()
+            .filter(|record| record.kind == GuestStderrKind::TracebackException)
+            .map(|record| record.line.as_str())
+            .collect()
+    }
+
+    /// Stint 0417: the benign CPython WASI startup line classifies as noise so
+    /// it doesn't drown real guest tracebacks — but only that line, and never
+    /// at the cost of the traceback it is concatenated in front of.
     #[test]
-    fn is_benign_cpython_wasi_stderr_recognizes_known_benign_line() {
-        assert!(is_benign_cpython_wasi_stderr(
-            "Could not find platform dependent libraries <exec_prefix>\n"
-        ));
-        // Repeated/whitespace-padded — still benign.
-        assert!(is_benign_cpython_wasi_stderr(
+    fn guest_stderr_isolates_benign_wasi_startup_noise_from_the_payload() {
+        let records = classify_stderr(&[
             "  Could not find platform dependent libraries <exec_prefix>  \n\
-             Could not find platform dependent libraries <exec_prefix>\n"
-        ));
-        // Empty stderr trivially has no non-benign lines.
-        assert!(is_benign_cpython_wasi_stderr(""));
-        assert!(is_benign_cpython_wasi_stderr("\n\n"));
-    }
-
-    #[test]
-    fn is_benign_cpython_wasi_stderr_keeps_real_tracebacks_at_error() {
-        assert!(!is_benign_cpython_wasi_stderr(
-            "Traceback (most recent call last):\n  File \"logs.py\", line 10\nNameError: x"
-        ));
-        // A benign line mixed with a real traceback must not be swallowed.
-        assert!(!is_benign_cpython_wasi_stderr(
-            "Could not find platform dependent libraries <exec_prefix>\n\
-             Traceback (most recent call last):\n  ZeroDivisionError"
-        ));
-    }
-
-    #[test]
-    fn guest_stderr_records_split_noise_and_prefixable_traceback_lines() {
-        let records = guest_stderr_records(
-            "Could not find platform dependent libraries <exec_prefix>\n\
+             Could not find platform dependent libraries <exec_prefix>\n\
+             \n\
              Traceback (most recent call last):\n\
-               File \"main.py\", line 4, in <module>\n\
-             ImportError: cannot import name 'App' from 'plexi_sdk'\n",
-        );
+             \x20 File \"logs.py\", line 10, in <module>\n\
+             NameError: x\n",
+        ]);
         assert_eq!(
-            records,
+            records
+                .iter()
+                .filter(|record| record.kind == GuestStderrKind::BenignWasiStartup)
+                .count(),
+            2
+        );
+        assert_eq!(exception_lines(&records), vec!["NameError: x"]);
+        // Every record is one physical line: a continuation with no host
+        // prefix is exactly what stint 0643 exists to prevent.
+        assert!(records.iter().all(|record| !record.line.contains('\n')));
+    }
+
+    /// Stint 0643 regression. The marker must land on the exception, not on
+    /// whichever frame line happened to end a drain. Real repro shape: a
+    /// `RuntimeError` under the `runpy` bootstrap frames, arriving in the two
+    /// chunks the pane actually saw — the header and first frame in one
+    /// drain, the rest in the next.
+    #[test]
+    fn guest_stderr_marks_the_exception_not_the_first_frame_across_drains() {
+        let records = classify_stderr(&[
+            "Traceback (most recent call last):\n\
+             \x20 File \"<frozen runpy>\", line 198, in _run_module_as_main\n",
+            "  File \"<frozen runpy>\", line 88, in _run_code\n\
+             \x20 File \"/app/main.py\", line 7, in <module>\n\
+             \x20   raise RuntimeError(\"PR2530_TRACEBACK_SENTINEL\")\n\
+             RuntimeError: PR2530_TRACEBACK_SENTINEL\n",
+        ]);
+        assert_eq!(
+            exception_lines(&records),
+            vec!["RuntimeError: PR2530_TRACEBACK_SENTINEL"]
+        );
+        assert!(records
+            .iter()
+            .filter(|record| record.line.starts_with("File "))
+            .all(|record| record.kind == GuestStderrKind::TracebackFrame));
+    }
+
+    /// A chained traceback has two exceptions and must mark both — and must
+    /// not mark the sentence between them.
+    #[test]
+    fn guest_stderr_marks_both_halves_of_a_chained_traceback() {
+        let records = classify_stderr(&["Traceback (most recent call last):\n\
+             \x20 File \"/app/main.py\", line 3, in <module>\n\
+             \x20   1 / 0\n\
+             ZeroDivisionError: division by zero\n\
+             \n\
+             During handling of the above exception, another exception occurred:\n\
+             \n\
+             Traceback (most recent call last):\n\
+             \x20 File \"/app/main.py\", line 5, in <module>\n\
+             \x20   raise RuntimeError(\"PR2530_TRACEBACK_SENTINEL\")\n\
+             RuntimeError: PR2530_TRACEBACK_SENTINEL\n"]);
+        assert_eq!(
+            exception_lines(&records),
             vec![
-                GuestStderrRecord {
-                    kind: GuestStderrKind::BenignWasiStartup,
-                    line: "Could not find platform dependent libraries <exec_prefix>",
-                },
-                GuestStderrRecord {
-                    kind: GuestStderrKind::Payload,
-                    line: "Traceback (most recent call last):",
-                },
-                GuestStderrRecord {
-                    kind: GuestStderrKind::Payload,
-                    line: "File \"main.py\", line 4, in <module>",
-                },
-                GuestStderrRecord {
-                    kind: GuestStderrKind::TracebackException,
-                    line: "ImportError: cannot import name 'App' from 'plexi_sdk'",
-                },
+                "ZeroDivisionError: division by zero",
+                "RuntimeError: PR2530_TRACEBACK_SENTINEL",
             ]
         );
+        assert_eq!(
+            records
+                .iter()
+                .filter(|record| record.kind == GuestStderrKind::TracebackChainSeparator)
+                .map(|record| record.line.as_str())
+                .collect::<Vec<_>>(),
+            vec!["During handling of the above exception, another exception occurred:"]
+        );
     }
 
+    /// `raise ... from ...` uses the other separator sentence.
     #[test]
-    fn guest_stderr_records_never_preserve_raw_continuations() {
-        let records = guest_stderr_records("warning one\nwarning two\n");
+    fn guest_stderr_marks_both_halves_of_a_direct_cause_chain() {
+        let records = classify_stderr(&["Traceback (most recent call last):\n\
+             \x20 File \"/app/main.py\", line 3, in <module>\n\
+             KeyError: 'token'\n\
+             \n\
+             The above exception was the direct cause of the following exception:\n\
+             \n\
+             Traceback (most recent call last):\n\
+             \x20 File \"/app/main.py\", line 5, in <module>\n\
+             RuntimeError: config load failed\n"]);
+        assert_eq!(
+            exception_lines(&records),
+            vec!["KeyError: 'token'", "RuntimeError: config load failed"]
+        );
+    }
+
+    /// A multi-line exception message is one exception: the first line is the
+    /// exception, the rest are its detail, and no detail line steals the mark.
+    #[test]
+    fn guest_stderr_keeps_a_multi_line_exception_message_as_one_exception() {
+        let records = classify_stderr(&["Traceback (most recent call last):\n\
+             \x20 File \"/app/main.py\", line 9, in <module>\n\
+             ValueError: manifest is invalid:\n\
+             missing key: name\n\
+             missing key: version\n"]);
+        assert_eq!(
+            exception_lines(&records),
+            vec!["ValueError: manifest is invalid:"]
+        );
+        assert_eq!(
+            records
+                .iter()
+                .filter(|record| record.kind == GuestStderrKind::TracebackExceptionDetail)
+                .map(|record| record.line.as_str())
+                .collect::<Vec<_>>(),
+            vec!["missing key: name", "missing key: version"]
+        );
+    }
+
+    /// A compile-time `SyntaxError` prints no `Traceback` header at all, and
+    /// its caret line is part of the frame, not the exception.
+    #[test]
+    fn guest_stderr_marks_a_headerless_syntax_error_block() {
+        let records = classify_stderr(&["  File \"/app/main.py\", line 2\n\
+             \x20   def broken(:\n\
+             \x20              ^\n\
+             SyntaxError: invalid syntax\n"]);
+        assert_eq!(
+            exception_lines(&records),
+            vec!["SyntaxError: invalid syntax"]
+        );
+        assert_eq!(
+            records
+                .iter()
+                .filter(|record| record.kind == GuestStderrKind::TracebackFrame)
+                .count(),
+            3
+        );
+    }
+
+    /// A bare `KeyboardInterrupt` has no `: message` and is still the
+    /// exception — the frame block ended at it.
+    #[test]
+    fn guest_stderr_marks_a_bare_keyboard_interrupt() {
+        let records = classify_stderr(&["Traceback (most recent call last):\n\
+             \x20 File \"/app/main.py\", line 12, in <module>\n\
+             \x20   sleep(60)\n\
+             KeyboardInterrupt\n"]);
+        assert_eq!(exception_lines(&records), vec!["KeyboardInterrupt"]);
+    }
+
+    /// `drain_stderr` splits on byte boundaries, not line boundaries: a line
+    /// cut in half must be rejoined before it is classified, never logged as
+    /// two fragments.
+    #[test]
+    fn guest_stderr_rejoins_a_line_split_mid_drain() {
+        let records = classify_stderr(&[
+            "Traceback (most recent call last):\n  File \"/app/main.py\", line 7, in <mod",
+            "ule>\nRuntimeError: PR2530_TRAC",
+            "EBACK_SENTINEL",
+        ]);
+        assert_eq!(
+            exception_lines(&records),
+            vec!["RuntimeError: PR2530_TRACEBACK_SENTINEL"]
+        );
+        assert_eq!(records.len(), 3);
+    }
+
+    /// A guest that never writes a newline must still reach the log.
+    #[test]
+    fn guest_stderr_flushes_an_unterminated_line_past_the_buffer_cap() {
+        let mut classifier = GuestStderrClassifier::new();
+        assert!(classifier
+            .push(&"x".repeat(MAX_BUFFERED_STDERR_LINE))
+            .is_empty());
+        let records = classifier.push("y");
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].kind, GuestStderrKind::Payload);
+        assert_eq!(records[0].line.len(), MAX_BUFFERED_STDERR_LINE + 1);
+    }
+
+    /// Ordinary guest stderr with no traceback in it stays ordinary.
+    #[test]
+    fn guest_stderr_leaves_plain_output_unmarked() {
+        let records = classify_stderr(&["warning one\nwarning two\n"]);
         assert_eq!(records.len(), 2);
-        assert!(records.iter().all(|record| !record.line.contains('\n')));
         assert!(records
             .iter()
             .all(|record| record.kind == GuestStderrKind::Payload));

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,6 +64,9 @@ fn main() -> eframe::Result {
     // Parse --profile <name> early so config_dir() resolves correctly for
     // both logging and all downstream I/O.
     let raw_args: Vec<String> = std::env::args().collect();
+    let is_app_prune_command = raw_args
+        .windows(2)
+        .any(|args| args[0] == "app" && args[1] == "prune");
 
     // Top-level --help/-h: print grouped subcommand sections before any
     // logging or config init, so no noise appears alongside help output.
@@ -122,6 +125,16 @@ fn main() -> eframe::Result {
         for o in &core_outcomes {
             if let crate::cli::install_host::InstallStatus::Failed(msg) = &o.status {
                 log::warn!("core pack: FAILED {}: {msg}", o.id);
+            }
+        }
+        if !is_app_prune_command {
+            let pruned = crate::cli::install_host::reconcile_orphaned_pre_v3_first_party_apps(&apps_dir);
+            if !pruned.is_empty() {
+                log::info!(
+                "core pack: quarantined {} orphaned pre-v3 app(s) from {}",
+                    pruned.len(),
+                    apps_dir.display()
+                );
             }
         }
     }
@@ -550,6 +563,9 @@ fn main() -> eframe::Result {
                                 std::process::exit(cli::app_uninstall(&id, yes))
                             }
                             AppCmd::List => std::process::exit(cli::app_list()),
+                            AppCmd::Prune { dry_run } => {
+                                std::process::exit(cli::app_prune_cli(dry_run))
+                            }
                             AppCmd::Trust { path } => {
                                 log::info!("app_trust:cli: path={path}");
                                 std::process::exit(cli::app_trust_cli(&path));

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -452,6 +452,7 @@ Manage your Plexi apps — open, install, list, scaffold, and inspect
 | `install` | Install an app from a local path, a remote source, or a pack file |
 | `uninstall` | Remove an installed app by id |
 | `list` | Show all installed apps with their versions |
+| `prune` | Report obsolete first-party pre-v3 apps that launch-time reseeding quarantines |
 | `render` | Render an app headlessly (JSON frame tree by default, or PNG with --png) |
 | `check` | Check a local app with manifest, scaffold metadata, SDK, and render-size checks |
 | `test` | Run an app's AppHarness tests with `uv run pytest tests/` |
@@ -526,6 +527,14 @@ Example: plexi app uninstall github-tree
 ### `plexi app list`
 
 Show all installed apps with their versions
+
+### `plexi app prune`
+
+Report obsolete first-party pre-v3 apps that launch-time reseeding quarantines
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `--dry-run` | flag | no | Show candidates without removing anything |
 
 ### `plexi app render`
 


### PR DESCRIPTION
## Summary

Implements stints 0643 and 0642. No linked GitHub issue; stint is authoritative.

- Logs CPython WASM stderr as attributed per-line records, separating benign WASI noise and marking the traceback exception.
- Reconciles identified retired pre-v3 apps into a recoverable hidden profile quarantine; `plexi app prune --dry-run` reports candidates without mutating the profile.
- Preserves current core apps plus unknown, user, marketplace, and non-legacy reused-ID apps.

## Test evidence

- Focused cargo test: guest stderr records 2 passed; quarantine mixed fixture 1 passed; dry-run fixture 1 passed.
- cargo build: passed.
- Full env-stripped cargo test --bin plexi with RSS watchdog: 2125 passed, 1 failed, 5 ignored; watchdog did not fire. The sole failure was the known fleet-load timeout `headless_frame_fails_fast_when_the_guest_dies_at_import`; the exact test passed in the audited alpha baseline (`/tmp/plexi-0643-0642-alpha-baseline.zsOVda`).
- Conclusion: binary install required for independent tester validation of host/profile behavior; worker mode intentionally did not install or boot a host.

## Done When

- Every guest traceback line is attributable and greppable by app id, with its exception highlighted.
- Identified legacy pre-v3 apps are no longer listed or launchable; ambiguous content is quarantined, not deleted.
- A dry-run path shows profile candidates before mutation.