### PR TITLE
feat(build): bs- recipe namespace — deterministic babysitter lane mechanics (stints 0675, 0676)

### DIFF
--- a/.agents/skills/implement-stint/SKILL.md
+++ b/.agents/skills/implement-stint/SKILL.md
@@ -174,28 +174,15 @@ Stop if the linked issue is closed or already labeled `in progress`, unless this
 
 ## Phase 2 - Claim, Create Worktree, Name Pane
 
-Build a short slug from the task title: lowercase, ASCII, words separated by `-`, no punctuation, max about 8 words.
-
-For fresh work, claim then immediately create the worktree. `stint` owns task state; no git commit is needed:
+For fresh work, one recipe owns the mechanics — alpha clean/synced assertions, worktree mint from alpha HEAD, base verification, slug derivation, and the claim (`stint` owns task state; no git commit is needed):
 
 ```bash
-stint claim <task-id>
+just bs-start <task-id>
 ```
 
-Create the worktree from alpha HEAD:
+Its last output line is the worktree path. On failure it names exactly what is wrong and where — fix that, or run `just bs-reset <task-id>` to wipe the lane and start over. Never hand-roll the `stint claim` / `wtp add` / base-verification sequence.
 
-```bash
-wtp add -b feature/stint-<task-id>-<short-slug> HEAD
-```
-
-Verify the worktree base:
-
-```bash
-git -C worktrees/feature/stint-<task-id>-<short-slug> log --oneline -1
-git log --oneline -1
-```
-
-If the commits differ, delete the new worktree/branch and recreate it before touching code.
+For a multi-task batch (worker mode), pass every id — `just bs-start <id> <id> ...` claims them all and mints the multi-id branch `feature/stint-<id>[-<id>...]-<slug>` that `just merge-pr` resolves.
 
 Name the pane:
 

--- a/.agents/skills/validate-pr/SKILL.md
+++ b/.agents/skills/validate-pr/SKILL.md
@@ -102,7 +102,7 @@ Hard stops:
 - The PR is closed or merged.
 - You are about to edit files before the guard above has passed.
 
-While handling validation feedback, `just install` is banned. Reinstall only with `just pr-install $PR_NUMBER` from `WORKTREE`.
+While handling validation feedback, `just install` is banned. Reinstall only with `just bs-validate-setup $PR_NUMBER`.
 
 ---
 
