### PR TITLE
Fix Plexi-owned app theming end to end (stint 0696)

### DIFF
--- a/sdk/protocol/pgap.schema.json
+++ b/sdk/protocol/pgap.schema.json
@@ -169,7 +169,7 @@
           "type": "object"
         },
         "NotifyKind": {
-          "description": "The shape / interaction model of a notification.\n\n- `Message` — title + body, single Acknowledge button.\n- `Choice`  — title + body + N options; Enter picks the focused one, ↑↓/j-k\n              cycles, 1-9 direct-selects, optional per-option `shortcut` key.\n- `Input`   — title + body + a text field; Enter submits.\n\nFuture kinds (image / audio / video / rich) will land here without breaking\nexisting apps — `#[serde(default)]` on the field means missing `kind`\ndeserializes to `Message`.",
+          "description": "The shape / interaction model of a notification.\n\n- `Message` — title + body, single Acknowledge button.\n- `Choice`  — title + body + N options; Enter picks the focused one, ↑↓/j-k\n  cycles, 1-9 direct-selects, optional per-option `shortcut` key.\n- `Input`   — title + body + a text field; Enter submits.\n\nFuture kinds (image / audio / video / rich) will land here without breaking\nexisting apps — `#[serde(default)]` on the field means missing `kind`\ndeserializes to `Message`.",
           "enum": [
             "message",
             "choice",
@@ -664,6 +664,43 @@
             "title",
             "body",
             "priority"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Remove a notification posted by the caller. The host verifies the\ncaller identity against the notification's stamped provenance.",
+          "properties": {
+            "notify_id": {
+              "type": "string"
+            },
+            "response_file": {
+              "type": "string"
+            },
+            "source_context_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "source_pane_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "type": {
+              "const": "dismiss_notification",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "notify_id",
+            "response_file"
           ],
           "type": "object"
         },
@@ -1417,6 +1454,55 @@
             "type",
             "pane_id",
             "text"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Configure or disable a host-owned recurring terminal prompt.",
+          "properties": {
+            "every_ms": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "off": {
+              "default": false,
+              "type": "boolean"
+            },
+            "pane_id": {
+              "format": "uint64",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "response_file": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "text": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": {
+              "const": "pane_heartbeat",
+              "type": "string"
+            },
+            "while_idle_only": {
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "pane_id"
           ],
           "type": "object"
         },
@@ -2678,7 +2764,7 @@
           "type": "object"
         },
         {
-          "description": "Open a workspace artifact (file or directory) via the host.\n\nModes:\n  - `OpenInPane`        — open the path in a new app pane, e.g. a\n                          file browser at a directory or a text\n                          editor on a file. Implementation: routes\n                          through the file-browser app for\n                          directories; falls through to the OS\n                          default for files in this PR.\n  - `RevealInFinder`    — `open -R <path>` on macOS.\n  - `OpenWithDefault`   — `open <path>` on macOS — uses Launch\n                          Services to pick the registered app for\n                          the file's UTI.\n\nCapability: `terminal.bindings`. All fields required.",
+          "description": "Open a workspace artifact (file or directory) via the host.\n\nModes:\n  - `OpenInPane` — open the path in a new app pane, e.g. a file\n    browser at a directory or a text editor on a file.\n    Implementation: routes through the file-browser app for\n    directories; falls through to the OS default for files in\n    this PR.\n  - `RevealInFinder` — `open -R <path>` on macOS.\n  - `OpenWithDefault` — `open <path>` on macOS — uses Launch\n    Services to pick the registered app for the file's UTI.\n\nCapability: `terminal.bindings`. All fields required.",
           "properties": {
             "mode": {
               "$ref": "#/$defs/ArtifactOpenMode"
@@ -3857,7 +3943,7 @@
           "type": "object"
         },
         {
-          "description": "Pane group CWD broadcast. Apps in the same group receive this when any\nmember's CWD changes.",
+          "description": "Pane group CWD broadcast. **Declared, never constructed** — no host path\nemits this today; `sync_app_cwd` reassigns `workspace_root` in place\ninstead. Do not cite it as the mechanism behind a cwd-scoping symptom.",
           "properties": {
             "cwd": {
               "type": "string"
@@ -3913,7 +3999,7 @@
           "type": "object"
         },
         {
-          "description": "Host theme changed (config hot-reload or macOS system appearance toggle).\nApp should update its color state; the next render will pick up the new colors.",
+          "description": "Host theme changed through Plexi configuration.\nApp should update its color state; the next render will pick up the new colors.",
           "properties": {
             "colors": {
               "additionalProperties": {

--- a/sdk/python/plexi_sdk/_v3_runtime.py
+++ b/sdk/python/plexi_sdk/_v3_runtime.py
@@ -223,6 +223,7 @@ class V3AppRuntime:
         elif t == "theme":
             from ._theme import theme as _theme
             _theme.update_from(ev.get("colors"))
+            _emit({"type": "schedule_render", "after_ms": 16})
         elif t == "inject_state":
             payload = ev.get("payload") or {}
             if isinstance(payload, dict):

--- a/sdk/python/tests/test_v3_runtime_regression.py
+++ b/sdk/python/tests/test_v3_runtime_regression.py
@@ -122,6 +122,32 @@ def _find_events(events: list[dict], event_type: str) -> list[dict]:
     return [e for e in events if e.get("type") == event_type]
 
 
+def test_theme_event_schedules_render(tmp_path):
+    app = tmp_path / "theme_app.py"
+    app.write_text(textwrap.dedent("""
+        from plexi_sdk.ui import Text
+
+        def init(size, args):
+            return []
+
+        def update(event):
+            return []
+
+        def view():
+            return Text("theme")
+    """).lstrip())
+    proc = _spawn_v3_app(app)
+    try:
+        _init_app(proc)
+        _send_event(proc, {"type": "theme", "colors": {"fg": "#123456"}})
+        events = _render(proc)
+        assert _find_events(events, "schedule_render"), (
+            "a Theme event must schedule a render so the new colors become visible"
+        )
+    finally:
+        proc.kill()
+
+
 def test_protocol_output_flushes_one_batch_per_input_event(monkeypatch):
     from plexi_sdk import _v3_runtime as runtime
 

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -1070,10 +1070,6 @@ impl PlexiApp {
         self.binding_table = crate::host::keys::build_binding_table(&self.key_bindings);
         log::info!("keybindings: rebuilt after config reload");
 
-        // Reset so the auto-switch re-evaluates against the current system theme (#1776, #1812).
-        // Without this, a config reload that restores a disk preset would leave
-        // last_system_theme unchanged, silently suppressing the auto-switch.
-        self.last_system_theme = None;
         log::info!(
             "Configuration reloaded from disk. active_workspace={}",
             active_workspace
@@ -1082,49 +1078,26 @@ impl PlexiApp {
         );
     }
 
-    /// Auto-switch to the paired preset for `system_theme`.
-    /// No-ops if the configured preset has no paired variant (e.g. nord, dracula).
-    pub(super) fn apply_auto_theme(&mut self, system_theme: egui::Theme) {
-        let current_preset = self
-            .config
-            .theme
-            .as_ref()
-            .and_then(|t| t.preset.as_deref())
-            .unwrap_or("");
-        let Some(new_preset) = crate::ui::theme::paired_preset(current_preset, system_theme) else {
-            return;
-        };
-        log::info!("theme: auto-switch to {new_preset} (system_theme={system_theme:?})");
-        if let Some(preset) = crate::ui::theme::preset_colors(new_preset) {
-            let user_theme = self.config.theme.clone().unwrap_or_default();
-            let theme_cfg = crate::ui::theme::apply_preset(&preset, &user_theme);
-            let new_colors = crate::ui::theme::Colors::from_config(&theme_cfg);
-            if self.colors != new_colors {
-                self.colors = new_colors;
-                let dark_mode = !crate::ui::theme::is_light_preset(new_preset);
-                crate::ui::theme::setup_style(&self.ctx, &new_colors, dark_mode);
-                let window_theme = if dark_mode {
-                    egui::SystemTheme::Dark
-                } else {
-                    egui::SystemTheme::Light
-                };
-                self.ctx
-                    .send_viewport_cmd(egui::ViewportCommand::SetTheme(window_theme));
-                self.theme = crate::ui::theme::terminal_theme(&theme_cfg);
-                self.broadcast_theme_event();
-            }
-        }
-    }
-
     /// Push the current host `Colors` to every running app as a `Theme` event.
-    /// Called after `self.colors` is updated — both on config hot-reload and on
-    /// macOS system-appearance change — so apps never need to poll for theme changes.
-    fn broadcast_theme_event(&mut self) {
+    /// Called after `self.colors` is updated on config hot-reload.
+    pub(crate) fn broadcast_theme_event(&mut self) {
         let event = crate::app_protocol::PlexiEvent::Theme {
             colors: self.colors.to_theme_map(),
         };
-        let _ = event;
-        log::info!("theme: broadcast Theme event to all running apps");
+        let mut delivered = 0;
+        for window in &mut self.windows {
+            for pane in window.panes.values_mut() {
+                if let Some(app) = pane.as_app_mut() {
+                    app.runtime.queue_outbound_event(event.clone());
+                    delivered += 1;
+                }
+            }
+        }
+        for (_, app) in self.background_apps.values_mut() {
+            app.queue_outbound_event(event.clone());
+            delivered += 1;
+        }
+        log::info!("theme: broadcast Theme event to {delivered} running apps");
     }
 
     /// Reconcile the confirm-close focus layer with `pending_close`. Mirrors

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -452,8 +452,6 @@ pub struct PlexiApp {
     /// Written on every heartbeat and on clean pane transitions; deleted on
     /// clean shutdown. If present at startup → emit crash_recovery event.
     pub(crate) focus_journal_path: std::path::PathBuf,
-    /// Last observed system theme for auto-switching catppuccin variants (#1776).
-    pub(crate) last_system_theme: Option<egui::Theme>,
     /// App commands held while a modal overlay owns keyboard input. Released and
     /// dispatched on the first frame where `input_captured_by_overlay()` is false.
     /// Only overlay-unsafe side effects are held here; safe commands (ShowNotification,
@@ -1487,7 +1485,6 @@ impl PlexiApp {
                     focus_started_at: None,
                     terminal_traversal_lock: None,
                     focus_journal_path: crate::config::config_dir().join("focus-journal.jsonl"),
-                    last_system_theme: None,
                     overlay_held_cmds: Vec::new(),
                     agent_host: crate::agent::AgentHost::production(config.ai),
                     pending_pane_clicks: HashMap::new(),
@@ -1747,7 +1744,6 @@ impl PlexiApp {
             focus_started_at: None,
             terminal_traversal_lock: None,
             focus_journal_path: crate::config::config_dir().join("focus-journal.jsonl"),
-            last_system_theme: None,
             overlay_held_cmds: Vec::new(),
             agent_host,
             pending_pane_clicks: HashMap::new(),
@@ -2196,7 +2192,6 @@ impl PlexiApp {
                 focus_started_at: None,
                 terminal_traversal_lock: None,
                 focus_journal_path: crate::config::config_dir().join("focus-journal.jsonl"),
-                last_system_theme: None,
                 overlay_held_cmds: Vec::new(),
                 agent_host: crate::agent::AgentHost::inert(),
                 pending_pane_clicks: HashMap::new(),
@@ -3382,15 +3377,6 @@ impl eframe::App for PlexiApp {
         });
         if config_changed {
             self.reload_config();
-        }
-
-        // Auto-switch paired theme variant on macOS appearance change (#1776, #1812).
-        let current_system_theme = self.ctx.system_theme();
-        if current_system_theme != self.last_system_theme {
-            self.last_system_theme = current_system_theme;
-            if let Some(sys_theme) = current_system_theme {
-                self.apply_auto_theme(sys_theme);
-            }
         }
 
         // App registry hot-reload (#1712): drain filesystem watcher signals.

--- a/src/app/tests/focus_tests.rs
+++ b/src/app/tests/focus_tests.rs
@@ -1,5 +1,108 @@
 use super::super::*;
 use crate::testing::HostHarness;
+use std::sync::{Arc, Mutex};
+
+struct ThemeEventRecorder {
+    events: Arc<Mutex<Vec<crate::app_protocol::PlexiEvent>>>,
+}
+
+impl crate::app::app_trait::App for ThemeEventRecorder {
+    fn type_id(&self) -> &'static str {
+        "theme-event-recorder"
+    }
+
+    fn display_name(&self) -> String {
+        "Theme event recorder".to_string()
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn ui(
+        &mut self,
+        _ui: &mut egui::Ui,
+        _ctx: &crate::app::app_trait::AppRenderContext<'_>,
+        _pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
+    }
+
+    fn queue_outbound_event(&mut self, event: crate::app_protocol::PlexiEvent) {
+        self.events.lock().expect("event recorder").push(event);
+    }
+}
+
+fn add_theme_event_recorder(
+    app: &mut PlexiApp,
+    window_index: usize,
+    hidden: bool,
+) -> Arc<Mutex<Vec<crate::app_protocol::PlexiEvent>>> {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let pane_id = app.host.alloc_pane_id();
+    let pane = crate::host::pane::Pane::App(Box::new(crate::host::pane::AppPane {
+        pip_status: None,
+        id: pane_id,
+        runtime: crate::host::pane::AppRuntime::Builtin(Box::new(ThemeEventRecorder {
+            events: events.clone(),
+        })),
+        workspace_root: "/tmp".into(),
+        permissions: crate::app::permissions::AppPermissions::builtin(),
+        manifest_id: "theme-event-recorder".to_string(),
+        name: "theme-event-recorder".to_string(),
+        pane_group: None,
+        linked_pane_id: None,
+        overlay_replaced: None,
+        hidden,
+        agent: None,
+        slots: HashMap::new(),
+        semantic_state: Default::default(),
+    }));
+    app.windows[window_index].panes.insert(pane_id, pane);
+    let tile = app.windows[window_index].tree.tiles.insert_pane(pane_id);
+    if app.windows[window_index].tree.root().is_none() {
+        app.windows[window_index].tree.root = Some(tile);
+    }
+    events
+}
+
+#[test]
+fn theme_broadcast_reaches_background_apps_in_every_window() {
+    let ctx = egui::Context::default();
+    let frame_tick = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _) = PlexiApp::new_for_test(ctx, frame_tick);
+    let background_events = add_theme_event_recorder(&mut app, 0, true);
+    app.windows.push(crate::host::context::Window {
+        name: "inactive".to_string(),
+        path: "/tmp".into(),
+        tree: egui_tiles::Tree::empty("inactive-theme-window"),
+        panes: HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 1,
+        grid_y: 0,
+        window_id: 2,
+        context_id: 2,
+    });
+    let inactive_events = add_theme_event_recorder(&mut app, 1, false);
+    let parked_events = Arc::new(Mutex::new(Vec::new()));
+    app.background_apps.insert(
+        "parked-theme-recorder".to_string(),
+        (
+            1,
+            Box::new(ThemeEventRecorder {
+                events: parked_events.clone(),
+            }),
+        ),
+    );
+
+    app.broadcast_theme_event();
+
+    for events in [background_events, inactive_events, parked_events] {
+        let events = events.lock().expect("event recorder");
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], crate::app_protocol::PlexiEvent::Theme { .. }));
+    }
+}
 
 // ── Focus history tests ───────────────────────────────────────────────────
 

--- a/src/cli/app_check.rs
+++ b/src/cli/app_check.rs
@@ -45,6 +45,12 @@ pub(crate) fn python_launch_config_from_parts(
         workspace_root: app_dir.to_path_buf(),
         capabilities: capabilities.to_vec(),
         allowed_hosts: allowed_hosts.to_vec(),
+        theme: crate::ui::theme::colors_from_config(
+            &crate::config::PlexiConfig::load_with_workspace(
+                crate::config::active_workspace_root().as_deref(),
+            ),
+        )
+        .to_theme_map(),
     }
 }
 

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -319,6 +319,7 @@ pub struct PythonLaunchConfig {
     pub workspace_root: PathBuf,
     pub capabilities: Vec<String>,
     pub allowed_hosts: Vec<String>,
+    pub theme: std::collections::HashMap<String, String>,
 }
 
 impl PythonLaunchConfig {
@@ -365,7 +366,37 @@ impl PythonLaunchConfig {
             workspace_root: app_dir.to_path_buf(),
             capabilities: manifest.app.capabilities.capabilities,
             allowed_hosts: manifest.app.capabilities.allowed_hosts,
+            theme: crate::ui::theme::colors_from_config(
+                &crate::config::PlexiConfig::load_with_workspace(Some(app_dir)),
+            )
+            .to_theme_map(),
         }))
+    }
+}
+
+fn python_init_payload(
+    config: &PythonLaunchConfig,
+    state: Value,
+    size: (f32, f32),
+) -> Value {
+    json!({
+        "type": "init",
+        "app_id": config.app_id,
+        "workspace_root": config.workspace_root,
+        "capabilities": config.capabilities,
+        "state": state,
+        "theme": config.theme,
+        "args": config.launch_args,
+        "size": [size.0, size.1],
+    })
+}
+
+fn cache_python_theme_for_relaunch(
+    config: &mut PythonLaunchConfig,
+    event: &crate::app_protocol::PlexiEvent,
+) {
+    if let crate::app_protocol::PlexiEvent::Theme { colors } = event {
+        config.theme.clone_from(colors);
     }
 }
 
@@ -569,16 +600,11 @@ impl HeadlessPythonSession {
         seed_state: Option<Value>,
     ) -> Result<Self, WasmPythonError> {
         let runtime = WasmPythonRuntime::launch(config)?;
-        runtime.send(&json!({
-            "type": "init",
-            "app_id": config.app_id,
-            "workspace_root": config.workspace_root,
-            "capabilities": config.capabilities,
-            "state": seed_state,
-            "theme": {},
-            "args": config.launch_args,
-            "size": [size.0, size.1],
-        }))?;
+        runtime.send(&python_init_payload(
+            config,
+            seed_state.unwrap_or(Value::Null),
+            size,
+        ))?;
         let mut session = Self {
             runtime,
             last_tree: None,
@@ -1508,13 +1534,11 @@ impl LivePythonPane {
             }
             self.initialized = true;
             self.viewport_size = Some((size.x, size.y));
-            if let Err(error) = self.runtime.send(&json!({
-                "type": "init", "app_id": self.app_id,
-                "workspace_root": self.config.workspace_root,
-                "capabilities": self.config.capabilities, "state": self.persisted_state, "theme": {},
-                "args": self.config.launch_args,
-                "size": [size.x, size.y]
-            })) {
+            if let Err(error) = self.runtime.send(&python_init_payload(
+                &self.config,
+                Value::Object(self.persisted_state.clone()),
+                (size.x, size.y),
+            )) {
                 self.error = Some(error.to_string());
                 if pending_click.is_some() {
                     log::error!(
@@ -2298,6 +2322,7 @@ impl LivePythonPane {
     }
 
     pub fn queue_outbound_event(&mut self, event: crate::app_protocol::PlexiEvent) {
+        cache_python_theme_for_relaunch(&mut self.config, &event);
         match encode_python_host_event(event) {
             Ok(value) => {
                 if let Err(error) = self.runtime.send(&value) {
@@ -4269,7 +4294,49 @@ mod tests {
             workspace_root: workspace_root.to_path_buf(),
             capabilities: Vec::new(),
             allowed_hosts: Vec::new(),
+            theme: crate::ui::theme::colors_from_config(
+                &crate::config::PlexiConfig::default(),
+            )
+            .to_theme_map(),
         }
+    }
+
+    #[test]
+    fn python_init_payload_carries_the_active_host_theme() {
+        let workspace = tempdir().expect("workspace");
+        let mut config = state_test_config(workspace.path(), "test.theme-init");
+        config.theme = std::collections::HashMap::from([
+            ("fg".to_string(), "#123456".to_string()),
+            ("bg".to_string(), "#abcdef".to_string()),
+        ]);
+
+        let payload = python_init_payload(&config, json!({}), (480.0, 320.0));
+
+        assert_eq!(payload["theme"], json!(config.theme));
+        assert!(
+            payload["theme"]
+                .as_object()
+                .is_some_and(|theme| !theme.is_empty())
+        );
+    }
+
+    #[test]
+    fn theme_event_updates_the_cached_python_relaunch_theme() {
+        let workspace = tempdir().expect("workspace");
+        let mut config = state_test_config(workspace.path(), "test.theme-relaunch");
+        let colors = std::collections::HashMap::from([(
+            "fg".to_string(),
+            "#123456".to_string(),
+        )]);
+
+        cache_python_theme_for_relaunch(
+            &mut config,
+            &crate::app_protocol::PlexiEvent::Theme {
+                colors: colors.clone(),
+            },
+        );
+
+        assert_eq!(config.theme, colors);
     }
 
     /// Stint 0678 audit evidence (Q2/Q5): two live instances of one app under
@@ -5504,13 +5571,14 @@ mod tests {
             workspace_root: app.path().to_path_buf(),
             capabilities: Vec::new(),
             allowed_hosts: Vec::new(),
+            theme: crate::ui::theme::colors_from_config(
+                &crate::config::PlexiConfig::default(),
+            )
+            .to_theme_map(),
         };
         let mut runtime = WasmPythonRuntime::launch(&config).expect("launch CPython WASM");
         runtime
-            .send(&json!({
-                "type": "init", "app_id": config.app_id, "workspace_root": "/",
-                "capabilities": [], "state": {}, "theme": {}
-            }))
+            .send(&python_init_payload(&config, json!({}), (480.0, 320.0)))
             .expect("send init");
         runtime
             .send(&json!({"type": "render", "frame_id": 1}))
@@ -5626,6 +5694,10 @@ mod tests {
             workspace_root: app.path().to_path_buf(),
             capabilities: Vec::new(),
             allowed_hosts: Vec::new(),
+            theme: crate::ui::theme::colors_from_config(
+                &crate::config::PlexiConfig::default(),
+            )
+            .to_theme_map(),
         };
         let colors = crate::ui::theme::colors_from_config(&crate::config::PlexiConfig::default());
         let mut runtime = crate::host::pane::AppRuntime::Python(Box::new(
@@ -5709,6 +5781,10 @@ mod tests {
             workspace_root: app.path().to_path_buf(),
             capabilities: Vec::new(),
             allowed_hosts: Vec::new(),
+            theme: crate::ui::theme::colors_from_config(
+                &crate::config::PlexiConfig::default(),
+            )
+            .to_theme_map(),
         };
         let err = run_headless_frame(&config, (480.0, 320.0), None)
             .expect_err("an entry that raises at import must fail the headless probe");

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -484,6 +484,7 @@ impl PlexiApp {
             .map(|capability| capability.as_str().to_string())
             .collect();
         config.allowed_hosts = permissions.allowed_hosts.clone();
+        config.theme = self.colors.to_theme_map();
         let app_id = config.app_id.clone();
         let runtime = crate::host::wasm_python::LivePythonPane::launch(config)
             .map_err(|error| error.to_string())?;

--- a/src/protocol/events.rs
+++ b/src/protocol/events.rs
@@ -161,7 +161,7 @@ pub enum PlexiEvent {
     Resume,
     /// App is being closed. Process must exit within a short timeout.
     Shutdown,
-    /// Host theme changed (config hot-reload or macOS system appearance toggle).
+    /// Host theme changed through Plexi configuration.
     /// App should update its color state; the next render will pick up the new colors.
     Theme {
         /// Updated role → #rrggbb map. Same roles as the Init `theme` field.

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -227,7 +227,11 @@ impl Colors {
 /// preset). Shared by the GUI and the headless `app render` path.
 pub fn colors_from_config(config: &crate::config::PlexiConfig) -> Colors {
     let user_theme = config.theme.clone().unwrap_or_default();
-    let cfg = match config.theme.as_ref().and_then(|t| t.preset.as_deref()) {
+    let preset_name = user_theme
+        .preset
+        .as_deref()
+        .or(config.theme_preset.as_deref());
+    let cfg = match preset_name {
         Some(preset_name) => match preset_colors(preset_name) {
             Some(preset) => apply_preset(&preset, &user_theme),
             None => user_theme,
@@ -258,15 +262,15 @@ fn hex_to_bytes(s: Option<&str>, default: [u8; 3]) -> [u8; 3] {
 fn canonical_preset_name(name: &str) -> Option<&'static str> {
     let normalized = name.trim().to_lowercase().replace([' ', '_'], "-");
     match normalized.as_str() {
-        "catppuccin" | "catppuccin-mocha" | "mocha" => Some("catppuccin-mocha"),
+        "catppuccin-mocha" | "mocha" => Some("catppuccin-mocha"),
         "catppuccin-latte" | "latte" => Some("catppuccin-latte"),
         "dracula" => Some("dracula"),
-        "tokyo-night" | "tokyonight" | "tokyo" => Some("tokyo-night"),
+        "tokyo-night" => Some("tokyo-night"),
         "tokyo-day" | "tokyonight-day" => Some("tokyo-day"),
-        "gruvbox" | "gruvbox-dark" => Some("gruvbox-dark"),
+        "gruvbox-dark" => Some("gruvbox-dark"),
         "gruvbox-light" => Some("gruvbox-light"),
         "nord" => Some("nord"),
-        "solarized" | "solarized-dark" => Some("solarized-dark"),
+        "solarized-dark" => Some("solarized-dark"),
         "solarized-light" => Some("solarized-light"),
         "matrix" => Some("matrix"),
         "bios" | "retro" | "retro-bios" => Some("bios"),
@@ -286,29 +290,6 @@ pub fn is_light_preset(name: &str) -> bool {
             | Some("tokyo-day")
             | Some("plexi-day")
     )
-}
-
-/// Returns the paired preset for auto-style family aliases under
-/// `system_theme`, or `None` for explicit variants. `catppuccin` may follow
-/// the OS; `catppuccin-latte` and `catppuccin-mocha` mean exactly that flavor.
-pub fn paired_preset(name: &str, system_theme: egui::Theme) -> Option<&'static str> {
-    let normalized = name.trim().to_lowercase().replace([' ', '_'], "-");
-    match system_theme {
-        egui::Theme::Dark => match normalized.as_str() {
-            "catppuccin" => Some("catppuccin-mocha"),
-            "solarized" => Some("solarized-dark"),
-            "gruvbox" => Some("gruvbox-dark"),
-            "tokyo" | "tokyonight" => Some("tokyo-night"),
-            _ => None,
-        },
-        egui::Theme::Light => match normalized.as_str() {
-            "catppuccin" => Some("catppuccin-latte"),
-            "solarized" => Some("solarized-light"),
-            "gruvbox" => Some("gruvbox-light"),
-            "tokyo" | "tokyonight" => Some("tokyo-day"),
-            _ => None,
-        },
-    }
 }
 
 /// Returns the list of available preset names.
@@ -1263,17 +1244,17 @@ mod tests {
     }
 
     #[test]
-    fn explicit_catppuccin_variants_do_not_auto_flip() {
-        assert_eq!(paired_preset("catppuccin-latte", egui::Theme::Dark), None);
-        assert_eq!(paired_preset("catppuccin-mocha", egui::Theme::Light), None);
-        assert_eq!(
-            paired_preset("catppuccin", egui::Theme::Light),
-            Some("catppuccin-latte")
-        );
-        assert_eq!(
-            paired_preset("catppuccin", egui::Theme::Dark),
-            Some("catppuccin-mocha")
-        );
+    fn concrete_light_presets_remain_selectable() {
+        for name in [
+            "catppuccin-latte",
+            "solarized-light",
+            "gruvbox-light",
+            "tokyo-day",
+            "plexi-day",
+        ] {
+            assert!(preset_colors(name).is_some(), "missing light preset {name}");
+            assert!(is_light_preset(name), "{name} must be classified as light");
+        }
     }
 
     #[test]

--- a/website/src/content/docs/pgap.md
+++ b/website/src/content/docs/pgap.md
@@ -147,6 +147,17 @@ Post a notification. All three action_types must dispatch correctly (no TODO).
 | `timeout_secs` | `integer?` | no |
 | `title` | `string` | yes |
 
+### `dismiss_notification`
+
+Remove a notification posted by the caller. The host verifies the caller identity against the notification's stamped ...
+
+| Field | Type | Required |
+|-------|------|----------|
+| `notify_id` | `string` | yes |
+| `response_file` | `string` | yes |
+| `source_context_id` | `integer?` | no |
+| `source_pane_id` | `integer?` | no |
+
 ### `set_agent_state`
 
 Report agent state for a pane. Called by hook scripts via `plexi agent report`.
@@ -416,6 +427,19 @@ Write text to a running pane's PTY stdin. Sent by `plexi pane send`. `\n` in tex
 | `response_file` | `string?` | no |
 | `submit` | `boolean` | no |
 | `text` | `string` | yes |
+
+### `pane_heartbeat`
+
+Configure or disable a host-owned recurring terminal prompt.
+
+| Field | Type | Required |
+|-------|------|----------|
+| `every_ms` | `integer?` | no |
+| `off` | `boolean` | no |
+| `pane_id` | `integer` | yes |
+| `response_file` | `string?` | no |
+| `text` | `string?` | no |
+| `while_idle_only` | `boolean?` | no |
 
 ### `key_pane`
 
@@ -1179,7 +1203,7 @@ Typed pipe message (JSON mode only; binary mode travels on the side channel).
 
 ### `path_changed`
 
-Pane group CWD broadcast. Apps in the same group receive this when any member's CWD changes.
+Pane group CWD broadcast. **Declared, never constructed** — no host path emits this today; `sync_app_cwd` reassigns `...
 
 | Field | Type | Required |
 |-------|------|----------|
@@ -1205,7 +1229,7 @@ App is being closed. Process must exit within a short timeout.
 
 ### `theme`
 
-Host theme changed (config hot-reload or macOS system appearance toggle). App should update its color state; the next...
+Host theme changed through Plexi configuration. App should update its color state; the next render will pick up the n...
 
 | Field | Type | Required |
 |-------|------|----------|


### PR DESCRIPTION
## Summary

Covers stint 0696. No linked GitHub issue; stint is authoritative.

- Python apps receive Plexi's active color roles at launch and keep the latest roles across hot reloads.
- Theme changes reach every running app across windows, inactive contexts, hidden panes, and parked background apps. Python schedules a new frame after applying the event.
- Plexi no longer reads OS appearance or resolves ambiguous theme-family aliases. Concrete light presets remain selectable.

`egui::ViewportCommand::SetTheme` remains intentionally. It applies Plexi's explicitly selected concrete light or dark preset to native window chrome. It does not read or follow OS appearance.

## Done When

- [x] App launch payloads contain the active Plexi theme.
- [x] Theme broadcasts reach running foreground, inactive, hidden, and background apps.
- [x] Python schedules a render after a Theme event.
- [x] OS appearance detection, appearance state, paired aliases, and appearance-driven re-resolution are deleted.
- [x] Concrete light themes remain selectable in config.
- [ ] Human Gate: install this PR, inspect Todo's entry and the loading spinner, switch Plexi's theme, and confirm running apps update without restart.

## Test evidence

Falsifying tests failed against alpha before the fix:

- `test_theme_event_schedules_render`: no `schedule_render` event.
- `theme_broadcast_reaches_background_apps_in_every_window`: recorder received zero Theme events.
- `python_init_payload_carries_the_active_host_theme`: launch-payload helper was absent.

Final checks:

- `cargo build`: passed.
- Focused Rust theme tests: passed for launch payload, all-window/background broadcast, relaunch theme cache, and concrete light presets.
- `uv run pytest sdk/python/tests/test_v3_runtime_regression.py`: 51 passed, 1 skipped.
- mypy: clean across 28 SDK files.
- Protocol schema and generated docs checks: passed.
- Codex review: clean after two passes. The second pass found and fixed stale theme state across Python hot reloads.
- Full `cargo test --bin plexi`: 2,164 passed, 1 failed, 5 ignored. The sole failure, `headless_frame_fails_fast_when_the_guest_dies_at_import`, reproduces identically on current alpha and is tracked by stint 0663.
- Full suite with alpha's documented 0663 CI skip: 2,164 passed, 0 failed, 5 ignored, 1 filtered.
- Styled text-input renderer screenshot: inspected; valid field chrome and text rendered. A real Todo headless render hit alpha's known 15-second CPython startup boundary twice, so this PR claims no headless Todo color proof.

Conclusion: binary install required. This changes app launch and live runtime delivery, and stint 0696 carries a visual Human Gate.

PR install: required via `just pr-install <PR>`.
