### PR TITLE
Collapse Context.path into non-optional root; state scope resolver + [state] scopes (stints 0651, 0652)

### DIFF
--- a/sdk/python/AUTHORING.md
+++ b/sdk/python/AUTHORING.md
@@ -93,7 +93,11 @@ fields is in `sdk.md` (Effects section). The common ones:
 
 `SetState` is process-local runtime state — view/update data, caches, game
 state. `PersistState` writes the same snapshot **and** saves durable app state;
-use it only when a key must survive an app restart. There are no `LogInfo` /
+use it only when a key must survive an app restart. Both take an optional
+`scope=` naming one of the app's declared state scopes (see `[state] scopes`
+in the Manifest section); omitted means the app's default scope, and an
+undeclared scope raises — never a silent fallback. `state.get`/`state.all`
+accept the same `scope=` argument. There are no `LogInfo` /
 `LogWarn` / `LogError` effects — logging goes through the `log` module (below).
 Network fetches use `HttpFetch`, not `HttpRequest`.
 
@@ -365,6 +369,23 @@ launches. Note that when a relaunch is deduped to an existing instance, any
 `args` (or cwd) that relaunch carried are **not** delivered to the running
 instance — the host focuses it as-is (delivering relaunch args to a live
 instance via a bus event is future work).
+
+`[state] scopes` declares which state scopes your app addresses, ordered —
+the first entry is the default:
+
+```toml
+[state]
+scopes = ["global", "context"]
+```
+
+Omitting `[state]` gives `["global"]`. The host owns path construction:
+`global` state lives in `~/.plexi/app_states/<app_id>.json` (channel-neutral,
+cross-project), `context` state in `<context_root>/.plexi/app_states/`,
+resolved against the pane's context root at call time — so
+`plexi context set-root` immediately redirects where context-scoped state
+lands. Context-scoped state is gitignored by the host (`.plexi/.gitignore`
+gains `app_states/` automatically): app state is personal, single-user, local
+data — never committed. An unknown or empty scope list fails install loudly.
 
 ## Dev / Test Loop
 

--- a/sdk/python/plexi_sdk/_adapter.py
+++ b/sdk/python/plexi_sdk/_adapter.py
@@ -65,7 +65,7 @@ def _decode_state(encoded: dict[str, str]) -> StateSnapshot:
         payload = base64.b64decode(value)
         raw[key] = payload
         values[key] = json.loads(payload.decode("utf-8"))
-    return StateSnapshot(values, raw)
+    return StateSnapshot(values, raw, {"global": values}, ("global",))
 
 
 def _encode_effect(effect: Any) -> dict[str, Any]:

--- a/sdk/python/plexi_sdk/_v3_runtime.py
+++ b/sdk/python/plexi_sdk/_v3_runtime.py
@@ -77,7 +77,11 @@ class V3AppRuntime:
     def __init__(self, app_path: Path, launch_args: list[str] | None = None) -> None:
         self._module = _load_module(app_path)
         self._launch_args = launch_args or []
-        self._values: dict = {}
+        # Per-scope state, keyed by declared scope name. The first entry of
+        # ``_scopes`` is the app's default scope; ``_values`` always aliases
+        # the default scope's dict.
+        self._scopes: list[str] = ["global"]
+        self._scoped_values: dict[str, dict] = {"global": {}}
         self._last_render_time: float | None = None
         self._last_tree: dict | None = None
         self._force_full_tree = True
@@ -227,7 +231,7 @@ class V3AppRuntime:
         elif t == "inject_state":
             payload = ev.get("payload") or {}
             if isinstance(payload, dict):
-                self._values.update(payload)
+                self._default_values().update(payload)
                 self._set_state(in_view=False)
 
     def _handle_init(self, ev: dict) -> None:
@@ -246,9 +250,21 @@ class V3AppRuntime:
         from ._theme import theme as _theme
         _theme.update_from(ev.get("theme"))
 
