### PR TITLE
Context-scoped state persistence audit + duplicate-root/rollup design brief (stints 0678, 0679)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -21,6 +21,8 @@ A PRM is the destination spec for a feature. It describes what to build and why.
 | `assistant-authority-model.md` | Assistant threat model, reference monitor, grant binding, runtime boundary | see file |
 | `assistant-host-app.md` | Host assistant app spec | see file |
 | `browser-surface.md` | Native browser App pane, profiles, context binding, automation, and live validation | see file |
+| `context-root-uniqueness-and-rollup.md` | Duplicate-root hard stop + parent-dir todo rollup — design brief awaiting a ruling | 0679 |
+| `context-state-persistence-audit.md` | Why context-scoped app state does not survive a restart — findings and evidence | 0678 |
 | `marketplace-hosted.md` | Hosted marketplace (Sprint S4) | see file |
 | `marketplace-monetization.md` | Accounts, payments, no-license commercial model | 0338–0341, 0322 |
 | `notes-editor.md` | Native Notes editor, Live Preview, links, attachments, and agent validation | see file |

--- a/docs/context-root-uniqueness-and-rollup.md
+++ b/docs/context-root-uniqueness-and-rollup.md
@@ -23,22 +23,48 @@ context-scoped thing is derived from: the app registry scan, the workspace
 config overlay, the agent set, `PLEXI_CONTEXT_ROOT` in every pane's
 environment, notes scoping, and — the subject of the audit — app state paths.
 
-**Every place a root is set or changed:**
+**Every place a root is set or changed** — enumerated by grepping every write
+to `Context::root`, not by following the entry points a reader would expect:
 
 | Path | Root it assigns |
 |---|---|
 | `new_context_empty` (`plexi context create` with no root, ⌘-new-context) | the home directory, unconditionally |
 | `new_context_at_path` (`context create --root`, open-folder-as-context) | the given path |
-| `new_child_context` / `push_pane_to_subcontext` (sub-contexts, portals) | **the parent context's root, verbatim** |
-| `set_context_root` (`plexi context set-root`, ⇧⌘I, sidebar row menu, root overlay commit) | the given path, on one context, with no other checks |
+| `push_pane_to_subcontext` (push a pane into a sub-context) | **the parent context's `root`, verbatim** |
+| `new_child_context` (sub-contexts, portals) | the path its caller passes — and `new_child_context_from_keyboard` passes the parent's **`path`**, not its `root` |
+| `set_context_root` (`plexi context set-root`, ⇧⌘I, sidebar `SetRoot`, root-overlay commit with a non-empty path) | the given path, on one context, with no other checks |
+| `WindowMenuAction::ClearRoot` (sidebar row menu) | **clears the root by direct field write**, bypassing `set_context_root` |
+| Root-overlay commit with an empty buffer (`OverlayTarget::ContextRoot`) | **clears the root by direct field write**, likewise |
 | Workspace restore | whatever the saved file holds |
 