@@ -144,43 +144,14 @@ If skipping → mark Install row as `skipped — <reason>`, proceed to Step 3 (w
 
 ## Step 2 — Install
 
-**Worktree gate — run this exact sequence. No shortcuts.**
+One recipe owns the mechanics — PR/branch/worktree resolution, the install, and provenance. `just pr-install` resolves and builds the PR's actual head itself (cwd-independent), so there is nothing to hand-derive here:
 
 ```bash
-# 1. Resolve WORKTREE from the alpha root — never from git rev-parse (returns CWD's worktree).
-ALPHA_ROOT=$(git worktree list --porcelain | awk '
-  /^worktree / { path=$2 }
-  /^branch refs\/heads\/alpha$/ { print path; exit }
-')
-test -n "$ALPHA_ROOT" || { echo "HARD STOP: could not resolve alpha worktree"; exit 1; }
-WORKTREE="$ALPHA_ROOT/worktrees/$BRANCH"
-test -d "$WORKTREE" || { echo "HARD STOP: feature worktree not found: $WORKTREE"; exit 1; }
-
-# 2. Verify the worktree is on the right branch before touching anything.
-ACTIVE_BRANCH=$(git -C "$WORKTREE" branch --show-current)
-test "$ACTIVE_BRANCH" = "$BRANCH" || { echo "HARD STOP: worktree branch mismatch: $ACTIVE_BRANCH != $BRANCH"; exit 1; }
-cd "$WORKTREE"
-
-# 3. Run install and capture output to check for actual recompile.
-INSTALL_OUT=$(just pr-install $PR_NUMBER 2>&1)
-echo "$INSTALL_OUT"
-
-# 4. Hard stop if no compile happened — binary would be stale alpha code.
-if ! echo "$INSTALL_OUT" | grep -q "Compiling plexi"; then
-  echo "WARNING: no 'Compiling plexi' in output — binary may be cached from wrong worktree."
-  echo "Forcing recompile..."
-  # Touch every changed file to invalidate cargo's cache for this worktree.
-  git diff --name-only origin/alpha...HEAD | grep '\.rs$' | xargs -I{} touch "$WORKTREE/{}" 2>/dev/null || true
-  INSTALL_OUT=$(just pr-install $PR_NUMBER 2>&1)
-  echo "$INSTALL_OUT"
-  if ! echo "$INSTALL_OUT" | grep -q "Compiling plexi"; then
-    echo "HARD STOP: still no recompile after touch. Binary source is unknown. Do not proceed."
-    exit 1
-  fi
-fi
-
-PR_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*= "//' | tr -d '"')
+eval "$(just bs-validate-setup $PR_NUMBER | tee /dev/stderr | grep -E '^(BRANCH|WORKTREE|HEAD)=')"
+PR_VERSION=$(grep '^version' "${WORKTREE:-.}/Cargo.toml" | head -1 | sed 's/.*= "//' | tr -d '"')
 ```
+
+The recipe fails loudly (and publishes a `validate:failed` slot report) when the PR is not open or the install fails — stop and report; never hand-roll the install or fall back to `just install`. Provenance (PR, head sha, worktree) is appended to `~/.plexi-pr-<N>/install.log`.
 
 Wait for completion. The binary is now installed (`$PR_VERSION`). Move immediately to Step 3.
 
@@ -355,7 +326,7 @@ git commit -m "fix: <description>"
 git push
 ```
 
-Run `cargo build` from `WORKTREE` to confirm the fix compiles, then reinstall using the Step 2 worktree gate (verify branch, run install, hard stop if no "Compiling plexi" in output). Never run `just install` during validation. Re-surface the testing block (which flips status back to `needs-you`). Do not expand scope.
+Run `cargo build` from `WORKTREE` to confirm the fix compiles, then reinstall with `just bs-validate-setup $PR_NUMBER` (Step 2). Never run `just install` during validation. Re-surface the testing block (which flips status back to `needs-you`). Do not expand scope.
 
 Append to Ship Log:
 ```markdown
@@ -391,7 +362,7 @@ git commit -m "fix: <description from failure>"
 git push
 ```
 
-Run `cargo build` from `WORKTREE` to confirm the fix compiles, then reinstall using the Step 2 worktree gate (verify branch, run install, hard stop if no "Compiling plexi" in output). Never run `just install` during validation.
+Run `cargo build` from `WORKTREE` to confirm the fix compiles, then reinstall with `just bs-validate-setup $PR_NUMBER` (Step 2). Never run `just install` during validation.
 
 Append to Ship Log:
 ```markdown
@@ -509,9 +480,8 @@ pipeline_slots_set validate "$ISSUE_NUMBER" "$PR_NUMBER" needs-you "Review the d
 - `modify` is only valid if pass criteria not yet met
 - A user reply after a `[TESTING]` block stays inside `/validate-pr` by default, even after context compaction
 - Before any validation fix, rehydrate the PR with Step 0b and move into `WORKTREE`; no edits from repo root
-- `just install` is forbidden during validation; only `just pr-install $PR_NUMBER` from `WORKTREE`
-- Every `just pr-install` must produce a "Compiling plexi" line. If absent, binary is cached from the wrong worktree — hard stop, touch changed files, retry. Do not surface a testing block until the recompile is confirmed.
-- Always resolve `WORKTREE` from `git worktree list --porcelain` + alpha branch match, never from `git rev-parse --show-toplevel` (returns CWD's worktree, which may be wrong after context compaction)
+- `just install` is forbidden during validation; reinstall only via `just bs-validate-setup $PR_NUMBER` (which runs `just pr-install` against the PR's actual head)
+- Always resolve `WORKTREE` from `just bs-validate-setup`'s output (or `git worktree list --porcelain` + alpha branch match), never from `git rev-parse --show-toplevel` (returns CWD's worktree, which may be wrong after context compaction)
 - Never commit or release-bump `alpha`, `beta`, or `main` while handling `pass`, `fail`, or `modify`
 - Attempt count comes from the Ship Log, not arguments
 - Max 3 soft rejects. Hard reject requires explicit confirmation unless user already typed "fail" 3 times.

--- a/justfile
+++ b/justfile
@@ -472,6 +472,33 @@ merge-close ISSUE PR:
 merge-close-stints PR +STINTS:
     bash scripts/merge-pr.sh close-stints {{PR}} {{STINTS}}
 
+# Babysitter pipeline mechanics (bs- namespace): deterministic lane operations
+# so agent transcripts carry judgment only. Each publishes a typed JSON slot
+# report via scripts/bs-slot.sh.
+
+# Start a stint lane: assert alpha clean+synced, mint the wtp worktree from
+# alpha HEAD, claim the stint(s). Multiple ids = one batch lane (one worktree,
+# multi-id branch, one PR). Last output line is the worktree path.
+bs-start +stints:
+    bash scripts/bs-start.sh {{stints}}
+
+# Start-over button: force-wipe the stint's worktree+branch, uninstall its
+# plexi-pr-* build, unclaim, then re-run bs-start. Idempotent.
+bs-reset stint:
+    bash scripts/bs-reset.sh {{stint}}
+
+# Validation setup: resolve branch/worktree from the PR, run `just pr-install`.
+# Prints BRANCH= / WORKTREE= / HEAD= lines for the calling skill.
+bs-validate-setup pr:
+    bash scripts/bs-validate-setup.sh {{pr}}
+
+# Merge + retire the lane: `just merge-pr`, uninstall plexi-pr-<N>, confirm
+# the worktree was reaped (hard error if it survived).
+#   just bs-merge 2542
+#   just bs-merge 2542 no-issue
+bs-merge pr *flags:
+    bash scripts/bs-merge.sh {{pr}} {{flags}}
+
 # Dispatch Claude agents at one or more issues. Labels each "in progress" first
 # to prevent double-claiming when multiple dispatches run close together.
 # TODO: replace `c` with `claude --dangerously-skip-permissions` once this flow

--- a/scripts/bs-merge.sh
+++ b/scripts/bs-merge.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# bs-merge.sh — merge a validated PR and fully retire its lane (bs- pipeline).
+#
+# Usage: bs-merge.sh <pr-number> [merge-pr flags, e.g. no-issue]
+#
+# Wraps `just merge-pr` (rebase → squash → sync → cleanup → close), then
+# uninstalls the plexi-pr-<N> build, confirms the feature worktree was reaped
+# (hard error if not), and publishes a final slot report.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -lt 1 ]]; then
+  echo "bs-merge: missing PR number. Usage: just bs-merge <pr> [flags]" >&2
+  exit 1
+fi
+pr="$1"; shift
+
+alpha_root="$(git worktree list --porcelain | awk '
+  /^worktree / { path=substr($0, 10) }
+  /^branch refs\/heads\/alpha$/ { print path; exit }
+')"
+if [[ -z "$alpha_root" ]]; then
+  echo "bs-merge: could not resolve the alpha worktree from 'git worktree list'." >&2
+  exit 1
+fi
+
+branch="$(gh pr view "$pr" --json headRefName --jq '.headRefName' 2>/dev/null || true)"
+if [[ -z "$branch" ]]; then
+  echo "bs-merge: could not resolve PR #$pr via gh (gh pr view failed)." >&2
+  exit 1
+fi
+
+bash "$SCRIPT_DIR/bs-slot.sh" merge working "pr=$pr" "detail=merging $branch"
+rc=0
+(cd "$alpha_root" && just merge-pr "$pr" "$@") || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  bash "$SCRIPT_DIR/bs-slot.sh" merge failed "pr=$pr" "detail=merge-pr exited $rc"
+  echo "bs-merge: 'just merge-pr $pr' failed with exit $rc — recover with the merge-* sub-steps (see justfile), then re-run bs-merge only if the merge itself did not land." >&2
+  exit "$rc"
+fi
+
+# Retire the PR build. channel-clean is safe when nothing is installed.
+(cd "$alpha_root" && just channel-clean "pr-$pr")
+
+# merge-pr's cleanup owns worktree reaping — confirm it actually happened.
+worktree="$alpha_root/worktrees/$branch"
+git -C "$alpha_root" worktree prune
+if [[ -d "$worktree" ]]; then
+  bash "$SCRIPT_DIR/bs-slot.sh" merge failed "pr=$pr" "detail=worktree not reaped: $worktree"
+  echo "bs-merge: PR #$pr merged but its worktree survived cleanup: $worktree — inspect it (uncommitted files?), then remove with 'wtp remove -f $branch'." >&2
+  exit 1
+fi
+
+bash "$SCRIPT_DIR/bs-slot.sh" merge done "pr=$pr" "verdict=PASS" "detail=merged, pr-$pr uninstalled, worktree reaped"
+echo "bs-merge: PR #$pr merged; plexi-pr-$pr uninstalled; worktree reaped."

--- a/scripts/bs-reset.sh
+++ b/scripts/bs-reset.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# bs-reset.sh — the start-over button for a stint lane (bs- pipeline).
+#
+# Usage: bs-reset.sh <stint-id>
+#
+# Force-wipes the stint's worktree and local branch, uninstalls any
+# plexi-pr-<N> build whose PR heads that branch, unclaims the stint, then
+# re-runs bs-start. Idempotent: missing pieces are skipped with a note, never
+# an error. Refuses only when the stint is already done/archived.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -ne 1 ]]; then
+  echo "bs-reset: missing stint id. Usage: just bs-reset <stint-id>" >&2
+  exit 1
+fi
+stint_id="$1"
+
+alpha_root="$(git worktree list --porcelain | awk '
+  /^worktree / { path=substr($0, 10) }
+  /^branch refs\/heads\/alpha$/ { print path; exit }
+')"
+if [[ -z "$alpha_root" ]]; then
+  echo "bs-reset: could not resolve the alpha worktree from 'git worktree list'." >&2
+  exit 1
+fi
+
+# Refuse to reset finished work.
+shopt -s nullglob
+task_files=("$alpha_root/.stint/tasks/${stint_id}"-*.md)
+shopt -u nullglob
+if [[ ${#task_files[@]} -eq 0 ]]; then
+  echo "bs-reset: no task file matches .stint/tasks/${stint_id}-*.md in $alpha_root — check the id with 'stint list'." >&2
+  exit 1
+fi
+status="$(sed -n 's/^status: *//p' "${task_files[0]}" | head -1)"
+if [[ "$status" == "done" || "$status" == "archived" ]]; then
+  echo "bs-reset: stint $stint_id is '$status' — refusing to reset finished work." >&2
+  exit 1
+fi
+
+# Find this stint's lane branch(es). The id can sit anywhere in a multi-id
+# batch branch (feature/stint-<id>[-<id>...]-<slug>), so match by segment.
+branches="$(git -C "$alpha_root" for-each-ref --format='%(refname:short)' 'refs/heads/feature/stint-*' \
+  | grep -E "^feature/stint-([0-9]+-)*${stint_id}-" || true)"
+if [[ -z "$branches" ]]; then
+  echo "bs-reset: no local branch carries stint ${stint_id} (feature/stint-*${stint_id}-*) — nothing to wipe."
+fi
+
+for branch in $branches; do
+  # Uninstall any PR build whose open PR heads this branch.
+  pr="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+  if [[ -n "$pr" ]]; then
+    echo "bs-reset: uninstalling PR build plexi-pr-$pr (open PR #$pr heads $branch)"
+    (cd "$alpha_root" && just channel-clean "pr-$pr")
+  fi
+
+  worktree="$alpha_root/worktrees/$branch"
+  if [[ -d "$worktree" ]]; then
+    echo "bs-reset: force-removing worktree $worktree and branch $branch"
+    (cd "$alpha_root" && wtp remove -f --with-branch "$branch")
+  else
+    echo "bs-reset: no worktree at $worktree — deleting branch $branch"
+    git -C "$alpha_root" worktree prune
+    git -C "$alpha_root" branch -D "$branch"
+  fi
+done
+
+# Unclaim so bs-start's claim starts a fresh timing record.
+if [[ "$status" == "in-progress" ]]; then
+  (cd "$alpha_root" && stint unclaim "$stint_id")
+fi
+
+bash "$SCRIPT_DIR/bs-slot.sh" reset done "stint=$stint_id" "detail=lane wiped, restarting"
+exec bash "$SCRIPT_DIR/bs-start.sh" "$stint_id"

--- a/scripts/bs-slot.sh
+++ b/scripts/bs-slot.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# bs-slot.sh — publish a typed one-line JSON slot report for the bs- pipeline.
+#
+# Usage: bs-slot.sh <phase> <state> [stint=<id>] [pr=<n>] [verdict=<v>] [detail=<text>]
+#   phase: start | reset | validate | merge
+#   state: working | done | failed
+#
+# Writes {phase, state, stint, pr, verdict, detail} to the pane's `report` slot
+# and mirrors `<phase>:<state>` to the `status` slot (the babysitter head's
+# existing contract). Outside a pane (PLEXI_PANE_ID unset) the report is printed
+# to stdout instead — loudly, never silently dropped.
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "bs-slot: usage: bs-slot.sh <phase> <state> [stint=..] [pr=..] [verdict=..] [detail=..]" >&2
+  exit 1
+fi
+
+phase="$1"; state="$2"; shift 2
+stint=""; pr=""; verdict=""; detail=""
+for kv in "$@"; do
+  case "$kv" in
+    stint=*)   stint="${kv#stint=}" ;;
+    pr=*)      pr="${kv#pr=}" ;;
+    verdict=*) verdict="${kv#verdict=}" ;;
+    detail=*)  detail="${kv#detail=}" ;;
+    *) echo "bs-slot: unknown argument '$kv' (expected stint=/pr=/verdict=/detail=)" >&2; exit 1 ;;
+  esac
+done
+
+report="$(BS_PHASE="$phase" BS_STATE="$state" BS_STINT="$stint" BS_PR="$pr" BS_VERDICT="$verdict" BS_DETAIL="$detail" python3 - <<'PY'
+import json, os
+print(json.dumps({
+    "phase": os.environ["BS_PHASE"],
+    "state": os.environ["BS_STATE"],
+    "stint": os.environ["BS_STINT"] or None,
+    "pr": int(os.environ["BS_PR"]) if os.environ["BS_PR"] else None,
+    "verdict": os.environ["BS_VERDICT"] or None,
+    "detail": os.environ["BS_DETAIL"] or None,
+}))
+PY
+)"
+
+if [[ -z "${PLEXI_PANE_ID:-}" ]]; then
+  echo "bs-slot: no pane (PLEXI_PANE_ID unset) — report not published: $report"
+  exit 0
+fi
+
+if ! plexi pane slot write report "$report" --replace \
+  || ! plexi pane slot write status "${phase}:${state}" --replace; then
+  echo "bs-slot: slot write failed on pane $PLEXI_PANE_ID — report was: $report" >&2
+  exit 1
+fi
+echo "bs-slot: published $report"

