### PR TITLE
chore(sdk): regenerate uv.lock for the v0.2.3 version bump

### DIFF
--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "plexi-sdk"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
One-line lockfile fix, no code change.

Release commit `8e3c2b49 chore: release v0.2.3` bumped `sdk/python/pyproject.toml` to `0.2.3` but did not regenerate the lockfile, so `sdk/python/uv.lock` still pins `plexi-sdk 0.2.2`. Regenerated with `uv lock` (not hand-edited).

Same follow-up commit `73409558 chore(sdk): regenerate uv.lock for the v0.2.0 version bump` made after the v0.2.0 release, so this is an established pattern rather than a new convention.

Found incidentally while rebasing #2545 (stint 0677): the drift showed up as an unstaged working-tree change during that gate. It was deliberately kept out of that PR to avoid scope creep and is landing on its own here.

**Verification:** `uv lock` resolved 9 packages and reported `Updated plexi-sdk v0.2.2 -> v0.2.3`; the resulting diff is exactly the one version line.