### PR TITLE
feat: expose app tools through host MCP (stint 0653)

### DIFF
--- a/sdk/protocol/pgap.schema.json
+++ b/sdk/protocol/pgap.schema.json
@@ -1334,89 +1334,6 @@
         },
         {
           "additionalProperties": false,
-          "description": "Acquire a host-owned named lease for the calling pane. The reply is\nparked by the host until FIFO capacity grants it or its deadline passes.",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "pane_id": {
-              "format": "uint64",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "response_file": {
-              "type": "string"
-            },
-            "timeout_secs": {
-              "format": "double",
-              "type": "number"
-            },
-            "type": {
-              "const": "lock_acquire",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "name",
-            "pane_id",
-            "timeout_secs",
-            "response_file"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "description": "Release a named lease held by the calling pane.",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "pane_id": {
-              "format": "uint64",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "response_file": {
-              "type": "string"
-            },
-            "type": {
-              "const": "lock_release",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "name",
-            "pane_id",
-            "response_file"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "description": "Report the current holders, queue depth, and oldest queued wait.",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "response_file": {
-              "type": "string"
-            },
-            "type": {
-              "const": "lock_status",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "name",
-            "response_file"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
           "description": "List named host-managed pane file slots.",
           "properties": {
             "pane_id": {
@@ -2434,31 +2351,6 @@
             },
             "type": {
               "const": "tool_result",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "call_id"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "description": "App returns the result of a `PlexiEvent::McpToolCall` invocation.\n`call_id` must match the `call_id` from the `McpToolCall` event.\nEither `result` or `error` must be set.",
-          "properties": {
-            "call_id": {
-              "type": "string"
-            },
-            "error": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "result": true,
-            "type": {
-              "const": "mcp_tool_result",
               "type": "string"
             }
           },
@@ -4622,29 +4514,6 @@
             "name",
             "input_json",
             "caller_id"
-          ],
-          "type": "object"
-        },
-        {
-          "description": "External MCP client called a tool declared in `[app.mcp]`. The app must\nreply with `DrawCommand::Host(AppRequest::McpToolResult { call_id, … })`.",
-          "properties": {
-            "arguments": true,
-            "call_id": {
-              "type": "string"
-            },
-            "tool_name": {
-              "type": "string"
-            },
-            "type": {
-              "const": "mcp_tool_call",
-              "type": "string"
-            }
-          },
-          "required": [
-            "type",
-            "call_id",
-            "tool_name",
-            "arguments"
           ],
           "type": "object"
         },

--- a/sdk/python/AUTHORING.md
+++ b/sdk/python/AUTHORING.md
@@ -129,9 +129,11 @@ pointing at a JSON array of `{"paths": [...]}` / `{"cancel": true}` outcomes
 
 ## App Tools
 
-Apps can expose tools to the Assistant with `ExposeTools`. Declare the full
-set in `init()`. When the Assistant calls one, `update()` receives a
-`ToolCall`; return one `ToolResult` with the matching `call_id`.
+Apps can expose tools with `ExposeTools`. The Assistant can call them directly;
+external MCP agents in the same workspace see them as
+`<app_id>__<tool>` through the config printed by `plexi events mcp-config`.
+Declare the full set in `init()`. When any caller invokes one, `update()`
+receives a `ToolCall`; return one `ToolResult` with the matching `call_id`.
 
 ```python
 import json
@@ -191,15 +193,15 @@ Reach for the raw `AiTool`/`ExposeTools`/`ToolResult` types below only for a
 schema the decorator's type map cannot express.
 
 `input_schema` and `output_schema` are JSON Schema objects. `ToolCall.input_json`
-is the JSON string supplied by the Assistant. Return `output_json` matching the
-declared output schema for success or `error` for failure, never both. A
-declaration replaces the pane's previous tool set, so send every current tool
-when it changes.
+is the caller-supplied JSON string. Return `output_json` matching the declared
+output schema for success or `error` for failure, never both. A declaration
+replaces the pane's previous tool set, so send every current tool when it
+changes.
 
 Set `read_only=True` only for tools that never mutate app or workspace state.
-The Assistant runs read-only tools without a write-grant prompt, while still
-recording every call. Mutating tools prompt for an allow-once or persisted
-narrow grant before they run.
+For Assistant calls specifically, read-only tools run without a write-grant
+prompt while every call is still recorded. Mutating Assistant calls prompt for
+an allow-once or persisted narrow grant before they run.
 
 ## Cross-app events
 

--- a/sdk/wasm/AUTHORING.md
+++ b/sdk/wasm/AUTHORING.md
@@ -68,7 +68,8 @@ The `effects` module constructs every effect in the standard app world:
   `subscribe_event_streams(SubscribeEventStreamsEffect)` expose their full WIT
   payload records. `unsubscribe_event_streams(request_id, subscription_id)`
   stops a pane-session subscription.
-- `declare_tools(Vec<ToolDecl>)` exposes Assistant-callable tools, and
+- `declare_tools(Vec<ToolDecl>)` exposes tools to the Assistant and same-workspace
+  external MCP agents, and
   `tool_result(call_id, output_json, error)` completes a matching call.
 - `set_timer(id, delay_ms, repeat)`, `cancel_timer(id)`, and
   `get_system_stats()` return timer and system-stat events through `update`.
@@ -157,10 +158,12 @@ fn handle_tool(event: InputEvent) -> Vec<Effect> {
 
 Both schemas are JSON Schema encoded as strings in WIT. Invalid schema JSON is
 rejected at declaration time. `read_only` must be true only when a call cannot
-mutate app or workspace state. The Assistant auto-grants read-only calls unless
-an explicit deny applies. Mutating calls use the normal app-connector permission
-prompt, and denied calls never enter the component. The host audit logs every
-allowed invocation.
+mutate app or workspace state. External MCP agents in the same workspace see
+tools namespaced as `<app_id>__<tool>` through the config printed by
+`plexi events mcp-config`. For Assistant calls specifically, read-only calls
+are auto-granted unless an explicit deny applies. Mutating Assistant calls use
+the normal app-connector permission prompt, and denied calls never enter the
+component. The host audit logs every allowed invocation.
 
 ## UI nodes
 

--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -43,6 +43,10 @@ CLI or app SDK; do not inspect Plexi profile files directly.
   and refresh CLI-tool knowledge: `plexi account --help`, `plexi registry --help`.
 - **Notes** — capture, browse, and process scratchpad notes: `plexi note --help`
   and `plexi notes --help`.
+- **Events** — subscribe to an app's event stream, declare/emit events, and print
+  the singleton host MCP config for this pane's scoped credential (exposes event
+  tools and `<app_id>__<tool>` for live apps in the pane's workspace):
+  `plexi events --help`.
 
 The release gate verifies these feature-map entry points:
 
@@ -56,6 +60,7 @@ workspace
 run
 secret
 routine
+events
 agent
 config
 ai

--- a/src/app/canvas_bindings.rs
+++ b/src/app/canvas_bindings.rs
@@ -69,7 +69,7 @@ impl PlexiApp {
         let ctx_desc = self.context_description_for(ctx_id);
         let ctx_root = self.context_root_for(ctx_id);
         let ctx_depth = self.context_depth_for(ctx_id);
-        let settings = Self::make_backend_settings(
+        let (settings, pending_credential) = Self::make_backend_settings(
             new_id,
             resolved_cwd,
             &self.colors,
@@ -99,6 +99,7 @@ impl PlexiApp {
         self.windows[active]
             .panes
             .insert(new_id, Pane::Terminal(Box::new(term)));
+        pending_credential.mark_live();
 
         // Split the tree directly, adjacent to sender_tile, without touching focused_pane.
         // place_below=false → side-by-side (vertical=true), Canvas app left, terminal right.

--- a/src/app/host_mcp.rs
+++ b/src/app/host_mcp.rs
@@ -1,70 +1,189 @@
-//! Host-level event-subscription MCP server — `stint 0214`.
+//! Host-level MCP server — `stints 0214, 0653`.
 //!
 //! The native transport for MCP-aware agents (Claude Code, Codex). Unlike the
-//! app-scoped tool bridges, this is a single host-wide
-//! server started once at boot. It exposes the same subscription primitive the
-//! `plexi events` CLI wraps, backed by the one host subscription core — CLI and
-//! MCP are transports, not separate event buses.
+//! rejected per-app-server design, this is a single host-wide server started
+//! once at boot. It exposes event subscription tools and the live app tools
+//! registered through `ExposeTools`.
 //!
 //! Tools:
 //! - `list_event_streams` — discover the `(app, stream)` pairs running apps declare.
 //! - `subscribe_and_wait` — broker-checked subscribe, block for the next event,
 //!   return it, then drop the subscription. A long-poll, so an agent can "wait
 //!   for the next event and report it" in one tool call.
+//! - `<app_id>__<tool>` — workspace-scoped tools registered by live app panes.
 //!
 //! Discovery: the bound port + bearer token are injected into every pane's PTY
 //! env as `PLEXI_HOST_MCP_PORT` / `PLEXI_HOST_MCP_TOKEN`, so an agent in a pane
 //! can configure this server without a wrapper subprocess.
 //!
-//! Persistence: the `(port, token)` is stored in `config_dir/host_mcp.json` and
-//! reused on every launch. This makes the server install-once — an agent runs
-//! `plexi events mcp-config` a single time, bakes the URL + bearer into a static
-//! MCP client config, and it keeps resolving across Plexi restarts instead of
-//! breaking when a fresh port/token is rolled each boot.
+//! Persistence: the port is stored in `config_dir/host_mcp.json` and reused on
+//! every launch. Bearers are pane-scoped runtime credentials: the host binds
+//! each one to the trusted pane id + workspace root while building that pane's
+//! environment. Requests never accept a client-provided workspace path.
 //!
-//! Identity: subscriptions are recorded under the host-stamped id `mcp:host`
-//! (set by this trusted transport, never from a tool argument), so an MCP client
-//! cannot spoof another subscriber.
+//! Identity: calls and subscriptions are stamped `mcp:pane:<id>` from the
+//! authenticated credential, never from tool arguments.
 
 use crate::app::ui_mailbox::UiMailbox;
 use crate::host::event_subscriptions::{HostSubscribeReply, HostSubscribeRequest};
 use crate::mcp_http::{read_json_rpc_request, write_http_response, RequestOutcome};
+use std::collections::HashMap;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-/// The host-stamped subscriber identity for all MCP-routed subscriptions.
-const MCP_SUBSCRIBER_ID: &str = "mcp:host";
 /// Hard cap on `subscribe_and_wait` blocking, kept under common MCP client
 /// request timeouts. The client may request less via `timeout_secs`.
 const MAX_WAIT_SECS: u64 = 55;
 const DEFAULT_WAIT_SECS: u64 = 25;
 
-/// Process-wide discovery info for the singleton host MCP server: `(port,
-/// token)`. Set once when the server binds; read by the pane PTY env builder so
-/// every pane gets `PLEXI_HOST_MCP_PORT` / `PLEXI_HOST_MCP_TOKEN`.
-static DISCOVERY: OnceLock<(u16, String)> = OnceLock::new();
+/// Process-wide port for the singleton host MCP server.
+static DISCOVERY: OnceLock<u16> = OnceLock::new();
 
-/// The bound `(port, token)` once the server has started, else `None`.
-pub fn discovery() -> Option<&'static (u16, String)> {
-    DISCOVERY.get()
+fn discovery() -> Option<u16> {
+    DISCOVERY.get().copied()
 }
 
-/// The persisted host-MCP identity (`config_dir/host_mcp.json`). Survives
-/// restarts so a baked MCP client config keeps working — see the module docs.
+#[derive(Clone)]
+struct McpCaller {
+    pane_id: u64,
+    workspace_root: PathBuf,
+}
+
+#[derive(Default)]
+struct CredentialRegistry {
+    by_token: HashMap<String, McpCaller>,
+    by_pane: HashMap<u64, String>,
+}
+
+static CREDENTIALS: OnceLock<Mutex<CredentialRegistry>> = OnceLock::new();
+
+fn credentials() -> &'static Mutex<CredentialRegistry> {
+    CREDENTIALS.get_or_init(|| Mutex::new(CredentialRegistry::default()))
+}
+
+/// Register or refresh the credential injected into one pane. The caller's
+/// workspace comes from host-owned pane construction, never the MCP request.
+fn register_pane_credential(pane_id: u64, workspace_root: PathBuf) -> String {
+    let mut registry = credentials().lock().unwrap();
+    if let Some(token) = registry.by_pane.get(&pane_id).cloned() {
+        registry.by_token.insert(
+            token.clone(),
+            McpCaller {
+                pane_id,
+                workspace_root,
+            },
+        );
+        return token;
+    }
+    let token = uuid::Uuid::new_v4().to_string();
+    registry.by_pane.insert(pane_id, token.clone());
+    registry.by_token.insert(
+        token.clone(),
+        McpCaller {
+            pane_id,
+            workspace_root: workspace_root.clone(),
+        },
+    );
+    log::info!(
+        "host_mcp: registered scoped credential pane={pane_id} workspace={}",
+        workspace_root.display()
+    );
+    token
+}
+
+/// Return the singleton endpoint plus a credential bound to this host-owned
+/// pane identity. This is the only discovery surface pane environments use.
+pub(crate) fn discovery_for_pane(pane_id: u64, workspace_root: PathBuf) -> Option<(u16, String)> {
+    discovery().map(|port| {
+        let token = register_pane_credential(pane_id, workspace_root);
+        (port, token)
+    })
+}
+
+pub(crate) fn revoke_pane_credentials(pane_id: u64) {
+    let mut registry = credentials().lock().unwrap();
+    if let Some(token) = registry.by_pane.remove(&pane_id) {
+        registry.by_token.remove(&token);
+        log::info!("host_mcp: revoked scoped credential pane={pane_id}");
+    }
+}
+
+/// Owns a credential between environment construction and installation of the
+/// terminal pane. Dropping an uncommitted lease closes the credential, so every
+/// early return from `TerminalPane::new` is safe by construction.
+pub(crate) struct PendingPaneCredential {
+    pane_id: Option<u64>,
+}
+
+impl PendingPaneCredential {
+    pub(crate) fn new(pane_id: u64) -> Self {
+        Self {
+            pane_id: Some(pane_id),
+        }
+    }
+
+    pub(crate) fn mark_live(mut self) {
+        self.pane_id = None;
+    }
+}
+
+impl Drop for PendingPaneCredential {
+    fn drop(&mut self) {
+        if let Some(pane_id) = self.pane_id.take() {
+            revoke_pane_credentials(pane_id);
+        }
+    }
+}
+
+/// Update the trusted workspace attached to a live pane without rotating its
+/// credential. Context roots can change while their panes remain alive.
+pub(crate) fn rebind_pane_credential(pane_id: u64, workspace_root: PathBuf) {
+    let mut registry = credentials().lock().unwrap();
+    let Some(token) = registry.by_pane.get(&pane_id).cloned() else {
+        return;
+    };
+    registry.by_token.insert(
+        token,
+        McpCaller {
+            pane_id,
+            workspace_root: workspace_root.clone(),
+        },
+    );
+    log::info!(
+        "host_mcp: rebound scoped credential pane={pane_id} workspace={}",
+        workspace_root.display()
+    );
+}
+
+fn authenticate(token: &str) -> Option<McpCaller> {
+    credentials().lock().unwrap().by_token.get(token).cloned()
+}
+
+#[cfg(test)]
+pub(crate) fn register_pane_credential_for_test(pane_id: u64, workspace_root: PathBuf) -> String {
+    register_pane_credential(pane_id, workspace_root)
+}
+
+#[cfg(test)]
+pub(crate) fn authenticated_workspace_for_test(token: &str) -> Option<PathBuf> {
+    authenticate(token).map(|caller| caller.workspace_root)
+}
+
+/// Persisted host-MCP endpoint (`config_dir/host_mcp.json`). Credentials are
+/// deliberately runtime-only because they carry a live pane identity.
 #[derive(serde::Serialize, serde::Deserialize)]
 struct HostMcpIdentity {
     port: u16,
-    token: String,
 }
 
 fn identity_path(config_dir: &Path) -> PathBuf {
     config_dir.join("host_mcp.json")
 }
 
-/// Load the persisted `(port, token)` if the file exists and parses. A corrupt
-/// file is logged and ignored so the next launch re-rolls a fresh identity
+/// Load the persisted port if the file exists and parses. A corrupt file is
+/// logged and ignored so the next launch rolls a fresh endpoint
 /// rather than failing to start the transport.
 fn load_identity(config_dir: &Path) -> Option<HostMcpIdentity> {
     let path = identity_path(config_dir);
@@ -78,16 +197,12 @@ fn load_identity(config_dir: &Path) -> Option<HostMcpIdentity> {
     }
 }
 
-/// Atomically persist `(port, token)` with owner-only permissions — the file
-/// carries a bearer secret. Best-effort: a write failure only means the next
-/// launch re-rolls the identity, so it is logged rather than propagated.
-fn save_identity(config_dir: &Path, port: u16, token: &str) {
+/// Atomically persist the port. Best-effort: a write failure only means the
+/// next launch rolls the endpoint, so it is logged rather than propagated.
+fn save_identity(config_dir: &Path, port: u16) {
     let path = identity_path(config_dir);
     let tmp = path.with_extension("json.tmp");
-    let body = match serde_json::to_vec_pretty(&HostMcpIdentity {
-        port,
-        token: token.to_string(),
-    }) {
+    let body = match serde_json::to_vec_pretty(&HostMcpIdentity { port }) {
         Ok(b) => b,
         Err(e) => {
             log::warn!("host_mcp: could not serialize identity: {e}");
@@ -111,20 +226,13 @@ fn save_identity(config_dir: &Path, port: u16, token: &str) {
 /// Start the host MCP server. `subscribe_tx` routes subscribe requests to the
 /// UI thread (which owns the grant store); the mailbox wakes the UI so it
 /// drains the subscribe channel promptly even while idle. `config_dir` is the
-/// profile dir where the `(port, token)` identity is persisted across restarts.
+/// profile dir where the port is persisted across restarts.
 /// Idempotent at the discovery level — the first successful bind wins.
 pub fn start_host_mcp_server(
     subscribe_tx: UiMailbox<HostSubscribeRequest>,
     config_dir: &Path,
-) -> std::io::Result<(u16, String)> {
+) -> std::io::Result<u16> {
     let persisted = load_identity(config_dir);
-    // Reuse the persisted token so a baked `Authorization: Bearer` keeps
-    // authenticating; generate one only on first launch.
-    let token = persisted
-        .as_ref()
-        .map(|id| id.token.clone())
-        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-
     // Reuse the persisted port so a static MCP URL keeps resolving. Fall back to
     // an OS-assigned port if it is taken (e.g. another channel grabbed it while
     // this instance was down) and re-persist whatever we actually bound.
@@ -139,10 +247,9 @@ pub fn start_host_mcp_server(
     };
     let port = listener.local_addr()?.port();
 
-    save_identity(config_dir, port, &token);
+    save_identity(config_dir, port);
 
-    let _ = DISCOVERY.set((port, token.clone()));
-    let token_arc = std::sync::Arc::new(token.clone());
+    let _ = DISCOVERY.set(port);
 
     std::thread::Builder::new()
         .name(format!("host-mcp-accept-{port}"))
@@ -150,12 +257,11 @@ pub fn start_host_mcp_server(
             for stream in listener.incoming() {
                 match stream {
                     Ok(stream) => {
-                        let token = std::sync::Arc::clone(&token_arc);
                         let subscribe_tx = subscribe_tx.clone();
                         std::thread::Builder::new()
                             .name("host-mcp-conn".to_string())
                             .spawn(move || {
-                                if let Err(e) = handle_connection(stream, &token, &subscribe_tx) {
+                                if let Err(e) = handle_connection(stream, &subscribe_tx) {
                                     log::warn!("host_mcp: connection error: {e}");
                                 }
                             })
@@ -171,17 +277,17 @@ pub fn start_host_mcp_server(
         .map_err(std::io::Error::other)?;
 
     log::info!("host_mcp: started on 127.0.0.1:{port}");
-    Ok((port, token))
+    Ok(port)
 }
 
-fn tool_defs() -> serde_json::Value {
-    serde_json::json!([
-        {
+fn tool_defs(dispatcher: &crate::plexi_ai::tool_dispatch::ToolDispatcher) -> serde_json::Value {
+    let mut tools = vec![
+        serde_json::json!({
             "name": "list_event_streams",
             "description": "List the event streams currently declared by running Plexi apps. Returns an array of {app_id, stream} pairs.",
             "inputSchema": { "type": "object", "properties": {}, "additionalProperties": false }
-        },
-        {
+        }),
+        serde_json::json!({
             "name": "subscribe_and_wait",
             "description": "Subscribe to a Plexi app's event stream and block until the next event arrives (or the timeout elapses), then return it. The subscription is dropped when the call returns.",
             "inputSchema": {
@@ -196,13 +302,23 @@ fn tool_defs() -> serde_json::Value {
                 "required": ["app_id"],
                 "additionalProperties": false
             }
-        }
-    ])
+        }),
+    ];
+    let mut app_tools = dispatcher.all_tools();
+    app_tools.sort_by(|a, b| a.name.cmp(&b.name));
+    tools.extend(app_tools.into_iter().map(|tool| {
+        serde_json::json!({
+            "name": tool.name,
+            "description": tool.description,
+            "inputSchema": tool.input_schema,
+            "outputSchema": tool.output_schema,
+        })
+    }));
+    serde_json::Value::Array(tools)
 }
 
 fn handle_connection(
     stream: std::net::TcpStream,
-    token: &str,
     subscribe_tx: &UiMailbox<HostSubscribeRequest>,
 ) -> std::io::Result<()> {
     let peer = stream
@@ -211,10 +327,14 @@ fn handle_connection(
         .unwrap_or_else(|_| "unknown".to_string());
     let mut write_stream = stream.try_clone()?;
 
-    let json = match read_json_rpc_request(&stream, token)? {
-        RequestOutcome::Json(v) => v,
+    let (json, caller) = match read_json_rpc_request(&stream, authenticate)? {
+        RequestOutcome::Json { body, auth } => (body, auth),
         RequestOutcome::Handled => return Ok(()),
     };
+    let dispatcher = crate::plexi_ai::tool_dispatch::ToolDispatcher::from_namespaced_registry(
+        caller.pane_id,
+        caller.workspace_root.clone(),
+    );
 
     let id = json.get("id").cloned().unwrap_or(serde_json::Value::Null);
     let method_name = json.get("method").and_then(|m| m.as_str()).unwrap_or("");
@@ -225,14 +345,14 @@ fn handle_connection(
             "result": {
                 "protocolVersion": "2024-11-05",
                 "capabilities": { "tools": {} },
-                "serverInfo": { "name": "plexi-host-events", "version": "1.0.0" }
+                "serverInfo": { "name": "plexi-host", "version": "1.0.0" }
             }
         }),
         "notifications/initialized" => serde_json::json!({
             "jsonrpc": "2.0", "id": serde_json::Value::Null, "result": serde_json::Value::Null
         }),
         "tools/list" => serde_json::json!({
-            "jsonrpc": "2.0", "id": id, "result": { "tools": tool_defs() }
+            "jsonrpc": "2.0", "id": id, "result": { "tools": tool_defs(&dispatcher) }
         }),
         "tools/call" => {
             let params = json.get("params").cloned().unwrap_or_default();
@@ -241,11 +361,30 @@ fn handle_connection(
                 .get("arguments")
                 .cloned()
                 .unwrap_or(serde_json::Value::Object(Default::default()));
-            log::info!("host_mcp: tool_call tool={tool_name} peer={peer}");
+            log::info!(
+                "host_mcp: tool_call caller_pane={} workspace={} tool={tool_name} peer={peer}",
+                caller.pane_id,
+                caller.workspace_root.display()
+            );
             let result = match tool_name {
                 "list_event_streams" => tool_list_event_streams(),
-                "subscribe_and_wait" => tool_subscribe_and_wait(&arguments, subscribe_tx),
-                other => Err(format!("unknown tool: {other}")),
+                "subscribe_and_wait" => tool_subscribe_and_wait(&arguments, subscribe_tx, &caller),
+                other => {
+                    let input_json = serde_json::to_string(&arguments)
+                        .map_err(|error| format!("serialize tool arguments: {error}"));
+                    match input_json {
+                        Ok(input_json) => {
+                            let call_id = format!("mcp-{}", uuid::Uuid::new_v4());
+                            let result = dispatcher.dispatch_call(call_id, other, input_json);
+                            match (result.output_json, result.error) {
+                                (_, Some(error)) => Err(error),
+                                (Some(output), None) => Ok(output),
+                                (None, None) => Ok("null".to_string()),
+                            }
+                        }
+                        Err(error) => Err(error),
+                    }
+                }
             };
             match result {
                 Ok(text) => serde_json::json!({
@@ -287,6 +426,7 @@ fn tool_list_event_streams() -> Result<String, String> {
 fn tool_subscribe_and_wait(
     args: &serde_json::Value,
     subscribe_tx: &UiMailbox<HostSubscribeRequest>,
+    caller: &McpCaller,
 ) -> Result<String, String> {
     let app_id = args
         .get("app_id")
@@ -316,11 +456,11 @@ fn tool_subscribe_and_wait(
 
     // Route the broker-checked subscribe through the UI thread.
     //
-    // Identity is split (#2290): the broker actor stays the stable `mcp:host`
-    // so one "Always" grant covers every host-MCP connection, while the delivery
-    // routing key is minted unique per call so two concurrent waiters never
-    // cross-talk or tear each other down.
-    let delivery_id = format!("{MCP_SUBSCRIBER_ID}:{}", uuid::Uuid::new_v4());
+    // The authenticated pane identity owns both broker provenance and workspace
+    // scope. A unique delivery suffix prevents concurrent waiters from
+    // cross-talking or tearing each other down.
+    let actor_id = format!("mcp:pane:{}", caller.pane_id);
+    let delivery_id = format!("{actor_id}:{}", uuid::Uuid::new_v4());
     let (reply_tx, reply_rx) = std::sync::mpsc::sync_channel::<HostSubscribeReply>(1);
     let req = HostSubscribeRequest {
         publisher_app_id: app_id.clone(),
@@ -328,11 +468,11 @@ fn tool_subscribe_and_wait(
         payload_mode,
         trigger_mode: crate::app_protocol::TriggerMode::Conversation,
         resource_id: None,
-        from_pane_id: None,
+        from_pane_id: Some(caller.pane_id),
         subscriber_override: Some(delivery_id),
         subscriber_type_override: None,
-        broker_actor_override: Some(MCP_SUBSCRIBER_ID.to_string()),
-        workspace_root_override: None,
+        broker_actor_override: Some(actor_id),
+        workspace_root_override: Some(caller.workspace_root.clone()),
         reply: reply_tx,
     };
     subscribe_tx
@@ -434,10 +574,15 @@ mod tests {
     /// A test server whose subscribe channel is serviced by a granted service
     /// bound to the global timeline (the production wiring, minus the UI loop).
     fn start_test_server(grant_target: Option<&str>) -> (u16, String) {
+        static NEXT_PANE_ID: std::sync::atomic::AtomicU64 =
+            std::sync::atomic::AtomicU64::new(80_000);
         use crate::broker::{
             ActorScope, ActorType, Decision, GrantDuration, GrantRecord, GrantSource,
             ResourceScope, TargetType,
         };
+        let pane_id = NEXT_PANE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let actor_id = format!("mcp:pane:{pane_id}");
+        let workspace_root = PathBuf::from(format!("/workspace/host-mcp-test-{pane_id}"));
         let (tx, rx) = UiMailbox::<HostSubscribeRequest>::channel(
             std::sync::Arc::new(crate::app::ui_mailbox::RecordingWake::new()),
             "host_mcp_test",
@@ -446,9 +591,9 @@ mod tests {
         if let Some(target) = grant_target {
             store.record(GrantRecord {
                 actor_type: ActorType::Agent,
-                actor_id: MCP_SUBSCRIBER_ID.to_string(),
+                actor_id,
                 actor_scope: ActorScope::User,
-                workspace_root: None,
+                workspace_root: Some(workspace_root.clone()),
                 target_type: TargetType::AppEventStream,
                 target_id: target.to_string(),
                 resource_scope: ResourceScope::Global,
@@ -473,34 +618,64 @@ mod tests {
             }
         });
         // Each test server gets an isolated profile dir so its persisted
-        // identity never collides with a sibling test's port/token.
+        // endpoint never collides with a sibling test's port.
         let dir = tempfile::tempdir().unwrap();
-        start_host_mcp_server(tx, dir.path()).unwrap()
+        let port = start_host_mcp_server(tx, dir.path()).unwrap();
+        let token = register_pane_credential(pane_id, workspace_root);
+        (port, token)
     }
 
     #[test]
     fn identity_round_trips_through_disk() {
         let dir = tempfile::tempdir().unwrap();
-        save_identity(dir.path(), 4242, "tok-abc");
+        save_identity(dir.path(), 4242);
         let loaded = load_identity(dir.path()).expect("identity file written");
         assert_eq!(loaded.port, 4242);
-        assert_eq!(loaded.token, "tok-abc");
     }
 
     #[test]
-    fn restart_reuses_persisted_token() {
-        let dir = tempfile::tempdir().unwrap();
-        let (tx, _rx) = UiMailbox::<HostSubscribeRequest>::channel(
-            std::sync::Arc::new(crate::app::ui_mailbox::RecordingWake::new()),
-            "host_mcp_test",
+    fn pending_pane_credentials_revoke_on_abort_and_survive_commit() {
+        let aborted_ids = [65_300_301u64, 65_300_302u64];
+        let aborted_tokens: Vec<_> = aborted_ids
+            .iter()
+            .map(|pane_id| {
+                register_pane_credential(
+                    *pane_id,
+                    PathBuf::from(format!("/workspace/aborted-{pane_id}")),
+                )
+            })
+            .collect();
+        let pending: Vec<_> = aborted_ids
+            .iter()
+            .map(|pane_id| PendingPaneCredential::new(*pane_id))
+            .collect();
+
+        drop(pending);
+
+        assert!(aborted_tokens
+            .iter()
+            .all(|token| authenticate(token).is_none()));
+
+        let live_id = 65_300_303u64;
+        let live_root = PathBuf::from("/workspace/live");
+        let live_token = register_pane_credential(live_id, live_root.clone());
+        PendingPaneCredential::new(live_id).mark_live();
+
+        assert_eq!(
+            authenticate(&live_token).map(|caller| caller.workspace_root),
+            Some(live_root)
         );
-        let (port1, token1) = start_host_mcp_server(tx.clone(), dir.path()).unwrap();
-        // A second boot against the same profile dir must reuse the token so a
-        // baked `Authorization: Bearer` keeps authenticating across restarts.
-        let (_port2, token2) = start_host_mcp_server(tx, dir.path()).unwrap();
-        assert_eq!(token1, token2, "token must persist across restarts");
-        assert_eq!(load_identity(dir.path()).unwrap().token, token1);
-        assert!(port1 > 0);
+        revoke_pane_credentials(live_id);
+    }
+
+    #[test]
+    fn persisted_endpoint_contains_no_bearer() {
+        let dir = tempfile::tempdir().unwrap();
+        save_identity(dir.path(), 4242);
+        let json: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(identity_path(dir.path())).unwrap()).unwrap();
+        assert_eq!(json["port"], 4242);
+        assert!(json.get("token").is_none());
     }
 
     #[test]
@@ -532,6 +707,122 @@ mod tests {
             .collect();
         assert!(names.contains(&"list_event_streams"));
         assert!(names.contains(&"subscribe_and_wait"));
+    }
+
+    #[test]
+    fn pane_credential_lists_and_calls_only_workspace_app_tools() {
+        use crate::app_protocol::{AiTool, PlexiEvent};
+        use crate::plexi_ai::tool_dispatch::{self, AppEventSender, ToolCallResult};
+
+        let (port, _test_token) = start_test_server(None);
+        let workspace_a = PathBuf::from("/workspace/host-mcp-a");
+        let workspace_b = PathBuf::from("/workspace/host-mcp-b");
+        let caller_token = register_pane_credential(7_001, workspace_a.clone());
+        let (provider_tx, provider_rx) = std::sync::mpsc::channel();
+        let (other_tx, _other_rx) = std::sync::mpsc::channel();
+        let tool = |name: &str| AiTool {
+            name: name.to_string(),
+            description: format!("test tool {name}"),
+            input_schema: serde_json::json!({"type": "object"}),
+            output_schema: serde_json::json!({"type": "object"}),
+            timeout_ms: Some(1_000),
+            read_only: true,
+        };
+        tool_dispatch::register(
+            7_002,
+            "workspace-a-app".to_string(),
+            vec![tool("echo")],
+            AppEventSender::Channel(provider_tx),
+            workspace_a,
+        );
+        tool_dispatch::register(
+            7_003,
+            "workspace-b-app".to_string(),
+            vec![tool("secret")],
+            AppEventSender::Channel(other_tx),
+            workspace_b,
+        );
+
+        let (status, body) = post(
+            port,
+            Some(&caller_token),
+            br#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#,
+        );
+        assert_eq!(status, 200);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let names: Vec<&str> = json["result"]["tools"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|tool| tool["name"].as_str())
+            .collect();
+        assert!(names.contains(&"workspace-a-app__echo"));
+        assert!(!names.contains(&"workspace-b-app__secret"));
+
+        let (status, body) = post(
+            port,
+            Some(&caller_token),
+            br#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"workspace-b-app__secret","arguments":{"workspace_root":"/workspace/host-mcp-b"}}}"#,
+        );
+        assert_eq!(status, 200);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["result"]["isError"], true);
+        assert!(
+            json["result"]["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("tool_not_found"),
+            "client arguments cannot override credential workspace: {json}"
+        );
+
+        let responder = std::thread::spawn(move || {
+            let line = provider_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("provider receives ToolCall");
+            let event: PlexiEvent = serde_json::from_str(line.trim()).unwrap();
+            let PlexiEvent::ToolCall {
+                call_id,
+                name,
+                input_json,
+                caller_id,
+            } = event
+            else {
+                panic!("expected ToolCall");
+            };
+            assert_eq!(name, "echo");
+            assert_eq!(input_json, r#"{"value":7}"#);
+            assert_eq!(caller_id, "mcp:pane:7001");
+            tool_dispatch::resolve_pending(
+                &call_id,
+                ToolCallResult {
+                    output_json: Some(r#"{"echo":7}"#.to_string()),
+                    error: None,
+                },
+            );
+        });
+        let (status, body) = post(
+            port,
+            Some(&caller_token),
+            br#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"workspace-a-app__echo","arguments":{"value":7}}}"#,
+        );
+        responder.join().unwrap();
+        assert_eq!(status, 200);
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json["result"]["content"][0]["text"],
+            serde_json::json!(r#"{"echo":7}"#)
+        );
+        assert_eq!(json["result"]["isError"], false);
+
+        tool_dispatch::unregister(7_002);
+        tool_dispatch::unregister(7_003);
+        revoke_pane_credentials(7_001);
+        let (status, _) = post(
+            port,
+            Some(&caller_token),
+            br#"{"jsonrpc":"2.0","id":4,"method":"tools/list"}"#,
+        );
+        assert_eq!(status, 401, "closed-pane credentials must be revoked");
     }
 
     /// End-to-end proof the MCP adapter is wired, not just that a host test can

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1144,7 +1144,7 @@ impl PlexiApp {
             event_subscribe_mailbox.with_source("host_mcp_subscribe"),
             &crate::config::config_dir(),
         ) {
-            log::warn!("host_mcp: failed to start event MCP server: {e}");
+            log::warn!("host_mcp: failed to start host MCP server: {e}");
         }
 
         // One-time migration: remove the legacy file-queue directory if it
@@ -1271,7 +1271,7 @@ impl PlexiApp {
                             .get(&saved_win.context_id)
                             .copied()
                             .unwrap_or(0);
-                        let settings = Self::make_backend_settings(
+                        let (settings, pending_credential) = Self::make_backend_settings(
                             saved_pane.id,
                             cwd,
                             &colors,
@@ -1290,6 +1290,7 @@ impl PlexiApp {
                         ) {
                             pane.name = saved_pane.name.clone();
                             pane_entry = Some(Pane::Terminal(Box::new(pane)));
+                            pending_credential.mark_live();
                         }
                     }
 
@@ -2328,7 +2329,7 @@ impl PlexiApp {
         context_description: &str,
         context_root: Option<&PathBuf>,
         context_depth: u32,
-    ) -> BackendSettings {
+    ) -> (BackendSettings, host_mcp::PendingPaneCredential) {
         log::info!(
             "make_backend_settings: pane_id={pane_id} context_id={context_id} \
              context_name={context_name:?} context_root={context_root:?} context_depth={context_depth}"
@@ -2340,12 +2341,15 @@ impl PlexiApp {
             .to_string_lossy()
             .into_owned();
         env.insert("PLEXI_SOCKET".into(), socket);
-        // Host-level event MCP server discovery (stint 0214). Lets an MCP-aware
-        // agent in this pane configure the Plexi host MCP server without a
-        // wrapper subprocess.
-        if let Some((port, token)) = host_mcp::discovery() {
+        // Host MCP discovery. The bearer is registered against this trusted
+        // pane/context identity; requests cannot supply their own workspace.
+        let workspace_root = context_root
+            .cloned()
+            .or_else(|| working_directory.clone())
+            .unwrap_or_default();
+        if let Some((port, token)) = host_mcp::discovery_for_pane(pane_id, workspace_root) {
             env.insert("PLEXI_HOST_MCP_PORT".into(), port.to_string());
-            env.insert("PLEXI_HOST_MCP_TOKEN".into(), token.clone());
+            env.insert("PLEXI_HOST_MCP_TOKEN".into(), token);
         }
         env.insert("PLEXI_CONTEXT_ID".into(), context_id.to_string());
         env.insert("PLEXI_CONTEXT_NAME".into(), context_name.to_string());
@@ -2360,13 +2364,16 @@ impl PlexiApp {
             );
         }
         env.insert("PLEXI_CONTEXT_DEPTH".into(), context_depth.to_string());
-        BackendSettings {
-            shell: shell::detect_shell(),
-            args: vec!["-l".to_string()],
-            env,
-            dynamic_colors: theme::terminal_dynamic_colors(colors),
-            working_directory,
-        }
+        (
+            BackendSettings {
+                shell: shell::detect_shell(),
+                args: vec!["-l".to_string()],
+                env,
+                dynamic_colors: theme::terminal_dynamic_colors(colors),
+                working_directory,
+            },
+            host_mcp::PendingPaneCredential::new(pane_id),
+        )
     }
 
     /// Single entry point for Cmd+R. Opens the pane rename modal for the

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -195,11 +195,6 @@ pub struct AppManifestApp {
     /// `serde(default)`, which would conflate "absent" with "false" at the
     /// type level and lose the diagnostic that the field was never set.
     pub watch: Option<bool>,
-    /// Optional `[app.mcp]` section. When present the host starts an HTTP MCP server
-    /// on a dynamic port and injects PLEXI_MCP_PORT into the app's environment.
-    #[serde(default)]
-    pub mcp: Option<McpSection>,
-
     /// App author name or org.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub author: Option<String>,
@@ -249,23 +244,6 @@ impl From<DefaultNotifyScope> for crate::app_protocol::NotifyScope {
             DefaultNotifyScope::Global => crate::app_protocol::NotifyScope::Global,
         }
     }
-}
-
-/// Manifest `[app.mcp.tools]` entry — one tool the app exposes to external MCP clients.
-#[derive(Deserialize, Debug, Clone)]
-pub struct McpTool {
-    pub name: String,
-    pub description: String,
-    pub input_schema: serde_json::Value,
-}
-
-/// Manifest `[app.mcp]` section. Presence means the host starts an HTTP MCP server.
-#[derive(Deserialize, Debug, Clone)]
-pub struct McpSection {
-    #[serde(default)]
-    pub description: String,
-    #[serde(default)]
-    pub tools: Vec<McpTool>,
 }
 
 /// v3 capability section — `[app.capabilities]`. Holds launch capabilities,
@@ -587,7 +565,7 @@ impl AppRegistry {
                 Ok(installed) => {
                     let id = installed.manifest.id.clone();
                     log::debug!(
-                        "AppRegistry: contract id={} target={:?} world={:?} python_compat={:?} min_sdk={:?} watch={:?} background={} keyboard_capture={} min_size={:?}x{:?} widths={:?}/{:?} startup={:?} secrets={} mcp_tools={}",
+                        "AppRegistry: contract id={} target={:?} world={:?} python_compat={:?} min_sdk={:?} watch={:?} background={} keyboard_capture={} min_size={:?}x{:?} widths={:?}/{:?} startup={:?} secrets={}",
                         id,
                         installed.runtime.target,
                         installed.runtime.world,
@@ -602,12 +580,6 @@ impl AppRegistry {
                         installed.launch.regular,
                         installed.launch.startup_message,
                         installed.secrets.len(),
-                        installed.manifest.mcp.as_ref().map_or(0, |mcp| {
-                            mcp.tools.iter().map(|tool| {
-                                let _ = (&tool.description, &tool.input_schema);
-                                1usize
-                            }).sum()
-                        }),
                     );
                     if let Some(existing) = self.apps.get(&id) {
                         if source != existing.source {

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -706,7 +706,7 @@ fn delete_context_portal_resets_stale_focused_pane() {
 /// Issue #1392: deleting a context must cascade to all descendants AND
 /// clean up router.depth_stack entries pointing to deleted contexts.
 #[test]
-fn delete_context_cascades_and_cleans_depth_stack() {
+fn delete_context_cascades_cleans_depth_stack_and_revokes_credentials() {
     let ctx = egui::Context::default();
     let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
     let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
@@ -721,6 +721,16 @@ fn delete_context_cascades_and_cleans_depth_stack() {
     let b_id = 9002u64;
     let a_win_id = 9003u64;
     let b_win_id = 9004u64;
+    let a_pane_id = 65_300_111u64;
+    let b_pane_id = 65_300_112u64;
+    let a_token = crate::app::host_mcp::register_pane_credential_for_test(
+        a_pane_id,
+        std::path::PathBuf::from("/tmp/a"),
+    );
+    let b_token = crate::app::host_mcp::register_pane_credential_for_test(
+        b_pane_id,
+        std::path::PathBuf::from("/tmp/b"),
+    );
 
     app.router.push(crate::host::context::Context {
         name: "A".to_string(),
@@ -746,12 +756,14 @@ fn delete_context_cascades_and_cleans_depth_stack() {
     app.context_active_window.insert(b_id, b_win_id);
     {
         let mut tiles_a = egui_tiles::Tiles::default();
-        let r_a = tiles_a.insert_pane(88881);
+        let r_a = tiles_a.insert_pane(a_pane_id);
+        let mut panes = std::collections::HashMap::new();
+        panes.insert(a_pane_id, test_app_pane(a_pane_id));
         app.windows.push(crate::host::context::Window {
             name: String::new(),
             path: std::path::PathBuf::from("/tmp/a"),
             tree: egui_tiles::Tree::new("plexi_a", r_a, tiles_a),
-            panes: std::collections::HashMap::new(),
+            panes,
             focused_pane: None,
             zoomed_pane: None,
             grid_x: 0,
@@ -762,12 +774,14 @@ fn delete_context_cascades_and_cleans_depth_stack() {
     }
     {
         let mut tiles_b = egui_tiles::Tiles::default();
-        let r_b = tiles_b.insert_pane(88882);
+        let r_b = tiles_b.insert_pane(b_pane_id);
+        let mut panes = std::collections::HashMap::new();
+        panes.insert(b_pane_id, test_app_pane(b_pane_id));
         app.windows.push(crate::host::context::Window {
             name: String::new(),
             path: std::path::PathBuf::from("/tmp/b"),
             tree: egui_tiles::Tree::new("plexi_b", r_b, tiles_b),
-            panes: std::collections::HashMap::new(),
+            panes,
             focused_pane: None,
             zoomed_pane: None,
             grid_x: 0,
@@ -786,6 +800,16 @@ fn delete_context_cascades_and_cleans_depth_stack() {
     let a_idx_now = app.router.position(|c| c.context_id == a_id).unwrap();
     app.delete_context(a_idx_now);
 
+    assert_eq!(
+        crate::app::host_mcp::authenticated_workspace_for_test(&a_token),
+        None,
+        "deleting a context must revoke credentials for its panes"
+    );
+    assert_eq!(
+        crate::app::host_mcp::authenticated_workspace_for_test(&b_token),
+        None,
+        "cascade deletion must revoke credentials for descendant panes"
+    );
     // A and B should both be gone from the router.
     assert!(
         app.router.iter().find(|c| c.context_id == a_id).is_none(),
@@ -821,6 +845,44 @@ fn delete_context_cascades_and_cleans_depth_stack() {
             }
         }
     }
+}
+
+#[test]
+fn delete_window_revokes_removed_pane_credentials() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let context_id = app.router.active().context_id;
+    let removed_pane_id = 65_300_101u64;
+    let removed_token = crate::app::host_mcp::register_pane_credential_for_test(
+        removed_pane_id,
+        std::path::PathBuf::from("/tmp/removed"),
+    );
+
+    let mut tiles = egui_tiles::Tiles::default();
+    let root = tiles.insert_pane(removed_pane_id);
+    let mut panes = std::collections::HashMap::new();
+    panes.insert(removed_pane_id, test_app_pane(removed_pane_id));
+    app.windows.push(Window {
+        name: "removed".to_string(),
+        path: std::path::PathBuf::from("/tmp/removed"),
+        tree: egui_tiles::Tree::new("removed_window", root, tiles),
+        panes,
+        focused_pane: Some(root),
+        zoomed_pane: None,
+        grid_x: 1,
+        grid_y: 0,
+        window_id: 65_300_102,
+        context_id,
+    });
+
+    app.delete_window(1);
+
+    assert_eq!(
+        crate::app::host_mcp::authenticated_workspace_for_test(&removed_token),
+        None
+    );
 }
 
 /// Stint 0454: deleting a root context whose descendant tree covers every
@@ -1521,8 +1583,19 @@ fn dissolve_portal_grafts_single_child_window_tree_in_place() {
     });
     app.router
         .push_depth(child_ctx_id, child_win_id, Some(child_right_tile));
+    let moved_token = crate::app::host_mcp::register_pane_credential_for_test(
+        child_left,
+        std::path::PathBuf::from("/tmp/dissolve_single_child"),
+    );
 
     app.dissolve_portal(child_ctx_id);
+
+    assert_eq!(
+        crate::app::host_mcp::authenticated_workspace_for_test(&moved_token),
+        Some(std::path::PathBuf::from("/tmp/dissolve_single_child")),
+        "dissolving a context moves its panes and must not revoke their credentials"
+    );
+    crate::app::host_mcp::revoke_pane_credentials(child_left);
 
     assert!(
         app.router.iter().all(|ctx| ctx.context_id != child_ctx_id),
@@ -2337,6 +2410,29 @@ fn set_context_root_ipc_targets_caller_context() {
     h.app
         .router
         .push(test_context(other_id, active_id, "background"));
+    let pane_id = 65_300_201u64;
+    let mut tiles = egui_tiles::Tiles::default();
+    let pane_tile = tiles.insert_pane(pane_id);
+    let mut panes = std::collections::HashMap::new();
+    panes.insert(pane_id, test_app_pane(pane_id));
+    h.app.windows.push(Window {
+        name: "background".to_string(),
+        path: std::path::PathBuf::from("/tmp/background"),
+        tree: egui_tiles::Tree::new("background", pane_tile, tiles),
+        panes,
+        focused_pane: Some(pane_tile),
+        zoomed_pane: None,
+        grid_x: 1,
+        grid_y: 0,
+        window_id: 65_300_202,
+        context_id: other_id,
+    });
+    let old_root = std::path::PathBuf::from("/tmp/background");
+    let token = crate::app::host_mcp::register_pane_credential_for_test(pane_id, old_root.clone());
+    assert_eq!(
+        crate::app::host_mcp::authenticated_workspace_for_test(&token),
+        Some(old_root)
+    );
 
     let tmp = tempfile::tempdir().expect("tempdir");
     let payload = serde_json::json!({
@@ -2365,6 +2461,12 @@ fn set_context_root_ipc_targets_caller_context() {
         active_root_before,
         "active context root must be untouched"
     );
+    assert_eq!(
+        crate::app::host_mcp::authenticated_workspace_for_test(&token),
+        Some(tmp.path().to_path_buf()),
+        "set-root must rebind live pane credentials to the new workspace"
+    );
+    crate::app::host_mcp::revoke_pane_credentials(pane_id);
 }
 
 /// Setting a context root must ensure `<root>/.plexi/.gitignore` covers
@@ -2641,7 +2743,7 @@ fn make_backend_settings_stamps_the_context_it_is_given() {
     let ctx = egui::Context::default();
     let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
     let (app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
-    let settings = PlexiApp::make_backend_settings(
+    let (settings, _pending_credential) = PlexiApp::make_backend_settings(
         7,
         Some(std::path::PathBuf::from("/tmp")),
         &app.colors,

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1361,7 +1361,7 @@ fn copy_dir_all_inner(
     Ok(())
 }
 
-/// `plexi app info <id>` — show manifest info for an installed app, including MCP URL if applicable.
+/// `plexi app info <id>` — show manifest info for an installed app.
 pub fn app_info(id: &str) -> i32 {
     let registry =
         crate::app::registry::AppRegistry::load(&std::env::current_dir().unwrap_or_default());
@@ -1382,33 +1382,6 @@ pub fn app_info(id: &str) -> i32 {
     }
     if let Some(ref repo) = m.repo {
         println!("repo:        {repo}");
-    }
-    if let Some(mcp) = &m.mcp {
-        if !mcp.description.is_empty() {
-            println!("mcp_desc:    {}", mcp.description);
-        }
-        let tool_names: Vec<&str> = mcp.tools.iter().map(|t| t.name.as_str()).collect();
-        println!(
-            "mcp_tools:   {}",
-            if tool_names.is_empty() {
-                "(none declared)".to_string()
-            } else {
-                tool_names.join(", ")
-            }
-        );
-        println!(
-            "mcp_url:     http://localhost:${{PLEXI_MCP_PORT}}/mcp  (port assigned at runtime)"
-        );
-        println!();
-        println!("Claude Desktop config:");
-        println!("  {{");
-        println!("    \"mcpServers\": {{");
-        println!(
-            "      \"{}\": {{ \"url\": \"http://localhost:${{PLEXI_MCP_PORT}}/mcp\" }}",
-            m.id
-        );
-        println!("    }}");
-        println!("  }}");
     }
     0
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -398,12 +398,13 @@ pub enum EventsCmd {
         #[arg(long)]
         json: bool,
     },
-    /// Print the host event MCP server config for an MCP-aware agent.
+    /// Print the host MCP server config for an MCP-aware agent.
     ///
     /// Emits a `mcpServers` JSON block pointing at this instance's host MCP
     /// server (read from `PLEXI_HOST_MCP_PORT` / `PLEXI_HOST_MCP_TOKEN`), so a
-    /// Claude Code or Codex agent in this pane can subscribe to app events
-    /// natively over MCP.
+    /// Claude Code or Codex agent in this pane can call workspace app tools and
+    /// subscribe to app events natively over MCP. The emitted credential is
+    /// valid only while the originating pane remains alive.
     McpConfig,
 }
 

--- a/src/cli/events.rs
+++ b/src/cli/events.rs
@@ -257,14 +257,14 @@ pub fn events_mcp_config_cli() -> i32 {
         _ => {
             eprintln!(
                 "error: PLEXI_HOST_MCP_PORT / PLEXI_HOST_MCP_TOKEN not set — run this inside a \
-                 Plexi terminal pane on a build with the host event MCP server"
+                 Plexi terminal pane on a build with the host MCP server"
             );
             return 1;
         }
     };
     let config = serde_json::json!({
         "mcpServers": {
-            "plexi-events": {
+            "plexi-host": {
                 "type": "http",
                 "url": format!("http://127.0.0.1:{port}/mcp"),
                 "headers": { "Authorization": format!("Bearer {token}") }

--- a/src/mcp_http.rs
+++ b/src/mcp_http.rs
@@ -1,10 +1,9 @@
 //! Shared minimal HTTP/1.1 JSON-RPC transport for Plexi's MCP servers.
 //!
-//! Both app-scoped tool bridges and the host-level
-//! event MCP server (`app::host_mcp`) speak the same wire protocol: a single
-//! `POST /mcp` request carrying a JSON-RPC body, authenticated with
-//! `Authorization: Bearer <token>`. This module owns the request framing, auth
-//! check, body-size guard, and response writer so neither server duplicates it.
+//! The host MCP server (`app::host_mcp`) speaks a single `POST /mcp` request
+//! carrying a JSON-RPC body, authenticated with `Authorization: Bearer
+//! <token>`. This module owns request framing, the caller-supplied credential
+//! lookup, the body-size guard, and response writing.
 
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::TcpStream;
@@ -13,9 +12,9 @@ use std::net::TcpStream;
 pub const MAX_BODY: usize = 10 * 1024 * 1024; // 10 MB
 
 /// Outcome of reading one request.
-pub enum RequestOutcome {
+pub enum RequestOutcome<A> {
     /// Authenticated `POST /mcp` with a parsed JSON-RPC body.
-    Json(serde_json::Value),
+    Json { body: serde_json::Value, auth: A },
     /// A non-200 HTTP response was already written; the caller should close.
     Handled,
 }
@@ -23,7 +22,10 @@ pub enum RequestOutcome {
 /// Read and authenticate one request on `stream`. On success returns the parsed
 /// JSON-RPC body. On any protocol or auth failure, writes the appropriate HTTP
 /// status to `stream` and returns [`RequestOutcome::Handled`].
-pub fn read_json_rpc_request(stream: &TcpStream, token: &str) -> std::io::Result<RequestOutcome> {
+pub fn read_json_rpc_request<A>(
+    stream: &TcpStream,
+    authenticate: impl FnOnce(&str) -> Option<A>,
+) -> std::io::Result<RequestOutcome<A>> {
     let mut reader = BufReader::new(stream.try_clone()?);
     let mut write_stream = stream.try_clone()?;
 
@@ -37,8 +39,7 @@ pub fn read_json_rpc_request(stream: &TcpStream, token: &str) -> std::io::Result
     let is_post_mcp = method == "POST" && path == "/mcp";
 
     let mut content_length: usize = 0;
-    let mut auth_ok = false;
-    let expected_auth = format!("bearer {}", token.to_lowercase());
+    let mut bearer = None;
     loop {
         let mut header = String::new();
         if reader.read_line(&mut header)? == 0 {
@@ -48,19 +49,28 @@ pub fn read_json_rpc_request(stream: &TcpStream, token: &str) -> std::io::Result
         if trimmed.is_empty() {
             break; // blank line ends headers
         }
-        let lower = trimmed.to_lowercase();
+        let lower = trimmed.to_ascii_lowercase();
         if let Some(rest) = lower.strip_prefix("content-length:") {
             content_length = rest.trim().parse().unwrap_or(0);
         }
-        if let Some(rest) = lower.strip_prefix("authorization:") {
-            auth_ok = rest.trim() == expected_auth;
+        if lower.starts_with("authorization:") {
+            let value = trimmed
+                .split_once(':')
+                .map(|(_, value)| value.trim())
+                .unwrap_or("");
+            if value
+                .get(..7)
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case("bearer "))
+            {
+                bearer = value.get(7..).map(|token| token.trim().to_string());
+            }
         }
     }
 
-    if !auth_ok {
+    let Some(auth) = bearer.as_deref().and_then(authenticate) else {
         write_http_response(&mut write_stream, 401, b"{\"error\":\"unauthorized\"}")?;
         return Ok(RequestOutcome::Handled);
-    }
+    };
     if !is_post_mcp || content_length == 0 {
         write_http_response(
             &mut write_stream,
@@ -77,7 +87,7 @@ pub fn read_json_rpc_request(stream: &TcpStream, token: &str) -> std::io::Result
     let mut buf = vec![0u8; content_length];
     reader.read_exact(&mut buf)?;
     match serde_json::from_slice(&buf) {
-        Ok(v) => Ok(RequestOutcome::Json(v)),
+        Ok(body) => Ok(RequestOutcome::Json { body, auth }),
         Err(e) => {
             log::warn!("mcp_http: invalid JSON body: {e}");
             write_http_response(&mut write_stream, 400, b"{\"error\":\"invalid json\"}")?;

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -911,9 +911,10 @@ impl PlexiApp {
         let total = commands.len();
         let mut panes: HashMap<PaneId, Pane> = HashMap::new();
         let mut pane_ids: Vec<PaneId> = Vec::with_capacity(total);
+        let mut pending_credentials = Vec::with_capacity(total);
         for (idx, initial_cmd) in commands.iter().enumerate() {
             let new_id = self.host.alloc_pane_id();
-            let mut settings = Self::make_backend_settings(
+            let (mut settings, pending_credential) = Self::make_backend_settings(
                 new_id,
                 Some(cwd.clone()),
                 &self.colors,
@@ -955,6 +956,7 @@ impl PlexiApp {
             );
             panes.insert(new_id, Pane::Terminal(Box::new(pane)));
             pane_ids.push(new_id);
+            pending_credentials.push(pending_credential);
         }
         let (tree, first_tile) = super::layout::build_squad_tree(&pane_ids, layout);
         log::info!(
@@ -963,6 +965,9 @@ impl PlexiApp {
             pane_ids,
             cwd.display()
         );
+        for credential in pending_credentials {
+            credential.mark_live();
+        }
         Some((tree, panes, first_tile, pane_ids))
     }
 
@@ -974,7 +979,7 @@ impl PlexiApp {
         close_on_exit: bool,
     ) -> Option<(Tree<PaneId>, HashMap<PaneId, Pane>, TileId)> {
         let new_id = self.host.alloc_pane_id();
-        let mut settings = Self::make_backend_settings(
+        let (mut settings, pending_credential) = Self::make_backend_settings(
             new_id,
             cwd,
             &self.colors,
@@ -1006,6 +1011,7 @@ impl PlexiApp {
         let root_tile = tiles.insert_pane(new_id);
         let tree = Tree::new("plexi", root_tile, tiles);
 
+        pending_credential.mark_live();
         Some((tree, panes, root_tile))
     }
 
@@ -1033,7 +1039,7 @@ impl PlexiApp {
             "spawn_terminal_pane_at: win_idx={win_idx} target_tile={target_tile:?} new_id={new_id} \
              vertical={vertical} keep_focus={keep_focus} initial_cmd={initial_cmd:?}"
         );
-        let mut settings = Self::make_backend_settings(
+        let (mut settings, pending_credential) = Self::make_backend_settings(
             new_id,
             cwd,
             &self.colors,
@@ -1060,6 +1066,7 @@ impl PlexiApp {
         self.windows[win_idx]
             .panes
             .insert(new_id, Pane::Terminal(Box::new(pane)));
+        pending_credential.mark_live();
 
         let share =
             crate::host::command::ShareRatio::new(1.0, 1.0).expect("1:1 is a valid ShareRatio");

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -352,7 +352,7 @@ impl PlexiApp {
         let ctx_desc = self.context_description_for(ctx_id);
         let ctx_root = self.context_root_for(ctx_id);
         let ctx_depth = self.context_depth_for(ctx_id);
-        let mut settings = Self::make_backend_settings(
+        let (mut settings, pending_credential) = Self::make_backend_settings(
             new_id,
             cwd,
             &self.colors,
@@ -380,6 +380,7 @@ impl PlexiApp {
         self.windows[self.active_window]
             .panes
             .insert(new_id, Pane::Terminal(Box::new(pane)));
+        pending_credential.mark_live();
 
         let split_target = match self.windows[self.active_window].find_ancestor_tabs(focused) {
             Some((tabs_id, _)) => tabs_id,
@@ -477,7 +478,7 @@ impl PlexiApp {
             log::info!(
                 "new_tab (empty context): target_win_idx={target_win_idx} cwd={cwd:?} context_root={ctx_root:?}"
             );
-            let mut settings = Self::make_backend_settings(
+            let (mut settings, pending_credential) = Self::make_backend_settings(
                 new_id,
                 Some(cwd),
                 &self.colors,
@@ -506,6 +507,7 @@ impl PlexiApp {
             pane.ephemeral = close_on_exit;
             let ctx = &mut self.windows[target_win_idx];
             ctx.panes.insert(new_id, Pane::Terminal(Box::new(pane)));
+            pending_credential.mark_live();
             let pane_tile = ctx.tree.tiles.insert_pane(new_id);
             let tab_tile = ctx.tree.tiles.insert_tab_tile(vec![pane_tile]);
             ctx.tree.root = Some(tab_tile);
@@ -541,7 +543,7 @@ impl PlexiApp {
         log::info!(
             "new_tab: target_win_idx={target_win_idx} cwd={cwd:?} context_root={ctx_root:?}"
         );
-        let mut settings = Self::make_backend_settings(
+        let (mut settings, pending_credential) = Self::make_backend_settings(
             new_id,
             cwd,
             &self.colors,
@@ -569,6 +571,7 @@ impl PlexiApp {
         self.windows[target_win_idx]
             .panes
             .insert(new_id, Pane::Terminal(Box::new(pane)));
+        pending_credential.mark_live();
         self.push_focus_history(old_window_id, old_focus);
 
         let ctx = &mut self.windows[target_win_idx];
@@ -890,6 +893,7 @@ impl PlexiApp {
         // without it a closed run would block its routine forever), then park
         // background WASM app runtimes; drop everything else.
         if let Some(pane_id) = closed_pane_id {
+            crate::app::host_mcp::revoke_pane_credentials(pane_id);
             if self.pane_heartbeats.remove(&pane_id).is_some() {
                 log::info!("pane_heartbeat: pane_id={pane_id} removed reason=closed");
             }

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -101,6 +101,12 @@ fn two_windows_mut(
     }
 }
 
+fn revoke_window_pane_credentials(window: &Window) {
+    for pane_id in window.panes.keys() {
+        crate::app::host_mcp::revoke_pane_credentials(*pane_id);
+    }
+}
+
 fn clone_tile_subtree(
     source_tiles: &egui_tiles::Tiles<PaneId>,
     source_id: egui_tiles::TileId,
@@ -1051,7 +1057,17 @@ impl PlexiApp {
             &deleted[1..]
         );
 
-        // 3. Remove all windows belonging to any deleted context.
+        // 3. Remove all windows belonging to any deleted context. Release
+        // their host MCP credentials before dropping the panes: a context
+        // delete bypasses close_tile and therefore has no terminal-exit
+        // cleanup.
+        for window in self
+            .windows
+            .iter()
+            .filter(|window| deleted.contains(&window.context_id))
+        {
+            revoke_window_pane_credentials(window);
+        }
         self.windows.retain(|c| !deleted.contains(&c.context_id));
 
         // 4. Remove Portal tiles in surviving windows that point to any deleted ctx.
@@ -1240,6 +1256,7 @@ impl PlexiApp {
         self.minimap_visible_per_context
             .insert(removed_ws_id, self.minimap.visible);
 
+        revoke_window_pane_credentials(&self.windows[index]);
         self.windows.remove(index);
 
         // If the deleted window was the stored last-visited for its context,
@@ -1511,6 +1528,15 @@ impl PlexiApp {
             root.display()
         );
         auto_init_workspace(&root);
+        let context_id = self.router.get(idx).context_id;
+        for pane_id in self
+            .windows
+            .iter()
+            .filter(|window| window.context_id == context_id)
+            .flat_map(|window| window.panes.keys())
+        {
+            crate::app::host_mcp::rebind_pane_credential(*pane_id, root.clone());
+        }
         self.router.get_mut(idx).root = root;
         // Transition effects (registry rescan, watcher restart, agent reload)
         // only apply when the *active* context's root changed.
@@ -1743,8 +1769,18 @@ impl PlexiApp {
             );
         }
 
-        self.windows
-            .retain(|w| w.window_id != primary_child_window_id && w.context_id != child_ctx_id);
+        for window in self.windows.iter().filter(|window| {
+            window.window_id == primary_child_window_id || window.context_id == child_ctx_id
+        }) {
+            // The primary window's panes were grafted into the parent above,
+            // and promoted windows were rebound to the parent context. Revoke
+            // only credentials for panes still present in windows that this
+            // retain is about to destroy.
+            revoke_window_pane_credentials(window);
+        }
+        self.windows.retain(|window| {
+            window.window_id != primary_child_window_id && window.context_id != child_ctx_id
+        });
         if let Some(idx) = self.router.position(|c| c.context_id == child_ctx_id) {
             self.router.remove_at(idx);
         }

--- a/src/plexi_ai/tool_dispatch.rs
+++ b/src/plexi_ai/tool_dispatch.rs
@@ -152,8 +152,11 @@ impl ToolRegistry {
     /// Silently picking a winner would dispatch to an arbitrary pane — callers
     /// instead get `tool_not_found`, which is the correct fail-visible signal
     /// until the apps are fixed or namespaced.
-    fn snapshot_for_caller(&self, caller_workspace: &Path) -> HashMap<String, (u64, AiTool)> {
-        let mut map: HashMap<String, (u64, AiTool)> = HashMap::new();
+    fn snapshot_for_caller(
+        &self,
+        caller_workspace: &Path,
+    ) -> HashMap<String, (u64, String, AiTool)> {
+        let mut map: HashMap<String, (u64, String, AiTool)> = HashMap::new();
         // Use component-by-component comparison to avoid false mismatches from
         // trailing separators or platform path normalization differences.
         let mut pane_ids: Vec<u64> = self
@@ -178,7 +181,10 @@ impl ToolRegistry {
                     .entry(tool.name.clone())
                     .or_default()
                     .push(pane_id);
-                map.insert(tool.name.clone(), (pane_id, tool.clone()));
+                map.insert(
+                    tool.name.clone(),
+                    (pane_id, tool.name.clone(), tool.clone()),
+                );
             }
         }
         for (name, mut owners) in owners_by_name {
@@ -194,6 +200,65 @@ impl ToolRegistry {
             }
         }
         map
+    }
+
+    /// Snapshot for the host MCP server, where every app tool is externally
+    /// named `<app_id>__<tool>`. The original tool name remains attached to
+    /// the target so dispatch sends the provider exactly what it registered.
+    ///
+    /// Multiple live instances of the same app expose the same external name.
+    /// Those collisions are withheld instead of selecting an arbitrary pane.
+    fn namespaced_snapshot_for_caller(
+        &self,
+        caller_workspace: &Path,
+    ) -> HashMap<String, (u64, String, AiTool)> {
+        let mut pane_ids: Vec<u64> = self
+            .entries
+            .iter()
+            .filter(|(_, entry)| {
+                entry
+                    .workspace_root
+                    .components()
+                    .eq(caller_workspace.components())
+            })
+            .map(|(&pane_id, _)| pane_id)
+            .collect();
+        pane_ids.sort_unstable();
+
+        let mut candidates: HashMap<String, Vec<(u64, String, AiTool)>> = HashMap::new();
+        for pane_id in pane_ids {
+            let Some(entry) = self.entries.get(&pane_id) else {
+                continue;
+            };
+            for tool in &entry.tools {
+                let external_name = format!("{}__{}", entry.app_id, tool.name);
+                let mut external_tool = tool.clone();
+                external_tool.name = external_name.clone();
+                candidates.entry(external_name).or_default().push((
+                    pane_id,
+                    tool.name.clone(),
+                    external_tool,
+                ));
+            }
+        }
+
+        let mut snapshot = HashMap::new();
+        for (external_name, mut owners) in candidates {
+            if owners.len() == 1 {
+                snapshot.insert(external_name, owners.pop().unwrap());
+            } else {
+                let mut pane_ids: Vec<u64> =
+                    owners.iter().map(|(pane_id, _, _)| *pane_id).collect();
+                pane_ids.sort_unstable();
+                log::error!(
+                    "tool_dispatch: namespaced tool {:?} conflict — exposed by panes {:?}; \
+                     tool withheld from external MCP callers",
+                    external_name,
+                    pane_ids
+                );
+            }
+        }
+        snapshot
     }
 
     /// Map from app_id to tool list for all panes in `caller_workspace`.
@@ -314,9 +379,9 @@ pub trait ToolCallHooks: Send + Sync {
 /// workspace tools are excluded at construction time and never visible to the
 /// dispatching app or the model it drives.
 pub struct ToolDispatcher {
-    /// Snapshot: tool_name → (provider_pane_id, AiTool).
+    /// Snapshot: exposed_name → (provider_pane_id, provider_tool_name, AiTool).
     /// Already filtered to the caller's workspace.
-    tools: HashMap<String, (u64, AiTool)>,
+    tools: HashMap<String, (u64, String, AiTool)>,
     /// Caller-local host tools (Phase D3: the Assistant's
     /// `host.events.subscribe`/`unsubscribe`). Dispatched through
     /// `host_handler`, never sent to a pane. Unaffected by `retain_allowed`
@@ -373,6 +438,31 @@ impl ToolDispatcher {
         }
     }
 
+    /// Build the workspace-scoped snapshot exposed by the singleton host MCP
+    /// server. Definitions are namespaced `<app_id>__<tool>` while dispatch
+    /// retains the provider's original tool name.
+    pub(crate) fn from_namespaced_registry(
+        caller_pane_id: u64,
+        caller_workspace: std::path::PathBuf,
+    ) -> Self {
+        let caller_app_id = format!("mcp:pane:{caller_pane_id}");
+        let registry = global_registry().lock().unwrap();
+        let tools = registry.namespaced_snapshot_for_caller(&caller_workspace);
+        log::info!(
+            "tool_dispatch: external MCP dispatcher caller={caller_app_id} workspace={} — {} tool(s) visible",
+            caller_workspace.display(),
+            tools.len(),
+        );
+        Self {
+            tools,
+            host_tools: HashMap::new(),
+            host_handler: None,
+            caller_app_id,
+            caller_pane_id,
+            hooks: None,
+        }
+    }
+
     /// Register caller-local host tools (Phase D3). They are visible in
     /// `all_tools()` and dispatched through `handler` on the broker worker
     /// thread — never routed to a pane. Hooks still observe these calls.
@@ -398,7 +488,7 @@ impl ToolDispatcher {
     pub fn all_tools(&self) -> Vec<AiTool> {
         self.tools
             .values()
-            .map(|(_, t)| t.clone())
+            .map(|(_, _, tool)| tool.clone())
             .chain(self.host_tools.values().cloned())
             .collect()
     }
@@ -491,7 +581,7 @@ impl ToolDispatcher {
     }
 
     fn dispatch_inner(&self, call_id: String, name: &str, input_json: String) -> ToolCallResult {
-        let (pane_id, tool) = match self.tools.get(name) {
+        let (pane_id, provider_tool_name, tool) = match self.tools.get(name) {
             Some(entry) => entry,
             None => {
                 log::warn!(
@@ -528,7 +618,7 @@ impl ToolDispatcher {
                 sender
                     .send_event(&PlexiEvent::ToolCall {
                         call_id: call_id.clone(),
-                        name: name.to_string(),
+                        name: provider_tool_name.clone(),
                         input_json,
                         caller_id: self.caller_app_id.clone(),
                     })
@@ -771,6 +861,38 @@ mod tests {
             snap.contains_key("unique_b"),
             "non-conflicting tool from pane 20 must remain visible"
         );
+    }
+
+    #[test]
+    fn namespaced_snapshot_withholds_duplicate_app_instances() {
+        let mut reg = ToolRegistry::new();
+        let workspace = PathBuf::from("/workspace/mcp-duplicates");
+        let (tx1, _rx1) = std::sync::mpsc::channel();
+        let (tx2, _rx2) = std::sync::mpsc::channel();
+        reg.register(
+            30,
+            "same-app".to_string(),
+            vec![make_tool("echo")],
+            AppEventSender::Channel(tx1),
+            workspace.clone(),
+        );
+        reg.register(
+            20,
+            "same-app".to_string(),
+            vec![make_tool("echo"), make_tool("unique")],
+            AppEventSender::Channel(tx2),
+            workspace.clone(),
+        );
+
+        let snapshot = reg.namespaced_snapshot_for_caller(&workspace);
+        assert!(
+            !snapshot.contains_key("same-app__echo"),
+            "two live instances must not select an arbitrary provider"
+        );
+        let (pane_id, provider_name, tool) = &snapshot["same-app__unique"];
+        assert_eq!(*pane_id, 20);
+        assert_eq!(provider_name, "unique");
+        assert_eq!(tool.name, "same-app__unique");
     }
 
     /// A `before_call` error must block the call and skip `after_call`;

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -822,16 +822,6 @@ pub enum AppRequest {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         error: Option<String>,
     },
-    /// App returns the result of a `PlexiEvent::McpToolCall` invocation.
-    /// `call_id` must match the `call_id` from the `McpToolCall` event.
-    /// Either `result` or `error` must be set.
-    McpToolResult {
-        call_id: String,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        result: Option<serde_json::Value>,
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        error: Option<String>,
-    },
     /// Host-owned audio playback via `rodio`.
     AudioPlay {
         #[serde(default)]

--- a/src/protocol/events.rs
+++ b/src/protocol/events.rs
@@ -303,13 +303,6 @@ pub enum PlexiEvent {
         /// this call is being serviced.
         caller_id: String,
     },
-    /// External MCP client called a tool declared in `[app.mcp]`. The app must
-    /// reply with `DrawCommand::Host(AppRequest::McpToolResult { call_id, … })`.
-    McpToolCall {
-        call_id: String,
-        tool_name: String,
-        arguments: serde_json::Value,
-    },
     /// Response to a `DrawCommand::ListAudioDevices` request (#277).
     /// Both vectors are always present — empty when enumeration finds no
     /// devices of that direction. `error` is set only when device

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -1057,7 +1057,7 @@ Apps declare named event streams (e.g. `probe.tick`) and emit events on them. `p
 | `declare` | Declare an event stream so it can be emitted on and subscribed to |
 | `emit` | Emit an event onto a declared stream |
 | `list` | List event streams currently declared by running apps |
-| `mcp-config` | Print the host event MCP server config for an MCP-aware agent |
+| `mcp-config` | Print the host MCP server config for an MCP-aware agent |
 
 ### `plexi events subscribe`
 
@@ -1124,9 +1124,9 @@ List event streams currently declared by running apps
 
 ### `plexi events mcp-config`
 
-Print the host event MCP server config for an MCP-aware agent.
+Print the host MCP server config for an MCP-aware agent.
 
-Emits a `mcpServers` JSON block pointing at this instance's host MCP server (read from `PLEXI_HOST_MCP_PORT` / `PLEXI_HOST_MCP_TOKEN`), so a Claude Code or Codex agent in this pane can subscribe to app events natively over MCP.
+Emits a `mcpServers` JSON block pointing at this instance's host MCP server (read from `PLEXI_HOST_MCP_PORT` / `PLEXI_HOST_MCP_TOKEN`), so a Claude Code or Codex agent in this pane can call workspace app tools and subscribe to app events natively over MCP. The emitted credential is valid only while the originating pane remains alive.
 
 ## `plexi notify`
 

--- a/website/src/content/docs/pgap.md
+++ b/website/src/content/docs/pgap.md
@@ -371,36 +371,6 @@ Block until a named pane file slot's value matches `pattern`.
 | `slot_name` | `string` | yes |
 | `timeout_secs` | `number` | yes |
 
-### `lock_acquire`
-
-Acquire a host-owned named lease for the calling pane. The reply is parked by the host until FIFO capacity grants it ...
-
-| Field | Type | Required |
-|-------|------|----------|
-| `name` | `string` | yes |
-| `pane_id` | `integer` | yes |
-| `response_file` | `string` | yes |
-| `timeout_secs` | `number` | yes |
-
-### `lock_release`
-
-Release a named lease held by the calling pane.
-
-| Field | Type | Required |
-|-------|------|----------|
-| `name` | `string` | yes |
-| `pane_id` | `integer` | yes |
-| `response_file` | `string` | yes |
-
-### `lock_status`
-
-Report the current holders, queue depth, and oldest queued wait.
-
-| Field | Type | Required |
-|-------|------|----------|
-| `name` | `string` | yes |
-| `response_file` | `string` | yes |
-
 ### `slot_list`
 
 List named host-managed pane file slots.

--- a/website/src/content/docs/pgap.md
+++ b/website/src/content/docs/pgap.md
@@ -721,16 +721,6 @@ v3.7 tool protocol (#399). App returns the result of a `PlexiEvent::ToolCall` in
 | `error` | `string?` | no |
 | `output_json` | `string?` | no |
 
-### `mcp_tool_result`
-
-App returns the result of a `PlexiEvent::McpToolCall` invocation. `call_id` must match the `call_id` from the `McpToo...
-
-| Field | Type | Required |
-|-------|------|----------|
-| `call_id` | `string` | yes |
-| `error` | `string?` | no |
-| `result` | `any` | no |
-
 ### `audio_play`
 
 Host-owned audio playback via `rodio`.
@@ -1431,16 +1421,6 @@ Host-to-app tool invocation (#399). The broker calls a tool exposed via `DrawCom
 | `caller_id` | `string` | yes |
 | `input_json` | `string` | yes |
 | `name` | `string` | yes |
-
-### `mcp_tool_call`
-
-External MCP client called a tool declared in `[app.mcp]`. The app must reply with `DrawCommand::Host(AppRequest::Mcp...
-
-| Field | Type | Required |
-|-------|------|----------|
-| `arguments` | `any` | yes |
-| `call_id` | `string` | yes |
-| `tool_name` | `string` | yes |
 
 ### `audio_devices_listed`
 


### PR DESCRIPTION
## Summary

Implements stint 0653. The stint is authoritative; there is no linked GitHub issue.

- bridge live app tools through the existing singleton host MCP endpoint as `<app_id>__<tool>`
- bind each bearer credential to its pane and workspace, including structural lifecycle cleanup
- delete the dead `[app.mcp]` manifest/CLI/protocol/documentation surface

## Validation

- `cargo build`
- focused host MCP, namespace collision, credential lifecycle, context deletion, window deletion, portal dissolve, root rebind, and pane creation tests
- `cargo test --bin plexi`: 2125 passed, 0 failed, 5 ignored before the final test-only lifecycle isolation adjustment
- final lifecycle filter twice: 3 passed, 0 failed with 8 test threads
- `just check-schema`
- `just check-cli-docs`
- `just check-capability-docs`
- `just check-docs-coverage`
- `just check-authoring-docs`
- deletion-completeness grep: no dead app MCP surface remains; the sole `McpTool` match is the unrelated broker permission variant

The final fleet-loaded full-suite rerun produced only known timing-class failures plus two new-test fixture collisions. The fixture collisions were fixed and passed twice under parallel execution. One isolated timing rerun still hit its 15-second backstop while multiple other workers were running full suites; no production path touched by this PR is implicated.

Binary install required: host/runtime credential injection and pane lifecycle need installed-build validation by the separate tester. Worker Mode did not install, boot, foreground, or drive the GUI host.

## Review

Automated Codex review was unavailable because the account usage limit was reached. An orchestrator diff review found and fixed credential cleanup gaps across partial construction, pane/window/context deletion, context-root rebinding, and portal dissolve.
