### PR TITLE
fix(ci): rust-host drop redundant build job, fix cache key collision (stint 0710)

### DIFF
--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [alpha]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # CPython-WASI bundle strategy for the network-fetched integration test
   # (host::wasm_python::tests::cpython_wasi_executes_inside_wasmtime_without_native_python).
@@ -22,29 +26,6 @@ env:
   PLEXI_CPYTHON_BUNDLE_DIR: /Users/runner/.plexi-ci/wasm-bundles
 
 jobs:
-  build:
-    name: build
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Restore Cargo cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
-
-      - name: Build host
-        run: cargo build
-
   test:
     name: test
     runs-on: macos-latest
@@ -61,9 +42,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-test-
 
       - name: Restore CPython WASI bundle cache
         if: env.WASI_BUNDLE_MODE == 'prefetch'
@@ -117,9 +98,9 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-clippy-
 
       - name: Lint host
         run: cargo clippy --bin plexi -- -D warnings

--- a/.github/workflows/rust-host.yml
+++ b/.github/workflows/rust-host.yml
@@ -3,8 +3,22 @@ name: Rust host
 on:
   push:
     branches: [alpha]
+    paths-ignore:
+      - '**/*.md'
+      - '.agents/**'
+      - '.claude/**'
+      - 'docs/**'
+      - 'website/**'
+      - '.stint/**'
   pull_request:
     branches: [alpha]
+    paths-ignore:
+      - '**/*.md'
+      - '.agents/**'
+      - '.claude/**'
+      - 'docs/**'
+      - 'website/**'
+      - '.stint/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Implements stint 0710. No linked GitHub issue — stint is authoritative.

- Delete the `build` job — `test` and `clippy` already compile the bin via `cargo test --bin plexi` and `cargo clippy --bin plexi`, so the dedicated `cargo build` job proved nothing extra while costing a third of the runner load.
- Give `test` and `clippy` their own Cargo cache keys (`-cargo-test-` / `-cargo-clippy-` with matching `restore-keys`) — all three jobs previously restored and wrote the identical key while holding different `target/` artifact kinds (debug bin vs `--test` cfg vs clippy metadata), so only one write won per run and the others recompiled near-cold.
- Add a `concurrency` group (`${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`) so a force-push cancels the superseded run instead of burning a macOS runner while the new run queues.
- Add `paths-ignore` to both `push` and `pull_request` triggers (`**/*.md`, `.agents/**`, `.claude/**`, `docs/**`, `website/**`, `.stint/**`) — `rust-host.yml` was the only workflow in the repo without a path filter, so a docs/skill-only commit (e.g. `25385ef4`) still ran the full 10-minute build. Every other workflow (`check-docs`, `check-protocol`, `check-cli-docs`, `check-config-docs`, `sdk-typecheck`, `website-smoke`) already has one. **Important semantics:** `paths-ignore` only skips the run when *every* changed file in the push/PR matches the ignore list — a commit touching even one `.rs`/`Cargo.toml`/non-listed file alongside a `.md` still runs the full suite. This is a denylist by design, not an allowlist: it fails safe (runs CI) if a new source directory is added later, rather than failing dangerous (silently skipping CI) the way an allowlist would. Verified `alpha` branch protection has no `required_status_checks` (`gh api repos/ianjamesburke/PLEXI/branches/alpha/protection`), so a skipped run cannot strand a PR waiting on an expected-but-never-reported check.

Preserved verbatim: `WASI_BUNDLE_MODE` prefetch/skip machinery and `PLEXI_CPYTHON_BUNDLE_DIR`, the CPython-WASI bundle cache/prefetch steps, `--skip headless_frame_fails_fast_when_the_guest_dies_at_import` and its comment, and the `env -u PLEXI_*` scrubbing on the test invocation.

**Baseline:** alpha push run 2026-08-01 22:12:57 → 22:23:09 = 10m12s.
**This PR's run:** TBD once CI completes — will update this description.

## Done When

A PR run shows only `test` and `clippy` jobs, both green, with wall-clock materially under the 10m baseline.

## Note on PR #2555 overlap

PR #2555 (feature/stint-0591-...) also touches `.github/workflows/rust-host.yml` inside the `test` job (an `Install just` step and a `Verify roadmap evidence` step). Expect a rebase conflict if #2555 lands first; this PR's `build`-job deletion is unaffected and stands regardless.