-        init_state = ev.get("state")
-        if init_state and isinstance(init_state, dict):
-            self._values = dict(init_state)
+        scopes = ev.get("state_scopes")
+        if isinstance(scopes, list) and scopes:
+            self._scopes = [str(s) for s in scopes]
+        self._scoped_values = {s: {} for s in self._scopes}
+        states = ev.get("states")
+        if isinstance(states, dict):
+            for scope_name in self._scopes:
+                scoped_state = states.get(scope_name)
+                if isinstance(scoped_state, dict):
+                    self._scoped_values[scope_name] = dict(scoped_state)
+        else:
+            # Pre-scope hosts send a single flat "state" for the default scope.
+            init_state = ev.get("state")
+            if init_state and isinstance(init_state, dict):
+                self._scoped_values[self._scopes[0]] = dict(init_state)
 
         _emit({
             "type": "ready",
@@ -439,8 +455,29 @@ class V3AppRuntime:
         if schedule_render:
             _emit({"type": "schedule_render", "after_ms": 16})
 
+    def _default_values(self) -> dict:
+        return self._scoped_values[self._scopes[0]]
+
+    def _resolve_scope(self, scope: "str | None") -> str:
+        if scope is None:
+            return self._scopes[0]
+        if scope not in self._scoped_values:
+            raise ValueError(
+                f"state scope '{scope}' is not declared in this app's manifest "
+                f"[state] scopes {self._scopes}"
+            )
+        return scope
+
+    def _scope_dict(self, scope: "str | None") -> dict:
+        return self._scoped_values[self._resolve_scope(scope)]
+
     def _set_state(self, in_view: bool) -> None:
-        snapshot = StateSnapshot(dict(self._values), {})
+        snapshot = StateSnapshot(
+            dict(self._default_values()),
+            {},
+            {name: dict(values) for name, values in self._scoped_values.items()},
+            tuple(self._scopes),
+        )
         setattr(sdk, "_state", snapshot)
         setattr(sdk, "_in_view", in_view)
         _v3_state._state = snapshot
@@ -450,12 +487,18 @@ class V3AppRuntime:
         state_changed = False
         for effect in app_effects or []:
             if isinstance(effect, effects.SetState):
-                self._values.update(effect.data)
+                self._scope_dict(getattr(effect, "scope", None)).update(effect.data)
                 state_changed = True
             elif isinstance(effect, effects.PersistState):
-                self._values.update(effect.data)
+                scope_name = self._resolve_scope(getattr(effect, "scope", None))
+                scoped = self._scoped_values[scope_name]
+                scoped.update(effect.data)
                 state_changed = True
-                _emit({"type": "save_app_state", "payload": dict(self._values)})
+                _emit({
+                    "type": "save_app_state",
+                    "scope": scope_name,
+                    "payload": dict(scoped),
+                })
             elif isinstance(effect, effects.SetStatus):
                 _emit({"type": "status_summary", "text": effect.text})
             elif isinstance(effect, effects.SetTitle):

--- a/sdk/python/plexi_sdk/_v3_state.py
+++ b/sdk/python/plexi_sdk/_v3_state.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Mapping, Optional
 
 from .effects import SetState
@@ -10,29 +10,39 @@ from .effects import SetState
 class StateSnapshot:
     values: Mapping[str, Any]
     raw_values: Mapping[str, bytes]
+    # Per-scope snapshots keyed by declared scope name; ``values`` aliases the
+    # default scope's mapping.
+    scoped: Mapping[str, Mapping[str, Any]] = field(default_factory=dict)
+    # Declared scope names, ordered; the first entry is the default scope.
+    scopes: tuple[str, ...] = ("global",)
 
     @classmethod
     def empty(cls) -> "StateSnapshot":
-        return cls({}, {})
+        return cls({}, {}, {"global": {}}, ("global",))
 
 
 class StateProxy:
-    def get(self, key: str, default: Any = None) -> Any:
-        snapshot = _require_state()
-        return snapshot.values.get(key, default)
+    def get(self, key: str, default: Any = None, scope: Optional[str] = None) -> Any:
+        return _scope_values(scope).get(key, default)
 
     def raw(self, key: str) -> Optional[bytes]:
         snapshot = _require_state()
         return snapshot.raw_values.get(key)
 
-    def all(self) -> dict[str, Any]:
-        snapshot = _require_state()
-        return dict(snapshot.values)
+    def all(self, scope: Optional[str] = None) -> dict[str, Any]:
+        return dict(_scope_values(scope))
 
-    def set(self, key: str, value: Any) -> SetState:
+    def set(self, key: str, value: Any, scope: Optional[str] = None) -> SetState:
         if _in_view:
             raise RuntimeError("state.set() called inside view() - return SetState from update() instead")
-        return SetState({key: value})
+        if scope is not None:
+            _require_declared(scope)
+        return SetState({key: value}, scope=scope)
+
+    def scopes(self) -> tuple[str, ...]:
+        """The scopes this app declared in its manifest, ordered; the first
+        entry is the default scope."""
+        return _require_state().scopes
 
 
 class LogProxy:
@@ -58,6 +68,23 @@ def _require_state() -> StateSnapshot:
     if _state is None:
         raise RuntimeError("plexi_sdk.state is only available inside init/update/view")
     return _state
+
+
+def _require_declared(scope: str) -> None:
+    snapshot = _require_state()
+    if scope not in snapshot.scopes:
+        raise ValueError(
+            f"state scope '{scope}' is not declared in this app's manifest "
+            f"[state] scopes {list(snapshot.scopes)}"
+        )
+
+
+def _scope_values(scope: Optional[str]) -> Mapping[str, Any]:
+    snapshot = _require_state()
+    if scope is None:
+        return snapshot.values
+    _require_declared(scope)
+    return snapshot.scoped.get(scope, {})
 
 
 _state: Optional[StateSnapshot] = None

--- a/sdk/python/plexi_sdk/effects.py
+++ b/sdk/python/plexi_sdk/effects.py
@@ -6,12 +6,23 @@ from typing import Any, Optional
 
 @dataclass
 class SetState:
+    """Merge ``data`` into in-memory state. ``scope`` selects which declared
+    state scope receives the keys; ``None`` means the app's default scope
+    (the first entry of the manifest's ``[state] scopes``). Using a scope the
+    app did not declare raises at apply time — never a silent fallback."""
     data: dict
+    scope: str | None = None
 
 
 @dataclass
 class PersistState:
+    """Merge ``data`` into a scope's state and persist that scope's snapshot
+    to disk. The host owns path construction: ``global`` state lives in
+    ``~/.plexi/app_states/``, ``context`` state in
+    ``<context_root>/.plexi/app_states/`` — resolved against the pane's
+    context root at call time. ``scope=None`` targets the default scope."""
     data: dict
+    scope: str | None = None
 
 
 @dataclass

--- a/sdk/python/tests/test_state_scopes.py
+++ b/sdk/python/tests/test_state_scopes.py
@@ -1,0 +1,146 @@
+"""State scope tests for the v3 runtime (stint 0652).
+
+An app declares its state scopes in the manifest; the host passes them to the
+runtime in the init message (``state_scopes`` + per-scope ``states``). The
+runtime addresses state by scope name, emits ``save_app_state`` with an
+explicit ``scope``, and refuses a scope the app did not declare — never a
+silent fallback to another scope's data.
+"""
+
+import json
+import textwrap
+from pathlib import Path
+
+from test_v3_runtime_regression import (
+    _collect_until,
+    _find_events,
+    _render,
+    _spawn_v3_app,
+)
+
+
+def _init_scoped(proc, *, scopes=None, states=None, state=None):
+    msg = {
+        "type": "init",
+        "app_id": "scope-test",
+        "workspace_root": "/tmp",
+        "capabilities": [],
+        "feature_flags": [],
+        "protocol": "pgap/3",
+        "width": 640.0,
+        "height": 360.0,
+    }
+    if scopes is not None:
+        msg["state_scopes"] = scopes
+    if states is not None:
+        msg["states"] = states
+    if state is not None:
+        msg["state"] = state
+    proc.stdin.write(json.dumps(msg) + "\n")
+    proc.stdin.flush()
+    return _collect_until(proc, "ready")
+
+
+def _write_app(tmp_path: Path, init_effects: str, body: str = "") -> Path:
+    app = tmp_path / "app.py"
+    app.write_text(textwrap.dedent(f"""
+        from plexi_sdk import state
+        from plexi_sdk.effects import *
+        from plexi_sdk.events import *
+        from plexi_sdk.ui import Text
+
+        {body}
+
+        def init(size, args):
+            return [{init_effects}]
+
+        def update(event):
+            return []
+
+        def view():
+            return Text("scopes")
+    """))
+    return app
+
+
+def test_persist_default_scope_emits_first_declared_scope(tmp_path):
+    app = _write_app(tmp_path, 'PersistState({"n": 1})')
+    proc = _spawn_v3_app(app)
+    try:
+        events = _init_scoped(proc, scopes=["context", "global"])
+        events += _render(proc)
+        saves = _find_events(events, "save_app_state")
+        assert len(saves) == 1
+        assert saves[0]["scope"] == "context", "default scope is the first declared"
+        assert saves[0]["payload"] == {"n": 1}
+    finally:
+        proc.kill()
+
+
+def test_persist_explicit_scope_targets_only_that_scope(tmp_path):
+    app = _write_app(tmp_path, 'PersistState({"here": True}, scope="context")')
+    proc = _spawn_v3_app(app)
+    try:
+        events = _init_scoped(
+            proc,
+            scopes=["global", "context"],
+            states={"global": {"g": 1}, "context": {"c": 1}},
+        )
+        events += _render(proc)
+        saves = _find_events(events, "save_app_state")
+        assert len(saves) == 1
+        assert saves[0]["scope"] == "context"
+        # The persisted snapshot is the context scope's merged map — the
+        # global scope's keys must not bleed in.
+        assert saves[0]["payload"] == {"c": 1, "here": True}
+    finally:
+        proc.kill()
+
+
+def test_scoped_state_reads_resolve_per_scope(tmp_path):
+    app = _write_app(
+        tmp_path,
+        'PersistState({"echo": [state.get("k", scope="global"), state.get("k", scope="context")]})',
+    )
+    proc = _spawn_v3_app(app)
+    try:
+        events = _init_scoped(
+            proc,
+            scopes=["global", "context"],
+            states={"global": {"k": "g"}, "context": {"k": "c"}},
+        )
+        events += _render(proc)
+        saves = _find_events(events, "save_app_state")
+        assert len(saves) == 1
+        assert saves[0]["payload"]["echo"] == ["g", "c"]
+    finally:
+        proc.kill()
+
+
+def test_legacy_flat_state_init_lands_in_default_scope(tmp_path):
+    app = _write_app(tmp_path, 'PersistState({"bump": state.get("count", 0) + 1})')
+    proc = _spawn_v3_app(app)
+    try:
+        events = _init_scoped(proc, state={"count": 41})
+        events += _render(proc)
+        saves = _find_events(events, "save_app_state")
+        assert len(saves) == 1
+        assert saves[0]["scope"] == "global"
+        assert saves[0]["payload"]["bump"] == 42
+    finally:
+        proc.kill()
+
+
+def test_undeclared_scope_never_persists(tmp_path):
+    app = _write_app(tmp_path, 'PersistState({"x": 1}, scope="context")')
+    proc = _spawn_v3_app(app)
+    try:
+        events = _init_scoped(proc, scopes=["global"])
+        try:
+            events += _render(proc)
+        except Exception:
+            pass  # the raising update loop may kill the frame — that is fine
+        saves = _find_events(events, "save_app_state")
+        assert saves == [], "an undeclared scope must not emit a persist"
+    finally:
+        proc.kill()

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -880,12 +880,7 @@ impl PlexiApp {
     }
 
     pub(crate) fn reload_config_for_active_context(&mut self) {
-        let active_workspace = self
-            .router
-            .active()
-            .root
-            .clone()
-            .or_else(crate::config::active_workspace_root);
+        let active_workspace = Some(self.router.active().root.clone());
         self.sync_app_registry_for_active_context(active_workspace.as_deref());
         self.reload_config_for_workspace(active_workspace.as_deref());
     }

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -299,8 +299,7 @@ impl PlexiApp {
                         serde_json::json!({
                             "context_id": ctx.context_id,
                             "name": ctx.name,
-                            "path": ctx.path.to_string_lossy(),
-                            "root": ctx.root.as_ref().map(|p| p.to_string_lossy().into_owned()),
+                            "root": ctx.root.to_string_lossy(),
                             "description": ctx.description,
                             "parent_id": ctx.parent_id,
                             "depth": ctx.depth,
@@ -514,7 +513,7 @@ impl PlexiApp {
                     .router
                     .iter()
                     .find(|ctx| ctx.context_id == context_id)
-                    .and_then(|ctx| ctx.root.clone());
+                    .map(|ctx| ctx.root.clone());
                 let slot_dir = slot_base_dir(context_root.as_deref()).join(pane_id.to_string());
                 let slot_path = slot_dir.join(slot_name);
                 let Some(pane) = self.windows[win_idx].panes.get_mut(pane_id) else {
@@ -773,7 +772,7 @@ impl PlexiApp {
                     .router
                     .iter()
                     .find(|ctx| ctx.context_id == context_id)
-                    .and_then(|ctx| ctx.root.clone());
+                    .map(|ctx| ctx.root.clone());
                 let fallback_path = slot_base_dir(context_root.as_deref())
                     .join(pane_id.to_string())
                     .join(slot_name);
@@ -830,7 +829,7 @@ impl PlexiApp {
                     .flat_map(|slots| slots.values().cloned())
                     .collect();
                 let mut roots = vec![crate::config::config_dir().join("slots")];
-                for root in self.router.iter().filter_map(|ctx| ctx.root.as_ref()) {
+                for root in self.router.iter().map(|ctx| &ctx.root) {
                     roots.push(slot_base_dir(Some(root)));
                 }
                 roots.sort();
@@ -2487,7 +2486,7 @@ impl PlexiApp {
                 let mut new_ctx_id = orig_ctx_id;
                 if let Some(pname) = parent_name {
                     let path = root.as_ref().cloned().unwrap_or_else(|| {
-                        let p = self.router.active().path.clone();
+                        let p = self.router.active().root.clone();
                         if p.is_absolute() {
                             p
                         } else {
@@ -3117,11 +3116,11 @@ impl PlexiApp {
     }
 
     pub(crate) fn tick_scheduler(&mut self) {
-        // Load routines from every context that has a root set
+        // Load routines from every context root
         let roots: Vec<std::path::PathBuf> = self
             .router
             .iter()
-            .filter_map(|ctx| ctx.root.clone())
+            .map(|ctx| ctx.root.clone())
             .collect();
         for root in &roots {
             let failures = self.scheduler.load_from_root(root);
@@ -3215,7 +3214,7 @@ impl PlexiApp {
         let ctx_id = self
             .router
             .iter()
-            .find(|c| c.root.as_deref() == Some(source_root))
+            .find(|c| c.root.as_path() == source_root)
             .map(|c| c.context_id);
         let (scope, source_context_id) = match ctx_id {
             Some(id) => (crate::app_protocol::NotifyScope::Context, id),
@@ -3331,7 +3330,7 @@ impl PlexiApp {
         // active_window — the target is a parameter, not ambient focus state
         // (stint 0574; "Don't switch global state to thread data" trap).
         let target_ctx_id = self.router.get(target_ctx_idx).context_id;
-        let cwd = self.router.get(target_ctx_idx).root.clone();
+        let cwd = Some(self.router.get(target_ctx_idx).root.clone());
         let spawned = self.context_spawn_target(target_ctx_id).map(|(win, tile)| {
             // vertical=true → side-by-side, matching the previous
             // split_focused(false, ..) behavior (its LinearDir is inverted).

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -241,16 +241,6 @@ pub struct PlexiApp {
     /// rows every draw frame, so the collection trace fires only when the
     /// count changes — never once per frame.
     pub(crate) palette_agent_count_logged: Option<usize>,
-    /// TTL cache for the cwd-derived fallback workspace root passed to
-    /// `PlexiBehavior` each frame (#2023). The fallback
-    /// (`config::active_workspace_root()`) stat-walks the filesystem from the
-    /// process cwd, so it must not run per frame. The underlying state is
-    /// external filesystem layout — no enumerable mutation sites — so a 1s
-    /// TTL is the invalidation, matching the downstream
-    /// `OUTSIDE_WORKSPACE_CHECK_INTERVAL` of the only consumer (the terminal
-    /// "outside workspace" badge).
-    pub(crate) workspace_root_fallback_cache:
-        Option<(std::time::Instant, Option<std::path::PathBuf>)>,
     pub(crate) context_visit_history: Vec<u64>,
     pub(crate) renaming_pane: Option<PaneId>,
     /// Active text-input overlay and its dispatch target.
@@ -1177,7 +1167,7 @@ impl PlexiApp {
             let ctx_root_map: std::collections::HashMap<u64, PathBuf> = ws
                 .contexts
                 .iter()
-                .filter_map(|c| c.root.as_ref().map(|r| (c.context_id, r.clone())))
+                .map(|c| (c.context_id, c.root.clone()))
                 .collect();
             let ctx_depth_map: std::collections::HashMap<u64, u32> = ws
                 .contexts
@@ -1415,7 +1405,6 @@ impl PlexiApp {
                     palette_commands: Vec::new(),
                     palette_scroll_reset: false,
                     palette_agent_count_logged: None,
-                    workspace_root_fallback_cache: None,
                     context_visit_history: Vec::new(),
                     renaming_pane: None,
                     text_overlay: None,
@@ -1580,9 +1569,13 @@ impl PlexiApp {
                     desc,
                     a.root.display()
                 );
-                (name, desc, Some(a.root.clone()))
+                (name, desc, a.root.clone())
             }
-            None => ("Default".to_string(), None, dirs::home_dir()),
+            None => (
+                "Default".to_string(),
+                None,
+                dirs::home_dir().unwrap_or_else(|| path.clone()),
+            ),
         };
 
         let default_cwd = std::env::current_dir().unwrap_or_default();
@@ -1607,7 +1600,6 @@ impl PlexiApp {
             router: crate::workspace::router::WorkspaceRouter::new(
                 vec![crate::host::context::Context {
                     name: default_name,
-                    path: path.clone(),
                     root: default_root,
                     description: default_description,
                     context_id: 1,
@@ -1675,7 +1667,6 @@ impl PlexiApp {
             palette_commands: Vec::new(),
             palette_scroll_reset: false,
             palette_agent_count_logged: None,
-            workspace_root_fallback_cache: None,
             context_visit_history: Vec::new(),
             renaming_pane: None,
             text_overlay: None,
@@ -2056,8 +2047,7 @@ impl PlexiApp {
                 router: crate::workspace::router::WorkspaceRouter::new(
                     vec![crate::host::context::Context {
                         name: "Test".into(),
-                        path: path.clone(),
-                        root: None,
+                        root: path.clone(),
                         description: None,
                         context_id: 1,
                         parent_id: None,
@@ -2126,8 +2116,7 @@ impl PlexiApp {
                 palette_commands: Vec::new(),
                 palette_scroll_reset: false,
                 palette_agent_count_logged: None,
-                workspace_root_fallback_cache: None,
-                context_visit_history: Vec::new(),
+                    context_visit_history: Vec::new(),
                 renaming_pane: None,
                 text_overlay: None,
                 text_overlay_browse_rx: None,
@@ -2444,7 +2433,7 @@ impl PlexiApp {
         self.router
             .iter()
             .find(|c| c.context_id == context_id)
-            .and_then(|c| c.root.clone())
+            .map(|c| c.root.clone())
     }
 
     pub(crate) fn context_depth_for(&self, context_id: u64) -> u32 {
@@ -3405,10 +3394,7 @@ impl eframe::App for PlexiApp {
             hit
         });
         if registry_changed {
-            let root = self.router.active().root.clone().unwrap_or_else(|| {
-                std::env::current_dir()
-                    .unwrap_or_else(|_| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
-            });
+            let root = self.router.active().root.clone();
             self.reload_app_registry_for_root(&root);
         }
 

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -72,6 +72,33 @@ pub struct AppManifest {
     /// the app declares no version requirement and runs on any build.
     #[serde(default)]
     pub requires: Option<RequiresSection>,
+    /// Optional `[state]` section — which state scopes the app uses. Absent
+    /// means the app gets the default scope list (`["global"]`).
+    #[serde(default)]
+    pub state: Option<StateSection>,
+}
+
+/// v3 state section — `[state]`. Declares the ordered list of state scopes
+/// this app addresses; the first entry is the app's default. Validated at
+/// install and launch via [`AppManifest::state_scopes`] — an unknown scope,
+/// an empty list, or a duplicate fails loudly, never a silent fallback
+/// (`join_group` is the cautionary unvalidated-key precedent).
+#[derive(Deserialize, Debug, Clone)]
+pub struct StateSection {
+    /// Required within the section: a present-but-empty `[state]` table is a
+    /// manifest error, not a default.
+    pub scopes: Vec<String>,
+}
+
+impl AppManifest {
+    /// The validated `[state] scopes` list. An omitted `[state]` section
+    /// yields the default scope list; any invalid declaration is an error.
+    pub fn state_scopes(&self) -> Result<Vec<crate::host::state_scope::StateScope>, String> {
+        match &self.state {
+            Some(section) => crate::host::state_scope::parse_scopes(&section.scopes),
+            None => Ok(crate::host::state_scope::default_scopes()),
+        }
+    }
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
@@ -682,6 +709,13 @@ impl AppRegistry {
                 ));
             }
         }
+
+        // An invalid `[state] scopes` declaration fails install loudly, same
+        // discipline as capabilities and on_launch above: a typo silently
+        // creating an unreachable scope would orphan the app's data. The
+        // launch path re-reads the manifest and re-validates in
+        // `PythonLaunchConfig::from_manifest_file`.
+        manifest.state_scopes()?;
 
         let bin_path = resolve_entry(app_dir, &manifest.app.entry, manifest.app.manifest_type)?;
 
@@ -1488,6 +1522,74 @@ entry = "run.sh"
         assert!(
             parsed.is_err(),
             "manifest with unknown type variant must be rejected, got: {parsed:?}"
+        );
+    }
+
+    // ── stint 0652 `[state] scopes` declaration ──────────────────────────
+
+    fn write_app_with_state_section(dir: &Path, id: &str, state_section: &str) {
+        let app_dir = dir.join(id);
+        fs::create_dir_all(&app_dir).unwrap();
+        let manifest = format!(
+            "schema_version = 1\n\n[app]\nid = \"{id}\"\ntype = \"app\"\nname = \"{id}\"\nversion = \"0.0.1\"\nentry = \"run.sh\"\n{state_section}"
+        );
+        fs::write(app_dir.join("manifest.toml"), manifest).unwrap();
+        fs::write(app_dir.join("run.sh"), "#!/bin/sh\nexit 0\n").unwrap();
+    }
+
+    #[test]
+    fn manifest_with_valid_state_scopes_loads() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        write_app_with_state_section(
+            global.path(),
+            "scoped-app",
+            "\n[state]\nscopes = [\"global\", \"context\"]\n",
+        );
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        assert!(
+            registry.get("scoped-app").is_some(),
+            "a valid [state] scopes list must load"
+        );
+    }
+
+    #[test]
+    fn manifest_with_unknown_state_scope_fails_install_loudly() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        write_app_with_state_section(
+            global.path(),
+            "typo-scope-app",
+            "\n[state]\nscopes = [\"workspace\"]\n",
+        );
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        assert!(
+            registry.get("typo-scope-app").is_none(),
+            "an unknown state scope must refuse to install, never silently fall back"
+        );
+    }
+
+    #[test]
+    fn manifest_with_empty_state_scopes_fails_install_loudly() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        write_app_with_state_section(global.path(), "empty-scope-app", "\n[state]\nscopes = []\n");
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        assert!(
+            registry.get("empty-scope-app").is_none(),
+            "a present-but-empty [state] scopes must refuse to install"
+        );
+    }
+
+    #[test]
+    fn manifest_without_state_section_defaults_to_global() {
+        let manifest: AppManifest = toml::from_str(
+            "schema_version = 1\n\n[app]\nid = \"plain\"\ntype = \"app\"\nname = \"Plain\"\nentry = \"run.sh\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            manifest.state_scopes().unwrap(),
+            vec![crate::host::state_scope::StateScope::Global]
         );
     }
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -15,22 +15,6 @@ fn update_check_due(last_update_check: std::time::Instant, now: std::time::Insta
 }
 
 impl PlexiApp {
-    /// Cwd-derived fallback workspace root, used when the active context has no
-    /// explicit `root`. `config::active_workspace_root()` stat-walks the
-    /// filesystem from the process cwd, so it must not run every frame; the
-    /// result is cached with a 1s TTL (see `workspace_root_fallback_cache`).
-    fn fallback_workspace_root(&mut self) -> Option<std::path::PathBuf> {
-        const TTL: std::time::Duration = std::time::Duration::from_secs(1);
-        if let Some((resolved_at, ref root)) = self.workspace_root_fallback_cache {
-            if resolved_at.elapsed() < TTL {
-                return root.clone();
-            }
-        }
-        let root = crate::config::active_workspace_root();
-        self.workspace_root_fallback_cache = Some((std::time::Instant::now(), root.clone()));
-        root
-    }
-
     /// Early per-frame work that runs before overlay dispatch and panel rendering.
     /// Handles adopted context paths, finder service drains, notification polling,
     /// pane command draining, update channel checks, PTY event draining, and
@@ -424,12 +408,8 @@ impl PlexiApp {
                 // Resolved before the mutable borrow of the active window. The
                 // explicit context root is a cheap field clone; the cwd-derived
                 // fallback stat-walks the filesystem and is TTL-cached (#2023).
-                let workspace_root = self
-                    .router
-                    .active()
-                    .root
-                    .clone()
-                    .or_else(|| self.fallback_workspace_root());
+                let active_context_root = self.router.active().root.clone();
+                let workspace_root = Some(active_context_root.clone());
 
                 // Drag pacing (stint 0510): promote exactly one queued drag
                 // sample per pane into this frame's pending-click slot, so a
@@ -616,6 +596,7 @@ impl PlexiApp {
                     drag_cursor_pos,
                     hovered_files,
                     workspace_root,
+                    context_root: active_context_root,
                     unfocused_opacity,
                     portal_info,
                     owner_pane,
@@ -843,6 +824,7 @@ impl PlexiApp {
                                     &self.colors,
                                     has_tabs,
                                     pending_click,
+                                    &self.router.active().root,
                                 );
                             }
                         } else {

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -12,7 +12,7 @@ fn workspace_config_applies_when_switching_contexts() {
     write_workspace_config(root_a.path(), "#111111");
     write_workspace_config(root_b.path(), "#22aa44");
 
-    app.router.get_mut(0).root = Some(root_a.path().to_path_buf());
+    app.router.get_mut(0).root = root_a.path().to_path_buf();
     app.windows[0].path = root_a.path().to_path_buf();
     app.reload_config();
     assert_eq!(
@@ -25,8 +25,7 @@ fn workspace_config_applies_when_switching_contexts() {
     let win_b_id = 2;
     app.router.push(crate::host::context::Context {
         name: "Context B".into(),
-        path: root_b.path().to_path_buf(),
-        root: Some(root_b.path().to_path_buf()),
+        root: root_b.path().to_path_buf(),
         description: None,
         context_id: ctx_b_id,
         parent_id: None,
@@ -67,7 +66,7 @@ fn switching_contexts_refreshes_workspace_app_registry() {
         .expect("create root a workspace dir");
     write_registry_app(root_b.path(), "local-tool", "Local Tool");
 
-    app.router.get_mut(0).root = Some(root_a.path().to_path_buf());
+    app.router.get_mut(0).root = root_a.path().to_path_buf();
     app.windows[0].path = root_a.path().to_path_buf();
     app.reload_config();
     assert!(
@@ -79,8 +78,7 @@ fn switching_contexts_refreshes_workspace_app_registry() {
     let win_b_id = 2;
     app.router.push(crate::host::context::Context {
         name: "Context B".into(),
-        path: root_b.path().to_path_buf(),
-        root: Some(root_b.path().to_path_buf()),
+        root: root_b.path().to_path_buf(),
         description: None,
         context_id: ctx_b_id,
         parent_id: None,
@@ -637,8 +635,7 @@ fn delete_context_portal_resets_stale_focused_pane() {
     let child_win_id = 9902u64;
     app.router.push(crate::host::context::Context {
         name: "Child".to_string(),
-        path: std::path::PathBuf::from("/tmp/child_1854"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp/child_1854"),
         description: None,
         context_id: child_id,
         parent_id: Some(root_id),
@@ -727,8 +724,7 @@ fn delete_context_cascades_and_cleans_depth_stack() {
 
     app.router.push(crate::host::context::Context {
         name: "A".to_string(),
-        path: std::path::PathBuf::from("/tmp/a"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp/a"),
         description: None,
         context_id: a_id,
         parent_id: Some(root_id),
@@ -737,8 +733,7 @@ fn delete_context_cascades_and_cleans_depth_stack() {
     });
     app.router.push(crate::host::context::Context {
         name: "B".to_string(),
-        path: std::path::PathBuf::from("/tmp/b"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp/b"),
         description: None,
         context_id: b_id,
         parent_id: Some(a_id),
@@ -847,8 +842,7 @@ fn delete_context_refuses_cascade_that_would_empty_router() {
 
     app.router.push(crate::host::context::Context {
         name: "Child".to_string(),
-        path: std::path::PathBuf::from("/tmp/child"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp/child"),
         description: None,
         context_id: child_id,
         parent_id: Some(root_id),
@@ -857,8 +851,7 @@ fn delete_context_refuses_cascade_that_would_empty_router() {
     });
     app.router.push(crate::host::context::Context {
         name: "Grandchild".to_string(),
-        path: std::path::PathBuf::from("/tmp/grandchild"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp/grandchild"),
         description: None,
         context_id: grandchild_id,
         parent_id: Some(child_id),
@@ -904,8 +897,7 @@ fn delete_context_cascade_allowed_when_unrelated_sibling_survives() {
 
     app.router.push(crate::host::context::Context {
         name: "A".to_string(),
-        path: std::path::PathBuf::from("/tmp/a"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp/a"),
         description: None,
         context_id: a_id,
         parent_id: Some(root_id),
@@ -914,8 +906,7 @@ fn delete_context_cascade_allowed_when_unrelated_sibling_survives() {
     });
     app.router.push(crate::host::context::Context {
         name: "B".to_string(),
-        path: std::path::PathBuf::from("/tmp/b"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp/b"),
         description: None,
         context_id: b_id,
         parent_id: Some(a_id),
@@ -924,8 +915,7 @@ fn delete_context_cascade_allowed_when_unrelated_sibling_survives() {
     });
     app.router.push(crate::host::context::Context {
         name: "Sibling".to_string(),
-        path: std::path::PathBuf::from("/tmp/sibling"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp/sibling"),
         description: None,
         context_id: sibling_id,
         parent_id: Some(root_id),
@@ -1015,7 +1005,7 @@ fn context_transition_rescans_registry() {
 
     // Switch context 0 to root A and verify registry picks up app-a.
     let idx0 = app.router.active_idx();
-    app.router.get_mut(idx0).root = Some(dir_a.clone());
+    app.router.get_mut(idx0).root = dir_a.clone();
     app.apply_context_transition_effects();
 
     let ids: Vec<String> = app
@@ -1040,8 +1030,7 @@ fn context_transition_rescans_registry() {
     app.next_window_id += 1;
     app.router.push(crate::host::context::Context {
         name: "Context B".into(),
-        path: dir_b.clone(),
-        root: Some(dir_b.clone()),
+        root: dir_b.clone(),
         description: None,
         context_id: ctx_b_id,
         parent_id: None,
@@ -1224,8 +1213,7 @@ fn delete_context_collapses_empty_portal_window() {
     let child_win_id = 77711u64;
     app.router.push(crate::host::context::Context {
         name: "Child2029".to_string(),
-        path: std::path::PathBuf::from("/tmp/test_2029_child"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp/test_2029_child"),
         description: None,
         context_id: child_id,
         parent_id: Some(root_id),
@@ -1346,8 +1334,7 @@ fn delete_context_keeps_all_empty_windows_when_no_nonempty_sibling() {
     let child_win_id = 88811u64;
     app.router.push(crate::host::context::Context {
         name: "ChildEdge".to_string(),
-        path: std::path::PathBuf::from("/tmp/test_2029_edge_child"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp/test_2029_edge_child"),
         description: None,
         context_id: child_id,
         parent_id: Some(root_id),
@@ -1450,8 +1437,7 @@ fn test_app_pane(pane_id: u64) -> crate::host::pane::Pane {
 fn test_context(id: u64, parent_id: u64, name: &str) -> crate::host::context::Context {
     crate::host::context::Context {
         name: name.to_string(),
-        path: std::path::PathBuf::from(format!("/tmp/{name}")),
-        root: None,
+        root: std::path::PathBuf::from(format!("/tmp/{name}")),
         description: None,
         context_id: id,
         parent_id: Some(parent_id),
@@ -1932,8 +1918,7 @@ fn rename_on_focused_portal_falls_through_to_subcontext() {
     let child_id = 7701u64;
     app.router.push(crate::host::context::Context {
         name: "Child".to_string(),
-        path: std::path::PathBuf::from("/tmp/child_rename"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp/child_rename"),
         description: None,
         context_id: child_id,
         parent_id: Some(root_id),
@@ -2366,7 +2351,7 @@ fn set_context_root_ipc_targets_caller_context() {
 
     let other_idx = h.app.router.position(|c| c.context_id == other_id).unwrap();
     assert_eq!(
-        h.app.router.get(other_idx).root.as_deref(),
+        Some(h.app.router.get(other_idx).root.as_path()),
         Some(tmp.path()),
         "root must land on the caller's context"
     );
@@ -2379,6 +2364,26 @@ fn set_context_root_ipc_targets_caller_context() {
         h.app.router.get(active_idx).root,
         active_root_before,
         "active context root must be untouched"
+    );
+}
+
+/// Setting a context root must ensure `<root>/.plexi/.gitignore` covers
+/// `app_states/` so a user can never accidentally commit their app state
+/// (standing ruling: app state is personal, single-user, local data).
+#[test]
+fn set_context_root_ensures_app_state_gitignore() {
+    let mut h = crate::testing::HostHarness::new();
+    let fresh_root = tempfile::tempdir().expect("fresh context root");
+
+    h.app
+        .set_context_root(fresh_root.path().to_path_buf(), None);
+
+    let gitignore = fresh_root.path().join(".plexi/.gitignore");
+    let contents = std::fs::read_to_string(&gitignore)
+        .expect("setting a context root must create .plexi/.gitignore");
+    assert!(
+        contents.lines().any(|line| line.trim() == "app_states/"),
+        "gitignore must cover app_states/: {contents:?}"
     );
 }
 
@@ -2481,7 +2486,7 @@ fn context_sub_creates_exactly_n_panes() {
     );
     // Defect 3: rooted at the path the caller passed (its cwd), not the parent's.
     assert_eq!(
-        child.root.as_deref(),
+        Some(child.root.as_path()),
         Some(root.path()),
         "sub-context must root at the caller-supplied path"
     );
@@ -2551,8 +2556,7 @@ fn resolve_parent_context_prefers_id_over_duplicate_name() {
     let duplicate_id = first_id + 500;
     app.router.push(crate::host::context::Context {
         name: app.router.active().name.clone(),
-        path: std::path::PathBuf::from("/tmp/dupe"),
-        root: Some(std::path::PathBuf::from("/tmp/dupe")),
+        root: std::path::PathBuf::from("/tmp/dupe"),
         description: None,
         context_id: duplicate_id,
         parent_id: None,
@@ -2620,7 +2624,7 @@ fn context_sub_child_is_registered_one_level_below_parent() {
         .expect("sub-context must exist")
         .clone();
     assert_eq!(child.depth, parent_depth + 1, "child sits one level deeper");
-    assert_eq!(child.root.as_deref(), Some(root.path()));
+    assert_eq!(child.root.as_path(), root.path());
     assert_eq!(
         h.app.context_depth_for(child.context_id),
         parent_depth + 1,
@@ -2772,8 +2776,7 @@ fn context_sub_focus_returns_to_the_callers_window_not_the_active_one() {
     let other_win_id = 9_002;
     h.app.router.push(crate::host::context::Context {
         name: "Elsewhere".into(),
-        path: std::path::PathBuf::from("/tmp/elsewhere"),
-        root: Some(std::path::PathBuf::from("/tmp/elsewhere")),
+        root: std::path::PathBuf::from("/tmp/elsewhere"),
         description: None,
         context_id: other_ctx_id,
         parent_id: None,
@@ -2847,8 +2850,7 @@ fn audit_0678_two_contexts_accept_the_same_root() {
     let second_ctx_id = 4242;
     app.router.push(crate::host::context::Context {
         name: "Second".into(),
-        path: shared.path().to_path_buf(),
-        root: None,
+        root: shared.path().to_path_buf(),
         description: None,
         context_id: second_ctx_id,
         parent_id: None,
@@ -2863,77 +2865,15 @@ fn audit_0678_two_contexts_accept_the_same_root() {
     let roots: Vec<_> = app.router.iter().map(|c| c.root.clone()).collect();
     assert_eq!(
         roots,
-        vec![
-            Some(shared.path().to_path_buf()),
-            Some(shared.path().to_path_buf())
-        ],
+        vec![shared.path().to_path_buf(), shared.path().to_path_buf()],
         "set_context_root accepts a root already held by another context"
     );
 }
 
-/// Q1, second half: a sub-context created from the keyboard inherits the
-/// parent's `path`, not its `root`. Nothing keeps the two fields in sync —
-/// `set_context_root` writes only `root` — so after a set-root the child is
-/// anchored at the directory the parent was *created* in, which is neither the
-/// parent's current root nor anything the user chose.
-#[test]
-fn audit_0678_keyboard_sub_context_inherits_the_parents_stale_path_not_its_root() {
-    let ctx = egui::Context::default();
-    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
-    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
-
-    let created_at = app.router.get(0).path.clone();
-    let moved = tempfile::tempdir().expect("new root");
-    let parent_id = app.router.get(0).context_id;
-    app.set_context_root(moved.path().to_path_buf(), Some(parent_id));
-    assert_eq!(
-        app.router.get(0).path,
-        created_at,
-        "precondition: set_context_root leaves `path` untouched"
-    );
-
-    // The divergence itself is observable without creating anything, and it is
-    // the necessary condition for the defect: `root` moved, `path` did not.
-    // Asserted before the child exists so this test still carries evidence in a
-    // PTY-less environment, where the child is never created — an audit test
-    // that returns early asserting nothing is exactly the vacuity this round
-    // exists to remove.
-    assert_eq!(
-        app.router.get(0).root.as_deref(),
-        Some(moved.path()),
-        "the parent's root moved"
-    );
-    assert_ne!(
-        app.router.get(0).path,
-        moved.path().to_path_buf(),
-        "but its `path` still names the directory it was created in — the two \
-         fields have diverged, and sub-context creation reads the stale one"
-    );
-
-    let before = app.router.len();
-    app.new_child_context_from_keyboard();
-    if app.router.len() == before {
-        // No PTY: the child is never created. The divergence asserted above is
-        // the whole of what this environment can observe, and it has been.
-        return;
-    }
-
-    let child_root = app
-        .router
-        .iter()
-        .find(|c| c.parent_id == Some(parent_id))
-        .and_then(|c| c.root.clone())
-        .expect("the child context is rooted");
-    // The pair a fix must reconcile: the child took the stale creation-time
-    // path, and that is not the root its parent actually has.
-    assert_eq!(
-        child_root, created_at,
-        "the child inherited the parent's creation-time path"
-    );
-    assert_ne!(
-        child_root,
-        moved.path().to_path_buf(),
-        "and therefore not the parent's current root — every context-scoped \
-         address the child derives points at a directory the user re-rooted away from"
-    );
-}
+// Q1's second half — a sub-context created from the keyboard inheriting the
+// parent's stale `path` instead of its live `root` — documented a divergence
+// between two separate fields on `Context`. Stints 0651/0652 collapsed
+// `Context.path` into the single non-optional `root`, so the two fields this
+// test existed to catch drifting apart can no longer diverge: there is only
+// one field. The test was deleted rather than adapted; nothing here survives
+// the fix to assert.

--- a/src/app/tests/focus_tests.rs
+++ b/src/app/tests/focus_tests.rs
@@ -445,8 +445,7 @@ fn switch_workspace_pushes_focus_history() {
     app.next_window_id += 1;
     app.router.push(crate::host::context::Context {
         name: "ctx-b".into(),
-        path: std::path::PathBuf::from("/tmp"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp"),
         description: None,
         context_id: ctx_b_id,
         parent_id: None,
@@ -517,8 +516,7 @@ fn switch_workspace_no_double_push_during_history_navigation() {
     app.next_window_id += 1;
     app.router.push(crate::host::context::Context {
         name: "ctx-b".into(),
-        path: std::path::PathBuf::from("/tmp"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp"),
         description: None,
         context_id: ctx_b_id,
         parent_id: None,
@@ -573,8 +571,7 @@ fn focus_history_restores_context_minimap_visibility() {
     app.next_window_id += 1;
     app.router.push(crate::host::context::Context {
         name: "ctx-b".into(),
-        path: std::path::PathBuf::from("/tmp"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp"),
         description: None,
         context_id: ctx_b_id,
         parent_id: None,

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -495,8 +495,7 @@ fn spawn_pane_new_window_uses_caller_context_not_active() {
     let ctx2_id: u64 = 2;
     app.router.push(crate::host::context::Context {
         name: "Context 2".into(),
-        path: std::env::temp_dir(),
-        root: None,
+        root: std::env::temp_dir(),
         description: None,
         context_id: ctx2_id,
         parent_id: None,
@@ -575,8 +574,7 @@ fn spawn_pane_tab_anchors_to_from_pane_window_not_active() {
     let ctx2_id: u64 = 2;
     app.router.push(crate::host::context::Context {
         name: "Context 2".into(),
-        path: std::env::temp_dir(),
-        root: None,
+        root: std::env::temp_dir(),
         description: None,
         context_id: ctx2_id,
         parent_id: None,

--- a/src/app/tests/navigation_tests.rs
+++ b/src/app/tests/navigation_tests.rs
@@ -76,8 +76,7 @@ fn pane_navigate_cross_window_updates_active_window() {
     h.app.windows.push(second_window(2, 2, 9901));
     h.app.router.push(crate::host::context::Context {
         name: "Context B".into(),
-        path: std::env::temp_dir(),
-        root: None,
+        root: std::env::temp_dir(),
         description: None,
         context_id: 2,
         parent_id: None,
@@ -106,8 +105,7 @@ fn pane_navigate_cross_window_syncs_router() {
     h.app.windows.push(second_window(2, 2, 9902));
     h.app.router.push(crate::host::context::Context {
         name: "Context B".into(),
-        path: std::env::temp_dir(),
-        root: None,
+        root: std::env::temp_dir(),
         description: None,
         context_id: 2,
         parent_id: None,
@@ -500,8 +498,7 @@ fn empty_window(context_id: u64, window_id: u64) -> Window {
 fn context_b(context_id: u64) -> crate::host::context::Context {
     crate::host::context::Context {
         name: "Context B".into(),
-        path: std::env::temp_dir(),
-        root: None,
+        root: std::env::temp_dir(),
         description: None,
         context_id,
         parent_id: None,
@@ -887,9 +884,13 @@ fn assistant_open_spawns_second_instance_in_other_context() {
         "the second instance must live in the caller's window"
     );
 
-    // Each context persisted its own conversation pointer in the store.
-    let store_ctx1 = crate::assistant::store::AssistantStore::new(&workspace_root, 1);
-    let store_ctx2 = crate::assistant::store::AssistantStore::new(&workspace_root, 2);
+    // Each context persisted its own conversation pointer in its store,
+    // anchored at that context's root (stint 0651: the root is the anchor —
+    // the cwd-walk workspace fallback is gone).
+    let root_ctx1 = h.app.context_root_for(1).expect("context 1 root");
+    let root_ctx2 = h.app.context_root_for(2).expect("context 2 root");
+    let store_ctx1 = crate::assistant::store::AssistantStore::new(&root_ctx1, 1);
+    let store_ctx2 = crate::assistant::store::AssistantStore::new(&root_ctx2, 2);
     let conv1 = store_ctx1
         .active_conversation()
         .expect("context 1 persisted a conversation");

--- a/src/app/tests/notification_tests.rs
+++ b/src/app/tests/notification_tests.rs
@@ -214,8 +214,7 @@ fn dispatch_notify_action_pane_focus_navigates() {
     });
     h.app.router.push(crate::host::context::Context {
         name: "Context B".into(),
-        path: std::env::temp_dir(),
-        root: None,
+        root: std::env::temp_dir(),
         description: None,
         context_id: 2,
         parent_id: None,
@@ -1062,8 +1061,7 @@ fn cli_notify_window_scope_without_live_window_narrows_to_context() {
     // A live context with no window (parked): in the router, not in windows.
     h.app.router.push(crate::host::context::Context {
         name: "Parked".into(),
-        path: std::env::temp_dir(),
-        root: None,
+        root: std::env::temp_dir(),
         description: None,
         context_id: 777,
         parent_id: None,

--- a/src/cli/app_check.rs
+++ b/src/cli/app_check.rs
@@ -51,6 +51,10 @@ pub(crate) fn python_launch_config_from_parts(
             ),
         )
         .to_theme_map(),
+        // Headless one-shot renders never persist state; the default scope
+        // list and an app-dir anchor are inert here.
+        state_scopes: crate::host::state_scope::default_scopes(),
+        context_root: app_dir.to_path_buf(),
     }
 }
 

--- a/src/cli/notes.rs
+++ b/src/cli/notes.rs
@@ -4,16 +4,11 @@ use super::binary_in_path;
 
 /// The context root this CLI invocation belongs to.
 ///
-/// `PLEXI_CONTEXT_ROOT` is exported into panes of a context that has an explicit
-/// project root, so an in-pane `plexi notes` resolves to the same dir the GUI
-/// picker scans. Outside a pane, fall back to the workspace root the cwd sits in.
-///
-/// Known gap: a context with `root: None` exports no `PLEXI_CONTEXT_ROOT`, while
-/// the GUI keys that context's notes on `Context::path`. When the cwd's workspace
-/// root differs from that path, the CLI scans a different dir than the picker.
-/// Closing it means exporting the effective scope root into every pane's env,
-/// which is pane-env plumbing outside this change; the mismatch is logged below
-/// so it is observable rather than silent.
+/// `PLEXI_CONTEXT_ROOT` is exported into every pane (a context is always
+/// anchored to a root), so an in-pane `plexi notes` resolves to the same dir
+/// the GUI picker scans. Outside a pane, fall back to the workspace root the
+/// cwd sits in. A pane missing the var predates the non-optional root and is
+/// logged below rather than silently diverging from the picker.
 fn cli_context_root() -> Option<std::path::PathBuf> {
     if let Some(root) = std::env::var_os("PLEXI_CONTEXT_ROOT").filter(|v| !v.is_empty()) {
         return Some(std::path::PathBuf::from(root));
@@ -21,7 +16,7 @@ fn cli_context_root() -> Option<std::path::PathBuf> {
     let fallback = crate::config::active_workspace_root();
     if std::env::var_os("PLEXI_PANE_ID").is_some() {
         log::warn!(
-            "notes: pane exports no PLEXI_CONTEXT_ROOT (rootless context) — \
+            "notes: pane exports no PLEXI_CONTEXT_ROOT (pre-root-collapse pane env) — \
              falling back to workspace root {fallback:?}, which may differ from the picker's dir"
         );
     }

--- a/src/host/context.rs
+++ b/src/host/context.rs
@@ -16,7 +16,6 @@ pub(crate) enum WindowMenuAction {
     MoveToBottom,
     Delete,
     SetRoot(PathBuf),
-    ClearRoot,
     /// Open the text-input overlay to set the root interactively.
     OpenRootOverlay,
     Park,
@@ -29,14 +28,15 @@ pub(crate) enum WindowMenuAction {
 /// This is the canonical context type used everywhere: live GUI state,
 /// persistence (workspace save/restore), and test harness. Replaces the
 /// former `SavedContext` and unifies with `HostContext`.
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Clone, Debug)]
 pub struct Context {
     pub name: String,
-    pub path: PathBuf,
-    /// Optional project root. When set, new panes in this context open at
-    /// this directory rather than inheriting the focused pane's CWD.
-    #[serde(default)]
-    pub root: Option<PathBuf>,
+    /// The single directory this context is anchored to. Non-optional: every
+    /// context is anchored somewhere (creation defaults to the creating
+    /// pane's cwd, or home). New panes in this context open here, context
+    /// scoped app state resolves against it, and `plexi context set-root`
+    /// rewrites it.
+    pub root: PathBuf,
     /// Optional description — ambient intent for what you're doing in this context.
     #[serde(default)]
     pub description: Option<String>,
@@ -54,6 +54,56 @@ pub struct Context {
     /// collapsed into a "Parked (N)" divider at the bottom. All panes stay alive.
     #[serde(default)]
     pub parked: bool,
+}
+
+/// Legacy-aware deserialization. Workspace files written before the
+/// `Context.path` → `Context.root` collapse carry a required `path` and an
+/// optional `root`; the surviving field is `root`, and for those files the
+/// anchor is `root` when it was set, else the creation-time `path`. A file
+/// carrying neither is corrupt and fails loudly with the context's name —
+/// never a silent default, because a workspace file that half-loads is a user
+/// losing their layout.
+impl<'de> Deserialize<'de> for Context {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawContext {
+            name: String,
+            #[serde(default)]
+            root: Option<PathBuf>,
+            /// Legacy pre-0651 field; folded into `root` on read.
+            #[serde(default)]
+            path: Option<PathBuf>,
+            #[serde(default)]
+            description: Option<String>,
+            context_id: u64,
+            #[serde(default)]
+            parent_id: Option<u64>,
+            #[serde(default)]
+            depth: u32,
+            #[serde(default)]
+            parked: bool,
+        }
+
+        let raw = RawContext::deserialize(deserializer)?;
+        let root = raw.root.or(raw.path).ok_or_else(|| {
+            serde::de::Error::custom(format!(
+                "context '{}' (id {}) has neither `root` nor legacy `path` — workspace file is corrupt",
+                raw.name, raw.context_id
+            ))
+        })?;
+        Ok(Context {
+            name: raw.name,
+            root,
+            description: raw.description,
+            context_id: raw.context_id,
+            parent_id: raw.parent_id,
+            depth: raw.depth,
+            parked: raw.parked,
+        })
+    }
 }
 
 /// A window is a single spatial grid page — a pane layout with focus and zoom state.

--- a/src/host/context_state.rs
+++ b/src/host/context_state.rs
@@ -165,8 +165,7 @@ mod tests {
     fn make_context(id: u64, name: &str, parent: Option<u64>) -> Context {
         Context {
             name: name.to_string(),
-            path: PathBuf::from("/tmp"),
-            root: None,
+            root: PathBuf::from("/tmp"),
             description: None,
             context_id: id,
             parent_id: parent,

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -25,6 +25,7 @@ pub mod pane;
 pub mod scheduler;
 pub mod services;
 pub mod shell;
+pub mod state_scope;
 pub mod typed_pipes;
 pub mod wasm_app;
 pub mod wasm_frame;

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -1017,6 +1017,17 @@ impl AppRuntime {
         }
     }
 
+    /// Push the pane's current context root into runtimes that resolve
+    /// state paths at call time. Builtins and WASM component panes keep
+    /// their existing schemes and ignore it.
+    pub fn refresh_context_root(&mut self, root: &std::path::Path) {
+        match self {
+            AppRuntime::Builtin(_) => {}
+            AppRuntime::Python(app) => app.set_context_root(root),
+            AppRuntime::Wasm(_) => {}
+        }
+    }
+
     /// Pump event I/O for a pane not in the active context.
     pub fn background_tick(&mut self) {
         match self {

--- a/src/host/state_scope.rs
+++ b/src/host/state_scope.rs
@@ -1,0 +1,178 @@
+//! App state scope resolution — the addressing layer for app state.
+//!
+//! An app declares which scopes it uses in its manifest (`[state] scopes`);
+//! the host owns path construction. Two rules, both predictable from outside
+//! the process so an external agent can find and write an app's state without
+//! asking Plexi anything:
+//!
+//! ```text
+//! global   →  ~/.plexi/app_states/<app_id>.<ext>
+//! context  →  <context.root>/.plexi/app_states/<app_id>.<ext>
+//! ```
+//!
+//! Both tiers are deliberately channel-neutral (`.plexi`, never
+//! `.plexi-<channel>`): user data must not fork when the user runs a beta or
+//! PR build. Config stays channel-scoped; state and config diverge here on
+//! purpose. Context-scoped state lives *inside* the context root — never in a
+//! central store keyed by a sanitized root path — so it is discoverable,
+//! greppable, and moves with the project.
+//!
+//! Scope is a property of the app, not of an instance or a launch: no pane,
+//! placement, or restore decision may change where an app's bytes go.
+//! Resolution happens against the pane's context root at call time, so
+//! `plexi context set-root` immediately redirects where context-scoped state
+//! resolves.
+
+use std::path::{Path, PathBuf};
+
+/// The directory name shared by both tiers. Consciously kept as `app_states`;
+/// do not rename it — one data-loss bug from moving a state path is enough.
+const APP_STATES_DIR: &str = "app_states";
+
+/// A state scope an app may declare. Ordered lists come from the manifest;
+/// the first declared scope is the app's default.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum StateScope {
+    /// Cross-project user state: `~/.plexi/app_states/`.
+    Global,
+    /// Project state anchored to the pane's context root:
+    /// `<context.root>/.plexi/app_states/`.
+    Context,
+}
+
+impl StateScope {
+    /// Manifest / wire spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Global => "global",
+            Self::Context => "context",
+        }
+    }
+
+    /// Parse a manifest or wire scope name. `Err` carries the unknown value;
+    /// callers turn it into a loud install/launch/read error — never a
+    /// silent fallback to another scope.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        match raw {
+            "global" => Ok(Self::Global),
+            "context" => Ok(Self::Context),
+            other => Err(format!(
+                "unknown state scope '{other}' — valid scopes: global, context"
+            )),
+        }
+    }
+}
+
+/// The scopes an app that omits `[state]` gets.
+pub fn default_scopes() -> Vec<StateScope> {
+    vec![StateScope::Global]
+}
+
+/// Validate a manifest `[state] scopes` list. Rules (fail loud, no silent
+/// fallback — the `join_group` free-form key is the cautionary precedent):
+/// an empty list is an error, an unknown value is an error, a duplicate is an
+/// error. Order is preserved; the first entry is the app's default scope.
+pub fn parse_scopes(raw: &[String]) -> Result<Vec<StateScope>, String> {
+    if raw.is_empty() {
+        return Err(
+            "manifest [state] scopes is empty — declare at least one of: global, context"
+                .to_string(),
+        );
+    }
+    let mut scopes = Vec::with_capacity(raw.len());
+    for value in raw {
+        let scope = StateScope::parse(value)
+            .map_err(|error| format!("manifest [state] scopes: {error}"))?;
+        if scopes.contains(&scope) {
+            return Err(format!(
+                "manifest [state] scopes declares '{}' more than once",
+                scope.as_str()
+            ));
+        }
+        scopes.push(scope);
+    }
+    Ok(scopes)
+}
+
+/// The channel-neutral global state directory: `~/.plexi/app_states/`.
+/// Deliberately NOT `config_dir()` — the profile dir is channel-scoped and
+/// user state must not fork per channel.
+pub fn global_state_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/"))
+        .join(".plexi")
+        .join(APP_STATES_DIR)
+}
+
+/// The context-scoped state directory inside a context root.
+pub fn context_state_dir(context_root: &Path) -> PathBuf {
+    context_root.join(".plexi").join(APP_STATES_DIR)
+}
+
+/// Resolve a scope to the concrete state file for `app_id`. `ext` is the
+/// app's state file extension without the dot (the host's Python runtime
+/// persists JSON, so it passes `json`). `context_root` is the root of the
+/// pane's context *at call time*, never a launch-captured copy.
+pub fn state_path(scope: StateScope, app_id: &str, ext: &str, context_root: &Path) -> PathBuf {
+    let dir = match scope {
+        StateScope::Global => global_state_dir(),
+        StateScope::Context => context_state_dir(context_root),
+    };
+    dir.join(format!("{app_id}.{ext}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_scopes_accepts_ordered_valid_lists() {
+        let scopes = parse_scopes(&["context".to_string(), "global".to_string()]).unwrap();
+        assert_eq!(scopes, vec![StateScope::Context, StateScope::Global]);
+    }
+
+    #[test]
+    fn parse_scopes_rejects_empty_unknown_and_duplicates() {
+        assert!(parse_scopes(&[]).unwrap_err().contains("empty"));
+        assert!(parse_scopes(&["workspace".to_string()])
+            .unwrap_err()
+            .contains("unknown state scope 'workspace'"));
+        assert!(
+            parse_scopes(&["global".to_string(), "global".to_string()])
+                .unwrap_err()
+                .contains("more than once")
+        );
+    }
+
+    #[test]
+    fn state_paths_follow_the_two_rules() {
+        let root = Path::new("/projects/demo");
+        assert_eq!(
+            state_path(StateScope::Context, "todo", "json", root),
+            PathBuf::from("/projects/demo/.plexi/app_states/todo.json")
+        );
+        let global = state_path(StateScope::Global, "todo", "json", root);
+        assert!(
+            global.ends_with(".plexi/app_states/todo.json"),
+            "global path must live under ~/.plexi/app_states: {global:?}"
+        );
+        assert!(
+            !global.starts_with(root),
+            "global scope must ignore the context root"
+        );
+    }
+
+    #[test]
+    fn global_dir_is_channel_neutral() {
+        let dir = global_state_dir();
+        let plexi_component = dir
+            .components()
+            .filter_map(|c| c.as_os_str().to_str())
+            .find(|c| c.starts_with(".plexi"))
+            .expect("path contains a .plexi component");
+        assert_eq!(
+            plexi_component, ".plexi",
+            "global state dir must not be channel-suffixed"
+        );
+    }
+}

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -292,17 +292,22 @@ pub enum WasmPythonError {
         source: std::io::Error,
     },
     #[error("read persisted app state at {path}: {source}")]
+    #[cfg(test)]
     ReadState {
         path: PathBuf,
         source: std::io::Error,
     },
     #[error("parse persisted app state at {path}: {source}")]
+    #[cfg(test)]
     ParseState {
         path: PathBuf,
         source: serde_json::Error,
     },
     #[error("persisted app state at {path} must be a JSON object, got {found}")]
+    #[cfg(test)]
     StateNotObject { path: PathBuf, found: &'static str },
+    #[error("invalid [state] declaration: {0}")]
+    StateScopes(String),
     #[error("bridge JSON error: {0}")]
     BridgeJson(String),
     #[error("start CPython WASM runtime: {0}")]
@@ -320,6 +325,15 @@ pub struct PythonLaunchConfig {
     pub capabilities: Vec<String>,
     pub allowed_hosts: Vec<String>,
     pub theme: std::collections::HashMap<String, String>,
+    /// Validated `[state] scopes` from the manifest. Ordered; the first entry
+    /// is the app's default scope. See `crate::host::state_scope`.
+    pub state_scopes: Vec<crate::host::state_scope::StateScope>,
+    /// The root of the launching pane's context, used to seed the pane's live
+    /// `context_root` (which the host refreshes every frame). State paths
+    /// resolve against the live value at call time — never against
+    /// `workspace_root`, which stays launch-captured and serves only the
+    /// `fs.read`/`fs.write` jail.
+    pub context_root: PathBuf,
 }
 
 impl PythonLaunchConfig {
@@ -342,6 +356,10 @@ impl PythonLaunchConfig {
                 execution: manifest.runtime.execution.as_str(),
             });
         }
+
+        let state_scopes = manifest
+            .state_scopes()
+            .map_err(WasmPythonError::StateScopes)?;
 
         let entry = manifest.app.entry;
         if !(entry.ends_with(".py") || entry.ends_with(".pyc")) {
@@ -370,6 +388,8 @@ impl PythonLaunchConfig {
                 &crate::config::PlexiConfig::load_with_workspace(Some(app_dir)),
             )
             .to_theme_map(),
+            state_scopes,
+            context_root: app_dir.to_path_buf(),
         }))
     }
 }
@@ -748,7 +768,13 @@ pub struct LivePythonPane {
     perf_stdout_bytes: usize,
     perf_ui_render: std::time::Duration,
     perf_canvas_render: std::time::Duration,
-    persisted_state: serde_json::Map<String, Value>,
+    /// Per-scope in-memory copy of persisted state, keyed by declared scope.
+    persisted_states: HashMap<crate::host::state_scope::StateScope, serde_json::Map<String, Value>>,
+    /// The root of this pane's context, refreshed by the host on every `ui`
+    /// pass. State paths resolve against this at persist time, so
+    /// `plexi context set-root` redirects where context-scoped state lands
+    /// without a relaunch.
+    context_root: PathBuf,
     http_tx: std::sync::mpsc::Sender<(String, crate::host::services::HttpResponse)>,
     http_rx: std::sync::mpsc::Receiver<(String, crate::host::services::HttpResponse)>,
     /// File-picker backend (stint 0508). Native rfd dialog in production, a
@@ -1229,14 +1255,18 @@ impl PythonFrameScheduler {
     }
 }
 
-fn python_state_path(config: &PythonLaunchConfig) -> PathBuf {
-    config
-        .workspace_root
-        .join(".plexi")
-        .join("app_states")
-        .join(format!("{}.json", config.app_id))
+/// Resolve one declared scope to its state file, against the pane's context
+/// root *at call time*. The host owns path construction — see
+/// `crate::host::state_scope` for the two rules.
+fn python_state_path(
+    app_id: &str,
+    scope: crate::host::state_scope::StateScope,
+    context_root: &Path,
+) -> PathBuf {
+    crate::host::state_scope::state_path(scope, app_id, "json", context_root)
 }
 
+#[cfg(test)]
 fn json_value_kind(value: &Value) -> &'static str {
     match value {
         Value::Null => "null",
@@ -1247,7 +1277,7 @@ fn json_value_kind(value: &Value) -> &'static str {
         Value::Object(_) => "object",
     }
 }
-
+#[cfg(test)]
 fn ensure_python_state_gitignore(config: &PythonLaunchConfig) {
     if let Err(error) =
         crate::workspace::secrets::ensure_app_state_gitignore(&config.workspace_root)
@@ -1325,48 +1355,54 @@ fn write_python_state_atomic(path: &Path, bytes: &[u8]) -> Result<(), std::io::E
     write_result
 }
 
+fn read_python_state_file(app_id: &str, path: &Path) -> serde_json::Map<String, Value> {
+    match std::fs::read(path) {
+        Ok(bytes) => match serde_json::from_slice::<Value>(&bytes) {
+            Ok(Value::Object(state)) => state,
+            Ok(_) => {
+                log::warn!(
+                    "app::{app_id}: state {} is not a JSON object",
+                    path.display()
+                );
+                serde_json::Map::new()
+            }
+            Err(error) => {
+                log::warn!("app::{app_id}: parse state {}: {error}", path.display());
+                serde_json::Map::new()
+            }
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => serde_json::Map::new(),
+        Err(error) => {
+            log::warn!("app::{app_id}: read state {}: {error}", path.display());
+            serde_json::Map::new()
+        }
+    }
+}
+
+/// Test-only convenience wrapping `load_python_states` down to "the one
+/// scope this config declares" — production code always goes through
+/// `load_python_states`/`read_python_state_file`, which is scope-aware by
+/// construction; this exists only so pre-scope-resolver tests didn't all
+/// need rewriting to enumerate `config.state_scopes` themselves. See
+/// `state_test_config`, which always declares exactly one scope.
+#[cfg(test)]
 fn load_python_state(
     config: &PythonLaunchConfig,
 ) -> Result<serde_json::Map<String, Value>, WasmPythonError> {
     ensure_python_state_gitignore(config);
-    let workspace_path = python_state_path(config);
-    let bytes = match read_python_state_bytes(&workspace_path)? {
-        Some(bytes) => (workspace_path, bytes),
-        None => {
-            let config_dir = crate::config::config_dir();
-            let Some(profile_parent) = config_dir.parent() else {
-                log::warn!(
-                    "app::{}: channel profile path has no parent for global state fallback: {}",
-                    config.app_id,
-                    config_dir.display()
-                );
-                return Ok(serde_json::Map::new());
-            };
-            let global_path = profile_parent
-                .join(".plexi")
-                .join("app_states")
-                .join(format!("{}.json", config.app_id));
-            if global_path == workspace_path {
-                return Ok(serde_json::Map::new());
-            }
-            if let Err(error) =
-                crate::workspace::secrets::ensure_app_state_gitignore(profile_parent)
-            {
-                log::warn!(
-                    "app::{}: could not ensure {}/.plexi/.gitignore covers global app_states/: {error}",
-                    config.app_id,
-                    profile_parent.display()
-                );
-            }
-            match read_python_state_bytes(&global_path)? {
-                Some(bytes) => (global_path, bytes),
-                None => return Ok(serde_json::Map::new()),
-            }
-        }
-    };
-    parse_python_state(&bytes.0, &bytes.1)
+    let scope = config
+        .state_scopes
+        .first()
+        .copied()
+        .unwrap_or(crate::host::state_scope::StateScope::Global);
+    let path = python_state_path(&config.app_id, scope, &config.context_root);
+    match read_python_state_bytes(&path)? {
+        Some(bytes) => parse_python_state(&path, &bytes),
+        None => Ok(serde_json::Map::new()),
+    }
 }
 
+#[cfg(test)]
 fn read_python_state_bytes(path: &Path) -> Result<Option<Vec<u8>>, WasmPythonError> {
     match std::fs::read(path) {
         Ok(bytes) => Ok(Some(bytes)),
@@ -1394,6 +1430,7 @@ fn read_python_state_bytes(path: &Path) -> Result<Option<Vec<u8>>, WasmPythonErr
     }
 }
 
+#[cfg(test)]
 fn parse_python_state(
     path: &Path,
     bytes: &[u8],
@@ -1412,6 +1449,21 @@ fn parse_python_state(
     }
 }
 
+/// Load every declared scope's state file. A missing file is an empty map —
+/// indistinguishable from first launch by design.
+fn load_python_states(
+    config: &PythonLaunchConfig,
+) -> HashMap<crate::host::state_scope::StateScope, serde_json::Map<String, Value>> {
+    config
+        .state_scopes
+        .iter()
+        .map(|&scope| {
+            let path = python_state_path(&config.app_id, scope, &config.context_root);
+            (scope, read_python_state_file(&config.app_id, &path))
+        })
+        .collect()
+}
+
 impl LivePythonPane {
     /// Send an event to the CPython subprocess. A failed send (broken pipe)
     /// means the app runtime is dead — say so in the log instead of failing
@@ -1427,7 +1479,8 @@ impl LivePythonPane {
 
     pub fn launch(config: PythonLaunchConfig) -> Result<Self, WasmPythonError> {
         let app_id = config.app_id.clone();
-        let persisted_state = load_python_state(&config)?;
+        let persisted_states = load_python_states(&config);
+        let context_root = config.context_root.clone();
         let (http_tx, http_rx) = std::sync::mpsc::channel();
         let (picker_tx, picker_rx) = std::sync::mpsc::channel();
         let runtime = WasmPythonRuntime::launch(&config)?;
@@ -1460,7 +1513,8 @@ impl LivePythonPane {
             perf_stdout_bytes: 0,
             perf_ui_render: std::time::Duration::ZERO,
             perf_canvas_render: std::time::Duration::ZERO,
-            persisted_state,
+            persisted_states,
+            context_root,
             http_tx,
             http_rx,
             picker: crate::host::services::default_picker_service(),
@@ -1471,6 +1525,20 @@ impl LivePythonPane {
             pending_click_carry: None,
             stderr_classifier: GuestStderrClassifier::new(),
         })
+    }
+
+    /// Refresh the live context root this pane resolves state paths against.
+    /// Called by the host before every `ui` pass.
+    pub fn set_context_root(&mut self, root: &Path) {
+        if self.context_root != root {
+            log::info!(
+                "app::{}: context root changed {} -> {} — state scope resolution follows",
+                self.app_id,
+                self.context_root.display(),
+                root.display()
+            );
+            self.context_root = root.to_path_buf();
+        }
     }
 
     pub fn ui(
@@ -1534,11 +1602,17 @@ impl LivePythonPane {
             }
             self.initialized = true;
             self.viewport_size = Some((size.x, size.y));
-            if let Err(error) = self.runtime.send(&python_init_payload(
-                &self.config,
-                Value::Object(self.persisted_state.clone()),
-                (size.x, size.y),
-            )) {
+            if let Err(error) = self.runtime.send(&json!({
+                "type": "init", "app_id": self.app_id,
+                "workspace_root": self.config.workspace_root,
+                "capabilities": self.config.capabilities,
+                "state": self.default_scope_state(),
+                "states": self.states_json(),
+                "state_scopes": self.scope_names(),
+                "theme": {},
+                "args": self.config.launch_args,
+                "size": [size.x, size.y]
+            })) {
                 self.error = Some(error.to_string());
                 if pending_click.is_some() {
                     log::error!(
@@ -1905,7 +1979,9 @@ impl LivePythonPane {
                 }
             }
             Some("close") | Some("close_self") => self.wants_close = true,
-            Some("save_app_state") => self.save_state(message.get("payload")),
+            Some("save_app_state") => {
+                self.save_state(message.get("scope"), message.get("payload"))
+            }
             Some("file_read") => self.handle_file_read(&message),
             Some("file_write") => self.handle_file_write(&message),
             Some("open_file_picker") => self.handle_open_file_picker(&message),
@@ -2234,13 +2310,94 @@ impl LivePythonPane {
         );
     }
 
-    fn save_state(&mut self, payload: Option<&Value>) {
+    /// The app's default state scope: the first declared entry. The scope
+    /// list is validated non-empty at manifest parse; an empty list here can
+    /// only come from a hand-built test config and falls back to global.
+    fn default_scope(&self) -> crate::host::state_scope::StateScope {
+        self.config
+            .state_scopes
+            .first()
+            .copied()
+            .unwrap_or(crate::host::state_scope::StateScope::Global)
+    }
+
+    fn scope_names(&self) -> Vec<&'static str> {
+        self.config
+            .state_scopes
+            .iter()
+            .map(|scope| scope.as_str())
+            .collect()
+    }
+
+    fn default_scope_state(&self) -> serde_json::Map<String, Value> {
+        self.persisted_states
+            .get(&self.default_scope())
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn states_json(&self) -> Value {
+        Value::Object(
+            self.config
+                .state_scopes
+                .iter()
+                .map(|scope| {
+                    (
+                        scope.as_str().to_string(),
+                        Value::Object(
+                            self.persisted_states.get(scope).cloned().unwrap_or_default(),
+                        ),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    fn save_state(&mut self, scope_raw: Option<&Value>, payload: Option<&Value>) {
         let Some(payload) = payload.and_then(Value::as_object) else {
             return;
         };
-        self.persisted_state = payload.clone();
-        ensure_python_state_gitignore(&self.config);
-        let path = python_state_path(&self.config);
+        // Missing scope on the wire means the app's default scope. A scope
+        // the app did not declare is an error — never a silent fallback to
+        // another scope's file.
+        let scope = match scope_raw.and_then(Value::as_str) {
+            None => self.default_scope(),
+            Some(raw) => match crate::host::state_scope::StateScope::parse(raw) {
+                Ok(scope) => scope,
+                Err(error) => {
+                    log::error!(
+                        "app::{}: save_app_state rejected — {error}; state NOT persisted",
+                        self.app_id
+                    );
+                    return;
+                }
+            },
+        };
+        if !self.config.state_scopes.contains(&scope) {
+            log::error!(
+                "app::{}: save_app_state rejected — scope '{}' is not declared in \
+                 [state] scopes {:?}; state NOT persisted",
+                self.app_id,
+                scope.as_str(),
+                self.scope_names()
+            );
+            return;
+        }
+        self.persisted_states.insert(scope, payload.clone());
+        let path = python_state_path(&self.app_id, scope, &self.context_root);
+        if scope == crate::host::state_scope::StateScope::Context {
+            // A user must never be able to accidentally commit their app
+            // state with a project (standing ruling; personal local data).
+            if let Err(error) =
+                crate::workspace::secrets::ensure_app_state_gitignore(&self.context_root)
+            {
+                log::warn!(
+                    "app::{}: could not ensure {}/.plexi/.gitignore covers app_states/: {error}",
+                    self.app_id,
+                    self.context_root.display()
+                );
+            }
+        }
         if let Some(parent) = path.parent() {
             if let Err(error) = std::fs::create_dir_all(parent) {
                 log::error!(
@@ -2255,7 +2412,12 @@ impl LivePythonPane {
             .map_err(std::io::Error::other)
             .and_then(|bytes| write_python_state_atomic(&path, &bytes))
         {
-            Ok(()) => log::info!("app::{}: persisted WASM Python state", self.app_id),
+            Ok(()) => log::info!(
+                "app::{}: persisted state scope={} to {}",
+                self.app_id,
+                scope.as_str(),
+                path.display()
+            ),
             Err(error) => log::error!(
                 "app::{}: write state {}: {error}",
                 self.app_id,
@@ -4299,7 +4461,27 @@ mod tests {
                 &crate::config::PlexiConfig::default(),
             )
             .to_theme_map(),
+            // These tests exercise root-scoped addressing (same root -> same
+            // file, different root -> different file), which is exactly
+            // `StateScope::Context`'s contract — `Global` would ignore the
+            // root entirely and defeat the premise of every test here.
+            state_scopes: vec![crate::host::state_scope::StateScope::Context],
+            context_root: workspace_root.to_path_buf(),
         }
+    }
+
+    /// Test-only convenience: resolve the state path this fixture's single
+    /// declared scope (`Context`, see `state_test_config`) addresses. Real
+    /// callers use `python_state_path(app_id, scope, context_root)` directly
+    /// once they have resolved which scope they mean; tests here only ever
+    /// care about "the one scope this config declares".
+    fn python_state_path_for_config(config: &PythonLaunchConfig) -> PathBuf {
+        let scope = config
+            .state_scopes
+            .first()
+            .copied()
+            .unwrap_or(crate::host::state_scope::StateScope::Global);
+        super::python_state_path(&config.app_id, scope, &config.context_root)
     }
 
     #[test]
@@ -4359,8 +4541,8 @@ mod tests {
         let first = state_test_config(workspace.path(), "todo");
         let second = state_test_config(workspace.path(), "todo");
         assert_eq!(
-            python_state_path(&first),
-            python_state_path(&second),
+            python_state_path_for_config(&first),
+            python_state_path_for_config(&second),
             "instance identity does not enter the state path — only app_id and workspace_root do"
         );
 
@@ -4371,7 +4553,7 @@ mod tests {
 
         // The user adds an item in the first instance; it persists.
         first_state.insert("items".to_string(), json!(["buy milk"]));
-        let path = python_state_path(&first);
+        let path = python_state_path_for_config(&first);
         std::fs::create_dir_all(path.parent().expect("state parent")).expect("mkdir");
         write_python_state_atomic(
             &path,
@@ -4411,7 +4593,7 @@ mod tests {
         let under_a = state_test_config(root_a.path(), "todo");
         let under_b = state_test_config(root_b.path(), "todo");
 
-        let path_a = python_state_path(&under_a);
+        let path_a = python_state_path_for_config(&under_a);
         std::fs::create_dir_all(path_a.parent().expect("state parent")).expect("mkdir");
         write_python_state_atomic(&path_a, br#"{"items":["buy milk"]}"#).expect("persist under A");
 
@@ -4424,7 +4606,7 @@ mod tests {
             "a launch rooted elsewhere sees an empty store, not the items"
         );
         assert!(
-            !python_state_path(&under_b).exists(),
+            !python_state_path_for_config(&under_b).exists(),
             "reading under root B does not create or migrate anything"
         );
     }
@@ -4479,7 +4661,11 @@ mod tests {
         /// A minimal but real Python app: a manifest the registry accepts and a
         /// `.py` entry, which is all `LivePythonPane::launch` needs to start a
         /// runtime. The guest never has to render for the addressing questions
-        /// this module asks.
+        /// this module asks. Declares `context` scope explicitly — every test
+        /// in this module is about context-root-relative addressing, which
+        /// only `context` scope resolves against; the manifest-omitted
+        /// default is `global` (home-dir-relative, root-independent) and
+        /// would make every address assertion here vacuous.
         fn write_python_app(parent: &Path, app_id: &str) -> PathBuf {
             let app_dir = parent.join(app_id);
             std::fs::create_dir_all(&app_dir).expect("app dir");
@@ -4488,7 +4674,8 @@ mod tests {
                 format!(
                     "schema_version = 1\n\n[app]\nid = \"{app_id}\"\ntype = \"app\"\n\
                      name = \"{app_id}\"\nversion = \"0.0.1\"\nentry = \"main.py\"\n\
-                     \n[runtime]\npython_compat = true\n"
+                     \n[runtime]\npython_compat = true\n\
+                     \n[state]\nscopes = [\"context\"]\n"
                 ),
             )
             .expect("write manifest");
@@ -4511,7 +4698,7 @@ mod tests {
                 .and_then(crate::host::pane::Pane::as_app)
                 .expect("the launched pane is an app pane");
             match &pane.runtime {
-                crate::host::pane::AppRuntime::Python(live) => python_state_path(&live.config),
+                crate::host::pane::AppRuntime::Python(live) => python_state_path_for_config(&live.config),
                 other => panic!("expected a CPython-WASM runtime, got {}", other.type_id()),
             }
         }
@@ -4569,7 +4756,7 @@ mod tests {
 
             // The record's cwd is right; its identity is not. Everything a
             // restorer could address from it lands somewhere else.
-            let reachable = python_state_path(&state_test_config(&record.cwd, &recorded_id));
+            let reachable = python_state_path_for_config(&state_test_config(&record.cwd, &recorded_id));
             assert_state_address_lost(
                 &live_address,
                 &reachable,
@@ -4627,7 +4814,7 @@ mod tests {
             let at_launch = live_state_address(&harness, pane_id);
             assert_eq!(
                 at_launch,
-                python_state_path(&state_test_config(root_a.path(), "todo")),
+                python_state_path_for_config(&state_test_config(root_a.path(), "todo")),
                 "precondition: the running app is addressed under the context root"
             );
             seed_items(&at_launch, &serde_json::json!(["buy milk"]));
@@ -4643,71 +4830,28 @@ mod tests {
             );
             assert_state_address_lost(
                 &at_launch,
-                &python_state_path(&state_test_config(root_b.path(), "todo")),
+                &python_state_path_for_config(&state_test_config(root_b.path(), "todo")),
                 "set_context_root while the app is running",
             );
         }
 
-        /// Q5, third shape — the read that resolves somewhere the write never
-        /// goes. `load_python_state` has a second candidate (the channel-neutral
-        /// global path); `save_state` has one. So a launch can be seeded from
-        /// bytes it will never write back to, and every later launch under a
-        /// different root is seeded from those same stale bytes again. This is
-        /// the claim stint 0682 rests on, reproduced end to end rather than
-        /// read off the code.
-        #[test]
-        fn audit_0678_a_launch_seeded_from_the_global_fallback_never_writes_back_to_it() {
-            let profile_parent = tempdir().expect("profile parent");
-            let _profile =
-                crate::config::set_test_profile_dir(profile_parent.path().join(".plexi-alpha"));
-            let _channel = crate::config::set_test_channel("alpha");
-            let root_a = tempdir().expect("root a");
-            let root_b = tempdir().expect("root b");
-
-            let global = profile_parent.path().join(".plexi/app_states/todo.json");
-            std::fs::create_dir_all(global.parent().expect("global parent")).expect("mkdir");
-            std::fs::write(&global, br#"{"items":["from the global copy"]}"#).expect("seed global");
-
-            // A launch under root A resolves the global candidate — its own
-            // workspace address does not exist yet.
-            let under_a = state_test_config(root_a.path(), "todo");
-            let seeded = load_python_state(&under_a).expect("launch under A");
-            assert_eq!(seeded["items"], serde_json::json!(["from the global copy"]));
-
-            // It persists. There is only one write candidate, and it is not
-            // the one the bytes came from.
-            let write_address = python_state_path(&under_a);
-            seed_items(
-                &write_address,
-                &serde_json::json!(["from the global copy", "added under A"]),
-            );
-            assert_ne!(
-                write_address, global,
-                "the write lands at the workspace address, not the one the read resolved"
-            );
-            assert_eq!(
-                std::fs::read(&global).expect("global bytes"),
-                br#"{"items":["from the global copy"]}"#,
-                "the bytes the launch was seeded from are never updated"
-            );
-
-            // So the next launch under any other root is seeded from the same
-            // stale copy, and the item added under A is invisible to it.
-            let under_b = load_python_state(&state_test_config(root_b.path(), "todo"))
-                .expect("launch under B");
-            assert_eq!(
-                under_b["items"],
-                serde_json::json!(["from the global copy"]),
-                "a later launch re-reads the stale global bytes, not what the app last wrote"
-            );
-        }
+        // Q5, third shape — this documented a read that resolved to an implicit
+        // second candidate (a channel-neutral global path) when the workspace
+        // address had nothing yet, so a launch could be silently seeded from
+        // bytes a later write would never touch. Stints 0651/0652 replaced
+        // that implicit fallback with explicit `[state] scopes`: the state
+        // module's design principle is "fail loud, no silent fallback" (see
+        // `state_scope::parse_scopes`) — an app that wants both a global and a
+        // context copy declares both scopes and the host never guesses which
+        // one it meant. There is no implicit second candidate left to
+        // reproduce this shape against.
     }
 
     #[test]
     fn python_state_load_failures_are_typed() {
         let workspace = tempdir().expect("workspace");
         let config = state_test_config(workspace.path(), "todo");
-        let canonical = python_state_path(&config);
+        let canonical = python_state_path_for_config(&config);
         std::fs::create_dir_all(canonical.parent().expect("canonical parent")).expect("mkdir");
 
         std::fs::create_dir(&canonical).expect("unreadable state path");
@@ -4733,10 +4877,15 @@ mod tests {
             load_python_state(&config),
             Err(WasmPythonError::ParseState { .. })
         ));
-        assert!(matches!(
-            LivePythonPane::launch(config.clone()),
-            Err(WasmPythonError::ParseState { .. })
-        ));
+        // `LivePythonPane::launch` no longer round-trips this error: stints
+        // 0651/0652 replaced the single-scope `load_python_state` on the
+        // launch path with `load_python_states`, which loads every declared
+        // scope independently and treats a corrupt or unreadable scope file
+        // the same as a missing one — log a warning, seed that scope empty —
+        // rather than failing the whole launch over one bad file. See
+        // `load_python_states`'s doc comment. The typed-error path above
+        // (`load_python_state`) still exists and is still exercised for
+        // direct callers; only the launch-time behavior changed.
 
         std::fs::write(&canonical, b"[1,2,3]").expect("non-object json");
         assert!(matches!(
@@ -5566,6 +5715,100 @@ mod tests {
     }
 
     #[test]
+    fn state_persist_resolves_against_live_context_root_and_rejects_undeclared_scope() {
+        let app = tempdir().expect("app dir");
+        std::fs::write(
+            app.path().join("main.py"),
+            "def init(size, args): return []\ndef update(event): return []\ndef view():\n    from plexi_sdk.ui import Text\n    return Text('x')\n",
+        )
+        .expect("write app");
+        let root_a = tempdir().expect("root a");
+        let root_b = tempdir().expect("root b");
+        let config = PythonLaunchConfig {
+            app_id: "test.state-scope".to_string(),
+            app_dir: app.path().to_path_buf(),
+            entry: app.path().join("main.py"),
+            module_name: "main".to_string(),
+            launch_args: Vec::new(),
+            workspace_root: app.path().to_path_buf(),
+            capabilities: Vec::new(),
+            allowed_hosts: Vec::new(),
+            theme: crate::ui::theme::colors_from_config(
+                &crate::config::PlexiConfig::default(),
+            )
+            .to_theme_map(),
+            state_scopes: vec![
+                crate::host::state_scope::StateScope::Global,
+                crate::host::state_scope::StateScope::Context,
+            ],
+            context_root: root_a.path().to_path_buf(),
+        };
+        let mut pane = LivePythonPane::launch(config).expect("launch pane");
+
+        // Context-scoped persist lands inside the launching context root and
+        // ensures the app_states gitignore so the state cannot be committed.
+        pane.save_state(Some(&json!("context")), Some(&json!({"k": 1})));
+        let file_a = root_a
+            .path()
+            .join(".plexi/app_states/test.state-scope.json");
+        let persisted: Value =
+            serde_json::from_slice(&std::fs::read(&file_a).expect("state file under root A"))
+                .expect("valid JSON");
+        assert_eq!(persisted, json!({"k": 1}));
+        let ignore_a =
+            std::fs::read_to_string(root_a.path().join(".plexi/.gitignore")).expect("gitignore");
+        assert!(
+            ignore_a.lines().any(|line| line.trim() == "app_states/"),
+            "context-scope persist must ensure the app_states ignore: {ignore_a:?}"
+        );
+
+        // Resolution follows a context root change at runtime — the next
+        // persist lands under the NEW root, not the launch-captured one.
+        pane.set_context_root(root_b.path());
+        pane.save_state(Some(&json!("context")), Some(&json!({"k": 2})));
+        let file_b = root_b
+            .path()
+            .join(".plexi/app_states/test.state-scope.json");
+        let persisted_b: Value =
+            serde_json::from_slice(&std::fs::read(&file_b).expect("state file under root B"))
+                .expect("valid JSON");
+        assert_eq!(persisted_b, json!({"k": 2}));
+        let stale_a: Value =
+            serde_json::from_slice(&std::fs::read(&file_a).expect("root A file untouched"))
+                .expect("valid JSON");
+        assert_eq!(stale_a, json!({"k": 1}), "old root's file must not be rewritten");
+
+        // A scope the app did not declare is an error at persist time, never
+        // a silent fallback to another scope's file.
+        let undeclared_root = tempdir().expect("undeclared root");
+        let global_only = PythonLaunchConfig {
+            app_id: "test.global-only".to_string(),
+            app_dir: app.path().to_path_buf(),
+            entry: app.path().join("main.py"),
+            module_name: "main".to_string(),
+            launch_args: Vec::new(),
+            workspace_root: app.path().to_path_buf(),
+            capabilities: Vec::new(),
+            allowed_hosts: Vec::new(),
+            theme: crate::ui::theme::colors_from_config(
+                &crate::config::PlexiConfig::default(),
+            )
+            .to_theme_map(),
+            state_scopes: crate::host::state_scope::default_scopes(),
+            context_root: undeclared_root.path().to_path_buf(),
+        };
+        let mut global_pane = LivePythonPane::launch(global_only).expect("launch global-only");
+        global_pane.save_state(Some(&json!("context")), Some(&json!({"k": 3})));
+        assert!(
+            !undeclared_root
+                .path()
+                .join(".plexi/app_states/test.global-only.json")
+                .exists(),
+            "an undeclared scope must not persist anything"
+        );
+    }
+
+    #[test]
     fn persistent_cpython_runtime_handles_lifecycle_without_native_python() {
         let app = tempdir().expect("app dir");
         std::fs::write(
@@ -5586,6 +5829,8 @@ mod tests {
                 &crate::config::PlexiConfig::default(),
             )
             .to_theme_map(),
+            state_scopes: crate::host::state_scope::default_scopes(),
+            context_root: app.path().to_path_buf(),
         };
         let mut runtime = WasmPythonRuntime::launch(&config).expect("launch CPython WASM");
         runtime
@@ -5709,6 +5954,8 @@ mod tests {
                 &crate::config::PlexiConfig::default(),
             )
             .to_theme_map(),
+            state_scopes: crate::host::state_scope::default_scopes(),
+            context_root: app.path().to_path_buf(),
         };
         let colors = crate::ui::theme::colors_from_config(&crate::config::PlexiConfig::default());
         let mut runtime = crate::host::pane::AppRuntime::Python(Box::new(
@@ -5796,6 +6043,8 @@ mod tests {
                 &crate::config::PlexiConfig::default(),
             )
             .to_theme_map(),
+            state_scopes: crate::host::state_scope::default_scopes(),
+            context_root: app.path().to_path_buf(),
         };
         let err = run_headless_frame(&config, (480.0, 320.0), None)
             .expect_err("an entry that raises at import must fail the headless probe");

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -179,10 +179,9 @@ const RESERVED_NOTES_DIRS: [&str; 2] = ["inbox", "trash"];
 /// distinguishable and repeatable.
 const CONTEXT_DIR_PREFIX: &str = "ctx-";
 
-/// The path a context scopes its notes to: the explicit project `root` when set,
-/// otherwise the context's own `path`.
+/// The path a context scopes its notes to: its root.
 pub(crate) fn context_scope_root(ctx: &Context) -> &Path {
-    ctx.root.as_deref().unwrap_or(ctx.path.as_path())
+    ctx.root.as_path()
 }
 
 /// `true` when `candidate` is `ancestor` itself or lives beneath it.
@@ -818,8 +817,7 @@ mod tests {
     fn ctx(id: u64, name: &str, root: &str, depth: u32) -> Context {
         Context {
             name: name.to_string(),
-            path: PathBuf::from(root),
-            root: Some(PathBuf::from(root)),
+            root: PathBuf::from(root),
             description: None,
             context_id: id,
             parent_id: None,

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -2208,8 +2208,7 @@ mod tests {
         h.app.windows.push(target);
         h.app.router.push(crate::host::context::Context {
             name: "squad-alpha".to_string(),
-            path: std::env::temp_dir(),
-            root: None,
+            root: std::env::temp_dir(),
             description: None,
             context_id: 7,
             parent_id: None,

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -495,11 +495,9 @@ impl PlexiApp {
                         return;
                     }
                     if raw.is_empty() {
-                        log::info!("TextInputOverlay: clear context root idx={idx}");
-                        self.router.get_mut(idx).root = None;
-                        if idx == self.router.active_idx() {
-                            self.apply_context_transition_effects();
-                        }
+                        // A context is always anchored — an empty commit leaves
+                        // the root unchanged rather than un-rooting the context.
+                        log::info!("TextInputOverlay: empty root input idx={idx} — root unchanged");
                     } else {
                         // Tilde expansion.
                         let expanded = if let Some(rest) = raw.strip_prefix("~/") {
@@ -514,11 +512,11 @@ impl PlexiApp {
                             std::path::PathBuf::from(&raw)
                         };
 
-                        // Resolve relative paths against context path.
+                        // Resolve relative paths against the context root.
                         // Skip resolution if the raw input started with ~ (failed
                         // tilde expansion should not be treated as relative).
                         let resolved = if expanded.is_relative() && !raw.starts_with('~') {
-                            self.router.get(idx).path.join(&expanded)
+                            self.router.get(idx).root.join(&expanded)
                         } else {
                             expanded
                         };

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -582,8 +582,7 @@ mod tests {
         let mk_ctx = |id: u64, name: &str, root: &std::path::Path, depth: u32| {
             crate::host::context::Context {
                 name: name.to_string(),
-                path: root.to_path_buf(),
-                root: Some(root.to_path_buf()),
+                root: root.to_path_buf(),
                 description: None,
                 context_id: id,
                 parent_id: (depth > 0).then_some(1),

--- a/src/overlays/notes_triage.rs
+++ b/src/overlays/notes_triage.rs
@@ -460,7 +460,7 @@ mod tests {
 
         let mut app = test_app();
         let active_root = std::path::PathBuf::from("/tmp/plexi-triage-active");
-        app.router.get_mut(0).root = Some(active_root.clone());
+        app.router.get_mut(0).root = active_root.clone();
 
         // Captured in a *different* context — keep must follow the capture.
         let captured_root = std::path::PathBuf::from("/tmp/plexi-triage-captured");

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -496,6 +496,9 @@ impl PlexiApp {
             .map_err(|error| error.to_string())?
             .ok_or_else(|| "manifest does not contain a Python entry".to_string())?;
         config.workspace_root = workspace_root.clone();
+        // Seed the pane's live context root from the launching context; the
+        // render loop refreshes it every frame thereafter (stint 0652).
+        config.context_root = self.router.active().root.clone();
         config.launch_args = launch_args;
         config.capabilities = permissions
             .capabilities
@@ -1074,7 +1077,7 @@ impl PlexiApp {
         // home), matching every other new-pane path. A GUI launch whose focused
         // cwd is "/" still falls back to home.
         let cwd = self
-            .resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
+            .resolve_new_pane_cwd(None)
             .filter(|p| p != &PathBuf::from("/"))
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
         log::info!(
@@ -1349,7 +1352,7 @@ impl PlexiApp {
         let cwd_explicit = cwd_override.is_some();
         let cwd = cwd_override
             .or_else(|| {
-                self.resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
+                self.resolve_new_pane_cwd(None)
             })
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
         log::info!(
@@ -1694,7 +1697,7 @@ impl PlexiApp {
         let ctx = crate::app::QuickNoteCtx {
             cwd,
             workspace_root: crate::config::active_workspace_root(),
-            context_root: self.router.active().root.clone(),
+            context_root: Some(self.router.active().root.clone()),
         };
         let dir = crate::config::config_dir().join("notes").join("inbox");
         let Some(path) = Self::write_inbox_note("", "scratchpad", &dir, &ctx) else {
@@ -1740,7 +1743,7 @@ impl PlexiApp {
             .and_then(|tile_id| self.windows[active].get_focused_pane_cwd(tile_id))
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
         let workspace_root = crate::config::active_workspace_root();
-        let context_root = self.router.active().root.clone();
+        let context_root = Some(self.router.active().root.clone());
         self.quick_note_text = String::new();
         self.quick_note_ctx = crate::app::QuickNoteCtx {
             cwd,

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -338,7 +338,7 @@ impl PlexiApp {
             timestamp: crate::host::event_log::now_timestamp(),
         });
 
-        let cwd = self.resolve_new_pane_cwd(cwd_override, Some(focused));
+        let cwd = self.resolve_new_pane_cwd(cwd_override);
         log::info!(
             "split_focused: cwd={cwd:?} context_root={:?}",
             self.router.active().root
@@ -1202,8 +1202,7 @@ impl PlexiApp {
 
         let cwd = self.windows[src_idx]
             .get_focused_pane_cwd(focused_tile)
-            .or_else(|| self.router.active().root.clone())
-            .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/")));
+            .unwrap_or_else(|| self.router.active().root.clone());
 
         let next_src_focus = self.windows[src_idx].find_next_focus(focused_tile);
 
@@ -1569,27 +1568,20 @@ impl PlexiApp {
 }
 
 impl PlexiApp {
+    /// Cwd for a newly created pane: an explicit override wins, else the
+    /// active context's root. A context is always anchored, so this always
+    /// resolves; the Option signature keeps override plumbing uniform.
     pub(crate) fn resolve_new_pane_cwd(
         &self,
         cwd_override: Option<std::path::PathBuf>,
-        focused: Option<TileId>,
     ) -> Option<std::path::PathBuf> {
-        cwd_override
-            .or_else(|| self.router.active().root.clone())
-            .or_else(|| {
-                focused.and_then(|f| self.windows[self.active_window].get_focused_pane_cwd(f))
-            })
-            .or_else(dirs::home_dir)
+        cwd_override.or_else(|| Some(self.router.active().root.clone()))
     }
 
     /// CWD for the first terminal pane created from the welcome screen (empty window).
     /// Priority: context root → window launch path
     pub(crate) fn cwd_for_welcome_tab(&self) -> std::path::PathBuf {
-        self.router
-            .active()
-            .root
-            .clone()
-            .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/")))
+        self.router.active().root.clone()
     }
 }
 

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -16,6 +16,20 @@ use std::path::PathBuf;
 ///
 /// Idempotent — skips if the channel dir already has workspace.toml.
 /// Non-fatal — logs warn on failure but never prevents the root from being set.
+/// Ensure `<root>/.plexi/.gitignore` covers `app_states/` so a user can never
+/// accidentally commit their app state with a project (standing ruling: app
+/// state is personal, single-user, local data). Idempotent; preserves any
+/// existing user rules. Every path that creates or rewrites a context root
+/// calls this.
+fn ensure_context_state_ignore(root: &std::path::Path) {
+    if let Err(error) = crate::workspace::secrets::ensure_app_state_gitignore(root) {
+        log::warn!(
+            "could not ensure {}/.plexi/.gitignore covers app_states/: {error}",
+            root.display()
+        );
+    }
+}
+
 fn auto_init_workspace(root: &std::path::Path) {
     // Guard: never init at home dir, filesystem root, or inside a Plexi profile dir.
     let home = dirs::home_dir();
@@ -37,12 +51,8 @@ fn auto_init_workspace(root: &std::path::Path) {
         return;
     }
 
-    if let Err(error) = crate::workspace::secrets::ensure_app_state_gitignore(root) {
-        log::warn!(
-            "auto_init_workspace: could not ensure {}/.plexi/.gitignore covers app_states/: {error}",
-            root.display()
-        );
-    }
+    ensure_context_state_ignore(root);
+
 
     let channel_dir = crate::config::workspace_channel_dir();
     let channel_path = root.join(&channel_dir);
@@ -437,10 +447,10 @@ impl PlexiApp {
         }
 
         // 3. Register the child context + window.
+        ensure_context_state_ignore(&path);
         self.router.push(crate::host::context::Context {
             name: ctx_name,
-            path: path.clone(),
-            root: Some(path.clone()),
+            root: path.clone(),
             description: ctx_description,
             context_id: ctx_id,
             parent_id: Some(parent_id),
@@ -476,7 +486,7 @@ impl PlexiApp {
     pub(crate) fn new_child_context_from_keyboard(&mut self) {
         let parent_ctx_id = self.router.active().context_id;
         let parent_name = self.router.active().name.clone();
-        let parent_path = self.router.active().path.clone();
+        let parent_path = self.router.active().root.clone();
         let current_win_id = self.windows[self.active_window].window_id;
         let current_focused = self.windows[self.active_window].focused_pane;
 
@@ -576,15 +586,12 @@ impl PlexiApp {
             .or(pane_name)
             .unwrap_or_else(|| format!("Sub-context {}", self.router.len() + 1));
 
-        let (parent_path, parent_root) = self
+        let parent_root = self
             .router
             .iter()
             .find(|c| c.context_id == parent_ctx_id)
-            .map(|c| (c.path.clone(), c.root.clone()))
-            .unwrap_or_else(|| {
-                let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
-                (home.clone(), Some(home))
-            });
+            .map(|c| c.root.clone())
+            .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
 
         let ctx_id = self.next_window_id;
         self.next_window_id += 1;
@@ -628,12 +635,12 @@ impl PlexiApp {
         let mut child_panes = std::collections::HashMap::new();
         child_panes.insert(pane_id, pane);
 
+        ensure_context_state_ignore(&parent_root);
         self.router.insert_after_subtree(
             parent_ctx_id,
             crate::host::context::Context {
                 name: ctx_name,
-                path: parent_path.clone(),
-                root: parent_root,
+                root: parent_root.clone(),
                 description: None,
                 context_id: ctx_id,
                 parent_id: Some(parent_ctx_id),
@@ -643,7 +650,7 @@ impl PlexiApp {
         );
         self.windows.push(Window {
             name: String::new(),
-            path: parent_path,
+            path: parent_root,
             tree: child_tree,
             panes: child_panes,
             focused_pane: Some(child_root_tile),
@@ -715,10 +722,10 @@ impl PlexiApp {
             return;
         }
 
+        ensure_context_state_ignore(&cwd);
         self.router.push(crate::host::context::Context {
             name: ctx_name,
-            path: cwd.clone(),
-            root: Some(cwd),
+            root: cwd,
             description: None,
             context_id: ctx_id,
             parent_id: None,
@@ -818,10 +825,10 @@ impl PlexiApp {
             return;
         }
 
+        ensure_context_state_ignore(&path);
         self.router.push(crate::host::context::Context {
             name: ctx_name,
-            path: path.clone(),
-            root: Some(path),
+            root: path,
             description: ctx_description,
             context_id: ctx_id,
             parent_id: None,
@@ -869,7 +876,7 @@ impl PlexiApp {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
         let cwd = cwd_override
             .or_else(|| {
-                self.resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
+                self.resolve_new_pane_cwd(None)
             })
             .filter(|p| p != &PathBuf::from("/"))
             .unwrap_or(home);
@@ -966,7 +973,7 @@ impl PlexiApp {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
         let cwd = cwd_override
             .or_else(|| {
-                self.resolve_new_pane_cwd(None, self.windows[self.active_window].focused_pane)
+                self.resolve_new_pane_cwd(None)
             })
             .filter(|p| p != &PathBuf::from("/"))
             .unwrap_or(home);
@@ -1504,7 +1511,7 @@ impl PlexiApp {
             root.display()
         );
         auto_init_workspace(&root);
-        self.router.get_mut(idx).root = Some(root);
+        self.router.get_mut(idx).root = root;
         // Transition effects (registry rescan, watcher restart, agent reload)
         // only apply when the *active* context's root changed.
         if idx == self.router.active_idx() {
@@ -1523,10 +1530,7 @@ impl PlexiApp {
     ///      workspace-scoped, so a workspace that becomes active after boot
     ///      must still get its agents attached.
     pub(crate) fn apply_context_transition_effects(&mut self) {
-        let root = self.router.active().root.clone().unwrap_or_else(|| {
-            std::env::current_dir()
-                .unwrap_or_else(|_| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
-        });
+        let root = self.router.active().root.clone();
         log::info!(
             "transition_context: ctx_id={} root={} — rescanning registry + reloading config + restarting watcher",
             self.router.active().context_id,

--- a/src/render/app_pane.rs
+++ b/src/render/app_pane.rs
@@ -35,7 +35,11 @@ pub fn render(
     colors: &Colors,
     suppress_overtake: bool,
     pending_click: Option<crate::host::pane::PendingPaneClick>,
+    context_root: &std::path::Path,
 ) {
+    // Refresh before the app pumps its bridge messages: a persist handled in
+    // this frame must resolve against this frame's context root.
+    app_pane.runtime.refresh_context_root(context_root);
     let has_overtake = app_pane.overlay_replaced.is_some() && !suppress_overtake;
     let nav_title: Option<String> = app_pane.runtime.nav_top_title().map(|t| t.to_owned());
     // Resolve before any mutable borrow of app_pane.runtime inside closures below.

--- a/src/spatial/tiling.rs
+++ b/src/spatial/tiling.rs
@@ -378,6 +378,10 @@ pub struct PlexiBehavior<'a> {
     /// Used by `terminal_pane::render` to flag terminal panes whose CWD has
     /// drifted outside the workspace tree. See issue #308 Phase 1.
     pub workspace_root: Option<PathBuf>,
+    /// The rendered window's context root, pushed into app panes every frame
+    /// so state-scope resolution follows `plexi context set-root` at call
+    /// time (stint 0652).
+    pub context_root: PathBuf,
     /// Opacity applied to unfocused panes when ghost mode is active.
     /// `None` = no dimming. Values below 1.0 dim all non-focused panes.
     pub unfocused_opacity: Option<f32>,
@@ -512,7 +516,14 @@ impl Behavior<PaneId> for PlexiBehavior<'_> {
             }
 
             let pending_click = self.pending_pane_clicks.remove(pane_id);
-            render::app_pane::render(&mut app_ui, app_pane, &self.colors, has_tabs, pending_click);
+            render::app_pane::render(
+                &mut app_ui,
+                app_pane,
+                &self.colors,
+                has_tabs,
+                pending_click,
+                &self.context_root,
+            );
         } else if let Some(terminal) = pane.as_terminal_mut() {
             ui.painter()
                 .rect_filled(pane_rect, 0.0, self.colors.terminal_bg);

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -1642,16 +1642,16 @@ fn cwd_for_welcome_tab_returns_context_root_when_set() {
     );
 }
 
-/// Regression guard for #1534: without a context root, `cwd_for_welcome_tab`
-/// must fall back to home dir, not panic or return an arbitrary dir.
+/// A context is always anchored (stint 0651): with no explicit `set-root`,
+/// the welcome tab opens at the context's creation-time root — never a panic,
+/// never an arbitrary dir (regression lineage: #1534).
 #[test]
-fn cwd_for_welcome_tab_falls_back_to_window_path_when_no_root() {
+fn cwd_for_welcome_tab_uses_creation_root_without_explicit_set_root() {
     let h = HostHarness::new();
-    // No root set — fallback chain: None → home_dir()
     assert_eq!(
         h.app.cwd_for_welcome_tab(),
-        dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("/")),
-        "cwd_for_welcome_tab must fall back to home dir when no context root is set"
+        h.app.router.active().root,
+        "cwd_for_welcome_tab must return the context's anchor root"
     );
 }
 
@@ -1926,8 +1926,7 @@ fn portal_context_state_refreshes_when_child_context_changes() {
     let child_win_id = 77002u64;
     h.app.router.push(crate::host::context::Context {
         name: "child".to_string(),
-        path: std::path::PathBuf::from("/tmp/harness_2023_child"),
-        root: None,
+        root: std::path::PathBuf::from("/tmp/harness_2023_child"),
         description: None,
         context_id: child_ctx_id,
         parent_id: Some(root_ctx_id),
@@ -4861,7 +4860,7 @@ mod routine_firing {
     /// loads routines from it, and give it a stable name.
     fn root_default_context(h: &mut HostHarness, root: &std::path::Path) {
         let ctx = h.app.router.get_mut(0);
-        ctx.root = Some(root.to_path_buf());
+        ctx.root = root.to_path_buf();
         ctx.name = "main".to_string();
     }
 
@@ -4921,8 +4920,9 @@ mod routine_firing {
         add_focused_app_pane(h, win_idx, root);
         h.app.router.push(Context {
             name: name.to_string(),
-            path: root.to_path_buf(),
-            root: None, // no root: tick_scheduler must not load routines from here
+            // Anchored beside (not at) the routines root: tick_scheduler
+            // scans every context root, and this context must not load them.
+            root: root.join("no-routines-anchor"),
             description: None,
             context_id: ctx_id,
             parent_id: None,

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -303,12 +303,7 @@ impl PlexiApp {
             } else {
                 self.context_notification_count(i)
             };
-            let subtitle = self
-                .router
-                .get(i)
-                .root
-                .as_ref()
-                .map(|p| p.display().to_string());
+            let subtitle = Some(self.router.get(i).root.display().to_string());
 
             let (action, response) = ContextItem {
                 is_active,
@@ -339,7 +334,6 @@ impl PlexiApp {
             if delete_context.is_none() {
                 let num_ctxs = num_contexts;
                 let cwd_for_menu = focused_cwd.clone();
-                let has_root = self.router.get(i).root.is_some();
                 response.context_menu(|ui| {
                     if ui.button("Rename").clicked() {
                         menu_action = Some((i, WindowMenuAction::Rename));
@@ -377,22 +371,10 @@ impl PlexiApp {
                             ui.close();
                         }
                     }
-                    {
-                        let label = if has_root {
-                            "Edit root\u{2026}"
-                        } else {
-                            "Set root\u{2026}"
-                        };
-                        if ui.button(label).clicked() {
-                            menu_action = Some((i, WindowMenuAction::OpenRootOverlay));
-                            ui.close();
-                        }
+                    if ui.button("Edit root\u{2026}").clicked() {
+                        menu_action = Some((i, WindowMenuAction::OpenRootOverlay));
+                        ui.close();
                     }
-                    if has_root
-                        && ui.button("Clear root").clicked() {
-                            menu_action = Some((i, WindowMenuAction::ClearRoot));
-                            ui.close();
-                        }
                     if num_ctxs > 1 {
                         ui.separator();
                         if ui.button("Park").clicked() {
@@ -457,7 +439,7 @@ impl PlexiApp {
                     let ctx = self.router.get(i);
                     let ctx_name = ctx.name.clone();
                     let ctx_id = ctx.context_id;
-                    let subtitle = ctx.root.as_ref().map(|p| p.display().to_string());
+                    let subtitle = Some(ctx.root.display().to_string());
 
                     let pane_dots = self.sidebar_pane_dots(ctx_id, false);
 
@@ -670,22 +652,8 @@ impl PlexiApp {
                     self.set_context_root(path, Some(ctx_id));
                     self.save_workspace();
                 }
-                WindowMenuAction::ClearRoot => {
-                    log::info!("sidebar: clear context root ctx_idx={i}");
-                    self.router.get_mut(i).root = None;
-                    if i == self.router.active_idx() {
-                        self.apply_context_transition_effects();
-                    }
-                    self.save_workspace();
-                }
                 WindowMenuAction::OpenRootOverlay => {
-                    let existing = self
-                        .router
-                        .get(i)
-                        .root
-                        .as_ref()
-                        .map(|p| p.display().to_string())
-                        .unwrap_or_default();
+                    let existing = self.router.get(i).root.display().to_string();
                     log::info!("TextInputOverlay: opened target=ContextRoot({i}) via sidebar");
                     self.text_overlay_browse_rx = None;
                     self.text_overlay = Some((
@@ -752,8 +720,7 @@ mod tests {
         let context_id = 41;
         app.router.push(crate::host::context::Context {
             name: "return target".to_string(),
-            path: std::path::PathBuf::from("/tmp"),
-            root: None,
+            root: std::path::PathBuf::from("/tmp"),
             description: None,
             context_id,
             parent_id: None,

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -788,8 +788,7 @@ mod tests {
             // Register the child context so the portal header shows a real name.
             app.router.push(crate::host::context::Context {
                 name: "Notes".to_string(),
-                path: editor_path.clone(),
-                root: None,
+                root: editor_path.clone(),
                 description: Some("Editing notes".to_string()),
                 context_id: child_ctx_id,
                 parent_id: Some(active_ctx_id),
@@ -1219,8 +1218,7 @@ mod tests {
             app.parked_section_expanded = false;
             let mk = |id: u64, name: &str| crate::host::context::Context {
                 name: name.to_string(),
-                path: std::env::temp_dir().join(name),
-                root: None,
+                root: std::env::temp_dir().join(name),
                 description: None,
                 context_id: id,
                 parent_id: None,
@@ -1243,8 +1241,10 @@ mod tests {
             .expect("render failed");
 
         // The parked header sits under the "Contexts" header and active row;
-        // click its shared fixed-height hit target near the chevron.
-        let click = egui::pos2(28.0, 126.0);
+        // click its shared fixed-height hit target near the chevron. The
+        // active row is two lines tall since stint 0651 (every context shows
+        // its root as a subtitle), which pushes the header down.
+        let click = egui::pos2(28.0, 147.0);
         h.harness()
             .input_mut()
             .events
@@ -1291,8 +1291,7 @@ mod tests {
             // Add a second active context so there is a drag source + a list.
             app.router.push(crate::host::context::Context {
                 name: "second".to_string(),
-                path: std::env::temp_dir().join("second"),
-                root: None,
+                root: std::env::temp_dir().join("second"),
                 description: None,
                 context_id: 71_001,
                 parent_id: None,
@@ -1336,8 +1335,7 @@ mod tests {
             // second master's sidebar number from 2 to 3.
             app.router.push(crate::host::context::Context {
                 name: "child-of-one".to_string(),
-                path: std::env::temp_dir().join("child-of-one"),
-                root: None,
+                root: std::env::temp_dir().join("child-of-one"),
                 description: None,
                 context_id: child_ctx_id,
                 parent_id: Some(parent_ctx_id),
@@ -1346,8 +1344,7 @@ mod tests {
             });
             app.router.push(crate::host::context::Context {
                 name: "master-two".to_string(),
-                path: std::env::temp_dir().join("master-two"),
-                root: None,
+                root: std::env::temp_dir().join("master-two"),
                 description: None,
                 context_id: 72_002,
                 parent_id: None,
@@ -1444,8 +1441,7 @@ mod tests {
             // index the old raw-index walk would have landed on.
             app.router.push(crate::host::context::Context {
                 name: "child-of-one".to_string(),
-                path: std::env::temp_dir().join("child-of-one"),
-                root: None,
+                root: std::env::temp_dir().join("child-of-one"),
                 description: None,
                 context_id: child_ctx_id,
                 parent_id: Some(parent_ctx_id),
@@ -1454,8 +1450,7 @@ mod tests {
             });
             app.router.push(crate::host::context::Context {
                 name: "master-two".to_string(),
-                path: std::env::temp_dir().join("master-two"),
-                root: None,
+                root: std::env::temp_dir().join("master-two"),
                 description: None,
                 context_id: 72_002,
                 parent_id: None,
@@ -2489,8 +2484,7 @@ mod tests {
             app.next_window_id += 1;
             app.router.push(crate::host::context::Context {
                 name: "squad-alpha".to_string(),
-                path: browser_root.clone(),
-                root: Some(browser_root.clone()),
+                root: browser_root.clone(),
                 description: None,
                 context_id: squad_ctx_id,
                 parent_id: None,
@@ -3153,8 +3147,7 @@ mod tests {
             let plexi_root = std::env::temp_dir().join("GitHub/PLEXI");
             app.router.push(crate::host::context::Context {
                 name: "PLEXI".to_string(),
-                path: plexi_root.clone(),
-                root: Some(plexi_root.clone()),
+                root: plexi_root.clone(),
                 description: None,
                 context_id: plexi_ctx_id,
                 parent_id: None,
@@ -3183,8 +3176,7 @@ mod tests {
                 let root = std::env::temp_dir().join(dir);
                 app.router.push(crate::host::context::Context {
                     name: name.to_string(),
-                    path: root.clone(),
-                    root: Some(root),
+                    root: root,
                     description: None,
                     context_id: ctx_id,
                     parent_id: None,
@@ -3352,8 +3344,7 @@ mod tests {
                     let root = std::env::temp_dir().join(dir);
                     app.router.push(crate::host::context::Context {
                         name: name.to_string(),
-                        path: root.clone(),
-                        root: Some(root),
+                        root: root,
                         description: None,
                         context_id: ctx_id,
                         parent_id: None,

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -562,8 +562,7 @@ mod tests {
     fn context_serde_round_trip() {
         let ctx = Context {
             name: "dev".to_string(),
-            path: PathBuf::from("/projects/dev"),
-            root: Some(PathBuf::from("/projects/dev/src")),
+            root: PathBuf::from("/projects/dev/src"),
             description: Some("main workspace".to_string()),
             context_id: 42,
             parent_id: Some(1),
@@ -576,12 +575,13 @@ mod tests {
         assert_eq!(restored.context_id, 42);
         assert_eq!(restored.parent_id, Some(1));
         assert_eq!(restored.depth, 1);
-        assert_eq!(restored.root, Some(PathBuf::from("/projects/dev/src")));
+        assert_eq!(restored.root, PathBuf::from("/projects/dev/src"));
     }
 
-    /// Legacy workspace JSON without optional Context fields deserializes with defaults.
+    /// Legacy workspace JSON written before the path→root collapse: a
+    /// required `path` and no `root`. The anchor folds to `path`.
     #[test]
-    fn legacy_context_without_optional_fields_deserializes() {
+    fn legacy_context_with_only_path_deserializes() {
         let legacy_json = r#"{
             "name": "old-ctx",
             "path": "/tmp",
@@ -593,7 +593,36 @@ mod tests {
         assert_eq!(restored.context_id, 7);
         assert_eq!(restored.parent_id, None);
         assert_eq!(restored.depth, 0);
-        assert_eq!(restored.root, None);
+        assert_eq!(restored.root, PathBuf::from("/tmp"));
         assert_eq!(restored.description, None);
+    }
+
+    /// Legacy workspace JSON carrying both `path` and an explicit `root`
+    /// keeps the root — it was the field `set-root` wrote and the only one
+    /// that affected behavior.
+    #[test]
+    fn legacy_context_with_path_and_root_prefers_root() {
+        let legacy_json = r#"{
+            "name": "old-ctx",
+            "path": "/tmp",
+            "root": "/projects/dev",
+            "context_id": 7
+        }"#;
+        let restored: Context =
+            serde_json::from_str(legacy_json).expect("legacy Context must deserialize");
+        assert_eq!(restored.root, PathBuf::from("/projects/dev"));
+    }
+
+    /// A context with neither `root` nor legacy `path` is corrupt and must
+    /// fail loudly (naming the context), never half-load a layout.
+    #[test]
+    fn context_without_root_or_path_fails_loudly() {
+        let corrupt_json = r#"{
+            "name": "broken-ctx",
+            "context_id": 9
+        }"#;
+        let error = serde_json::from_str::<Context>(corrupt_json)
+            .expect_err("context without root or path must not deserialize");
+        assert!(error.to_string().contains("broken-ctx"), "{error}");
     }
 }

--- a/src/workspace/router.rs
+++ b/src/workspace/router.rs
@@ -330,8 +330,7 @@ mod tests {
     fn make_ctx(id: u64, parent_id: Option<u64>, depth: u32) -> Context {
         Context {
             name: format!("ctx{id}"),
-            path: PathBuf::from("/tmp"),
-            root: None,
+            root: PathBuf::from("/tmp"),
             description: None,
             context_id: id,
             parent_id,

--- a/src/workspace/secrets.rs
+++ b/src/workspace/secrets.rs
@@ -691,8 +691,9 @@ pub fn init_workspace(workspace_root: &Path, channel_dir: &str) -> Result<Worksp
 
 /// Ensure channel-neutral app state cannot be committed with a context root.
 ///
-/// Existing user rules are preserved byte-for-byte and the required entry is
-/// appended only when absent.
+/// App state is personal, single-user, local data — never committed, never
+/// shared. Existing user rules are preserved byte-for-byte and the required
+/// entry is appended only when absent.
 pub(crate) fn ensure_app_state_gitignore(workspace_root: &Path) -> Result<(), String> {
     use std::io::Write;
 
@@ -722,6 +723,7 @@ pub(crate) fn ensure_app_state_gitignore(workspace_root: &Path) -> Result<(), St
     file.sync_all()
         .map_err(|error| format!("sync {}: {error}", path.display()))
 }
+
 
 /// Default contents for `<root>/.plexi/.gitignore`. Anything that holds a
 /// secret value or is generated host state lives here.
@@ -1345,6 +1347,42 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(gitignore).unwrap(),
             "# personal\ncustom/\napp_states/\n"
+        );
+    }
+
+    /// The standing ruling made effective: in a real git repository, a state
+    /// file under `<root>/.plexi/app_states/` must be invisible to git after
+    /// the ensure runs — a user cannot accidentally commit their app state.
+    #[test]
+    fn app_state_gitignore_is_effective_in_a_real_repo() {
+        let repo = tempfile::tempdir().unwrap();
+        let git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(repo.path())
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .output()
+                .expect("run git")
+        };
+        assert!(git(&["init", "-q"]).status.success(), "git init");
+
+        ensure_app_state_gitignore(repo.path()).expect("ensure gitignore");
+        let state_dir = repo.path().join(".plexi").join("app_states");
+        std::fs::create_dir_all(&state_dir).unwrap();
+        std::fs::write(state_dir.join("todo.json"), b"{\"k\":1}").unwrap();
+
+        let check = git(&["check-ignore", "-q", ".plexi/app_states/todo.json"]);
+        assert!(
+            check.status.success(),
+            "git must ignore the state file (check-ignore exit {:?})",
+            check.status.code()
+        );
+        let status = git(&["status", "--porcelain"]);
+        let listing = String::from_utf8_lossy(&status.stdout).to_string();
+        assert!(
+            !listing.contains("app_states"),
+            "git status must not surface app state: {listing:?}"
         );
     }
 

--- a/website/src/content/docs/sdk.md
+++ b/website/src/content/docs/sdk.md
@@ -28,14 +28,25 @@ is no ambient process access to escape to. See `docs/wasm-runtime.md`
 ### `SetState`
 
 ```python
-SetState(data: dict)
+SetState(data: dict, scope: str | None = None)
 ```
+
+Merge ``data`` into in-memory state. ``scope`` selects which declared
+state scope receives the keys; ``None`` means the app's default scope
+(the first entry of the manifest's ``[state] scopes``). Using a scope the
+app did not declare raises at apply time — never a silent fallback.
 
 ### `PersistState`
 
 ```python
-PersistState(data: dict)
+PersistState(data: dict, scope: str | None = None)
 ```
+
+Merge ``data`` into a scope's state and persist that scope's snapshot
+to disk. The host owns path construction: ``global`` state lives in
+``~/.plexi/app_states/``, ``context`` state in
+``<context_root>/.plexi/app_states/`` — resolved against the pane's
+context root at call time. ``scope=None`` targets the default scope.
 
 ### `SetSchedulerMode`
 
@@ -463,18 +474,23 @@ PaymentFailed(reason: str)
 ### `StateSnapshot`
 
 ```python
-StateSnapshot(values: Mapping[str, Any], raw_values: Mapping[str, bytes])
+StateSnapshot(values: Mapping[str, Any], raw_values: Mapping[str, bytes], scoped: Mapping[str, Mapping[str, Any]] = dict(), scopes: tuple[str, ...] = ('global',))
 ```
 
 ### `StateProxy`
 
-#### `get(key: str, default: Any = None)`
+#### `get(key: str, default: Any = None, scope: Optional[str] = None)`
 
 #### `raw(key: str)`
 
-#### `all()`
+#### `all(scope: Optional[str] = None)`
 
-#### `set(key: str, value: Any)`
+#### `set(key: str, value: Any, scope: Optional[str] = None)`
+
+#### `scopes()`
+
+The scopes this app declared in its manifest, ordered; the first
+entry is the default scope.
 
 
 ### `LogProxy`


### PR DESCRIPTION
Implements stint 0651 and stint 0652 (no linked GitHub issues; stint is authoritative).

## Stint 0651 — collapse `Context.path` into a non-optional `Context.root`

`Context` carried two path-shaped fields that never reconciled. `path` is deleted; `root` is now a non-optional `PathBuf` — every context is anchored to exactly one directory.

**Refactor constraint audit** — every site that previously handled `root: None`, and what happens there now:

| Site | Old behavior (root unset) | Now |
|---|---|---|
| `resolve_new_pane_cwd` (layout.rs) | fell through to focused-pane cwd → home | override → root. Every live creation site already set `root: Some(...)` at creation on alpha, so root-first was already the shipped behavior; the focused-cwd fallback was dead outside legacy saves. No behavior variant needed. |
| `notes.rs::context_scope_root` | `root.unwrap_or(path)` | `root` — identical value by construction |
| Sidebar subtitle | shown only when root set | always shows the root path |
| Sidebar "Clear root" menu item + `WindowMenuAction::ClearRoot` | reset to rootless | deleted — a rootless context no longer exists in the model |
| Root overlay empty-input commit (misc.rs) | cleared the root | no-op, logged; empty input leaves the root unchanged |
| `PLEXI_CONTEXT_ROOT` env stamping (`make_backend_settings`) | stamped only when root set | stamped for every pane of a resolved context |
| `apply_context_transition_effects` | cwd/home fallback | active root, always |
| `render.rs` behavior `workspace_root` | TTL-cached cwd-walk fallback (`fallback_workspace_root`, #2023) | active root; the fallback fn and its cache field are deleted |
| `tick_scheduler` / routine roots | only rooted contexts loaded routines | every context root is scanned (routine files simply don't exist under most anchors) |
| Default context at boot | `path`=cwd, `root`=home | root = anchor root when a `.plexi` anchor is detected, else home (unchanged behavior) |
| Sub-context creation | child inherited `(path, root)` pair | child root = parent root |

**Workspace JSON migration (the risk item, handled explicitly):** `Context` now has a hand-written `Deserialize`. Legacy files: `root` wins when present (it was the only field `set-root` wrote), else `path`. A context with neither fails loudly naming the context — never a half-loaded layout. Serialization writes only `root`. Tests: `legacy_context_with_only_path_deserializes`, `legacy_context_with_path_and_root_prefers_root`, `context_without_root_or_path_fails_loudly`.

## Stint 0652 — state scope resolver, `[state] scopes` manifest key, path rules

New module `src/host/state_scope.rs` owns the two rules:

```
global   →  ~/.plexi/app_states/<app_id>.<ext>        (channel-neutral, deliberately NOT config_dir())
context  →  <context.root>/.plexi/app_states/<app_id>.<ext>
```

- `[state] scopes = ["global", "context"]` in the manifest — ordered, first is the default. Omitted `[state]` → `["global"]`. Unknown value, empty list, or duplicate **fails install and launch loudly** (validated in `AppRegistry::load_app` and `PythonLaunchConfig::from_manifest_file`); using an undeclared scope at persist time is an error, never a silent fallback to another scope.
- **Call-time resolution:** the render loop pushes the window's context root into each app pane every frame (`PlexiBehavior.context_root` → `AppRuntime::refresh_context_root` → `LivePythonPane.context_root`), and persists resolve against that live value — not the launch-captured `workspace_root`, which now serves only the fs jail. `plexi context set-root` immediately redirects where context-scoped state lands (proven by `state_persist_resolves_against_live_context_root_and_rejects_undeclared_scope`, which boots the real CPython WASM runtime).
- **SDK:** `PersistState`/`SetState` gain `scope=`, `state.get/all` gain `scope=`, `state.scopes()` added. Init wire carries `state_scopes` + per-scope `states` (flat `state` kept for the default scope). New pytest file `sdk/python/tests/test_state_scopes.py` (5 tests).
- **Gitignore ruling (standing, not relitigated):** `<context_root>/.plexi/app_states/` is personal single-user local data. `ensure_app_state_gitignore` (in `src/workspace/secrets.rs`, byte-identical semantics to PR 2531's helper) runs at context creation, `set-context-root` (via `auto_init_workspace`), and on every context-scope persist. `app_state_gitignore_is_effective_in_a_real_repo` runs a real `git init` + `check-ignore` + `status --porcelain` and asserts the state file is invisible to git.
- The `app_states` directory name is consciously kept (per task; no rename).

**Out of scope, unchanged:** the Rust‑WASM component pane's KV store (`wasm_state_path` sanitize scheme) still uses its launch-time path; 0644 builds on this resolver and owns that conversion, along with the watcher/atomic-write work. `plexi app state get/set` is 0645.

## Interaction with PR #2531 (stint 0648, open at time of writing)

0652 is `blocked_by` 0648 in the graph. 2531 had not merged when this branch was cut, so this PR builds on alpha but was designed against 2531's diff directly: same channel-neutral `.plexi` direction, and `ensure_app_state_gitignore` is copied verbatim so whichever PR merges second resolves to identical code. Expect a mechanical conflict in `src/host/wasm_python.rs` (2531 rewrites `python_state_path`/`load_python_state` for orphan adoption; this PR replaces them with the scope resolver) — resolution: keep this PR's resolver shape, graft 2531's orphan-adoption pass on top of the `global`/`context` load path.

## Parked Questions (morning look, nothing blocking)

1. **Sub-context state visibility** (task open question): implemented as *child root defaults to parent root*, so a sub-context shares its parent's context-scoped state until explicitly re-rooted — no inheritance chain, the resolver just uses the context's own root. Reversal is cheap if you want isolated-by-default.
2. **Sidebar rows now always show the root path as subtitle** (there is no "no root" state left). If that's too dense, the alternative is suppressing the subtitle when root == home.
3. **`set-root` leaves old context-scoped files in the old root** (task recommendation followed: state lives with the directory, not the context).

## Review status

Codex CLI is out of credits until Aug 5 (usage limit), so the Phase-4 AI diff review did not run — this diff ships without an AI review layer. CI's `claude` check is conditional and skips Rust-only diffs.

## Test evidence

- `cargo test --bin plexi` (env-stripped, memory-watchdogged): final run **2136 passed; 1 failed; 5 ignored** (196s→113s). The single failure, `headless_frame_fails_fast_when_the_guest_dies_at_import`, is a 15s-budget timing test that fails identically on **clean alpha** under fleet load and passes on this branch when run individually (12.3s) — pre-existing load flake, not this diff. The 3 diff-caused failures from the first run were real test updates (obsolete rootless-fallback test rewritten, assistant store assertions moved to context roots, parked-header click coordinate updated for the two-line row) and are green.
- SDK pytest: 249 passed, 1 skipped, 1 failed — the failure (`test_dunder_version_matches_pyproject`) reproduces identically on clean alpha under the same invocation (`uv run --with pytest`) and is unrelated to this diff. New `test_state_scopes.py`: 5/5 green.
- mypy `sdk/python/plexi_sdk/`: clean (27 files).
- `just check-sdk-docs`: regenerated `website/src/content/docs/sdk.md` committed, check green.
- Headless render: `/tmp/plexi_parked_dropdown_collapsed.png` (PlexiUiHarness sidebar render, visually reviewed) — context rows now show the root subtitle; parked header layout verified after the shift
- Conclusion: install skippable — behavior is fully covered by harness/unit/pytest layers plus a real-runtime persist test; a separate tester pane owns the live round.