--- a/scripts/bs-start.sh
+++ b/scripts/bs-start.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# bs-start.sh — deterministic start of a stint lane (bs- pipeline).
+#
+# Usage: bs-start.sh <stint-id> [<stint-id> ...]
+#
+# Asserts alpha is clean and synced with origin (hard error naming what and
+# where otherwise), mints the wtp worktree feature/stint-<id>[-<id>...]-<slug>
+# from alpha HEAD, verifies the base, claims every given stint, and publishes
+# a slot report. Multiple ids form one batch lane: one worktree, one PR, and
+# a branch name `just merge-pr` resolves all the stints from.
+# Safe from any cwd inside the repo. The last stdout line is the worktree path.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -lt 1 ]]; then
+  echo "bs-start: missing stint id. Usage: just bs-start <stint-id> [<stint-id> ...]" >&2
+  exit 1
+fi
+stint_ids=("$@")
+
+# Resolve the canonical alpha checkout — never the caller's cwd.
+alpha_root="$(git worktree list --porcelain | awk '
+  /^worktree / { path=substr($0, 10) }
+  /^branch refs\/heads\/alpha$/ { print path; exit }
+')"
+if [[ -z "$alpha_root" ]]; then
+  echo "bs-start: could not resolve the alpha worktree from 'git worktree list'." >&2
+  exit 1
+fi
+
+# Alpha must be clean.
+git -C "$alpha_root" update-index -q --refresh || true
+dirty="$(git -C "$alpha_root" status --porcelain)"
+if [[ -n "$dirty" ]]; then
+  echo "bs-start: alpha is dirty at $alpha_root — commit or restore these before starting a lane:" >&2
+  echo "$dirty" >&2
+  exit 1
+fi
+
+# Alpha must be synced with origin (neither ahead nor behind).
+git -C "$alpha_root" fetch -q origin alpha
+behind="$(git -C "$alpha_root" rev-list --count HEAD..origin/alpha)"
+ahead="$(git -C "$alpha_root" rev-list --count origin/alpha..HEAD)"
+if [[ "$behind" != "0" ]]; then
+  echo "bs-start: alpha at $alpha_root is $behind commit(s) behind origin/alpha — run 'git pull --rebase origin alpha' there first." >&2
+  exit 1
+fi
+if [[ "$ahead" != "0" ]]; then
+  echo "bs-start: alpha at $alpha_root has $ahead unpushed commit(s) — push or drop them before starting a lane." >&2
+  exit 1
+fi
+
+# Resolve every stint's task file; the first id's filename provides the slug.
+slug=""
+for stint_id in "${stint_ids[@]}"; do
+  shopt -s nullglob
+  task_files=("$alpha_root/.stint/tasks/${stint_id}"-*.md)
+  shopt -u nullglob
+  if [[ ${#task_files[@]} -eq 0 ]]; then
+    echo "bs-start: no task file matches .stint/tasks/${stint_id}-*.md in $alpha_root — check the id with 'stint list'." >&2
+    exit 1
+  fi
+  if [[ ${#task_files[@]} -gt 1 ]]; then
+    echo "bs-start: stint id '$stint_id' is ambiguous — matches: ${task_files[*]}" >&2
+    exit 1
+  fi
+  status="$(sed -n 's/^status: *//p' "${task_files[0]}" | head -1)"
+  if [[ "$status" == "done" || "$status" == "archived" ]]; then
+    echo "bs-start: stint $stint_id is '$status' (${task_files[0]}) — nothing to start." >&2
+    exit 1
+  fi
+  if [[ -z "$slug" ]]; then
+    slug="$(basename "${task_files[0]}" .md)"
+    slug="${slug#"${stint_id}"-}"
+    # Cap the slug at 6 hyphen-words to keep branch names sane.
+    slug="$(printf '%s' "$slug" | cut -d- -f1-6)"
+  fi
+done
+
+ids_joined="$(printf '%s-' "${stint_ids[@]}")"
+branch="feature/stint-${ids_joined}${slug}"
+worktree="$alpha_root/worktrees/$branch"
+
+# Refuse to silently reuse prior state — that is bs-reset's job.
+if [[ -d "$worktree" ]]; then
+  echo "bs-start: worktree already exists: $worktree — resume there, or start over with 'just bs-reset ${stint_ids[0]}'." >&2
+  exit 1
+fi
+if git -C "$alpha_root" show-ref --verify --quiet "refs/heads/$branch"; then
+  echo "bs-start: local branch $branch already exists — resume it, or start over with 'just bs-reset ${stint_ids[0]}'." >&2
+  exit 1
+fi
+if git -C "$alpha_root" ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+  echo "bs-start: branch $branch already exists on origin — inspect it before re-minting a lane." >&2
+  exit 1
+fi
+
+# Mint the worktree from alpha HEAD (wtp, never raw git worktree).
+(cd "$alpha_root" && wtp add -b "$branch" HEAD)
+
+# Verify the base: the new worktree must sit exactly at alpha HEAD.
+alpha_head="$(git -C "$alpha_root" rev-parse HEAD)"
+wt_head="$(git -C "$worktree" rev-parse HEAD)"
+if [[ "$wt_head" != "$alpha_head" ]]; then
+  echo "bs-start: worktree base mismatch: $worktree is at ${wt_head:0:8}, alpha HEAD is ${alpha_head:0:8}. Removing the bad worktree." >&2
+  (cd "$alpha_root" && wtp remove -f --with-branch "$branch") || true
+  exit 1
+fi
+
+# Claim every stint (stint owns state; run from the canonical checkout).
+for stint_id in "${stint_ids[@]}"; do
+  (cd "$alpha_root" && stint claim "$stint_id")
+done
+
+bash "$SCRIPT_DIR/bs-slot.sh" start done "stint=${stint_ids[*]}" "detail=branch=$branch head=${alpha_head:0:8}"
+echo "bs-start: stint(s) ${stint_ids[*]} claimed, branch $branch at ${alpha_head:0:8}"
+echo "$worktree"

--- a/scripts/bs-validate-setup.sh
+++ b/scripts/bs-validate-setup.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# bs-validate-setup.sh — deterministic setup for PR validation (bs- pipeline).
+#
+# Usage: bs-validate-setup.sh <pr-number>
+#
+# Resolves the PR's branch and (if present) feature worktree, runs
+# `just pr-install <pr>` (cwd-independent — it resolves and builds the PR's
+# actual head itself), and publishes a slot report with the install result.
+# Prints BRANCH= and WORKTREE= lines for the calling skill to consume.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ $# -ne 1 ]]; then
+  echo "bs-validate-setup: missing PR number. Usage: just bs-validate-setup <pr>" >&2
+  exit 1
+fi
+pr="$1"
+
+alpha_root="$(git worktree list --porcelain | awk '
+  /^worktree / { path=substr($0, 10) }
+  /^branch refs\/heads\/alpha$/ { print path; exit }
+')"
+if [[ -z "$alpha_root" ]]; then
+  echo "bs-validate-setup: could not resolve the alpha worktree from 'git worktree list'." >&2
+  exit 1
+fi
+
+pr_json="$(gh pr view "$pr" --json headRefName,headRefOid,state 2>/dev/null || true)"
+if [[ -z "$pr_json" ]]; then
+  echo "bs-validate-setup: could not resolve PR #$pr via gh (gh pr view failed)." >&2
+  exit 1
+fi
+branch="$(python3 -c 'import sys,json; print(json.load(sys.stdin)["headRefName"])' <<<"$pr_json")"
+head_oid="$(python3 -c 'import sys,json; print(json.load(sys.stdin)["headRefOid"])' <<<"$pr_json")"
+state="$(python3 -c 'import sys,json; print(json.load(sys.stdin)["state"])' <<<"$pr_json")"
+if [[ "$state" != "OPEN" ]]; then
+  echo "bs-validate-setup: PR #$pr is $state, not OPEN — nothing to validate." >&2
+  exit 1
+fi
+
+worktree="$alpha_root/worktrees/$branch"
+if [[ ! -d "$worktree" ]]; then
+  # Not fatal: pr-install builds the PR head in its canonical detached tree.
+  worktree=""
+fi
+
+bash "$SCRIPT_DIR/bs-slot.sh" validate working "pr=$pr" "detail=installing head ${head_oid:0:8}"
+rc=0
+(cd "$alpha_root" && just pr-install "$pr") || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  bash "$SCRIPT_DIR/bs-slot.sh" validate failed "pr=$pr" "detail=pr-install exited $rc"
+  echo "bs-validate-setup: 'just pr-install $pr' failed with exit $rc — see output above; provenance in ~/.plexi-pr-$pr/install.log if the install got that far." >&2
+  exit "$rc"
+fi
+bash "$SCRIPT_DIR/bs-slot.sh" validate done "pr=$pr" "detail=installed head ${head_oid:0:8} as plexi-pr-$pr"
+
+echo "BRANCH=$branch"
+echo "WORKTREE=$worktree"
+echo "HEAD=$head_oid"


### PR DESCRIPTION
PoC for a just-recipe-centered babysitter pipeline (Ian's ruling 2026-07-31): all lane mechanics become deterministic recipes so agent transcripts carry judgment only.

Stints: 0675 (recipe namespace), 0676 (skill thinning). No linked GitHub issues; .stint is authoritative.

## What ships

**Recipes (`bs-` namespace, logic in `scripts/bs-*.sh`):**
- `just bs-start <id> [<id> ...]` — asserts alpha clean + synced with origin (hard error naming what and where), mints the wtp worktree `feature/stint-<id>[-<id>...]-<slug>` from alpha HEAD, verifies the base, claims every stint, publishes a slot report. Multi-id = one batch lane with the branch shape `just merge-pr` resolves. Last stdout line is the worktree path.
- `just bs-reset <id>` — start-over button: force-wipes the lane's worktree + branch (matches the id anywhere in a multi-id batch branch), uninstalls any `plexi-pr-*` build whose open PR heads it, unclaims, re-runs `bs-start`. Idempotent; refuses only on done/archived stints.
- `just bs-validate-setup <pr>` — resolves branch/worktree from the PR, runs `just pr-install <pr>`, publishes the install result; prints `BRANCH=`/`WORKTREE=`/`HEAD=` for the calling skill.
- `just bs-merge <pr> [flags]` — wraps `just merge-pr`, then uninstalls `plexi-pr-<N>`, confirms the worktree was actually reaped (hard error if it survived), publishes a final slot report.
- `scripts/bs-slot.sh` — one-line typed JSON report `{phase, state, stint, pr, verdict, detail}` to the pane's `report` slot, mirroring `<phase>:<state>` to `status` (existing babysitter head contract). Forward-compatible with stint 0666's typed result channel; does not build it. Outside a pane it prints the report loudly instead of dropping it.

**Skill thinning (smallest diffs, judgment untouched):**
- `validate-pr` Step 2's hand-rolled worktree gate + "Compiling plexi" cache heuristic → one `just bs-validate-setup` call (the heuristic predates cwd-independent `pr-install` and is obsolete); the two reinstall mentions and two Rules bullets updated to match.
- `implement-stint` Phase 2's claim + `wtp add` + base-verification sequence → one `just bs-start` call.

## Test evidence

Docs/scripts-only diff — no Rust touched, `cargo test` surface unaffected. All recipes exercised live:
- Failure paths (real repo): missing id, bogus id, done stint, bogus PR, merged PR — each fails loudly naming what and where. The clean-alpha gate caught a genuinely dirty alpha during testing; the ahead-of-origin gate caught an unpushed commit in the harness.
- Happy paths (scratch clone harness, real `wtp`/`stint`): `bs-start` single and multi-id (worktree at alpha HEAD verified, claims recorded, slot published, path on last line), rerun refusal, `bs-reset` round-trip incl. reset by a batch's second id.
- `bs-slot.sh`: pane publish + read-back, no-pane loud fallback, usage error.
- `just --list` parses; `bash -n` clean on all five scripts.

Not exercised: `bs-merge` happy path (requires actually merging a PR) and `bs-validate-setup`'s install path (full PR build) — both are thin wrappers over `just merge-pr` / `just pr-install`, which are already proven recipes.

Closes stints 0675, 0676.

**Validate attempt 1:** PASS
**Test date:** 2026-07-31
