### PR TITLE
release: stub v1 surfaces and verify roadmap evidence

### DIFF
--- a/.github/workflows/roadmap-evidence.yml
+++ b/.github/workflows/roadmap-evidence.yml
@@ -1,0 +1,62 @@
+name: Roadmap evidence
+
+# Executes every proof named by ROADMAP.toml, including the scenes that opt out
+# of scene_suite. This answers "is the roadmap honest" — a release question, not
+# a per-commit one — so it deliberately does NOT run on pull_request.
+#
+# Why it is not a PR gate: the evidence set re-runs the workspace test suite the
+# `Rust host` workflow already ran, then executes every scene serially. That is
+# ~25 minutes added to every PR to re-answer a question almost no PR changes.
+#
+# Deliberately on-demand only — no schedule. A recurring run nobody reads is
+# noise that burns runner minutes and trains people to ignore a red badge.
+# Dispatch it when it answers a question you are actually asking: before a
+# release cut, or after changing something ROADMAP.toml claims as evidence.
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # A scene's timeout_s catches a hang; it is not a performance budget. Scenes
+  # that finish in ~10s locally sit close to their 15s deadline on a shared
+  # runner, so widen the window here instead of editing every scene file.
+  # Consumed by `scene_timeout` in src/scenes.rs.
+  PLEXI_SCENE_TIMEOUT_SCALE: '4'
+
+jobs:
+  evidence:
+    name: evidence
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install just
+        uses: taiki-e/install-action@v2.85.6
+        with:
+          # taiki-e/install-action does not enforce `required` inputs for
+          # composite actions: omitting `tool` installs nothing, exits 0, and
+          # renders green. Never remove this block.
+          tool: just
+
+      - name: Restore Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-evidence-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-evidence-
+
+      - name: Evidence resolver fixtures
+        run: just roadmap-evidence-fixtures
+
+      - name: Execute roadmap evidence
+        run: just roadmap-evidence

--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -98,8 +98,10 @@ jobs:
 
       - name: Verify roadmap evidence
         run: |
-          just roadmap-evidence-fixtures
-          just roadmap-evidence
+          python3 scripts/test-roadmap-evidence.py
+          env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID \
+            -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID \
+            python3 scripts/roadmap-evidence.py
 
   clippy:
     name: clippy

--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Install just
         uses: taiki-e/install-action@v2.85.6
+        with:
+          tool: just
 
       - name: Restore Cargo cache
         uses: actions/cache@v4

--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -49,11 +49,6 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install just
-        uses: taiki-e/install-action@v2.85.6
-        with:
-          tool: just
-
       - name: Restore Cargo cache
         uses: actions/cache@v4
         with:
@@ -100,11 +95,6 @@ jobs:
             cargo test --bin plexi -- \
             --skip headless_frame_fails_fast_when_the_guest_dies_at_import \
             ${skip_args[@]+"${skip_args[@]}"}
-
-      - name: Verify roadmap evidence
-        run: |
-          just roadmap-evidence-fixtures
-          just roadmap-evidence
 
   clippy:
     name: clippy

--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install just
+        uses: taiki-e/install-action@v2.85.6
+
       - name: Restore Cargo cache
         uses: actions/cache@v4
         with:
@@ -98,10 +101,8 @@ jobs:
 
       - name: Verify roadmap evidence
         run: |
-          python3 scripts/test-roadmap-evidence.py
-          env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID \
-            -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID \
-            python3 scripts/roadmap-evidence.py
+          just roadmap-evidence-fixtures
+          just roadmap-evidence
 
   clippy:
     name: clippy

--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -96,6 +96,11 @@ jobs:
             --skip headless_frame_fails_fast_when_the_guest_dies_at_import \
             ${skip_args[@]+"${skip_args[@]}"}
 
+      - name: Verify roadmap evidence
+        run: |
+          just roadmap-evidence-fixtures
+          just roadmap-evidence
+
   clippy:
     name: clippy
     runs-on: macos-latest

--- a/ROADMAP.toml
+++ b/ROADMAP.toml
@@ -153,11 +153,11 @@ stints = []
 [[node]]
 id = "accessibility-tree"
 title = "AccessKit node tree exposure"
-status = "yellow"
+status = "red"
 deps = ["host-model"]
-evidence = ["accesskit_normalization_removes_children_outside_pane"]
+evidence = ["stable_and_rc_channels_disable_v1_stubbed_surfaces"]
 stints = []
-note = "One normalization test. No end-to-end screen-reader qualification exists."
+note = "Stable v1 stubs the unqualified AccessKit tree. The experimental tree requires beta or alpha; no screen-reader qualification is claimed."
 
 # ---------------------------------------------------------------------------
 # CLI and configuration
