### PR TITLE
fix(host): restore green clippy on alpha — drop needless &Path borrows

### DIFF
--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -1512,7 +1512,7 @@ fn adopt_python_state_orphan(
             parent.display()
         )));
     }
-    let (mut destination_file, remove_source) = match std::fs::hard_link(&source, destination) {
+    let (mut destination_file, remove_source) = match std::fs::hard_link(source, destination) {
         Ok(()) => match std::fs::OpenOptions::new()
             .read(true)
             .write(true)
@@ -1541,7 +1541,7 @@ fn adopt_python_state_orphan(
                 source.display(),
                 destination.display()
             );
-            match copy_python_state_orphan_no_clobber(config, &source, destination) {
+            match copy_python_state_orphan_no_clobber(config, source, destination) {
                 Ok(file) => (file, false),
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
                     log::warn!(
@@ -1561,11 +1561,11 @@ fn adopt_python_state_orphan(
         }
     };
     if let Err(error) =
-        verify_python_state_adoption(config, &source, destination, &mut destination_file)
+        verify_python_state_adoption(config, source, destination, &mut destination_file)
     {
         let reason = match cleanup_created_python_state(
             config,
-            &source,
+            source,
             destination,
             &destination_file,
         ) {
@@ -1583,7 +1583,7 @@ fn adopt_python_state_orphan(
         );
         return Ok(());
     }
-    if let Err(error) = std::fs::remove_file(&source) {
+    if let Err(error) = std::fs::remove_file(source) {
         return Err(adoption_error(format!(
             "destination verified but source removal failed: {error}"
         )));


### PR DESCRIPTION
## Why

Alpha HEAD fails the Rust CI clippy job. PR #2529 turned on the `cargo clippy --bin plexi -- -D warnings` gate, and PR #2531 landed afterwards carrying five lint errors, all in `adopt_python_state_orphan` in `src/host/wasm_python.rs`.

The lints are correct, not false positives. `source` is already a `&Path` parameter, so every `&source` constructed a `&&Path` that the compiler immediately re-dereferenced (or that got auto-deref'd into a generic `AsRef<Path>` bound). No `#[allow]` suppressions were used.

## What

Five call sites now pass `source` directly:

- `std::fs::hard_link(source, destination)` — was `needless_borrows_for_generic_args`
- `copy_python_state_orphan_no_clobber(config, source, destination)` — was `needless_borrow`
- `verify_python_state_adoption(config, source, ...)` — was `needless_borrow`
- `cleanup_created_python_state(config, source, ...)` — was `needless_borrow`
- `std::fs::remove_file(source)` — was `needless_borrows_for_generic_args`

No behavior change; the generated code was already identical after deref.

## Verification

Full gate run in a clean worktree branched from `origin/alpha`:

- `cargo clippy --bin plexi -- -D warnings` — clean
- `cargo build` — ok
- `cargo test --bin plexi` (with the documented `headless_frame_fails_fast_when_the_guest_dies_at_import` skip from the CI workflow) — **2149 passed, 0 failed, 5 ignored**