### PR TITLE
fix(navigation): cycle contexts through the master-only enumeration (stint 0605)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -4335,25 +4335,17 @@ impl eframe::App for PlexiApp {
                     log::info!("tab: prev — window={}", self.active_window);
                 }
                 Action::NextContext => {
-                    let active = self.router.active_idx();
-                    let num = self.router.len();
-                    for offset in 1..num {
-                        let idx = (active + offset) % num;
-                        if !self.router.get(idx).parked {
-                            log::info!("context: next — idx={}", idx);
-                            self.switch_workspace(idx);
-                            break;
-                        }
+                    // Cycle the sidebar's own enumeration, not raw router
+                    // indices: masters only, unparked, wrapping at both ends.
+                    if let Some(idx) = self.router.cycle_top_level(true) {
+                        log::info!("context: next — idx={}", idx);
+                        self.switch_workspace(idx);
                     }
                 }
                 Action::PrevContext => {
-                    let active = self.router.active_idx();
-                    for idx in (0..active).rev() {
-                        if !self.router.get(idx).parked {
-                            log::info!("context: prev — idx={}", idx);
-                            self.switch_workspace(idx);
-                            break;
-                        }
+                    if let Some(idx) = self.router.cycle_top_level(false) {
+                        log::info!("context: prev — idx={}", idx);
+                        self.switch_workspace(idx);
                     }
                 }
                 Action::MoveContextUp => {

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1427,6 +1427,70 @@ mod tests {
             .expect("render failed");
     }
 
+    /// Stint 0605: `NextContext`/`PrevContext` cycle the same enumeration the
+    /// sidebar draws. Against a live router carrying a real subcontext wedged
+    /// between two masters, cycling steps master → master and wraps, so it can
+    /// never activate a context with no row, no number, and no recorded depth
+    /// entry for zoom-out to pop.
+    #[test]
+    fn context_cycling_visits_master_contexts_only() {
+        let mut h = PlexiUiHarness::new_sized(900.0, 620.0);
+        let child_ctx_id = h.with_app_mut(|app| {
+            app.router.get_mut(0).name = "master-one".to_string();
+            let parent_ctx_id = app.router.get(0).context_id;
+            let child_ctx_id = parent_ctx_id + 9_000;
+
+            // Subcontext at router index 1, between the two masters — the
+            // index the old raw-index walk would have landed on.
+            app.router.push(crate::host::context::Context {
+                name: "child-of-one".to_string(),
+                path: std::env::temp_dir().join("child-of-one"),
+                root: None,
+                description: None,
+                context_id: child_ctx_id,
+                parent_id: Some(parent_ctx_id),
+                depth: 1,
+                parked: false,
+            });
+            app.router.push(crate::host::context::Context {
+                name: "master-two".to_string(),
+                path: std::env::temp_dir().join("master-two"),
+                root: None,
+                description: None,
+                context_id: 72_002,
+                parent_id: None,
+                depth: 0,
+                parked: false,
+            });
+            child_ctx_id
+        });
+        h.run_steps(2);
+
+        h.with_app(|app| {
+            // From master-one (idx 0): forward skips the subcontext at idx 1.
+            let next = app.router.cycle_top_level(true).expect("next exists");
+            assert_eq!(
+                app.router.get(next).name,
+                "master-two",
+                "cycling must skip the subcontext sitting between the masters"
+            );
+            assert_ne!(
+                app.router.get(next).context_id,
+                child_ctx_id,
+                "cycling must never activate a subcontext"
+            );
+
+            // Backward from the first master wraps to the last master, not to
+            // the subcontext that precedes it in raw router order.
+            let prev = app.router.cycle_top_level(false).expect("prev exists");
+            assert_eq!(
+                app.router.get(prev).name,
+                "master-two",
+                "cycling backward from the first master wraps to the last"
+            );
+        });
+    }
+
     /// Notes triage overlay: renders a note, and emptying the inbox returns
     /// to the picker instead of closing outright.
     #[test]

--- a/src/workspace/router.rs
+++ b/src/workspace/router.rs
@@ -94,6 +94,43 @@ impl WorkspaceRouter {
             .collect()
     }
 
+    /// The index sequential context cycling should land on, in the requested
+    /// direction, wrapping at both ends. `None` when there is nowhere else to go.
+    ///
+    /// Cycling is a sidebar affordance, so it enumerates exactly the rows the
+    /// sidebar draws — top-level and unparked — for the same reason `Cmd+1..9`
+    /// routes through `top_level_order`: every navigation surface agrees on one
+    /// enumeration. Landing on a subcontext would activate a context with no
+    /// row, no number, and no recorded `push_depth` for zoom-out to pop.
+    ///
+    /// The active context may itself be a subcontext, reached by descending
+    /// through a Portal, and therefore absent from the list. The search compares
+    /// router indices rather than list positions so that case still resolves to
+    /// the nearest master in the requested direction.
+    pub(crate) fn cycle_top_level(&self, forward: bool) -> Option<usize> {
+        let order: Vec<usize> = self
+            .top_level_order()
+            .into_iter()
+            .filter(|&i| !self.contexts[i].parked)
+            .collect();
+        let active = self.active;
+        let target = if forward {
+            order
+                .iter()
+                .copied()
+                .find(|&i| i > active)
+                .or_else(|| order.first().copied())
+        } else {
+            order
+                .iter()
+                .rev()
+                .copied()
+                .find(|&i| i < active)
+                .or_else(|| order.last().copied())
+        };
+        target.filter(|&i| i != active)
+    }
+
     /// Expand a top-level-only ordering into a full permutation of `0..len` by
     /// emitting each entry followed by its descendants in router order.
     ///
@@ -351,6 +388,80 @@ mod tests {
             ids_with, ids_without,
             "subcontexts must not shift top-level sidebar numbering"
         );
+    }
+
+    /// Stint 0605: cycling walks the sidebar's enumeration, so it steps master
+    /// to master and never activates a hidden subcontext.
+    #[test]
+    fn cycle_top_level_skips_subcontexts_and_wraps() {
+        let contexts = vec![
+            make_ctx(10, None, 0),
+            make_ctx(11, Some(10), 1),
+            make_ctx(12, Some(10), 1),
+            make_ctx(20, None, 0),
+            make_ctx(30, None, 0),
+        ];
+        let masters = [0usize, 3, 4];
+
+        for &from in &masters {
+            let router = WorkspaceRouter::new(contexts.clone(), from);
+            let next = router.cycle_top_level(true).expect("next exists");
+            let prev = router.cycle_top_level(false).expect("prev exists");
+            for idx in [next, prev] {
+                assert!(
+                    masters.contains(&idx),
+                    "cycling from {from} yielded subcontext idx {idx}"
+                );
+                assert!(
+                    router.get(idx).parent_id.is_none(),
+                    "cycling from {from} yielded idx {idx} with a live parent"
+                );
+            }
+        }
+
+        // Last master wraps forward to the first, first wraps back to the last.
+        let last = WorkspaceRouter::new(contexts.clone(), 4);
+        assert_eq!(last.cycle_top_level(true), Some(0));
+        let first = WorkspaceRouter::new(contexts, 0);
+        assert_eq!(first.cycle_top_level(false), Some(4));
+    }
+
+    /// Parked contexts have no sidebar row either, so cycling steps over them.
+    #[test]
+    fn cycle_top_level_skips_parked() {
+        let mut contexts = vec![
+            make_ctx(10, None, 0),
+            make_ctx(20, None, 0),
+            make_ctx(30, None, 0),
+        ];
+        contexts[1].parked = true;
+        let router = WorkspaceRouter::new(contexts, 0);
+        assert_eq!(router.cycle_top_level(true), Some(2));
+        assert_eq!(router.cycle_top_level(false), Some(2));
+    }
+
+    /// A lone master has nowhere to cycle to; cycling must be a no-op rather
+    /// than re-activating the context it is already on.
+    #[test]
+    fn cycle_top_level_is_none_with_a_single_destination() {
+        let router =
+            WorkspaceRouter::new(vec![make_ctx(10, None, 0), make_ctx(11, Some(10), 1)], 0);
+        assert_eq!(router.cycle_top_level(true), None);
+        assert_eq!(router.cycle_top_level(false), None);
+    }
+
+    /// Descending through a Portal makes a subcontext active, so it has no slot
+    /// in the enumeration. Cycling must still resolve to the nearest master.
+    #[test]
+    fn cycle_top_level_from_an_active_subcontext_resolves_to_masters() {
+        let contexts = vec![
+            make_ctx(10, None, 0),
+            make_ctx(11, Some(10), 1),
+            make_ctx(20, None, 0),
+        ];
+        let router = WorkspaceRouter::new(contexts, 1);
+        assert_eq!(router.cycle_top_level(true), Some(2));
+        assert_eq!(router.cycle_top_level(false), Some(0));
     }
 
     /// A context whose parent was deleted has no portal to be reached through,


### PR DESCRIPTION
Closes stint **0605** — *NextContext/PrevContext traverse raw router order and can activate a hidden subcontext*. No linked GitHub issue; stint is the ticket.

## Problem

`Action::NextContext` / `Action::PrevContext` walked raw router indices and skipped only `parked`. They never consulted `parent_id`, so cycling could land on a subcontext — a context with no sidebar row, no number, and no `Cmd+N` slot. It activated without a `push_depth`, so the depth stack recorded no descent and zoom-out had nothing to pop.

Pre-existing, not introduced by the prior navigation PR that enforced the master-only sidebar (already-closed prior work). That earlier change is what made this visible: every other navigation surface now agrees the sidebar lists masters only, and these two actions were the remaining dissenters.

## Approach — masters only

The task's decision of record. Both actions route through a new `WorkspaceRouter::cycle_top_level`, which enumerates exactly what the sidebar draws (top-level, unparked), the same way `SwitchContext` already routes `Cmd+1..9` through `top_level_order`. Descent keeps its sanctioned path via the Portal tile; a keyboard shortcut should not carry a second, invisible meaning no sidebar affordance reflects.

Two intentional behavior changes fall out:

- **`PrevContext` now wraps** to the last master instead of dead-ending at the first, making the pair symmetric.
- **Cycling from an active subcontext** (reached by Portal descent) resolves to the nearest master rather than walking hidden siblings. The search compares router indices, not list positions, so the active context need not appear in the enumeration.

Non-scope, untouched: Portal descent, the depth stack itself, and the master-only sidebar decision.

## Test evidence

- **cargo test:** 2158 passed, 0 failed, 5 ignored — full `--bin plexi` suite, env-stripped.
- **Router-level tests** (`src/workspace/router.rs`): `cycle_top_level_skips_subcontexts_and_wraps` (asserts no yielded index has a live parent, from every master, both directions, plus wrap at both ends), `cycle_top_level_skips_parked`, `cycle_top_level_is_none_with_a_single_destination`, `cycle_top_level_from_an_active_subcontext_resolves_to_masters`.
- **Harness test** (`src/ui_tests.rs`): `context_cycling_visits_master_contexts_only` — live `PlexiUiHarness` app router with a real subcontext wedged between two masters, at the exact index the old raw walk would have landed on.
- **No UI layer touched** — sidebar rendering is unchanged, so no screenshot surface applies.
- **AI diff review: NOT RUN.** Codex hit its usage limit (`You've hit your usage limit … try again at Aug 5th`) before producing findings. Per the pipeline contract this is the only AI review layer, and CI does not substitute — CodeRabbit is disabled and the `claude` check skips Rust-only diffs. **This diff ships unreviewed by AI unless the validator re-runs it.**
- **Conclusion:** install skippable — the decision function is a pure router method fully covered at both unit and live-harness level, and the handler change is a direct substitution with no new state. A validator wanting keyboard-level confirmation can drive `Cmd+Shift+[` / `]` on a `plexi-pr-<N>` build with a Portal subcontext present.

**Validate attempt 1:** PASS
**Test date:** 2026-07-31