@@ -749,38 +749,29 @@ stints = ["0249"]
 [[node]]
 id = "media-io"
 title = "Audio / MIDI / video device and decoder layer"
-status = "yellow"
+status = "red"
 deps = ["typed-pipes"]
-evidence = [
-  "mock_decoder_round_trips_frames",
-  "mock_device_round_trips_pcm_frames",
-  "ump_round_trip_channel_voice",
-  "sample_rate_negotiation_picks_closest_supported",
-  "avf_decoder_open_with_invalid_path_returns_error_not_panic",
-]
+evidence = ["stable_and_rc_channels_disable_v1_stubbed_surfaces"]
 stints = ["0521", "0522"]
-note = "Coverage is mock round-trips plus no-panic smoke on real devices. Frame-accurate seek and PTS (edit-grade decode) do not exist."
+note = "Stable v1 gates built-in audio/video playback and unqualified media I/O to beta. Mock/device coverage is not a stable media promise."
+
+[[node]]
+id = "basic-media-playback"
+title = "Basic audio and video playback"
+status = "red"
+deps = ["media-io"]
+evidence = ["stable_and_rc_channels_disable_v1_stubbed_surfaces"]
+stints = []
+note = "A beta-only experimental surface; stable v1 returns the release-gate message instead of opening a partial player."
 
 [[node]]
 id = "daw"
 title = "DAW engine, model, and bundle — tracks, clips, mixdown, undo"
-status = "green"
+status = "red"
 deps = ["media-io", "app-protocol"]
-evidence = [
-  "gate_core_matrix",
-  "gate_deterministic_long_sequence",
-  "gate_randomized_commands",
-  "gate_minimizer_shrinks_reproducible_failures",
-  "gate_serialization_round_trip",
-  "block_size_never_changes_output",
-  "hard_left_pan_silences_right_channel",
-  "full_undo_preserves_monotonic_next_id",
-  "daw_gate_mixdown_determinism",
-  "daw_gate_render_is_block_size_independent",
-  "daw_gate_pane_drive",
-  "daw-gate-bundle",
-]
+evidence = ["stable_and_rc_channels_disable_v1_stubbed_surfaces"]
 stints = []
+note = "DAW remains a beta/alpha proof of concept. Stable v1 gates the manifest POC app and makes no DAW qualification claim."
 
 [[node]]
 id = "video-editor"

--- a/ROADMAP.toml
+++ b/ROADMAP.toml
@@ -753,7 +753,7 @@ status = "red"
 deps = ["typed-pipes"]
 evidence = ["stable_and_rc_channels_disable_v1_stubbed_surfaces"]
 stints = ["0521", "0522"]
-note = "Stable v1 gates built-in audio/video playback and unqualified media I/O to beta. Mock/device coverage is not a stable media promise."
+note = "Stable v1 gates the built-in audio and video player apps to beta. Protocol-level media operations remain capability-gated only and are not release-tier gated; 0708 tracks the follow-up."
 
 [[node]]
 id = "basic-media-playback"

--- a/justfile
+++ b/justfile
@@ -49,6 +49,14 @@ website-smoke:
 test:
     env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID cargo test
 
+# Resolve every ROADMAP.toml evidence entry and execute every resolved proof.
+# This includes scenes that opt out of scene_suite.
+roadmap-evidence:
+    env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID python3 scripts/roadmap-evidence.py
+
+roadmap-evidence-fixtures:
+    python3 scripts/test-roadmap-evidence.py
+
 # Rebuild the WASM POC components and refresh the committed test fixtures the
 # host runtime gate tests load (G3/G5 etc). Run after changing any
 # apps/wasm-poc/* source. Requires cargo-component + the wasm32-wasip2 target.

--- a/scripts/RELEASE_CHANNELS.md
+++ b/scripts/RELEASE_CHANNELS.md
@@ -30,7 +30,8 @@ Release-gated features are centralized in `src/release.rs`.
 - Unknown named channels disable release-gated features.
 
 Use release gates for product surface that is not part of stable v1, such as
-Assistant, app wrappers, and marketplace/account flows. Use config sections for
+the experimental DAW, media I/O, accessibility, Assistant, app wrappers, and
+marketplace/account flows. Use config sections for
 stable user preferences, such as `[effects]`.
 
 ## Local RC Flow

