### PR TITLE
DO NOT MERGE: alpha test-suite CI baseline, zero skips (stint 0649)

### DIFF
--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -1,0 +1,44 @@
+name: Rust host
+
+on:
+  pull_request:
+    branches: [alpha]
+
+env:
+  PLEXI_CPYTHON_BUNDLE_DIR: /Users/runner/.plexi-ci/wasm-bundles
+
+jobs:
+  test:
+    name: test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Restore Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Restore CPython WASI bundle cache
+        uses: actions/cache@v4
+        with:
+          path: /Users/runner/.plexi-ci/wasm-bundles
+          key: cpython-wasi-3.12.12-wasi_sdk-20
+
+      - name: Prefetch verified CPython WASI bundle
+        run: bash scripts/fetch-cpython-bundle.sh
+
+      - name: Test host (NO skips - alpha baseline probe)
+        run: >-
+          env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID
+          -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID
+          cargo test --bin plexi


### PR DESCRIPTION
Measures which tests fail on clean alpha in the CI environment with no skips. Workflow file is the only change (the measuring instrument). Will be closed and deleted after the run. Never merge.