-Stint 0651 (open on PR #2536, not merged) makes `Context::root` non-optional,
-so "no root" stops being a state. It does not make roots unique.
+Two of these deserve spelling out, because both were missed on the first pass
+through this design and each is a hole a guard placed at the obvious entry
+point would leave open.
 
-**Are duplicates possible today?** They are not merely possible; two of the five
+**`Context::path` and `Context::root` are different fields, and nothing keeps
+them in sync.** `set_context_root` writes only `root`; nothing writes `path`
+after the context is created. So the keyboard sub-context path anchors the child
+at wherever its parent was *created* — which after any set-root is a directory
+the user deliberately moved away from. The audit reproduces this
+(`audit_0678_keyboard_sub_context_inherits_the_parents_stale_path_not_its_root`).
+A guard that only rejects *collisions* would wave this through: the child's root
+is not a duplicate, it is simply wrong.
+
+**Two paths clear the root by writing the field directly**, and both re-implement
+`set_context_root`'s transition-effects tail inline rather than calling it. That
+is the finding, not the typo: the choke point already exists and callers already
+go around it, so a convention that says "route root changes through
+`set_context_root`" is not a mechanism — it is a rule that has already been
+broken twice in shipped code.
+
+Stint 0651 (open on PR #2536, not merged) makes `Context::root` non-optional,
+so "no root" stops being a state. It does not make roots unique, and it does
+not close the direct-write paths.
+
+**Are duplicates possible today?** They are not merely possible; two of the
 paths above *guarantee* them. Every rootless new context lands on the home
-directory, and every sub-context inherits its parent's root by construction. The
+directory, and a pushed sub-context inherits its parent's root by construction.
+The
 audit records a live saved workspace holding two contexts both rooted at the home
 directory, and shows what that costs: a shared root means one shared
 context-scoped state file per app, addressed identically from both contexts,
@@ -53,12 +79,32 @@ shipped behavior.
 
 ### Recommended design
 
-**One guard, at one choke point, on the model.** Root assignment becomes a
-single fallible operation in `HostModel` — every path in the table above routes
-through it, and it returns a typed rejection naming the conflicting context.
-Guarding only `plexi context set-root`, or only creation, leaves four of five
-doors open; the audit's evidence is that the doors nobody thinks about (rootless
-create, sub-context inherit) are the ones duplicates actually come through.
+**One guard, at one choke point — and the choke point must be enforced by the
+compiler, not by convention.** Root assignment becomes a single fallible
+operation on the router: `set_root` and `clear_root`, both returning a typed
+rejection that names the conflicting context. Guarding only `plexi context
+set-root`, or only creation, leaves most of the table open; the audit's evidence
+is that the doors nobody thinks about (rootless create, sub-context inherit) are
+the ones duplicates actually come through.
+
+**`Context::root` becomes private to the router**, so those two methods are the
+only way to write it and a direct `.root = …` is a compile error. This is the
+part the first draft of this brief got wrong, and the correction is the whole
+lesson: the recommendation was "one choke point", the choke point already
+existed as `set_context_root`, and two shipped call sites already went around it
+by writing the field directly. A guard reachable only by a caller who chooses to
+call it does not survive its first busy afternoon. Encapsulation is what makes
+the count of mutation sites stop mattering — it stays correct when the eighth
+one is added by someone who never read this document.
+
+**The two clear paths route through `clear_root`**, which also owns the
+transition-effects tail both of them currently re-implement inline.
+
+**`Context::path` is the other half of the same defect.** Either it is kept in
+sync with `root` by the same operation, or the sub-context creation path stops
+reading it and reads `root` instead. Recommendation: the latter — `path` is the
+context's creation-time working directory and has no business anchoring a child.
+This is the seventh open decision in §5.
 
 **Sub-contexts are exempt, and the rule is restated to make that explicit:** *no
 two **top-level** contexts may share a root; a sub-context shares its parent's
@@ -108,7 +154,10 @@ that moment, so the set of duplicates can only shrink.
 - **Warn only, never block.** This is today's behavior. The audit is the
   evidence that a warning nobody reads does not prevent the data loss.
 - **Enforce in the CLI.** Leaves the GUI paths (⇧⌘I, sidebar, root overlay) and
-  workspace restore unguarded. The model is the only place all five paths meet.
+  workspace restore unguarded. The router is the only place they all meet.
+- **A guarded `set_context_root` that callers are expected to use.** This is
+  today's shape, and two call sites already bypass it. Rejected on the evidence
+  of its own track record.
 
 ### The comparison rule
 
@@ -241,14 +290,21 @@ filesystem ancestry.
    reversible.
 6. **Is rollup read-only?** Recommendation: yes for v1. Write-through can follow
    once the read view has been lived with.
+7. **Does a sub-context follow its parent's `root` or its `path`?** Today the
+   keyboard path takes `path`, which is frozen at creation and goes stale on
+   the first set-root. Recommendation: sub-context creation reads `root` only,
+   and `path` keeps its narrow meaning as the creation-time working directory.
+   The alternative — keeping the two fields in sync — preserves a second source
+   of truth for the same question, which is the anti-goal §4 cites.
 
 ## 6. Stints that would follow approval
 
 Described, not filed — this task files none.
 
-- **The guard.** Single fallible root-assignment operation on the model, every
-  assignment path routed through it, the path-comparison rule, and the rejection
-  error. Includes the sub-context exemption as ruled.
+- **The guard.** `Context::root` made private to the router behind fallible
+  `set_root` / `clear_root`, every assignment and clear path routed through
+  them, the path-comparison rule, and the rejection error. Includes the
+  sub-context exemption as ruled, and the `path`-vs-`root` decision from §5.7.
 - **Duplicate detection at load + `plexi context doctor`.** Warn trace, sidebar
   marking, and the one command that lists conflicts and resolves them.
 - **`plexi context set-root --steal`.** The takeover move the error text

--- a/docs/context-root-uniqueness-and-rollup.md
+++ b/docs/context-root-uniqueness-and-rollup.md
@@ -1,0 +1,264 @@
+# Duplicate-Root Hard Stop + Parent-Dir Rollup — Design Brief
+
+**Stint:** 0679
+**Status:** active — pre-approval. No code, no stints filed; the stints that
+would follow a ruling are described at the end.
+
+Ian's ruling of record: no two contexts may share a root, enforced as a hard
+stop at context creation with a clear error; and a parent directory's context
+should roll up the todos of child-directory contexts. Both change what a
+context *is*, so they get a written design checked against `NORTH_STAR.md`
+before any code. This brief recommends one design for each, names what was
+rejected, and lists the decisions that are Ian's to make.
+
+The empirical half — whether duplicates are possible today and what they break —
+is answered by the audit filed alongside this task,
+[`context-state-persistence-audit.md`](context-state-persistence-audit.md).
+Cited here, not re-derived.
+
+## 1. What a context root is today
+
+A root is a single directory a context is anchored to. It is the address every
+context-scoped thing is derived from: the app registry scan, the workspace
+config overlay, the agent set, `PLEXI_CONTEXT_ROOT` in every pane's
+environment, notes scoping, and — the subject of the audit — app state paths.
+
+**Every place a root is set or changed:**
+
+| Path | Root it assigns |
+|---|---|
+| `new_context_empty` (`plexi context create` with no root, ⌘-new-context) | the home directory, unconditionally |
+| `new_context_at_path` (`context create --root`, open-folder-as-context) | the given path |
+| `new_child_context` / `push_pane_to_subcontext` (sub-contexts, portals) | **the parent context's root, verbatim** |
+| `set_context_root` (`plexi context set-root`, ⇧⌘I, sidebar row menu, root overlay commit) | the given path, on one context, with no other checks |
+| Workspace restore | whatever the saved file holds |
+
+Stint 0651 (open on PR #2536, not merged) makes `Context::root` non-optional,
+so "no root" stops being a state. It does not make roots unique.
+
+**Are duplicates possible today?** They are not merely possible; two of the five
+paths above *guarantee* them. Every rootless new context lands on the home
+directory, and every sub-context inherits its parent's root by construction. The
+audit records a live saved workspace holding two contexts both rooted at the home
+directory, and shows what that costs: a shared root means one shared
+context-scoped state file per app, addressed identically from both contexts,
+overwritten whole by whichever instance persists last. Nothing warns, and nothing
+merges.
+
+That is the case for the rule. It is also the reason the rule cannot simply be
+switched on: **as literally stated, it outlaws the sub-context model**, which is
+shipped behavior.
+
+## 2. The hard stop
+
+### Recommended design
+
+**One guard, at one choke point, on the model.** Root assignment becomes a
+single fallible operation in `HostModel` — every path in the table above routes
+through it, and it returns a typed rejection naming the conflicting context.
+Guarding only `plexi context set-root`, or only creation, leaves four of five
+doors open; the audit's evidence is that the doors nobody thinks about (rootless
+create, sub-context inherit) are the ones duplicates actually come through.
+
+**Sub-contexts are exempt, and the rule is restated to make that explicit:** *no
+two **top-level** contexts may share a root; a sub-context shares its parent's
+root by definition and is addressed as part of it.* This is the smallest change
+that keeps the rule true and the shipped model intact — see the open decision in
+§5 if Ian wants the stronger version instead.
+
+**Error text** (CLI, on the rejected operation — never a silent no-op):
+
+```
+context root already in use by context "notes"
+  requested: /Users/ianburke/Documents/notes
+  in use by: context "notes" (id 14)
+A root anchors exactly one context — app state, agents, and config all resolve
+through it, so two contexts on one root overwrite each other's state.
+Next: switch to it            plexi context switch notes
+      or re-root this context plexi context set-root <other-dir>
+      or take the root over   plexi context set-root <dir> --steal
+```
+
+The user's next move is always named, and one of the three is always right.
+`--steal` clears the root from the other context and requires it to be re-rooted
+before it resolves anything — deliberately louder than a silent swap.
+
+**Existing duplicates when the rule turns on** — the sharp edge, and the place a
+creation-only guard fails. A rule that guards only new assignments leaves exactly
+the invalid state it exists to prevent, and the audit shows that state already
+exists in a live workspace.
+
+Recommendation: **load, flag, never silently mutate.** Workspace restore keeps
+every context exactly as saved — a workspace that fails to load, or that
+quietly re-roots the user's contexts at boot, is a far worse failure than the
+duplicate. On detecting a duplicate at load, the host logs it at `warn`, marks
+the affected contexts in the sidebar, and surfaces one resolution command
+(`plexi context doctor`) that lists each conflict and the same three moves as
+the error text. The rule is enforced strictly on every *new* assignment from
+that moment, so the set of duplicates can only shrink.
+
+### Rejected
+
+- **Refuse to load a workspace containing duplicates.** Correct-by-construction
+  and unusable: it bricks the user's session over a condition the host itself
+  created.
+- **Auto-migrate at load** (re-root duplicates to a generated subdirectory).
+  Silently moves where a user's state resolves — the exact failure the audit
+  documents, performed deliberately.
+- **Warn only, never block.** This is today's behavior. The audit is the
+  evidence that a warning nobody reads does not prevent the data loss.
+- **Enforce in the CLI.** Leaves the GUI paths (⇧⌘I, sidebar, root overlay) and
+  workspace restore unguarded. The model is the only place all five paths meet.
+
+### The comparison rule
+
+Two roots are the same root when they name the same directory, not when their
+strings match. Recommended, in order:
+
+1. **Canonicalize both sides** (resolve symlinks and `..`) before comparing.
+   Two contexts rooted at a symlink and its target are one root and must
+   collide.
+2. **A root that does not exist yet is rejected**, not created and not compared
+   lexically. Root assignment already writes into the directory
+   (`auto_init_workspace`), so a non-existent root is a typo far more often than
+   an intent; the error names the missing path. This keeps canonicalization
+   total — there is no "partially resolvable path" case to hand-roll.
+3. **On macOS, compare case-insensitively.** The default volume format is
+   case-insensitive, so two roots differing only in case *are* one directory and
+   would share one state file. Comparing case-sensitively there would let the
+   duplicate through the guard and produce exactly the bug the guard exists to
+   prevent. Per-volume detection is the theoretically correct version and is not
+   worth it: the cost of the blunt rule is a rejected duplicate on a
+   case-sensitive volume, which the error text already tells the user how to
+   resolve.
+4. **Hard links and bind-mount-style aliases are out of scope.** They cannot be
+   detected from the path, and no realistic user hits them.
+
+Comparison lives next to the guard, so there is one answer to "are these the
+same root" for the model, the CLI, and any future rollup ancestry check.
+
+## 3. Parent-directory rollup
+
+Ian's shape: a context whose root is an ancestor of another context's root sees
+the descendants' todos, aggregated and attributed.
+
+### Recommended design
+
+**A read-only, host-computed view over registered contexts — not a merge, and
+not a filesystem walk.**
+
+- **What crosses:** nothing by default. An app opts into being rolled up by
+  declaring it, and reads the aggregate through a host API that returns
+  *attributed* entries (each item carries the context it came from). This keeps
+  rollup inside the capability model — commandment 10 is that apps never get
+  ambient authority, and "a parent context can read every descendant's app
+  state" is ambient authority by any other name if it applies to all state
+  implicitly. Todo becomes the first opt-in app, not a special case in the host.
+- **Read-only, always.** The parent view can display and filter; it cannot write
+  through to a child's file. A write-through model needs conflict rules,
+  ownership rules, and an undo story, and buys little: the user can zoom into the
+  child context to edit, which is the motion the portal model already teaches.
+- **Ancestry is the context tree, not the directory tree.** A context rolls up
+  its *sub-contexts*, which are already an explicit parent/child relation in the
+  router with a shipped UI (portals, zoom, the depth stack). Using filesystem
+  ancestry instead means any context rooted anywhere under the home directory
+  silently starts feeding the home context — an accidental, invisible data flow
+  the user never asked for, across projects that have nothing to do with each
+  other. This is the one place the recommendation diverges from Ian's framing
+  ("a parent *directory's* context"), and it is the second open decision in §5.
+- **Depth is bounded by the tree, and the whole subtree is included.** With
+  ancestry defined as the context tree, depth is already user-authored — nobody
+  accidentally has a twelve-deep context tree — so no arbitrary cap is needed.
+  A cap on a filesystem-ancestry model would be mandatory, which is itself an
+  argument for the tree.
+- **Child state stays independently addressable.** Rollup adds a view; it moves
+  nothing. The child context keeps its own root, its own state file, and its own
+  panes, and remains fully usable with the parent closed. That is what makes
+  rollup reversible — turning it off can never lose data.
+
+### Rejected
+
+- **Merge child state into the parent's file.** Destroys the property that state
+  lives with the directory (commandment 1: portable files that still make sense
+  without Plexi), and makes rollup irreversible.
+- **General implicit aggregation of all context-scoped state.** Every app that
+  ever declares `context` scope would silently gain cross-context reads it never
+  asked for, and no app author could reason about who sees their bytes.
+- **Rollup by filesystem ancestry with a depth cap.** Rejected on the accidental
+  data-flow argument above; retained as an option for Ian in §5 because it is
+  the literal reading of his ruling.
+- **A new "rollup" pane type.** The portal already renders a child context
+  inside a parent. Rollup is a data question, not a layout one.
+
+## 4. Check against NORTH_STAR
+
+**Supported by the direction:**
+
+- *"Two sources of truth for state or permissions"* is listed under what does not
+  belong in Plexi. Two contexts on one root is precisely two sources of truth for
+  one address — the hard stop deletes a named anti-goal.
+- *Commandment 1 — all data lives in portable open files.* Both designs keep
+  state in the directory it belongs to; rollup reads, never relocates.
+- *Commandment 4 — every feature reachable through the CLI.* The guard's
+  resolution moves (`switch`, `set-root`, `--steal`, `doctor`) are all CLI-first
+  and agent-drivable.
+
+**Tensions, stated plainly:**
+
+- *Commandment 2 — friction is a bug.* A hard stop is friction by design. It is
+  justified only because the alternative is silent data loss, and only if the
+  error names the next move. An error that just says "already in use" would
+  fail this commandment.
+- *Commandment 10 — apps never get ambient authority.* Rollup is a
+  cross-context read. The opt-in declaration is what keeps it inside the
+  permission model; an implicit version would violate this commandment outright.
+- *"Grown, not universal."* Rollup shaped as "todos specifically" is a
+  special case in the host, which the direction resists. The declared-capability
+  shape is the general version of the same feature, which is why it is
+  recommended over hard-coding todo.
+
+Neither design conflicts with the fractal/spatial direction: contexts stay
+nestable, and rollup follows the same parent/child relation the spatial model
+already uses — which is the strongest argument for tree ancestry over
+filesystem ancestry.
+
+## 5. Open decisions — Ian's to own
+
+1. **Does the hard stop apply retroactively?** Recommendation: no — load, flag,
+   and offer one command. Alternatives: refuse to load, or auto-migrate.
+2. **Are sub-contexts exempt?** They inherit the parent's root by construction
+   today, so the rule as stated forbids them. Recommendation: exempt them and
+   restate the rule as "no two *top-level* contexts share a root." The
+   alternative is giving sub-contexts their own distinct roots, which changes
+   what a sub-context is and is a much larger change than this brief covers.
+3. **Rollup ancestry: context tree or filesystem?** Recommendation: the context
+   tree. Ian's ruling as stated says directory ancestry. This is the one place
+   the recommendation departs from the ruling, and it is worth an explicit call.
+4. **Is rollup todo-specific or general?** Recommendation: general mechanism,
+   opt-in per app, todo as the first adopter.
+5. **Does a child's state stay independently addressable once rolled up?**
+   Recommendation: yes, unconditionally — it is what makes the feature
+   reversible.
+6. **Is rollup read-only?** Recommendation: yes for v1. Write-through can follow
+   once the read view has been lived with.
+
+## 6. Stints that would follow approval
+
+Described, not filed — this task files none.
+
+- **The guard.** Single fallible root-assignment operation on the model, every
+  assignment path routed through it, the path-comparison rule, and the rejection
+  error. Includes the sub-context exemption as ruled.
+- **Duplicate detection at load + `plexi context doctor`.** Warn trace, sidebar
+  marking, and the one command that lists conflicts and resolves them.
+- **`plexi context set-root --steal`.** The takeover move the error text
+  promises.
+- **Rollup: the declaration and the host read API.** Manifest opt-in, attributed
+  aggregate read across a context's subtree, capability-gated.
+- **Rollup: the todo adoption.** Todo declares the capability and renders the
+  attributed parent view. Sequenced after the todo rebuild (0674) rather than
+  against the current app.
+
+The state-loss defects the audit found are already filed as their own stints and
+are **not** blocked on this ruling; they are fixes to shipped behavior, while
+this brief is a change to the model.

--- a/docs/context-state-persistence-audit.md
+++ b/docs/context-state-persistence-audit.md
@@ -1,0 +1,254 @@
+# Context-Scoped State Persistence — Audit Findings
+
+**Stint:** 0678 (this audit), 0680, 0681, 0682, 0683 (the fixes it justifies — the last one to close is this doc's delete trigger)
+**Status:** active
+**Date of evidence:** 2026-07-31, alpha at the branch point of this task
+
+An audit of why app state — todo's in particular — does not survive a restart.
+Everything below is reproduced, not reasoned: each answer names the test, the
+log trace, or the bytes on disk that produced it. Where alpha's behaviour and
+stint 0652's behaviour differ, both are stated separately; 0652 is **not
+merged** (see [Interaction with 0652](#interaction-with-0652)).
+
+## The answer in one paragraph
+
+State loss is not one bug. Three independent defects sit on the same path, and
+each of them alone is sufficient to lose a todo item. In order of how early
+they bite: **(1)** a Python app pane is not restored at all on the next boot —
+it is saved under its *runtime kind* (`python-wasm`), never its app id, so
+restore cannot rebuild it and substitutes a terminal; **(2)** a re-launched app
+resolves its state file from the *launch-time* `workspace_root`, so an item
+written under one root is invisible from another and nothing merges or warns;
+**(3)** when two instances of one app are live under the same root — the normal
+case, because contexts freely share a root — they address one file with no
+coordination, and whichever instance persists last writes its own launch-time
+map over the other's. None of the three is a write that never happens: the
+write always happens. Two of them are writes to a path nobody reads next, and
+one is a read that never occurs because the app is never relaunched.
+
+## Method
+
+- **Rust tests** (all deterministic, all currently green on this branch;
+  they assert what alpha *does*, so a fix is expected to change them):
+  `audit_0678_two_contexts_accept_the_same_root` and
+  `audit_0678_set_context_root_does_not_move_a_live_app_pane_root` in
+  `src/app/tests/context_tests.rs`;
+  `audit_0678_second_instance_clobbers_the_first_instances_items` and
+  `audit_0678_state_written_under_one_root_is_invisible_under_another` in
+  `src/host/wasm_python.rs`;
+  `audit_0678_wasm_app_panes_are_not_restorable_from_a_saved_workspace` in
+  `src/pane_ops/create.rs`.
+- **Live host logs**: `~/.plexi-alpha/plexi.log` and `~/.plexi-beta/plexi.log`
+  from Ian's running sessions on the evidence date
+  (`launch_app_by_id_with_layout`, `workspace_restore`, `app::todo: persisted
+  WASM Python state`).
+- **Bytes on disk**: the saved workspace files under each channel profile's
+  `workspaces/` dir, and every `app_states/` directory beneath the home
+  directory.
+
+Nothing here was concluded from reading code alone. Two structural facts
+(`AppRuntime::type_id` values, the absence of a uniqueness check on the create
+path) are code facts, and each is pinned by one of the tests above.
+
+## The resolution chain
+
+**Write** — `PersistState` from the guest → `save_app_state` message →
+`LivePythonPane::save_state` → `python_state_path(&self.config)` →
+`write_python_state_atomic`. The path is
+`<config.workspace_root>/.plexi/app_states/<app_id>.json`. `config` is the
+`PythonLaunchConfig` captured at launch; nothing mutates `workspace_root`
+afterwards. There is exactly one write path.
+
+**Read** — `LivePythonPane::launch` → `load_python_state` →
+`python_state_path` (same value as the write) → on miss only, a second
+candidate: `<parent of config_dir()>/.plexi/app_states/<app_id>.json`, the
+channel-neutral global fallback. Both candidates run
+`reclaim_python_state_orphans` first, which adopts or archives
+`<root>/.plexi-<channel>/app_states/<app_id>.json` copies left by builds that
+wrote channel-suffixed paths. **Read has two candidates; write has one.** An
+app that loaded from the global fallback persists to the workspace path, so its
+next launch under a different root reads the stale global copy again.
+
+**Where `workspace_root` comes from**, in resolution order at launch:
+`AppRegistry::InstalledApp::workspace_root` when the app was found inside a
+workspace (`resolve_workspace_root_with_channel` walks up from the cwd to the
+nearest channel-dir anchor), else the launch `cwd`, which
+`resolve_new_pane_cwd` resolves as *context root → focused pane cwd → home*.
+For a globally installed app such as todo, `InstalledApp::workspace_root` is
+`None`, so the context root wins in practice — and a context with no root falls
+through to whatever directory the focused pane happened to be in.
+
+**The divergent copies.** `PythonLaunchConfig::workspace_root` (launch-time,
+owns the state path *and* the fs jail), `AppPane::workspace_root` (launch-time,
+what workspace-save records as the pane's `cwd`), and `Context::root`
+(mutable, what `set_context_root` changes). Only the third can change while an
+app is running, and it steers nothing that a running app reads or writes.
+
+## The five questions
+
+### 1. Can two contexts hold the same root? Is there a uniqueness check?
+
+**Yes, and no.** `set_context_root` logs, calls `auto_init_workspace`, assigns
+`root`, and returns — it never inspects the other contexts. Neither does the
+create path: `create_context` over IPC routes to `new_context_at_path` (root =
+the given path) or `new_context`, and `new_context_empty` anchors **every**
+new context at the home directory unconditionally, so a second rootless context
+duplicates the first by construction. A sub-context inherits its parent's path
+when no root is passed.
+
+*Evidence.* `audit_0678_two_contexts_accept_the_same_root` sets one directory
+as the root of two contexts through the production entry point; both accept.
+On disk, `~/.plexi-alpha/workspaces/default.json` holds contexts `Default` and
+`Context 2` both rooted at `/Users/ianburke` — a duplicate root in a live saved
+workspace, not a constructed one.
+
+### 2. Two panes of one app — how many state files, and who wins?
+
+**One file, and the last instance to persist wins with whatever it loaded at
+its own launch.** The state path is a pure function of `app_id` and
+`workspace_root`; no pane id, instance counter, or context id enters it. Two
+instances under one root therefore share a file, and each keeps its own
+in-memory `persisted_state` that it serializes whole on every `PersistState` —
+there is no merge, no re-read before write, and no last-write-wins detection.
+
+*Evidence.* `audit_0678_second_instance_clobbers_the_first_instances_items`
+replays the exact host sequence through the production functions: both
+instances load empty, the first persists an item, the second persists its
+launch-time (empty) map, and the item is gone. Across contexts the answer is
+the same whenever the two contexts share a root (question 1), and different
+files when they do not (question 4). Live: `~/.plexi-alpha/workspaces/default.json`
+records two `python-wasm` panes named `todo`, in *different* contexts
+(`Default` and `Context 2`), both with `cwd` `/Users/ianburke` — two live
+instances addressing one file, exactly the shape the test reproduces. The alpha
+log for the same session shows the hot-reload watcher firing separately for each
+of those pane ids.
+
+### 3. Does `set-root` after launch move a running app?
+
+**No. A running app keeps its launch-time root.** `set_context_root` mutates
+`Context::root` and, only for the active context, re-runs
+`apply_context_transition_effects` (registry rescan, watcher restart, config
+reload). No pane's `workspace_root` and no `PythonLaunchConfig` is touched, so
+a live app keeps reading and writing where it launched while *new* launches in
+that context go somewhere else. The CLI half-says this already — `plexi context
+set-root` prints a tip that `PLEXI_CONTEXT_ROOT` is only picked up by newly
+opened panes — but nothing says it about app state.
+
+*Evidence.* `audit_0678_set_context_root_does_not_move_a_live_app_pane_root`
+records a live app pane's `workspace_root`, changes its context's root through
+the production entry point, and asserts the pane's root is unchanged.
+
+### 4. Where do todo's bytes go right now, and which path is read next?
+
+**Written to `<launch root>/.plexi/app_states/todo.json`.** On the evidence
+date, with the context root at the home directory, that is
+`~/.plexi/app_states/todo.json` — which is *also* the global fallback path, so
+under a home-rooted context the two read candidates coincide and the fallback
+is invisible. Under any other root they diverge.
+
+*Evidence — bytes on disk.* Every `app_states/todo.json` beneath the home
+directory at audit time, with mtimes: `~/.plexi/app_states/todo.json`
+(2026-07-31 17:48, one item), `~/Documents/GitHub/nooise/.plexi/app_states/todo.json`
+(2026-07-30 21:47, empty item list),
+`~/Documents/GitHub/PLEXI/.plexi-beta/app_states/todo.json` (2026-06-28),
+`~/Documents/GitHub/stint/.plexi-pr-2323/app_states/todo.json`,
+`~/Documents/GitHub/narrator-ai-v1/.plexi-pr-2323/app_states/todo.json`, plus
+`.superseded` archives under `~/.plexi-beta/` and `~/.plexi-alpha/` left by the
+orphan reclaim. The launch traces that produced the first two are in the logs:
+`launch_app_by_id_with_layout: id=todo cwd="/Users/ianburke/Documents/GitHub/nooise"`
+(2026-07-30) and `... cwd="/Users/ianburke"` (2026-07-31). Same app id, same
+user, one afternoon apart, two files — and neither launch could see the other's
+items.
+
+**Which one is read on the next launch** depends on the context root at that
+moment, which is the whole defect: it is not a property of the app.
+
+### 5. Is the loss a write that never happens, a write nobody reads, or a read that resolves elsewhere?
+
+**Never the first. Both of the others, plus a fourth shape the question did not
+anticipate: a read that never happens at all.**
+
+- *Read that never happens* — after a restart the app is not relaunched.
+  Workspace save records an app pane's `app_id` as `AppRuntime::type_id()`,
+  which is `python-wasm` for every CPython app and `wasm` for every native one;
+  `serialize_state` returns `None` for both, so `app_state` is saved as null.
+  Restore looks the saved id up in `builtin_factory`, finds nothing, and the
+  caller substitutes a `TerminalPane` in the pane's place. The state file is
+  never opened. *Evidence:*
+  `audit_0678_wasm_app_panes_are_not_restorable_from_a_saved_workspace`; and
+  across both channel logs, every `workspace_restore` line names a builtin
+  (`text-editor`) or the assistant — there is not one restored `python-wasm` or
+  `wasm` pane in either log's entire history.
+- *Write to a path nobody reads* — a relaunch under a different root writes and
+  reads a different file. *Evidence:*
+  `audit_0678_state_written_under_one_root_is_invisible_under_another`, and the
+  nooise/home file pair above.
+- *Read that resolves elsewhere* — the global fallback is read-only: an app that
+  loads from `<parent of config_dir()>/.plexi/app_states/` persists to its
+  workspace path, and can load the same stale global bytes again on a later
+  launch under another root.
+
+## The confirmed root cause
+
+**App state is addressed by the launch-time filesystem root of the pane, and
+nothing in the system guarantees that address is stable, unique, or revisited.**
+Every symptom follows: contexts duplicate roots freely, so one address serves
+several instances; the address is captured at launch, so moving the context does
+not move the app; and the pane that owned the address is not rebuilt at boot, so
+the address is not even re-read. The item is written every time. It is the
+addressing that fails, in three separable places.
+
+## Interaction with 0652
+
+Stints 0651 and 0652 are on **PR #2536, which is open, conflicting, and not
+merged to alpha.** Everything in the sections above is shipped alpha behaviour.
+This section describes where 0652 *lands* the resolution rules; it does not
+re-litigate them and the audit does not depend on them.
+
+0652 introduces `src/host/state_scope.rs` as the single owner of path
+construction, with two rules: `global` →
+`~/.plexi/app_states/<app_id>.<ext>`, `context` →
+`<context.root>/.plexi/app_states/<app_id>.<ext>`. An app declares its scopes
+in the manifest (`[state] scopes`); an omitted `[state]` means `["global"]`.
+Resolution moves to **call time** against the pane's live context root, pushed
+into each app pane every frame, so `set-root` redirects context-scoped state
+immediately. 0651 makes `Context::root` non-optional, which removes the
+rootless-context fallback that lets a launch cwd leak into the address.
+
+Mapped onto the five questions:
+
+- **Q3 is fixed by 0652** for context-scoped apps: call-time resolution is
+  exactly the missing half. The launch-captured `workspace_root` survives only
+  as the fs jail.
+- **Q4/Q5 second shape are fixed for todo specifically, by accident of the
+  default**: todo's manifest declares no `[state]`, so on that branch it
+  resolves `global` — one file for the whole machine, no root in the address.
+  Any app that declares `context` keeps the per-root split, which is the
+  intended behaviour, not a defect.
+- **Q1 is untouched.** 0651 makes every context have a root; nothing makes it
+  unique. Two contexts rooted at one directory still share one context-scoped
+  file.
+- **Q2 is untouched.** Scope is a property of the app, not of an instance —
+  by design — so two live instances still address one file and still overwrite
+  each other whole. 0652's own doc comment states the design intent; the
+  multi-instance write conflict is out of its scope.
+- **Q5 first shape is untouched.** 0652 changes addressing, not workspace
+  restore. A python-wasm pane still cannot be rebuilt at boot.
+
+The fixes below are therefore written to sit *on top of* 0652 where they
+overlap, and independently of it where they do not.
+
+## Follow-on stints
+
+Filed from these findings, one per distinct defect. None of them is in scope
+for 0678.
+
+| Stint | Defect | Question |
+|---|---|---|
+| 0680 | WASM/Python app panes are saved under their runtime kind and are not restored — the pane returns as a terminal | Q5 |
+| 0681 | Two live instances of one app overwrite each other's state whole; no merge, no reload-before-write, no conflict signal | Q2 |
+| 0682 | The state read path has a second candidate the write path does not, so a load can resolve to bytes the app will never write back | Q5 |
+| 0683 | State reads and writes are unobservable — the persist trace names no path, so where an app's bytes went cannot be answered from the log | method |
+
+The duplicate-root rule that question 1 exposes is a design question, not a bug
+fix; it is owned by stint 0679's design brief and awaits Ian's ruling.

--- a/docs/context-state-persistence-audit.md
+++ b/docs/context-state-persistence-audit.md
@@ -1,6 +1,6 @@
 # Context-Scoped State Persistence — Audit Findings
 
-**Stint:** 0678 (this audit), 0680, 0681, 0682, 0683 (the fixes it justifies — the last one to close is this doc's delete trigger)
+**Stint:** 0678 (this audit), 0680, 0681, 0682, 0683, 0686 (the fixes it justifies — the last one to close is this doc's delete trigger)
 **Status:** active
 **Date of evidence:** 2026-07-31, alpha at the branch point of this task
 
@@ -28,16 +28,23 @@ one is a read that never occurs because the app is never relaunched.
 
 ## Method
 
-- **Rust tests** (all deterministic, all currently green on this branch;
-  they assert what alpha *does*, so a fix is expected to change them):
+- **Rust tests written for this audit** (all deterministic; they assert what
+  alpha *does*, so a fix is expected to change them). In
+  `src/host/wasm_python.rs`, next to the function that computes a state
+  address: `audit_0678_second_instance_clobbers_the_first_instances_items`,
+  `audit_0678_state_written_under_one_root_is_invisible_under_another`, and the
+  `audit_0678` module — `audit_0678_a_saved_app_pane_cannot_re_address_its_own_state`,
+  `audit_0678_set_context_root_leaves_a_running_app_at_the_old_address`, and
+  `audit_0678_a_launch_seeded_from_the_global_fallback_never_writes_back_to_it`,
+  each of which launches a real CPython-WASM app through the production path.
+  In `src/app/tests/context_tests.rs`:
   `audit_0678_two_contexts_accept_the_same_root` and
-  `audit_0678_set_context_root_does_not_move_a_live_app_pane_root` in
-  `src/app/tests/context_tests.rs`;
-  `audit_0678_second_instance_clobbers_the_first_instances_items` and
-  `audit_0678_state_written_under_one_root_is_invisible_under_another` in
-  `src/host/wasm_python.rs`;
-  `audit_0678_wasm_app_panes_are_not_restorable_from_a_saved_workspace` in
-  `src/pane_ops/create.rs`.
+  `audit_0678_keyboard_sub_context_inherits_the_parents_stale_path_not_its_root`.
+- **Pre-existing tests cited as evidence** (not written here, already green in
+  alpha): `python_state_reclaims_global_legacy_into_global_neutral` and
+  `python_state_local_candidate_wins_over_global_fallback`, both in
+  `src/host/wasm_python.rs`, which pin the read path's second candidate and its
+  precedence.
 - **Live host logs**: `~/.plexi-alpha/plexi.log` and `~/.plexi-beta/plexi.log`
   from Ian's running sessions on the evidence date
   (`launch_app_by_id_with_layout`, `workspace_restore`, `app::todo: persisted
@@ -49,6 +56,23 @@ one is a read that never occurs because the app is never relaunched.
 Nothing here was concluded from reading code alone. Two structural facts
 (`AppRuntime::type_id` values, the absence of a uniqueness check on the create
 path) are code facts, and each is pinned by one of the tests above.
+
+**How these tests are stated, and why.** An earlier revision of this audit
+cited two tests that passed whether or not the defect existed — both asserted
+an implementation site's current value (a private helper returning `None`, a
+struct field that had not changed) rather than an invariant, and a fix is free
+to add a new code path and leave such a site untouched. They have been replaced.
+Every audit test now asserts the *pair a fix must reconcile*: the stale value
+**and** its disagreement with the live source of truth it should equal. The
+discipline, and the assertion helper that enforces it, are documented on the
+`audit_0678` module.
+
+**Limit of the reproduction, stated plainly.** Workspace *restore* cannot be
+driven end to end in a test: the restore loop lives inside `PlexiApp::new`,
+which also spawns socket listeners, the MCP server, and the update check, so no
+test can boot it. The restore-side evidence is therefore asserted one step
+earlier, at the saved record — which is the necessary condition for any restore
+implementation — plus the log evidence below. Closing that gap is stint 0686.
 
 ## The resolution chain
 
@@ -68,6 +92,16 @@ channel-neutral global fallback. Both candidates run
 wrote channel-suffixed paths. **Read has two candidates; write has one.** An
 app that loaded from the global fallback persists to the workspace path, so its
 next launch under a different root reads the stale global copy again.
+
+*Evidence.* The asymmetry itself is pinned by a pre-existing test,
+`python_state_reclaims_global_legacy_into_global_neutral`: a load resolves the
+global candidate while the write address is asserted still not to exist. Its
+consequence — the full round trip, where the item added after a
+fallback-seeded launch is invisible to the next launch under another root — is
+reproduced by
+`audit_0678_a_launch_seeded_from_the_global_fallback_never_writes_back_to_it`.
+Precedence between the two candidates is pinned by
+`python_state_local_candidate_wins_over_global_fallback`.
 
 **Where `workspace_root` comes from**, in resolution order at launch:
 `AppRegistry::InstalledApp::workspace_root` when the app was found inside a
@@ -93,11 +127,19 @@ app is running, and it steers nothing that a running app reads or writes.
 create path: `create_context` over IPC routes to `new_context_at_path` (root =
 the given path) or `new_context`, and `new_context_empty` anchors **every**
 new context at the home directory unconditionally, so a second rootless context
-duplicates the first by construction. A sub-context inherits its parent's path
-when no root is passed.
+duplicates the first by construction. Sub-contexts duplicate too, and by two
+different mechanisms: `push_pane_to_subcontext` copies the parent's `root`
+verbatim, while `new_child_context_from_keyboard` copies the parent's `path` —
+a separate field that nothing keeps in sync, because `set_context_root` writes
+only `root` and nothing ever writes `path` after creation. A keyboard
+sub-context is therefore anchored wherever its parent was *created*, which
+after any set-root is a directory the user re-rooted away from.
 
 *Evidence.* `audit_0678_two_contexts_accept_the_same_root` sets one directory
 as the root of two contexts through the production entry point; both accept.
+`audit_0678_keyboard_sub_context_inherits_the_parents_stale_path_not_its_root`
+re-roots a parent, creates a child from the keyboard path, and asserts the
+child's root is the parent's creation-time path and not its current root.
 On disk, `~/.plexi-alpha/workspaces/default.json` holds contexts `Default` and
 `Context 2` both rooted at `/Users/ianburke` — a duplicate root in a live saved
 workspace, not a constructed one.
@@ -134,9 +176,13 @@ that context go somewhere else. The CLI half-says this already — `plexi contex
 set-root` prints a tip that `PLEXI_CONTEXT_ROOT` is only picked up by newly
 opened panes — but nothing says it about app state.
 
-*Evidence.* `audit_0678_set_context_root_does_not_move_a_live_app_pane_root`
-records a live app pane's `workspace_root`, changes its context's root through
-the production entry point, and asserts the pane's root is unchanged.
+*Evidence.* `audit_0678_set_context_root_leaves_a_running_app_at_the_old_address`
+launches a real CPython-WASM app through the production launch path with its
+root set to the context's, seeds an item at the address the running instance
+reports from its own `PythonLaunchConfig`, changes the context root through the
+production entry point, and then asserts both halves: the running app still
+writes the launch-time address, and that address is not the one the context now
+resolves — where nothing exists at all.
 
 ### 4. Where do todo's bytes go right now, and which path is read next?
 
@@ -170,15 +216,22 @@ anticipate: a read that never happens at all.**
 
 - *Read that never happens* — after a restart the app is not relaunched.
   Workspace save records an app pane's `app_id` as `AppRuntime::type_id()`,
-  which is `python-wasm` for every CPython app and `wasm` for every native one;
-  `serialize_state` returns `None` for both, so `app_state` is saved as null.
-  Restore looks the saved id up in `builtin_factory`, finds nothing, and the
-  caller substitutes a `TerminalPane` in the pane's place. The state file is
-  never opened. *Evidence:*
-  `audit_0678_wasm_app_panes_are_not_restorable_from_a_saved_workspace`; and
-  across both channel logs, every `workspace_restore` line names a builtin
-  (`text-editor`) or the assistant — there is not one restored `python-wasm` or
-  `wasm` pane in either log's entire history.
+  which is `python-wasm` for every CPython app and `wasm` for every native one.
+  The app's real identity is on the pane the whole time, in `manifest_id`, and
+  is not what gets written. `serialize_state` returns `None` for both runtimes,
+  so `app_state` is saved as null — correctly, since an app's state belongs in
+  its state file rather than duplicated into workspace JSON, which is precisely
+  why the recorded identity is the *only* route back to it. Restore looks the
+  saved id up in `builtin_factory`, finds nothing, and the caller substitutes a
+  `TerminalPane` in the pane's place. The state file is never opened.
+  *Evidence:* `audit_0678_a_saved_app_pane_cannot_re_address_its_own_state`
+  launches a real CPython app, seeds its state file, saves the workspace
+  through `save_workspace`, reloads it from disk, and asserts that the address
+  derivable from the saved record is neither the file that holds the bytes nor
+  any file at all — while `manifest_id`, which would have addressed it, sits
+  unused on the pane. And across both channel logs, every `workspace_restore`
+  line names a builtin (`text-editor`) or the assistant — there is not one
+  restored `python-wasm` or `wasm` pane in either log's entire history.
 - *Write to a path nobody reads* — a relaunch under a different root writes and
   reads a different file. *Evidence:*
   `audit_0678_state_written_under_one_root_is_invisible_under_another`, and the
@@ -249,6 +302,7 @@ for 0678.
 | 0681 | Two live instances of one app overwrite each other's state whole; no merge, no reload-before-write, no conflict signal | Q2 |
 | 0682 | The state read path has a second candidate the write path does not, so a load can resolve to bytes the app will never write back | Q5 |
 | 0683 | State reads and writes are unobservable — the persist trace names no path, so where an app's bytes went cannot be answered from the log | method |
+| 0686 | Workspace restore is unobservable to tests — the restore loop is inside `PlexiApp::new` alongside socket, MCP, and update-check startup, so no test can boot it | method |
 
 The duplicate-root rule that question 1 exposes is a design question, not a bug
 fix; it is owned by stint 0679's design brief and awaits Ian's ruling.

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -2791,10 +2791,11 @@ fn context_sub_focus_returns_to_the_callers_window_not_the_active_one() {
 }
 
 // ── Stint 0678 audit evidence ────────────────────────────────────────────────
-// These two tests are the reproduction half of the context-scoped state
-// persistence audit (docs/context-state-persistence-audit.md). They assert
-// what alpha does today, not what it should do — a future fix is expected to
-// change them, and the doc names them as the evidence it rests on.
+// Part of the reproduction half of the context-scoped state persistence audit
+// (docs/context-state-persistence-audit.md). The rest of the audit's evidence
+// lives in `host::wasm_python::tests::audit_0678`, next to the function that
+// computes a state address; that module's doc comment carries the assertion
+// discipline every audit test follows.
 
 /// Q1: nothing rejects two contexts pointing at the same root. `set_context_root`
 /// has no uniqueness check, and `new_context_empty` anchors every new context at
@@ -2834,43 +2835,51 @@ fn audit_0678_two_contexts_accept_the_same_root() {
     );
 }
 
-/// Q3: a root change after launch does not follow a running app. The pane keeps
-/// the `workspace_root` captured when it was created, which is the value
-/// `python_state_path` reads, so `plexi context set-root` moves where *new*
-/// launches read and write while live panes keep writing the old location.
+/// Q1, second half: a sub-context created from the keyboard inherits the
+/// parent's `path`, not its `root`. Nothing keeps the two fields in sync —
+/// `set_context_root` writes only `root` — so after a set-root the child is
+/// anchored at the directory the parent was *created* in, which is neither the
+/// parent's current root nor anything the user chose.
 #[test]
-fn audit_0678_set_context_root_does_not_move_a_live_app_pane_root() {
+fn audit_0678_keyboard_sub_context_inherits_the_parents_stale_path_not_its_root() {
     let ctx = egui::Context::default();
     let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
     let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
 
-    let (_tile, pane_id) = app.add_test_pane();
-    let launch_root = app.windows[0]
-        .panes
-        .get(&pane_id)
-        .and_then(|p| p.as_app())
-        .expect("test pane is an app pane")
-        .workspace_root
-        .clone();
-
+    let created_at = app.router.get(0).path.clone();
     let moved = tempfile::tempdir().expect("new root");
-    let ctx_id = app.router.get(0).context_id;
-    app.set_context_root(moved.path().to_path_buf(), Some(ctx_id));
-
-    let after = app.windows[0]
-        .panes
-        .get(&pane_id)
-        .and_then(|p| p.as_app())
-        .expect("test pane is still an app pane")
-        .workspace_root
-        .clone();
+    let parent_id = app.router.get(0).context_id;
+    app.set_context_root(moved.path().to_path_buf(), Some(parent_id));
     assert_eq!(
-        after, launch_root,
-        "a live app pane keeps its launch-time workspace_root after set_context_root"
+        app.router.get(0).path,
+        created_at,
+        "precondition: set_context_root leaves `path` untouched"
+    );
+
+    let before = app.router.len();
+    app.new_child_context_from_keyboard();
+    if app.router.len() == before {
+        // No PTY available in this environment — the child is never created,
+        // so there is nothing to assert about its root.
+        return;
+    }
+
+    let child_root = app
+        .router
+        .iter()
+        .find(|c| c.parent_id == Some(parent_id))
+        .and_then(|c| c.root.clone())
+        .expect("the child context is rooted");
+    // The pair a fix must reconcile: the child took the stale creation-time
+    // path, and that is not the root its parent actually has.
+    assert_eq!(
+        child_root, created_at,
+        "the child inherited the parent's creation-time path"
     );
     assert_ne!(
-        after,
+        child_root,
         moved.path().to_path_buf(),
-        "the pane does not follow the context's new root"
+        "and therefore not the parent's current root — every context-scoped \
+         address the child derives points at a directory the user re-rooted away from"
     );
 }

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -2856,11 +2856,29 @@ fn audit_0678_keyboard_sub_context_inherits_the_parents_stale_path_not_its_root(
         "precondition: set_context_root leaves `path` untouched"
     );
 
+    // The divergence itself is observable without creating anything, and it is
+    // the necessary condition for the defect: `root` moved, `path` did not.
+    // Asserted before the child exists so this test still carries evidence in a
+    // PTY-less environment, where the child is never created — an audit test
+    // that returns early asserting nothing is exactly the vacuity this round
+    // exists to remove.
+    assert_eq!(
+        app.router.get(0).root.as_deref(),
+        Some(moved.path()),
+        "the parent's root moved"
+    );
+    assert_ne!(
+        app.router.get(0).path,
+        moved.path().to_path_buf(),
+        "but its `path` still names the directory it was created in — the two \
+         fields have diverged, and sub-context creation reads the stale one"
+    );
+
     let before = app.router.len();
     app.new_child_context_from_keyboard();
     if app.router.len() == before {
-        // No PTY available in this environment — the child is never created,
-        // so there is nothing to assert about its root.
+        // No PTY: the child is never created. The divergence asserted above is
+        // the whole of what this environment can observe, and it has been.
         return;
     }
 

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -2789,3 +2789,88 @@ fn context_sub_focus_returns_to_the_callers_window_not_the_active_one() {
         "return window must be the caller's, not the globally active one"
     );
 }
+
+// ── Stint 0678 audit evidence ────────────────────────────────────────────────
+// These two tests are the reproduction half of the context-scoped state
+// persistence audit (docs/context-state-persistence-audit.md). They assert
+// what alpha does today, not what it should do — a future fix is expected to
+// change them, and the doc names them as the evidence it rests on.
+
+/// Q1: nothing rejects two contexts pointing at the same root. `set_context_root`
+/// has no uniqueness check, and `new_context_empty` anchors every new context at
+/// the home directory, so duplicates are the default outcome rather than an edge
+/// case. Every context-scoped state path derived from a shared root collides.
+#[test]
+fn audit_0678_two_contexts_accept_the_same_root() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let shared = tempfile::tempdir().expect("shared root");
+    let second_ctx_id = 4242;
+    app.router.push(crate::host::context::Context {
+        name: "Second".into(),
+        path: shared.path().to_path_buf(),
+        root: None,
+        description: None,
+        context_id: second_ctx_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+
+    let first_ctx_id = app.router.get(0).context_id;
+    app.set_context_root(shared.path().to_path_buf(), Some(first_ctx_id));
+    app.set_context_root(shared.path().to_path_buf(), Some(second_ctx_id));
+
+    let roots: Vec<_> = app.router.iter().map(|c| c.root.clone()).collect();
+    assert_eq!(
+        roots,
+        vec![
+            Some(shared.path().to_path_buf()),
+            Some(shared.path().to_path_buf())
+        ],
+        "set_context_root accepts a root already held by another context"
+    );
+}
+
+/// Q3: a root change after launch does not follow a running app. The pane keeps
+/// the `workspace_root` captured when it was created, which is the value
+/// `python_state_path` reads, so `plexi context set-root` moves where *new*
+/// launches read and write while live panes keep writing the old location.
+#[test]
+fn audit_0678_set_context_root_does_not_move_a_live_app_pane_root() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let (_tile, pane_id) = app.add_test_pane();
+    let launch_root = app.windows[0]
+        .panes
+        .get(&pane_id)
+        .and_then(|p| p.as_app())
+        .expect("test pane is an app pane")
+        .workspace_root
+        .clone();
+
+    let moved = tempfile::tempdir().expect("new root");
+    let ctx_id = app.router.get(0).context_id;
+    app.set_context_root(moved.path().to_path_buf(), Some(ctx_id));
+
+    let after = app.windows[0]
+        .panes
+        .get(&pane_id)
+        .and_then(|p| p.as_app())
+        .expect("test pane is still an app pane")
+        .workspace_root
+        .clone();
+    assert_eq!(
+        after, launch_root,
+        "a live app pane keeps its launch-time workspace_root after set_context_root"
+    );
+    assert_ne!(
+        after,
+        moved.path().to_path_buf(),
+        "the pane does not follow the context's new root"
+    );
+}

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -4839,7 +4839,8 @@ mod tests {
                 app_dir.join("manifest.toml"),
                 format!(
                     "schema_version = 1\n\n[app]\nid = \"{app_id}\"\ntype = \"app\"\n\
-                     name = \"{app_id}\"\nversion = \"0.0.1\"\nentry = \"main.py\"\n"
+                     name = \"{app_id}\"\nversion = \"0.0.1\"\nentry = \"main.py\"\n\
+                     \n[runtime]\npython_compat = true\n"
                 ),
             )
             .expect("write manifest");

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -4698,6 +4698,9 @@ mod tests {
     /// the stale bytes first. Replays the exact host sequence: each instance
     /// loads at launch (`load_python_state`), then persists its own map through
     /// the same writer `save_state` uses (`write_python_state_atomic`).
+    ///
+    /// Assertion discipline for every `audit_0678_*` test: see the comment on
+    /// the `audit_0678` module below.
     #[test]
     fn audit_0678_second_instance_clobbers_the_first_instances_items() {
         // Isolate `config_dir()` so the global-state fallback in
@@ -4776,6 +4779,279 @@ mod tests {
             !python_state_path(&under_b).exists(),
             "reading under root B does not create or migrate anything"
         );
+    }
+
+    /// Stint 0678 audit evidence that needs a *live* app: a real CPython-WASM
+    /// pane launched through the production path, so the copy of the root that
+    /// actually owns the state path — `PythonLaunchConfig::workspace_root` —
+    /// is the one under test.
+    ///
+    /// **Assertion discipline.** Two earlier audit tests in this set passed
+    /// whether or not the defect existed. Both had the same shape: they
+    /// asserted an *implementation site's current value* — a private helper
+    /// returning `None`, a struct field that had not changed — instead of an
+    /// invariant. A fix is free to add a new code path and leave that site
+    /// exactly as it was, so such a test cannot tell a fixed system from a
+    /// broken one, and its green tick is worth nothing to the doc that cites
+    /// it.
+    ///
+    /// Every test here therefore asserts the **pair a fix must reconcile**:
+    /// the stale value *and* its disagreement with the live source of truth it
+    /// is supposed to equal. A fix must change one half or the other, so the
+    /// pair cannot survive one. `assert_state_address_lost` is the sanctioned
+    /// form for the address shape, and refuses to pass unless bytes genuinely
+    /// exist to be stranded — an empty fixture cannot fake a loss.
+    mod audit_0678 {
+        use super::*;
+
+        /// Fails unless an app's persisted bytes are genuinely stranded:
+        /// `live` must hold real bytes, and `reachable` — the address the
+        /// system can still resolve after the operation under test — must be
+        /// a different, empty location. Fixing the defect makes the two agree,
+        /// which fails this assertion by design.
+        fn assert_state_address_lost(live: &Path, reachable: &Path, what: &str) {
+            assert!(
+                live.is_file(),
+                "audit precondition failed for {what}: no bytes at {} to lose",
+                live.display()
+            );
+            assert_ne!(
+                reachable,
+                live,
+                "{what}: the system still resolves the address the bytes are at — \
+                 the defect this test documents no longer reproduces"
+            );
+            assert!(
+                !reachable.is_file(),
+                "{what}: the address the system resolves holds bytes of its own at {}",
+                reachable.display()
+            );
+        }
+
+        /// A minimal but real Python app: a manifest the registry accepts and a
+        /// `.py` entry, which is all `LivePythonPane::launch` needs to start a
+        /// runtime. The guest never has to render for the addressing questions
+        /// this module asks.
+        fn write_python_app(parent: &Path, app_id: &str) -> PathBuf {
+            let app_dir = parent.join(app_id);
+            std::fs::create_dir_all(&app_dir).expect("app dir");
+            std::fs::write(
+                app_dir.join("manifest.toml"),
+                format!(
+                    "schema_version = 1\n\n[app]\nid = \"{app_id}\"\ntype = \"app\"\n\
+                     name = \"{app_id}\"\nversion = \"0.0.1\"\nentry = \"main.py\"\n"
+                ),
+            )
+            .expect("write manifest");
+            std::fs::write(
+                app_dir.join("main.py"),
+                "def init(size, args): return []\ndef update(event): return []\n\
+                 def view(): return None\n",
+            )
+            .expect("write entry");
+            app_dir
+        }
+
+        /// The address the *running* instance writes to, read off its own
+        /// `PythonLaunchConfig` rather than reconstructed from a pane field.
+        fn live_state_address(harness: &crate::testing::HostHarness, pane_id: u64) -> PathBuf {
+            let win = &harness.app.windows[harness.app.active_window];
+            let pane = win
+                .panes
+                .get(&pane_id)
+                .and_then(crate::host::pane::Pane::as_app)
+                .expect("the launched pane is an app pane");
+            match &pane.runtime {
+                crate::host::pane::AppRuntime::Python(live) => python_state_path(&live.config),
+                other => panic!("expected a CPython-WASM runtime, got {}", other.type_id()),
+            }
+        }
+
+        fn seed_items(address: &Path, items: &serde_json::Value) {
+            std::fs::create_dir_all(address.parent().expect("state parent")).expect("mkdir");
+            write_python_state_atomic(
+                address,
+                &serde_json::to_vec_pretty(&serde_json::json!({ "items": items }))
+                    .expect("serialize"),
+            )
+            .expect("the app persists an item");
+        }
+
+        /// Q5, first shape — the read that never happens. A saved workspace
+        /// records an app pane under `AppRuntime::type_id()` (the runtime
+        /// kind), so nothing in the record names the app whose state file the
+        /// pane's bytes are in. Restoring cannot re-address that file no
+        /// matter how it is implemented: the identity is simply not in the
+        /// record. Asserted at that boundary rather than against the current
+        /// restore helper, because a fix is expected to introduce a new
+        /// restore path and leave the helper alone.
+        #[test]
+        fn audit_0678_a_saved_app_pane_cannot_re_address_its_own_state() {
+            let mut harness = crate::testing::HostHarness::new();
+            let root = tempdir().expect("workspace root");
+            let app_dir = write_python_app(root.path(), "todo");
+
+            let pane_id = harness
+                .app
+                .launch_app_by_path_with_layout_no_review_modal(
+                    &app_dir.to_string_lossy(),
+                    None,
+                    Some(root.path().to_path_buf()),
+                    &[],
+                )
+                .expect("launch the app")
+                .expect("a Python launch returns a pane id");
+
+            let live_address = live_state_address(&harness, pane_id);
+            seed_items(&live_address, &serde_json::json!(["buy milk"]));
+
+            harness.app.save_workspace();
+            let saved = crate::workspace::WorkspaceFile::load().expect("saved workspace");
+            let record = saved
+                .windows
+                .iter()
+                .flat_map(|window| &window.panes)
+                .find(|pane| pane.id == pane_id)
+                .expect("the app pane is in the saved workspace");
+            let recorded_id = record
+                .app_id
+                .clone()
+                .expect("an app pane records some app id");
+
+            // The record's cwd is right; its identity is not. Everything a
+            // restorer could address from it lands somewhere else.
+            let reachable = python_state_path(&state_test_config(&record.cwd, &recorded_id));
+            assert_state_address_lost(
+                &live_address,
+                &reachable,
+                "workspace save of a live CPython-WASM app pane",
+            );
+
+            // The other half of the pair: the identity that *would* re-address
+            // the file is on the pane the whole time, and is not what was
+            // written. A fix that records it flips this and the assertion above
+            // together.
+            let manifest_id = harness.app.windows[harness.app.active_window]
+                .panes
+                .get(&pane_id)
+                .and_then(crate::host::pane::Pane::as_app)
+                .expect("app pane")
+                .manifest_id
+                .clone();
+            assert_ne!(
+                recorded_id, manifest_id,
+                "the saved record names the runtime kind, not the app — \
+                 `manifest_id` is on the pane and carries the state file's name"
+            );
+        }
+
+        /// Q3 — `set-root` after launch. The context's root moves; the running
+        /// app's address does not, because it was captured into
+        /// `PythonLaunchConfig` at launch and nothing revisits it. Asserted as
+        /// a pair: the address is *unchanged*, and it *disagrees* with the
+        /// root the context now has. Any addressing fix — call-time resolution
+        /// against the live root, or a scope that drops the root entirely —
+        /// breaks one half or the other.
+        #[test]
+        fn audit_0678_set_context_root_leaves_a_running_app_at_the_old_address() {
+            let mut harness = crate::testing::HostHarness::new();
+            let root_a = tempdir().expect("root a");
+            let root_b = tempdir().expect("root b");
+            let context_id = harness.app.router.get(0).context_id;
+            harness
+                .app
+                .set_context_root(root_a.path().to_path_buf(), Some(context_id));
+
+            // The launch root is the context root — what `resolve_new_pane_cwd`
+            // yields for an app the registry has no workspace root for.
+            let app_dir = write_python_app(root_a.path(), "todo");
+            let pane_id = harness
+                .app
+                .launch_app_by_path_with_layout_no_review_modal(
+                    &app_dir.to_string_lossy(),
+                    None,
+                    Some(root_a.path().to_path_buf()),
+                    &[],
+                )
+                .expect("launch the app")
+                .expect("a Python launch returns a pane id");
+            let at_launch = live_state_address(&harness, pane_id);
+            assert_eq!(
+                at_launch,
+                python_state_path(&state_test_config(root_a.path(), "todo")),
+                "precondition: the running app is addressed under the context root"
+            );
+            seed_items(&at_launch, &serde_json::json!(["buy milk"]));
+
+            harness
+                .app
+                .set_context_root(root_b.path().to_path_buf(), Some(context_id));
+
+            assert_eq!(
+                live_state_address(&harness, pane_id),
+                at_launch,
+                "the running app still writes its launch-time address"
+            );
+            assert_state_address_lost(
+                &at_launch,
+                &python_state_path(&state_test_config(root_b.path(), "todo")),
+                "set_context_root while the app is running",
+            );
+        }
+
+        /// Q5, third shape — the read that resolves somewhere the write never
+        /// goes. `load_python_state` has a second candidate (the channel-neutral
+        /// global path); `save_state` has one. So a launch can be seeded from
+        /// bytes it will never write back to, and every later launch under a
+        /// different root is seeded from those same stale bytes again. This is
+        /// the claim stint 0682 rests on, reproduced end to end rather than
+        /// read off the code.
+        #[test]
+        fn audit_0678_a_launch_seeded_from_the_global_fallback_never_writes_back_to_it() {
+            let profile_parent = tempdir().expect("profile parent");
+            let _profile =
+                crate::config::set_test_profile_dir(profile_parent.path().join(".plexi-alpha"));
+            let _channel = crate::config::set_test_channel("alpha");
+            let root_a = tempdir().expect("root a");
+            let root_b = tempdir().expect("root b");
+
+            let global = profile_parent.path().join(".plexi/app_states/todo.json");
+            std::fs::create_dir_all(global.parent().expect("global parent")).expect("mkdir");
+            std::fs::write(&global, br#"{"items":["from the global copy"]}"#).expect("seed global");
+
+            // A launch under root A resolves the global candidate — its own
+            // workspace address does not exist yet.
+            let under_a = state_test_config(root_a.path(), "todo");
+            let seeded = load_python_state(&under_a).expect("launch under A");
+            assert_eq!(seeded["items"], serde_json::json!(["from the global copy"]));
+
+            // It persists. There is only one write candidate, and it is not
+            // the one the bytes came from.
+            let write_address = python_state_path(&under_a);
+            seed_items(
+                &write_address,
+                &serde_json::json!(["from the global copy", "added under A"]),
+            );
+            assert_ne!(
+                write_address, global,
+                "the write lands at the workspace address, not the one the read resolved"
+            );
+            assert_eq!(
+                std::fs::read(&global).expect("global bytes"),
+                br#"{"items":["from the global copy"]}"#,
+                "the bytes the launch was seeded from are never updated"
+            );
+
+            // So the next launch under any other root is seeded from the same
+            // stale copy, and the item added under A is invisible to it.
+            let under_b = load_python_state(&state_test_config(root_b.path(), "todo"))
+                .expect("launch under B");
+            assert_eq!(
+                under_b["items"],
+                serde_json::json!(["from the global copy"]),
+                "a later launch re-reads the stale global bytes, not what the app last wrote"
+            );
+        }
     }
 
     #[test]

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -4692,6 +4692,92 @@ mod tests {
         );
     }
 
+    /// Stint 0678 audit evidence (Q2/Q5): two live instances of one app under
+    /// the same root address one file, and the loser is the instance that
+    /// persists *last* with the older in-memory map — not the one that wrote
+    /// the stale bytes first. Replays the exact host sequence: each instance
+    /// loads at launch (`load_python_state`), then persists its own map through
+    /// the same writer `save_state` uses (`write_python_state_atomic`).
+    #[test]
+    fn audit_0678_second_instance_clobbers_the_first_instances_items() {
+        // Isolate `config_dir()` so the global-state fallback in
+        // `load_python_state` resolves inside a tempdir, never the real profile.
+        let profile = tempdir().expect("profile");
+        let _profile = crate::config::set_test_profile_dir(profile.path().join("profile"));
+        let workspace = tempdir().expect("workspace");
+        let first = state_test_config(workspace.path(), "todo");
+        let second = state_test_config(workspace.path(), "todo");
+        assert_eq!(
+            python_state_path(&first),
+            python_state_path(&second),
+            "instance identity does not enter the state path — only app_id and workspace_root do"
+        );
+
+        // Both instances launch against an empty store and hold their own copy.
+        let mut first_state = load_python_state(&first).expect("first launch load");
+        let second_state = load_python_state(&second).expect("second launch load");
+        assert!(first_state.is_empty() && second_state.is_empty());
+
+        // The user adds an item in the first instance; it persists.
+        first_state.insert("items".to_string(), json!(["buy milk"]));
+        let path = python_state_path(&first);
+        std::fs::create_dir_all(path.parent().expect("state parent")).expect("mkdir");
+        write_python_state_atomic(
+            &path,
+            &serde_json::to_vec_pretty(&first_state).expect("serialize"),
+        )
+        .expect("first persist");
+        assert_eq!(
+            load_python_state(&second).expect("readback")["items"],
+            json!(["buy milk"])
+        );
+
+        // The second instance persists anything at all — a draft keystroke is
+        // enough — and writes the empty item list it has held since launch.
+        write_python_state_atomic(
+            &path,
+            &serde_json::to_vec_pretty(&second_state).expect("serialize"),
+        )
+        .expect("second persist");
+
+        let survivor = load_python_state(&first).expect("post-clobber load");
+        assert!(
+            survivor.get("items").is_none(),
+            "the second instance's launch-time map overwrote the item: {survivor:?}"
+        );
+    }
+
+    /// Stint 0678 audit evidence (Q4/Q5): state is addressed by
+    /// `workspace_root`, so the same app id launched under a different root
+    /// reads a different file and sees nothing. Nothing merges the two, and
+    /// nothing warns — this is the "write to a path nobody reads" shape.
+    #[test]
+    fn audit_0678_state_written_under_one_root_is_invisible_under_another() {
+        let profile = tempdir().expect("profile");
+        let _profile = crate::config::set_test_profile_dir(profile.path().join("profile"));
+        let root_a = tempdir().expect("root a");
+        let root_b = tempdir().expect("root b");
+        let under_a = state_test_config(root_a.path(), "todo");
+        let under_b = state_test_config(root_b.path(), "todo");
+
+        let path_a = python_state_path(&under_a);
+        std::fs::create_dir_all(path_a.parent().expect("state parent")).expect("mkdir");
+        write_python_state_atomic(&path_a, br#"{"items":["buy milk"]}"#).expect("persist under A");
+
+        assert_eq!(
+            load_python_state(&under_a).expect("load under A")["items"],
+            json!(["buy milk"])
+        );
+        assert!(
+            load_python_state(&under_b).expect("load under B").is_empty(),
+            "a launch rooted elsewhere sees an empty store, not the items"
+        );
+        assert!(
+            !python_state_path(&under_b).exists(),
+            "reading under root B does not create or migrate anything"
+        );
+    }
+
     #[test]
     fn python_state_never_overwrites_canonical_with_orphan() {
         let workspace = tempdir().expect("workspace");

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -2027,27 +2027,4 @@ mod tests {
             "root tile must hold the launched wasm pane"
         );
     }
-
-    /// Stint 0678 audit evidence (Q5): a saved Python or native-WASM app pane
-    /// records `AppRuntime::type_id()` — the runtime kind, not the app id — so
-    /// the restore path has nothing to look the app up by. `builtin_factory`
-    /// has no entry for a runtime kind, restore returns `None`, and the caller
-    /// substitutes a terminal. The app is never relaunched, so its persisted
-    /// state is never read back on the next boot.
-    #[test]
-    fn audit_0678_wasm_app_panes_are_not_restorable_from_a_saved_workspace() {
-        let cwd = std::env::temp_dir();
-        assert!(
-            restore_builtin_app_pane("python-wasm", 900, cwd.clone(), None).is_none(),
-            "a CPython-WASM pane cannot be restored — the saved app_id is the runtime kind"
-        );
-        assert!(
-            restore_builtin_app_pane("wasm", 901, cwd.clone(), None).is_none(),
-            "a native-WASM pane cannot be restored either"
-        );
-        assert!(
-            restore_builtin_app_pane("todo", 902, cwd, None).is_none(),
-            "and the real app id would not resolve either — todo is not a builtin"
-        );
-    }
 }

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -2027,4 +2027,27 @@ mod tests {
             "root tile must hold the launched wasm pane"
         );
     }
+
+    /// Stint 0678 audit evidence (Q5): a saved Python or native-WASM app pane
+    /// records `AppRuntime::type_id()` — the runtime kind, not the app id — so
+    /// the restore path has nothing to look the app up by. `builtin_factory`
+    /// has no entry for a runtime kind, restore returns `None`, and the caller
+    /// substitutes a terminal. The app is never relaunched, so its persisted
+    /// state is never read back on the next boot.
+    #[test]
+    fn audit_0678_wasm_app_panes_are_not_restorable_from_a_saved_workspace() {
+        let cwd = std::env::temp_dir();
+        assert!(
+            restore_builtin_app_pane("python-wasm", 900, cwd.clone(), None).is_none(),
+            "a CPython-WASM pane cannot be restored — the saved app_id is the runtime kind"
+        );
+        assert!(
+            restore_builtin_app_pane("wasm", 901, cwd.clone(), None).is_none(),
+            "a native-WASM pane cannot be restored either"
+        );
+        assert!(
+            restore_builtin_app_pane("todo", 902, cwd, None).is_none(),
+            "and the real app id would not resolve either — todo is not a builtin"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Implements stints 0678 and 0679. No linked GitHub issue — stint is authoritative.
Ships two documents and the tests that prove them. **No host behaviour changes**:
the diff is `docs/` plus five `#[cfg(test)]` additions.

- **0678 — audit.** `docs/context-state-persistence-audit.md` answers all five of
  the task's questions with reproduced evidence (tests, live host logs, bytes on
  disk), and names the confirmed root cause: app state is addressed by the
  launch-time filesystem root of the pane, and nothing guarantees that address is
  stable, unique, or revisited. Three independent defects sit on that path, each
  sufficient on its own to lose an item.
- **0679 — design brief.** `docs/context-root-uniqueness-and-rollup.md` designs the
  duplicate-root hard stop and the parent-dir todo rollup for Ian's ruling,
  consuming the audit's findings rather than re-deriving them. Recommended design,
  rejected alternatives, six open decisions, and the stints that would follow
  approval. No stints filed pre-approval, per the task.

### What the audit found

1. A Python/native-WASM app pane is saved under its **runtime kind**
   (`AppRuntime::type_id()` → `python-wasm`), never its app id, and
   `serialize_state` returns `None`. Restore can't rebuild it and substitutes a
   `TerminalPane` — the app never relaunches, so its state is never read.
2. State is addressed by the launch-time `workspace_root`, so an item written
   under one root is invisible from another. Nothing merges, nothing warns.
3. Two live instances under one root address one file with no coordination; each
   serializes its own in-memory map whole, so the last one to persist overwrites
   the other's items.

Duplicate roots are not an edge case: `new_context_empty` anchors every rootless
context at the home directory, and a sub-context inherits its parent's root
verbatim. A live saved workspace on this machine holds two contexts both rooted at
home, with two todo panes — in different contexts — both resolving to one file.

### 0652 / PR #2536

Reported as a distinct thing from shipped alpha, per the task. #2536 is **open,
conflicting, and unmerged**; the audit describes where 0652 lands the resolution
rules (`src/host/state_scope.rs`, call-time resolution against the live context
root) and maps each question onto it: Q3 fixed, Q4 fixed for todo by its
`global` default, Q1/Q2 and the restore defect untouched. Its path rules are not
re-litigated and nothing here rebases or touches that branch.

### Fix stints filed from the findings

Filed through `/create-stint` (`stint add` owns id assignment), promoted to ready
in s10, and cross-referenced from the doc:

| Stint | Defect |
|---|---|
| 0680 | WASM/Python app panes are not restored — the pane returns as a terminal |
| 0681 | Two live instances of one app overwrite each other's state whole |
| 0682 | State read and write resolve to different paths (read has a fallback the write lacks) |
| 0683 | State reads/writes are untraced — the persist log line names no path |

## Done When

- 0678: findings doc under `docs/` stating the actual mechanism with reproduced
  evidence per question, the confirmed root cause, the interaction with 0652, and
  fix stints filed and cross-referenced. No code fix. ✔
- 0679: design brief for Ian's morning ruling — recommended design, rejected
  alternatives, open decisions he must own, stints that would follow approval,
  checked against `NORTH_STAR.md`. No code, no stints filed pre-approval. ✔
- Both docs follow `docs/AGENTS.md` (Stint + Status lines, indexed in the table)
  and carry no volatile line numbers or counts — symbols by name only.

## Test evidence

Diff classification: **docs + tests only.** No host logic, no UI layer, no SDK.

Five audit tests, all deterministic, asserting what alpha *does* today (a fix is
expected to change them). They are the reproduction the task required:

- `audit_0678_two_contexts_accept_the_same_root` (Q1)
- `audit_0678_set_context_root_does_not_move_a_live_app_pane_root` (Q3)
- `audit_0678_second_instance_clobbers_the_first_instances_items` (Q2/Q5)
- `audit_0678_state_written_under_one_root_is_invisible_under_another` (Q4/Q5)
- `audit_0678_wasm_app_panes_are_not_restorable_from_a_saved_workspace` (Q5)

`cargo test --bin plexi`, env-stripped, memory-watchdogged, one cargo process:

```
test result: ok. 2163 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out; finished in 135.41s
```

All five audit tests green in that run. An earlier run of this branch was killed
mid-suite for machine health (SIGTERM/SIGKILL, build-directory lock contention);
the one assistant-test failure it showed did not reproduce in the clean run above
and was an artifact of the kill.

Non-test evidence used by the audit and reproducible by hand: `workspace_restore`
and `launch_app_by_id_with_layout` traces in `~/.plexi-alpha/plexi.log` and
`~/.plexi-beta/plexi.log`; the saved workspace files under each channel profile's
`workspaces/` dir; and every `app_states/` directory beneath the home directory.

Conclusion: **docs-only — no install required.** Nothing in this PR is reachable
from the binary; there is no behaviour to drive. The Codex review layer did not
run (CLI out of credits until Aug 5), so this diff ships without an AI review
pass — it is prose plus test-only Rust.