--- a/scripts/roadmap-evidence.py
+++ b/scripts/roadmap-evidence.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Resolve and execute the evidence declared by ROADMAP.toml.
+
+This intentionally does not use scene_suite: roadmap evidence is a release
+contract, so a scene is run even when it opts out of the fast workspace suite.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import subprocess
+import sys
+import tomllib
+
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+TEST_RE = re.compile(r"^\s*#\s*\[\s*(?:[\w:]+::)?test[^\]]*\]\s*$")
+FN_RE = re.compile(r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+(\w+)\s*\(")
+
+
+def roadmap_evidence(path: pathlib.Path) -> list[str]:
+    data = tomllib.loads(path.read_text())
+    return [item for node in data.get("node", []) for item in node.get("evidence", [])]
+
+
+def rust_tests(root: pathlib.Path) -> dict[str, list[pathlib.Path]]:
+    found: dict[str, list[pathlib.Path]] = {}
+    for path in root.rglob("*.rs"):
+        if "target" in path.parts:
+            continue
+        test_attribute = False
+        for line in path.read_text(errors="replace").splitlines():
+            if TEST_RE.match(line):
+                test_attribute = True
+                continue
+            if test_attribute:
+                match = FN_RE.match(line)
+                if match:
+                    found.setdefault(match.group(1), []).append(path)
+                    test_attribute = False
+                elif line.strip() and not line.lstrip().startswith("#"):
+                    test_attribute = False
+    return found
+
+
+def resolve(root: pathlib.Path, evidence: list[str]) -> tuple[dict[str, pathlib.Path], list[str]]:
+    tests = rust_tests(root)
+    resolved: dict[str, pathlib.Path] = {}
+    errors: list[str] = []
+    for name in evidence:
+        scene = root / "tests" / "scenes" / f"{name}.toml"
+        matches = tests.get(name, [])
+        if scene.is_file() and matches:
+            errors.append(f"ambiguous evidence {name}: scene and Rust test")
+        elif scene.is_file():
+            resolved[name] = scene
+        elif len(matches) == 1:
+            resolved[name] = matches[0]
+        elif not matches:
+            errors.append(f"unresolved evidence {name}")
+        else:
+            errors.append(f"ambiguous Rust evidence {name}: " + ", ".join(map(str, matches)))
+    return resolved, errors
+
+
+def run(command: list[str], cwd: pathlib.Path) -> bool:
+    print("+", " ".join(command), flush=True)
+    return subprocess.run(command, cwd=cwd).returncode == 0
+
+
+def execute(root: pathlib.Path, resolved: dict[str, pathlib.Path]) -> list[str]:
+    failures: list[str] = []
+    listing = subprocess.run(
+        ["cargo", "test", "--workspace", "--", "--list"],
+        cwd=root,
+        text=True,
+        capture_output=True,
+    )
+    if listing.returncode:
+        print(listing.stdout, end="")
+        print(listing.stderr, end="", file=sys.stderr)
+        return ["cargo test --workspace -- --list"]
+    labels: dict[str, list[str]] = {}
+    for line in listing.stdout.splitlines():
+        if line.endswith(": test"):
+            label = line.removesuffix(": test")
+            labels.setdefault(label.rsplit("::", 1)[-1], []).append(label)
+    for name, path in resolved.items():
+        # `src/lib.rs` is linked by more than one package target in this
+        # workspace, so compiled labels can repeat. Source resolution above
+        # rejects multiple Rust definitions; here we only require that the
+        # one resolved definition is present in at least one test binary.
+        if path.suffix != ".toml" and not labels.get(name):
+            failures.append(f"{name} (missing from cargo test --list)")
+    if failures:
+        return failures
+    # A single workspace invocation executes every resolved Rust test. The
+    # preceding list check proves each evidence name maps to one exact test
+    # label, while this run retains Cargo's ordinary failure reporting.
+    # Keep this aligned with the documented host-CI exception. It is not
+    # roadmap evidence and fails reproducibly on clean alpha.
+    if not run(
+        [
+            "cargo",
+            "test",
+            "--workspace",
+            "--",
+            "--skip",
+            "headless_frame_fails_fast_when_the_guest_dies_at_import",
+        ],
+        root,
+    ):
+        return ["resolved Rust evidence"]
+    for name, path in resolved.items():
+        if path.suffix != ".toml":
+            continue
+        command = ["just", "scene", str(path.relative_to(root)), "/tmp/plexi-roadmap-evidence", "0"]
+        if not run(command, root):
+            failures.append(name)
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=pathlib.Path, default=ROOT)
+    parser.add_argument("--roadmap", type=pathlib.Path, default=ROOT / "ROADMAP.toml")
+    parser.add_argument("--resolve-only", action="store_true")
+    args = parser.parse_args()
+    evidence = roadmap_evidence(args.roadmap)
+    root = args.root.resolve()
+    resolved, errors = resolve(root, evidence)
+    if errors:
+        print("roadmap evidence resolution failed:", *errors, sep="\n", file=sys.stderr)
+        return 1
+    if args.resolve_only:
+        print(f"resolved {len(resolved)} roadmap evidence entries")
+        return 0
+    failures = execute(root, resolved)
+    if failures:
+        print("roadmap evidence execution failed:", *failures, sep="\n", file=sys.stderr)
+        return 1
+    print(f"roadmap evidence passed: {len(resolved)} entries")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-roadmap-evidence.py
+++ b/scripts/test-roadmap-evidence.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Regression fixtures for the ROADMAP evidence gate's failure boundaries."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import tempfile
+import textwrap
+
+
+SCRIPT = pathlib.Path(__file__).with_name("roadmap-evidence.py")
+
+
+def write(path: pathlib.Path, body: str, executable: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    if executable:
+        path.chmod(0o755)
+
+
+def gate(root: pathlib.Path, roadmap: pathlib.Path, bin_dir: pathlib.Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ | {"PATH": f"{bin_dir}:{os.environ['PATH']}"}
+    return subprocess.run(
+        ["python3", str(SCRIPT), "--root", str(root), "--roadmap", str(roadmap)],
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def fixture(name: str, evidence: str) -> tuple[tempfile.TemporaryDirectory[str], pathlib.Path, pathlib.Path, pathlib.Path]:
+    temp = tempfile.TemporaryDirectory(prefix=f"plexi-roadmap-{name}-")
+    root = pathlib.Path(temp.name)
+    roadmap = root / "ROADMAP.toml"
+    write(roadmap, f'[[node]]\nid = "fixture"\nevidence = ["{evidence}"]\n')
+    bin_dir = root / "bin"
+    write(bin_dir / "cargo", "#!/bin/sh\nexit 0\n", True)
+    return temp, root, roadmap, bin_dir
+
+
+def main() -> int:
+    # A typo must not silently turn into a skipped proof.
+    temp, root, roadmap, bin_dir = fixture("unresolved", "missing-proof")
+    try:
+        result = gate(root, roadmap, bin_dir)
+        assert result.returncode != 0 and "unresolved evidence missing-proof" in result.stderr, result
+    finally:
+        temp.cleanup()
+
+    # suite = false is still executed; the fake just deliberately fails only if invoked.
+    temp, root, roadmap, bin_dir = fixture("skipped", "must-run")
+    try:
+        write(root / "tests/scenes/must-run.toml", "suite = false\nsteps = []\n")
+        write(bin_dir / "just", "#!/bin/sh\nexit 23\n", True)
+        result = gate(root, roadmap, bin_dir)
+        assert result.returncode != 0 and "must-run" in result.stderr, result
+    finally:
+        temp.cleanup()
+
+    # A resolved Rust test must fail the release gate when its command fails.
+    temp, root, roadmap, bin_dir = fixture("failing", "failing_proof")
+    try:
+        write(root / "src/lib.rs", "#[test]\nfn failing_proof() {}\n")
+        write(
+            bin_dir / "cargo",
+            textwrap.dedent(
+                """\
+                #!/bin/sh
+                if [ "$3" = "--" ] && [ "$4" = "--list" ]; then
+                  echo 'suite::failing_proof: test'
+                  exit 0
+                fi
+                exit 31
+                """
+            ),
+            True,
+        )
+        result = gate(root, roadmap, bin_dir)
+        assert result.returncode != 0 and "resolved Rust evidence" in result.stderr, result
+    finally:
+        temp.cleanup()
+    print("roadmap evidence regression fixtures passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1022,7 +1022,11 @@ impl PlexiApp {
         log::info!(target: "plexi::frame_diag", "frame diagnostics active; summary every 10s");
 
         theme::setup_fonts(&cc.egui_ctx);
-        cc.egui_ctx.enable_accesskit();
+        if crate::release::feature_enabled(crate::release::ReleaseFeature::Accessibility) {
+            cc.egui_ctx.enable_accesskit();
+        } else {
+            crate::release::log_feature_blocked(crate::release::ReleaseFeature::Accessibility);
+        }
         cc.egui_ctx.set_visuals(egui::Visuals::dark());
         cc.egui_ctx.options_mut(|o| o.zoom_with_keyboard = false);
 

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -517,6 +517,22 @@ impl AppRegistry {
         self.apps.get(id)
     }
 
+    /// Return the manifest identity for a registered WASM entry at `wasm_path`.
+    ///
+    /// Raw WASM launches still need the manifest's identity when they point at
+    /// a registered component: release gates, consent state, and pane identity
+    /// are all keyed by that canonical id rather than by a filesystem filename.
+    pub(crate) fn manifest_id_for_wasm_path(&self, wasm_path: &Path) -> Option<&str> {
+        let canonical_path = std::fs::canonicalize(wasm_path).ok()?;
+        self.apps.values().find_map(|installed| {
+            (installed.manifest.manifest_type == ManifestType::Wasm
+                && std::fs::canonicalize(&installed.bin_path)
+                    .ok()
+                    .is_some_and(|entry| entry == canonical_path))
+            .then_some(installed.manifest.id.as_str())
+        })
+    }
+
     /// Scan one directory of manifest-bearing subdirs, inserting discovered
     /// entries. Calls made later in `load()` shadow earlier ones; on shadow
     /// the displaced entry's source is logged so users can debug discovery.

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -330,16 +330,16 @@ fn file_handler_config_routes_extension_to_app() {
 }
 
 #[test]
-fn media_files_route_to_native_viewer_apps() {
+fn stable_routes_only_images_to_native_viewer_apps() {
     let ctx = egui::Context::default();
     let ft = crate::platform::logging::new_frame_tick();
     let (mut app, _tx) = PlexiApp::new_for_test(ctx, ft);
     let (_tile, _pane) = app.add_test_pane();
 
-    for (filename, expected_id) in [
-        ("photo.png", "image-viewer"),
-        ("clip.mp4", "video-player"),
-        ("song.mp3", "audio-player"),
+    for (filename, expected_id, opens_pane) in [
+        ("photo.png", "image-viewer", true),
+        ("clip.mp4", "video-player", false),
+        ("song.mp3", "audio-player", false),
     ] {
         let panes_before: usize = app.windows.iter().map(|w| w.panes.len()).sum();
         let path = std::env::temp_dir()
@@ -350,21 +350,28 @@ fn media_files_route_to_native_viewer_apps() {
         app.dispatch_open_artifact(0, path, crate::app_protocol::ArtifactOpenMode::OpenInPane);
 
         let panes_after: usize = app.windows.iter().map(|w| w.panes.len()).sum();
-        assert_eq!(
-            panes_after,
-            panes_before + 1,
-            "{filename} should open exactly one in-Plexi pane"
-        );
-        assert!(
-            app.windows.iter().any(|w| {
-                w.panes.values().any(|p| {
-                    p.as_app()
-                        .map(|a| a.runtime.type_id() == expected_id)
-                        .unwrap_or(false)
-                })
-            }),
-            "{filename} should route to {expected_id}"
-        );
+        if opens_pane {
+            assert_eq!(
+                panes_after,
+                panes_before + 1,
+                "{filename} should open exactly one in-Plexi pane"
+            );
+            assert!(
+                app.windows.iter().any(|w| {
+                    w.panes.values().any(|p| {
+                        p.as_app()
+                            .map(|a| a.runtime.type_id() == expected_id)
+                            .unwrap_or(false)
+                    })
+                }),
+                "{filename} should route to {expected_id}"
+            );
+        } else {
+            assert_eq!(
+                panes_after, panes_before,
+                "stable must not open the beta-only {expected_id} surface for {filename}"
+            );
+        }
     }
 }
 

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1537,11 +1537,17 @@ impl PlexiApp {
         // A `.wasm` file is a sandboxed component app (the run primitive, G6),
         // not a manifest-backed process app. Route it to the wasmtime path.
         if app_dir.extension().and_then(|e| e.to_str()) == Some("wasm") {
-            let app_id = app_dir
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("wasm")
-                .to_string();
+            let app_id = self
+                .registry
+                .manifest_id_for_wasm_path(&app_dir)
+                .map(str::to_owned)
+                .unwrap_or_else(|| {
+                    app_dir
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("wasm")
+                        .to_string()
+                });
             let workspace_root = workspace_root_override.unwrap_or_else(|| {
                 app_dir
                     .parent()
@@ -1961,6 +1967,7 @@ fn sanitize_wasm_path_component(input: &str) -> String {
 mod tests {
     use super::*;
     use crate::app::permissions::AppPermissions;
+    use crate::app::registry::AppRegistry;
     use crate::host::wasm_app::{StateSnapshot, StateStore, WasmApp};
     use crate::testing::HostHarness;
 
@@ -1977,6 +1984,52 @@ mod tests {
         let app = WasmApp::load_ephemeral_run("counter-pane", &counter_fixture(), store)
             .expect("load counter fixture");
         (app, snapshot)
+    }
+
+    #[test]
+    fn raw_wasm_launch_uses_registered_manifest_identity_for_release_gate() {
+        let _channel = crate::config::set_test_channel("main");
+        let global_apps = tempfile::tempdir().expect("global apps");
+        let app_dir = global_apps.path().join("daw");
+        std::fs::create_dir_all(&app_dir).expect("create app dir");
+        let wasm_path = app_dir.join("renamed-component.wasm");
+        std::fs::copy(
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/wasm-fixtures/daw-engine.wasm"),
+            &wasm_path,
+        )
+        .expect("copy DAW fixture");
+        std::fs::write(
+            app_dir.join("manifest.toml"),
+            "schema_version = 1\n\
+             \n\
+             [app]\n\
+             id = \"com.plexi.daw-engine-poc\"\n\
+             type = \"wasm\"\n\
+             name = \"DAW Engine\"\n\
+             version = \"0.1.0\"\n\
+             entry = \"renamed-component.wasm\"\n",
+        )
+        .expect("write manifest");
+        let bare = tempfile::tempdir().expect("bare cwd");
+        let registry = AppRegistry::load_with_global(bare.path(), global_apps.path());
+        assert!(registry.get("com.plexi.daw-engine-poc").is_some());
+
+        let mut h = HostHarness::new();
+        h.app.registry = registry;
+        let error = h
+            .app
+            .launch_app_by_path_with_layout_no_review_modal(
+                wasm_path.to_str().expect("UTF-8 fixture path"),
+                None,
+                None,
+                &[],
+            )
+            .expect_err("stable must reject a raw path to the registered DAW component");
+
+        assert!(
+            error.contains("DAW requires the beta channel"),
+            "raw launch must use the manifest identity, not the unrelated file name: {error}"
+        );
     }
 
     /// Stint 0431: the native-WASM open path must honor the default `"overlay"`

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -86,6 +86,14 @@ pub(crate) fn builtin_factory(id: &str, cwd: &Path, args: &[String]) -> Option<B
     }
 }
 
+fn release_feature_for_app_id(id: &str) -> Option<crate::release::ReleaseFeature> {
+    match id {
+        "audio-player" | "video-player" => Some(crate::release::ReleaseFeature::MediaIo),
+        "com.plexi.daw-engine-poc" => Some(crate::release::ReleaseFeature::Daw),
+        _ => None,
+    }
+}
+
 fn builtin_default_group(type_id: &str) -> Option<String> {
     match type_id {
         "file_browser" => Some("cwd".to_string()),
@@ -113,6 +121,12 @@ pub(crate) fn restore_builtin_app_pane(
     cwd: PathBuf,
     app_state: Option<&serde_json::Value>,
 ) -> Option<Pane> {
+    if let Some(feature) = release_feature_for_app_id(app_id) {
+        if !crate::release::feature_enabled(feature) {
+            crate::release::log_feature_blocked(feature);
+            return None;
+        }
+    }
     let args = builtin_restore_args(app_id, app_state)?;
     let mut app = builtin_factory(app_id, &cwd, &args)?;
     if let Some(state) = app_state {
@@ -445,6 +459,12 @@ impl PlexiApp {
     ) -> Result<PaneId, String> {
         use crate::host::wasm_app::{StateStore, WasmApp};
 
+        if let Some(feature) = release_feature_for_app_id(app_id) {
+            if !crate::release::feature_enabled(feature) {
+                return Err(crate::release::feature_unavailable_message(feature));
+            }
+        }
+
         let store = StateStore::ephemeral();
         let snapshot = store.snapshot();
         let permission_store =
@@ -689,6 +709,12 @@ impl PlexiApp {
         use crate::host::wasm_app::{Grants, StateStore, WasmApp};
 
         let app_id = installed.manifest.id.clone();
+
+        if let Some(feature) = release_feature_for_app_id(&app_id) {
+            if !crate::release::feature_enabled(feature) {
+                return Err(crate::release::feature_unavailable_message(feature));
+            }
+        }
 
         // Cloud/remote execution is future work (stints 0286/0287): no
         // server-side wasmtime runtime or thin-client streaming exists yet.
@@ -1321,6 +1347,12 @@ impl PlexiApp {
                 "launch_app_by_id_with_layout: 'assistant' resolved as builtin pane_id={pane_id}"
             );
             return Ok(Some(pane_id));
+        }
+
+        if let Some(feature) = release_feature_for_app_id(id) {
+            if !crate::release::feature_enabled(feature) {
+                return Err(crate::release::feature_unavailable_message(feature));
+            }
         }
 
         // When the caller does not specify a placement, fall back to the app's

--- a/src/release.rs
+++ b/src/release.rs
@@ -10,6 +10,9 @@ pub enum ReleaseFeature {
     Assistant,
     AppWrappers,
     Marketplace,
+    Daw,
+    MediaIo,
+    Accessibility,
 }
 
 impl ReleaseFeature {
@@ -18,12 +21,20 @@ impl ReleaseFeature {
             Self::Assistant => "assistant",
             Self::AppWrappers => "app wrappers",
             Self::Marketplace => "marketplace",
+            Self::Daw => "DAW",
+            Self::MediaIo => "media I/O",
+            Self::Accessibility => "experimental accessibility",
         }
     }
 
     pub fn minimum_tier(self) -> ReleaseTier {
         match self {
-            Self::Assistant | Self::AppWrappers | Self::Marketplace => ReleaseTier::Beta,
+            Self::Assistant
+            | Self::AppWrappers
+            | Self::Marketplace
+            | Self::Daw
+            | Self::MediaIo
+            | Self::Accessibility => ReleaseTier::Beta,
         }
     }
 }
@@ -125,6 +136,21 @@ mod tests {
             ReleaseFeature::Assistant,
             Some("pr-2259")
         ));
+    }
+
+    #[test]
+    fn stable_and_rc_channels_disable_v1_stubbed_surfaces() {
+        for feature in [
+            ReleaseFeature::Daw,
+            ReleaseFeature::MediaIo,
+            ReleaseFeature::Accessibility,
+        ] {
+            assert!(!feature_enabled_for_channel(feature, None));
+            assert!(!feature_enabled_for_channel(feature, Some("main")));
+            assert!(!feature_enabled_for_channel(feature, Some("rc-010")));
+            assert!(feature_enabled_for_channel(feature, Some("alpha")));
+            assert!(feature_enabled_for_channel(feature, Some("beta")));
+        }
     }
 
     #[test]

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -40,6 +40,42 @@ use crate::ui_tests::PlexiUiHarness;
 pub const SCENE_REPORT_SCHEMA_VERSION: u32 = 4;
 const LIVE_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
+/// Scales a scene-declared timeout by `PLEXI_SCENE_TIMEOUT_SCALE`.
+///
+/// A scene's `timeout_s` exists to catch a hang, not to assert a performance
+/// budget: the same wait that finishes in 10s on a developer's machine can
+/// exceed 15s on a shared CI runner, and the resulting failure says "too slow
+/// to observe" while reading as "the thing never happened". The scale factor
+/// keeps one deadline in the scene file and lets a slower executor widen it
+/// without editing every scene.
+///
+/// Unset means 1.0. A non-numeric or non-positive value is a configuration
+/// error and panics rather than silently reverting to the default.
+fn scene_timeout(secs: f32) -> Duration {
+    let raw = std::env::var(SCENE_TIMEOUT_SCALE_VAR).ok();
+    Duration::from_secs_f32(secs * scene_timeout_scale(raw.as_deref()))
+}
+
+const SCENE_TIMEOUT_SCALE_VAR: &str = "PLEXI_SCENE_TIMEOUT_SCALE";
+
+/// Parses the scale factor. `None` means unset, which is 1.0.
+///
+/// A malformed or non-positive value panics: a scene deadline silently
+/// reverting to its default is the failure this knob exists to prevent.
+fn scene_timeout_scale(raw: Option<&str>) -> f32 {
+    let Some(raw) = raw else {
+        return 1.0;
+    };
+    let parsed: f32 = raw
+        .parse()
+        .unwrap_or_else(|e| panic!("{SCENE_TIMEOUT_SCALE_VAR}={raw:?} is not a number: {e}"));
+    assert!(
+        parsed.is_finite() && parsed > 0.0,
+        "{SCENE_TIMEOUT_SCALE_VAR}={raw:?} must be a finite number greater than zero"
+    );
+    parsed
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum HostStatusClass {
     Running,
@@ -1480,8 +1516,7 @@ impl LiveBackend {
             }
             Step::WaitAppFrame { wait_app_frame } => {
                 let pane_id = self.handles.resolve(&wait_app_frame.target)?;
-                let _ =
-                    self.settled_state(pane_id, Duration::from_secs_f32(wait_app_frame.timeout_s))?;
+                let _ = self.settled_state(pane_id, scene_timeout(wait_app_frame.timeout_s))?;
                 Ok(None)
             }
             Step::RunSteps { .. } => {
@@ -1815,7 +1850,7 @@ impl LiveBackend {
         }
         let mut history = Vec::new();
         let result = poll_live_until(
-            Duration::from_secs_f32(spec.timeout_s),
+            scene_timeout(spec.timeout_s),
             LIVE_POLL_INTERVAL,
             |elapsed| {
                 let state = self.pane_state(pane_id)?;
@@ -2458,7 +2493,7 @@ impl HeadlessBackend {
             Step::WaitAppFrame { wait_app_frame } => {
                 let pane_id = self.handles.resolve(&wait_app_frame.target)?;
                 self.h
-                    .wait_for_app_frame(pane_id, Duration::from_secs_f32(wait_app_frame.timeout_s))
+                    .wait_for_app_frame(pane_id, scene_timeout(wait_app_frame.timeout_s))
                     .map_err(|message| SceneError::new("wait_app_frame_failed", message))?;
                 Ok(None)
             }
@@ -2657,7 +2692,7 @@ impl HeadlessBackend {
                 &mut Vec::new(),
             )?;
         }
-        let deadline = Instant::now() + Duration::from_secs_f32(spec.timeout_s);
+        let deadline = Instant::now() + scene_timeout(spec.timeout_s);
         let started = Instant::now();
         let mut history = Vec::new();
         loop {
@@ -2802,6 +2837,25 @@ mod tests {
     use std::sync::Mutex;
 
     static LIVE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn scene_timeout_scale_defaults_to_one_and_multiplies_when_set() {
+        assert_eq!(scene_timeout_scale(None), 1.0);
+        assert_eq!(scene_timeout_scale(Some("4")), 4.0);
+        assert_eq!(scene_timeout_scale(Some("2.5")), 2.5);
+    }
+
+    #[test]
+    #[should_panic(expected = "is not a number")]
+    fn scene_timeout_scale_rejects_non_numeric() {
+        scene_timeout_scale(Some("soon"));
+    }
+
+    #[test]
+    #[should_panic(expected = "greater than zero")]
+    fn scene_timeout_scale_rejects_zero() {
+        scene_timeout_scale(Some("0"));
+    }
 
     fn scenes_dir() -> PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR"))


### PR DESCRIPTION
## Summary

Implements stints 0591, 0703, 0702, and 0701. No linked GitHub issue; stint is authoritative.

- Gates the DAW, built-in audio/video player apps, and experimental accessibility behind the centralized beta release tier.
- Resolves raw WASM launch identity through a registered component manifest, so a renamed DAW component cannot bypass the DAW gate.
- Makes roadmap claims red/stubbed where stable deliberately returns the future-channel boundary.
- Adds CI enforcement that resolves exact roadmap proofs and executes every declared scene, including suite-disabled scenes.

## Test evidence

- `cargo test --workspace`: pending final run.
- `python3 scripts/test-roadmap-evidence.py`: pending final run.
- Env-stripped `python3 scripts/roadmap-evidence.py`: pending final run.
- Conclusion: binary install required — release-tier and host launch behavior need the separate tester round.

## CI dependency audit

The roadmap-evidence path shells out to these external binaries:

- `just`: installed in the `test` job by `taiki-e/install-action@v2.85.6`; the tag was verified from that action's GitHub tags API.
- `python3`: supplied by the `macos-latest` runner; invoked by both evidence recipes.
- `cargo`: supplied by `dtolnay/rust-toolchain@stable`; invoked by the evidence script and the `scene` recipe.
- `/usr/bin/env`: supplied by the `macos-latest` runner; invoked by the evidence and `scene` recipes to strip Plexi context variables.

Lessons from the failed first fix:

- A successful action step is not evidence that the action performed its intended installation.
- For composite actions, `required: true` inputs are advisory; GitHub can run the step without them.

## Done When

- Stable DAW, built-in media players, and accessibility surfaces are explicitly unavailable while alpha and beta retain the experimental path.
- Roadmap evidence resolves exactly and every resolved proof executes.
- 0703's second Done-When is deliberately only partially met by Ian's priority ruling: protocol audio capture/playback and device listing, MIDI listing/input/output, and video decoder open/state/close remain capability-gated only. The remainder is tracked in stint 0708.

## Reachability audit

- DAW connector tools are not independently registered host tools. A running WASM pane emits `DeclareTools` during initialization, and dispatch registers those declarations against that pane only.
- Raw WASM path launches now resolve a registered component's canonical manifest identity before release gating; a file-name change cannot evade the DAW policy.
- Stable media entry points found: built-in audio and video players; protocol audio playback/capture and audio-device listing; MIDI-device listing, input, and output; and video decoder open/state/close. Only the built-in player launches are release-tier gated in this batch. The protocol operations remain capability-gated only by Ian's ruling and are explicitly deferred to stint 0708.
- `daw-gate-bundle` still fails headlessly at its input boundary. It remains wired into the installed DAW gate, is no longer represented as roadmap evidence, and has a separate follow-up stint.

## Review disposition

The stable boundary is honest and enforced for the selected surfaces. Protocol media release gating is intentionally deferred, not represented as complete.
