### PR TITLE
fix(host): surface failed Python guest lifecycle

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -2142,16 +2142,7 @@ impl PlexiApp {
                                 .unwrap_or(serde_json::Value::Array(vec![]));
                             let semantic = app_pane.semantic_state();
                             let app_state = app_pane.runtime.semantic_details();
-                            let lifecycle = match &app_pane.runtime {
-                                crate::host::pane::AppRuntime::Wasm(wasm) => if wasm.is_running() {
-                                    "running"
-                                } else {
-                                    "exited"
-                                }
-                                .to_string(),
-                                crate::host::pane::AppRuntime::Builtin(_) => "running".to_string(),
-                                crate::host::pane::AppRuntime::Python(_) => "running".to_string(),
-                            };
+                            let (lifecycle, error) = app_pane.runtime.lifecycle();
                             log::info!(
                                 "pane_ipc: get_pane_state: pane_id={pane_id} runtime={} schema_version={} node_count={}",
                                 app_pane.runtime.runtime_kind(),
@@ -2164,6 +2155,7 @@ impl PlexiApp {
                                 "title": app_pane.name,
                                 "manifest_id": app_pane.manifest_id,
                                 "lifecycle": lifecycle,
+                                "error": error,
                                 "frame": frame,
                                 "semantic": semantic,
                                 "app_state": app_state,

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -2142,9 +2142,9 @@ impl PlexiApp {
                                 .unwrap_or(serde_json::Value::Array(vec![]));
                             let semantic = app_pane.semantic_state();
                             let app_state = app_pane.runtime.semantic_details();
-                            let (lifecycle, error) = app_pane.runtime.lifecycle();
+                            let (lifecycle, guest_error) = app_pane.runtime.lifecycle();
                             log::info!(
-                                "pane_ipc: get_pane_state: pane_id={pane_id} runtime={} schema_version={} node_count={}",
+                                "pane_ipc: get_pane_state: pane_id={pane_id} lifecycle={lifecycle} runtime={} schema_version={} node_count={}",
                                 app_pane.runtime.runtime_kind(),
                                 semantic.schema_version,
                                 semantic.nodes.len(),
@@ -2155,7 +2155,12 @@ impl PlexiApp {
                                 "title": app_pane.name,
                                 "manifest_id": app_pane.manifest_id,
                                 "lifecycle": lifecycle,
-                                "error": error,
+                                // The CLI transport envelope signals failure
+                                // with a top-level `error` string. Guest-domain
+                                // failure detail therefore lives one level down
+                                // in a nested object, where no envelope check
+                                // on top-level scalars can ever read it.
+                                "failure": guest_error.map(|error| serde_json::json!({ "error": error })),
                                 "frame": frame,
                                 "semantic": semantic,
                                 "app_state": app_state,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -15,6 +15,19 @@ fn update_check_due(last_update_check: std::time::Instant, now: std::time::Insta
 }
 
 impl PlexiApp {
+    /// Keep app runtime state truthful before serving pane IPC. This lives in
+    /// the logic preamble because eframe can skip `ui()` while a host is
+    /// minimized or occluded.
+    fn poll_app_runtime_state(&mut self) {
+        for window in &mut self.windows {
+            for pane in window.panes.values_mut() {
+                if let Some(app_pane) = pane.as_app_mut() {
+                    app_pane.runtime.poll_runtime_state();
+                }
+            }
+        }
+    }
+
     /// Early per-frame work that runs before overlay dispatch and panel rendering.
     /// Handles adopted context paths, finder service drains, notification polling,
     /// pane command draining, update channel checks, PTY event draining, and
@@ -57,6 +70,7 @@ impl PlexiApp {
                 }
             }
         }
+        self.poll_app_runtime_state();
         self.drain_pane_cmd_channel();
         if self.shutdown_requested {
             // `plexi host stop`'s clean-shutdown path (AppRequest::Shutdown).

--- a/src/cli/pane.rs
+++ b/src/cli/pane.rs
@@ -1173,12 +1173,20 @@ pub fn pane_state_cli(pane_id: u64) -> i32 {
         Err(code) => return code,
     };
     if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
-        if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
+        if let Some(err) = pane_state_envelope_error(&v) {
             eprintln!("error: {err}");
             return 1;
         }
     }
     print_json_output(&content)
+}
+
+/// The pane-state transport envelope signals failure with a top-level `error`
+/// string. Successful responses never carry a top-level `error` key — guest
+/// failure detail is nested under `failure` (see the `get_pane_state` handler)
+/// — so a success can never be misread as a transport failure here.
+pub(crate) fn pane_state_envelope_error(value: &serde_json::Value) -> Option<&str> {
+    value.get("error").and_then(|e| e.as_str())
 }
 
 /// `plexi open <type_id> [args...] [--layout=X]`

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -964,6 +964,24 @@ impl AppRuntime {
         }
     }
 
+    /// Lifecycle is an observation of the runtime, not a pane-existence flag.
+    pub(crate) fn lifecycle(&self) -> (&'static str, Option<&str>) {
+        match self {
+            AppRuntime::Builtin(_) => ("running", None),
+            AppRuntime::Python(app) => app.lifecycle(),
+            AppRuntime::Wasm(app) if app.is_running() => ("running", None),
+            AppRuntime::Wasm(_) => ("exited", None),
+        }
+    }
+
+    /// Poll state that must stay current even when eframe skips rendering an
+    /// occluded host window.
+    pub(crate) fn poll_runtime_state(&mut self) {
+        if let AppRuntime::Python(app) = self {
+            app.poll_runtime_state();
+        }
+    }
+
     pub(crate) fn drop_file(&mut self, path_or_url: &str) -> Result<serde_json::Value, String> {
         match self {
             AppRuntime::Builtin(app) => app.drop_file(path_or_url),

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -1257,6 +1257,15 @@ impl PythonFrameScheduler {
     fn reset(&mut self, now: std::time::Instant) {
         *self = Self::new(now);
     }
+
+    /// A dead guest must not keep the host painting: drop pending frames and
+    /// stop requesting renders, so `poll_render` and `next_repaint_deadline`
+    /// both go quiet.
+    fn stop(&mut self) {
+        self.mode = PythonSchedulerMode::Scheduled;
+        self.render_requested = false;
+        self.pending.clear();
+    }
 }
 
 /// Resolve one declared scope to its state file, against the pane's context
@@ -1646,8 +1655,22 @@ impl LivePythonPane {
         }
         self.drain_runtime();
         if let Some(error) = &self.error {
+            // Fatal state: stop the frame scheduler so a dead guest no longer
+            // drives host repaints, and lead with the exception line.
+            self.frame_scheduler.stop();
             ui.colored_label(colors.danger, error);
             return;
+        }
+        if self.runtime.is_finished() {
+            self.frame_scheduler.stop();
+            // No guest is left to service timers; firing them would send to a
+            // dead runtime and misreport a clean exit as a failure.
+            self.timers.clear();
+            self.pending_timer_events.clear();
+            if self.tree.is_none() {
+                ui.colored_label(colors.danger, "app exited before rendering a frame");
+                return;
+            }
         }
         if !self.ready {
             if pending_click.is_some() {
@@ -1876,7 +1899,11 @@ impl LivePythonPane {
         // still runs off the raw stderr blob so a traceback that dies at
         // import surfaces through `self.error` (stint 0638).
         self.record_runtime_stderr(&stderr);
-        self.finish_pending_traceback_if_runtime_exited();
+        if !self.pending_traceback_stderr.is_empty() {
+            // The runtime may have exited after the last stderr push; that
+            // finalizes a trailing partial line.
+            self.refresh_guest_error();
+        }
     }
 
     /// One host record per guest stderr line, each carrying the `app::<id>`
@@ -2579,15 +2606,11 @@ impl LivePythonPane {
         python_semantic_state(self.tree.as_deref())
     }
     pub(crate) fn lifecycle(&self) -> (&'static str, Option<&str>) {
-        if let Some(error) = self.error.as_deref() {
-            ("failed", Some(error))
-        } else if self.tree.is_some() {
-            ("running", None)
-        } else if self.runtime.is_finished() {
-            ("exited", None)
-        } else {
-            ("starting", None)
-        }
+        python_lifecycle(
+            self.error.as_deref(),
+            self.runtime.is_finished(),
+            self.tree.is_some(),
+        )
     }
 
     fn record_runtime_stderr(&mut self, stderr: &str) {
@@ -2597,21 +2620,22 @@ impl LivePythonPane {
             return;
         }
         self.pending_traceback_stderr.push_str(stderr);
-        if self.pending_traceback_stderr.ends_with('\n') || self.runtime.is_finished() {
-            self.finish_pending_traceback();
-        }
+        self.refresh_guest_error();
     }
 
-    fn finish_pending_traceback_if_runtime_exited(&mut self) {
-        if self.runtime.is_finished() && !self.pending_traceback_stderr.is_empty() {
-            self.finish_pending_traceback();
-        }
-    }
-
-    fn finish_pending_traceback(&mut self) {
-        if let Some(exception) = traceback_exception_line(&self.pending_traceback_stderr) {
-            self.error = Some(exception.to_string());
-            self.pending_traceback_stderr.clear();
+    fn refresh_guest_error(&mut self) {
+        let Some(exception) =
+            pending_traceback_exception(&self.pending_traceback_stderr, self.runtime.is_finished())
+        else {
+            return;
+        };
+        if self.error.as_deref() != Some(exception) {
+            let exception = exception.to_string();
+            log::info!(
+                "app::{}: guest entered failed state: {exception}",
+                self.app_id
+            );
+            self.error = Some(exception);
         }
     }
 
@@ -2863,22 +2887,65 @@ fn is_traceback_frame_line(trimmed: &str) -> bool {
     trimmed.starts_with("File ") && trimmed.contains(", line ")
 }
 
-/// Extract the useful final exception line from a Python traceback. The full
-/// stderr remains in the host log; this compact line is what the failed pane
-/// and pane-state callers should lead with.
+/// Liveness has exactly one authoritative source: the runtime thread. A
+/// committed tree only refines a live guest into starting vs running — it must
+/// never decide dead vs alive, or a guest that dies after its first frame
+/// keeps reporting `running` from its stale tree.
+fn python_lifecycle(
+    error: Option<&str>,
+    runtime_finished: bool,
+    has_frame: bool,
+) -> (&'static str, Option<&str>) {
+    match (error, runtime_finished, has_frame) {
+        (Some(error), _, _) => ("failed", Some(error)),
+        (None, true, _) => ("exited", None),
+        (None, false, true) => ("running", None),
+        (None, false, false) => ("starting", None),
+    }
+}
+
+/// Extract the useful final exception line from accumulated traceback stderr.
+/// The full stderr remains in the host log; this compact line is what the
+/// failed pane and pane-state callers should lead with. While the guest is
+/// alive only complete lines count — `DrainableOutput` may split a line across
+/// drains; once the runtime has exited the buffer is final as-is.
+fn pending_traceback_exception(buffer: &str, runtime_finished: bool) -> Option<&str> {
+    let complete = if runtime_finished {
+        buffer
+    } else {
+        &buffer[..=buffer.rfind('\n')?]
+    };
+    traceback_exception_line(complete)
+}
+
+/// The last exception-record line following a traceback header wins: chained
+/// tracebacks ("During handling of the above exception, ...") put the
+/// authoritative exception at the end.
 fn traceback_exception_line(stderr: &str) -> Option<&str> {
-    let lines: Vec<&str> = stderr.lines().filter(|line| !line.trim().is_empty()).collect();
-    lines
-        .iter()
-        .position(|line| line.starts_with("Traceback (most recent call last):"))
-        .and_then(|traceback_start| {
-            lines[traceback_start + 1..]
-                .iter()
-                .rev()
-                .find(|line| !line.starts_with(char::is_whitespace))
-                .copied()
-        })
-        .map(str::trim)
+    let mut after_header = false;
+    let mut exception = None;
+    for line in stderr.lines() {
+        if line.starts_with("Traceback (most recent call last):") {
+            after_header = true;
+        } else if after_header && is_exception_record_line(line) {
+            exception = Some(line.trim_end());
+        }
+    }
+    exception
+}
+
+/// A Python exception record prints unindented as `Name: message` or a bare
+/// `Name`, where `Name` is a (dotted) identifier. Frame lines are indented,
+/// and chaining prose ("During handling of the above exception, ...") has
+/// spaces before any colon, so neither can match.
+fn is_exception_record_line(line: &str) -> bool {
+    if line.starts_with(char::is_whitespace) {
+        return false;
+    }
+    let head = line.split(':').next().unwrap_or_default();
+    let mut chars = head.chars();
+    chars.next().is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
 }
 
 fn python_key_name(key: egui::Key) -> String {
@@ -5372,6 +5439,55 @@ mod tests {
                 "Traceback (most recent call last):\n  File \"main.py\", line 1, in <module>\n"
             ),
             None
+        );
+    }
+
+    #[test]
+    fn traceback_exception_line_prefers_the_last_chained_exception() {
+        assert_eq!(
+            traceback_exception_line(
+                "Traceback (most recent call last):\n  File \"main.py\", line 1, in <module>\nValueError: original\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"main.py\", line 3, in <module>\nTypeError: chained failure\n"
+            ),
+            Some("TypeError: chained failure")
+        );
+    }
+
+    #[test]
+    fn traceback_exception_line_accepts_a_bare_exception_name() {
+        assert_eq!(
+            traceback_exception_line(
+                "Traceback (most recent call last):\n  File \"main.py\", line 1, in <module>\nKeyboardInterrupt\n"
+            ),
+            Some("KeyboardInterrupt")
+        );
+    }
+
+    #[test]
+    fn pending_traceback_exception_ignores_a_partial_line_while_the_guest_lives() {
+        let buffer = "Traceback (most recent call last):\n  File \"main.py\", line 1, in <module>\nImportErr";
+        assert_eq!(pending_traceback_exception(buffer, false), None);
+        assert_eq!(
+            pending_traceback_exception(buffer, true),
+            Some("ImportErr")
+        );
+        let completed = format!("{buffer}or: fixture import failure\n");
+        assert_eq!(
+            pending_traceback_exception(&completed, false),
+            Some("ImportError: fixture import failure")
+        );
+    }
+
+    #[test]
+    fn python_lifecycle_reads_liveness_from_the_runtime_not_the_tree() {
+        // The bug: a guest that dies after its first frame must not keep
+        // reporting `running` off its stale tree.
+        assert_eq!(python_lifecycle(None, true, true), ("exited", None));
+        assert_eq!(python_lifecycle(None, true, false), ("exited", None));
+        assert_eq!(python_lifecycle(None, false, true), ("running", None));
+        assert_eq!(python_lifecycle(None, false, false), ("starting", None));
+        assert_eq!(
+            python_lifecycle(Some("ImportError: nope"), true, true),
+            ("failed", Some("ImportError: nope"))
         );
     }
 

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -755,6 +755,10 @@ pub struct LivePythonPane {
     repaint: RepaintHook,
     wants_close: bool,
     error: Option<String>,
+    /// stderr accumulated from a Python traceback until its unindented
+    /// exception line arrives. `DrainableOutput` may split one traceback
+    /// across several non-blocking drains.
+    pending_traceback_stderr: String,
     timers: std::collections::HashMap<String, PythonTimer>,
     pending_timer_events: Vec<String>,
     viewport_size: Option<(f32, f32)>,
@@ -1500,6 +1504,7 @@ impl LivePythonPane {
             repaint,
             wants_close: false,
             error: None,
+            pending_traceback_stderr: String::new(),
             timers: std::collections::HashMap::new(),
             pending_timer_events: Vec::new(),
             viewport_size: None,
@@ -1640,6 +1645,10 @@ impl LivePythonPane {
                 .request_render_at(std::time::Instant::now());
         }
         self.drain_runtime();
+        if let Some(error) = &self.error {
+            ui.colored_label(colors.danger, error);
+            return;
+        }
         if !self.ready {
             if pending_click.is_some() {
                 log::info!(
@@ -1863,6 +1872,11 @@ impl LivePythonPane {
         for record in records {
             self.log_guest_stderr(&record);
         }
+        // The classifier above is for the host log; fatal-state detection
+        // still runs off the raw stderr blob so a traceback that dies at
+        // import surfaces through `self.error` (stint 0638).
+        self.record_runtime_stderr(&stderr);
+        self.finish_pending_traceback_if_runtime_exited();
     }
 
     /// One host record per guest stderr line, each carrying the `app::<id>`
@@ -1891,6 +1905,13 @@ impl LivePythonPane {
                 log::error!("app::{} CPython WASM stderr: {}", self.app_id, record.line)
             }
         }
+    }
+
+    /// Poll runtime output from the host logic pass as well as from `ui()`.
+    /// eframe suppresses `ui()` for an occluded host, but pane-state IPC must
+    /// still observe a guest's fatal traceback before serving its response.
+    pub(crate) fn poll_runtime_state(&mut self) {
+        self.drain_runtime();
     }
 
     /// Handle one non-tree bridge message. Tree framing (`component_tree` /
@@ -2557,6 +2578,43 @@ impl LivePythonPane {
     pub(crate) fn semantic_state(&self) -> crate::host::pane::SemanticPaneState {
         python_semantic_state(self.tree.as_deref())
     }
+    pub(crate) fn lifecycle(&self) -> (&'static str, Option<&str>) {
+        if let Some(error) = self.error.as_deref() {
+            ("failed", Some(error))
+        } else if self.tree.is_some() {
+            ("running", None)
+        } else if self.runtime.is_finished() {
+            ("exited", None)
+        } else {
+            ("starting", None)
+        }
+    }
+
+    fn record_runtime_stderr(&mut self, stderr: &str) {
+        if self.pending_traceback_stderr.is_empty()
+            && !stderr.contains("Traceback (most recent call last):")
+        {
+            return;
+        }
+        self.pending_traceback_stderr.push_str(stderr);
+        if self.pending_traceback_stderr.ends_with('\n') || self.runtime.is_finished() {
+            self.finish_pending_traceback();
+        }
+    }
+
+    fn finish_pending_traceback_if_runtime_exited(&mut self) {
+        if self.runtime.is_finished() && !self.pending_traceback_stderr.is_empty() {
+            self.finish_pending_traceback();
+        }
+    }
+
+    fn finish_pending_traceback(&mut self) {
+        if let Some(exception) = traceback_exception_line(&self.pending_traceback_stderr) {
+            self.error = Some(exception.to_string());
+            self.pending_traceback_stderr.clear();
+        }
+    }
+
     #[cfg(test)]
     pub fn has_rendered_tree(&self) -> bool {
         self.tree.is_some()
@@ -2564,6 +2622,10 @@ impl LivePythonPane {
     #[cfg(test)]
     pub fn error(&self) -> Option<&str> {
         self.error.as_deref()
+    }
+    #[cfg(test)]
+    pub fn record_runtime_stderr_for_test(&mut self, stderr: &str) {
+        self.record_runtime_stderr(stderr);
     }
     pub fn relaunch(&mut self) -> Result<(), WasmPythonError> {
         // Drop the old decoder (closes its stdout, joins the thread) before the
@@ -2580,6 +2642,7 @@ impl LivePythonPane {
         self.ready = false;
         self.frame_scheduler.reset(std::time::Instant::now());
         self.error = None;
+        self.pending_traceback_stderr.clear();
         self.wants_close = false;
         self.timers.clear();
         self.pending_timer_events.clear();
@@ -2798,6 +2861,24 @@ impl GuestStderrClassifier {
 /// traceback frame opens with, quoted path or angle-bracketed frozen module.
 fn is_traceback_frame_line(trimmed: &str) -> bool {
     trimmed.starts_with("File ") && trimmed.contains(", line ")
+}
+
+/// Extract the useful final exception line from a Python traceback. The full
+/// stderr remains in the host log; this compact line is what the failed pane
+/// and pane-state callers should lead with.
+fn traceback_exception_line(stderr: &str) -> Option<&str> {
+    let lines: Vec<&str> = stderr.lines().filter(|line| !line.trim().is_empty()).collect();
+    lines
+        .iter()
+        .position(|line| line.starts_with("Traceback (most recent call last):"))
+        .and_then(|traceback_start| {
+            lines[traceback_start + 1..]
+                .iter()
+                .rev()
+                .find(|line| !line.starts_with(char::is_whitespace))
+                .copied()
+        })
+        .map(str::trim)
 }
 
 fn python_key_name(key: egui::Key) -> String {
@@ -5272,6 +5353,26 @@ mod tests {
         assert!(records
             .iter()
             .all(|record| record.kind == GuestStderrKind::Payload));
+    }
+
+    #[test]
+    fn traceback_exception_line_uses_the_final_exception() {
+        assert_eq!(
+            traceback_exception_line(
+                "Traceback (most recent call last):\n  File \"main.py\", line 1, in <module>\nImportError: fixture import failure\n"
+            ),
+            Some("ImportError: fixture import failure")
+        );
+    }
+
+    #[test]
+    fn traceback_exception_line_waits_for_an_unindented_exception() {
+        assert_eq!(
+            traceback_exception_line(
+                "Traceback (most recent call last):\n  File \"main.py\", line 1, in <module>\n"
+            ),
+            None
+        );
     }
 
     #[test]

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -2763,31 +2763,26 @@ impl HeadlessBackend {
         self.h.with_app(|app| {
             for win in &app.windows {
                 if let Some(Pane::App(app_pane)) = win.panes.get(&pane_id) {
-                    if let AppRuntime::Builtin(_) = &app_pane.runtime {
-                        return Some(AppState {
-                            pane_id,
-                            lifecycle: "running".to_string(),
-                            tree: serde_json::json!({
-                                "semantic": app_pane.semantic_state(),
-                                "app_state": app_pane.runtime.semantic_details(),
-                            }),
-                        });
-                    }
-                    if let AppRuntime::Python(_) = &app_pane.runtime {
-                        return Some(AppState {
-                            pane_id,
-                            lifecycle: "running".to_string(),
-                            tree: serde_json::json!({"semantic": app_pane.semantic_state()}),
-                        });
-                    }
-                    if let AppRuntime::Wasm(w) = &app_pane.runtime {
-                        return Some(AppState {
-                            pane_id,
-                            lifecycle: if w.is_running() { "running" } else { "exited" }
-                                .to_string(),
-                            tree: serde_json::json!({"frame": w.last_render_text(), "semantic": app_pane.semantic_state()}),
-                        });
-                    }
+                    let (lifecycle, error) = app_pane.runtime.lifecycle();
+                    let tree = match &app_pane.runtime {
+                        AppRuntime::Builtin(_) => serde_json::json!({
+                            "semantic": app_pane.semantic_state(),
+                            "app_state": app_pane.runtime.semantic_details(),
+                        }),
+                        AppRuntime::Python(_) => serde_json::json!({
+                            "semantic": app_pane.semantic_state(),
+                            "error": error,
+                        }),
+                        AppRuntime::Wasm(w) => serde_json::json!({
+                            "frame": w.last_render_text(),
+                            "semantic": app_pane.semantic_state(),
+                        }),
+                    };
+                    return Some(AppState {
+                        pane_id,
+                        lifecycle: lifecycle.to_string(),
+                        tree,
+                    });
                 }
             }
             None

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -2763,7 +2763,7 @@ impl HeadlessBackend {
         self.h.with_app(|app| {
             for win in &app.windows {
                 if let Some(Pane::App(app_pane)) = win.panes.get(&pane_id) {
-                    let (lifecycle, error) = app_pane.runtime.lifecycle();
+                    let (lifecycle, guest_error) = app_pane.runtime.lifecycle();
                     let tree = match &app_pane.runtime {
                         AppRuntime::Builtin(_) => serde_json::json!({
                             "semantic": app_pane.semantic_state(),
@@ -2771,7 +2771,10 @@ impl HeadlessBackend {
                         }),
                         AppRuntime::Python(_) => serde_json::json!({
                             "semantic": app_pane.semantic_state(),
-                            "error": error,
+                            // Same nested shape as the get_pane_state IPC
+                            // response, so scene assertions exercise what
+                            // agents actually read.
+                            "failure": guest_error.map(|error| serde_json::json!({ "error": error })),
                         }),
                         AppRuntime::Wasm(w) => serde_json::json!({
                             "frame": w.last_render_text(),

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -308,12 +308,9 @@ python_compat = true
         panic!("fixture must launch through the Python runtime");
     };
     runtime.record_runtime_stderr_for_test(
-        "Traceback (most recent call last):\n  File \"main.py\", line 1, in <module>\n",
+        "Traceback (most recent call last):\n  File \"main.py\", line 1, in <module>\nImportError: fixture import failure\n",
     );
-    assert_eq!(runtime.lifecycle().0, "starting");
-    runtime.record_runtime_stderr_for_test("ImportErr");
-    assert_eq!(runtime.lifecycle().0, "starting");
-    runtime.record_runtime_stderr_for_test("or: fixture import failure\n");
+    assert_eq!(runtime.lifecycle().0, "failed");
 
     let response_file = temp_response(tmp.path(), "pane-state-import-failure");
     h.inject_ipc(AppRequest::GetPaneState {
@@ -325,10 +322,20 @@ python_compat = true
     let response = read_json_response(&response_file);
     assert_eq!(response["lifecycle"], "failed", "response={response}");
     assert!(
-        response["error"]
+        response["failure"]["error"]
             .as_str()
             .is_some_and(|error| error.contains("ImportError: fixture import failure")),
         "response={response}"
+    );
+    // The exact envelope check `plexi pane state` runs must read this failed
+    // guest's response as a SUCCESS — guest failure is payload, not transport.
+    assert!(
+        crate::cli::pane::pane_state_envelope_error(&response).is_none(),
+        "failed-guest pane state must not trip the CLI error envelope: response={response}"
+    );
+    assert!(
+        response.get("error").is_none(),
+        "success responses must not carry a top-level `error` key: response={response}"
     );
 }
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -260,6 +260,79 @@ fn pane_state_ipc_returns_non_empty_semantic_tree_for_live_builtin_app() {
 }
 
 #[test]
+fn pane_state_reports_failed_for_python_guest_that_dies_at_import() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let app_dir = tmp.path().join("import-failure");
+    std::fs::create_dir(&app_dir).expect("create fixture app directory");
+    std::fs::write(
+        app_dir.join("manifest.toml"),
+        r#"schema_version = 1
+
+[app]
+id = "import-failure"
+type = "app"
+name = "Import Failure"
+entry = "main.py"
+version = "0.1.0"
+description = "HostHarness import-failure fixture"
+
+[app.capabilities]
+capabilities = []
+
+[runtime]
+python_compat = true
+"#,
+    )
+    .expect("write fixture manifest");
+    std::fs::write(
+        app_dir.join("main.py"),
+        "raise ImportError('fixture import failure')\n",
+    )
+    .expect("write fixture entry");
+
+    let mut h = HostHarness::new();
+    h.app
+        .launch_app_by_path_with_layout(&app_dir.to_string_lossy(), None, None, &[])
+        .expect("launch fixture app");
+    let pane_id = *h
+        .state()
+        .open_panes
+        .last()
+        .expect("fixture app pane appears");
+    let pane = h.app.windows[h.app.active_window]
+        .panes
+        .get_mut(&pane_id)
+        .and_then(Pane::as_app_mut)
+        .expect("fixture app pane");
+    let AppRuntime::Python(runtime) = &mut pane.runtime else {
+        panic!("fixture must launch through the Python runtime");
+    };
+    runtime.record_runtime_stderr_for_test(
+        "Traceback (most recent call last):\n  File \"main.py\", line 1, in <module>\n",
+    );
+    assert_eq!(runtime.lifecycle().0, "starting");
+    runtime.record_runtime_stderr_for_test("ImportErr");
+    assert_eq!(runtime.lifecycle().0, "starting");
+    runtime.record_runtime_stderr_for_test("or: fixture import failure\n");
+
+    let response_file = temp_response(tmp.path(), "pane-state-import-failure");
+    h.inject_ipc(AppRequest::GetPaneState {
+        pane_id,
+        response_file: response_file.clone(),
+    });
+    h.run_hidden_frames(1);
+
+    let response = read_json_response(&response_file);
+    assert_eq!(response["lifecycle"], "failed", "response={response}");
+    assert!(
+        response["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("ImportError: fixture import failure")),
+        "response={response}"
+    );
+}
+
+#[test]
 fn notes_drop_uses_production_dispatch_and_exposes_semantic_rejection() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let note = tmp.path().join("note.md");


### PR DESCRIPTION
## Summary

Implements stints 0638 and 0641. No linked GitHub issue — stint is authoritative.

- Treat CPython-WASM tracebacks as fatal pane errors, retain the full stderr log, and render the final exception line.
- Make pane state report truthful `starting`, `running`, `failed`, and `exited` lifecycle states, with a failure reason.
- Poll Python runtime state during hidden-host logic passes and preserve traceback fragments across non-blocking stderr drains.

## Fix round (tester blockers)

The three blockers shared one root cause: liveness was inferred from incidental proxies (tree presence, field nullness) instead of the runtime. Fixed at that level:

- **One authoritative liveness source.** `python_lifecycle()` reads dead-vs-alive from `runtime.is_finished()` first; a committed tree only refines a live guest into `starting` vs `running`. A guest that dies after its first frame cannot report `running` anywhere — pane-state IPC and the scene harness share the single derivation.
- **Envelope collision made structurally impossible.** The pane-state success response no longer has any top-level `error` key. Guest failure detail is nested as `"failure": {"error": ...}` — the CLI transport envelope signals failure with a top-level `error` *string*, so payload data one level down can never match it, now or under future envelope keys. The harness test runs the CLI's own envelope check (`pane_state_envelope_error`) against a failed guest's response and asserts it reads as success.
- **Traceback finished at the right point.** A traceback completes on an unindented exception-shaped record line (identifier head, `Name: message` or bare `Name`), or when runtime exit finalizes a trailing partial line — never on an arbitrary newline. Chained tracebacks mark the last exception record, not chaining prose.
- **Scheduler stop.** Fatal/exited guests call `PythonFrameScheduler::stop()` and clear timers, so a dead guest no longer drives ~75fps host paints.
- **Instrumentation.** `log::info!` on the failed-state transition and `lifecycle=` added to the `get_pane_state` info trace.

## Done When

- [x] A CPython guest that raises during import has a visible failed state with the final exception line.
- [x] `plexi pane state` returns valid JSON (exit 0) for a failed guest, reports `failed`, and carries the failure reason under `failure.error`.
- [x] A dead guest never reports `lifecycle: running`, including after its first frame (`python_lifecycle_reads_liveness_from_the_runtime_not_the_tree`).
- [x] HostHarness covers an import traceback end-to-end through hidden frames, including the CLI envelope check.

## Verification (fix round, commit 6e05038)

- `cargo build` — green.
- Focused: `traceback*`, `pending_traceback*`, `python_lifecycle*`, `pane_state_reports_failed_for_python_guest_that_dies_at_import` — all pass.
- Full `env`-stripped `cargo test --bin plexi`: 2128 passed, 1 failed — `headless_frame_fails_fast_when_the_guest_dies_at_import`, the same pre-existing parallel-contention flake documented in the first round (its code path, `HeadlessPythonApp::wait_for`, is untouched by this diff). It passes solo in ~11s on a quiet box; under fleet load (loadavg 48–78) the 15s wasmtime boot budget starves. Scene suite fully green on the quiet rerun (49s), including the three scenes that starved under load.

## Worker Mode

Headless automated validation only. No install, GUI boot, or live-host drive was performed; live validation remains owned by the tester pane.
