### PR TITLE
docs: reserve stint IDs atomically

### DIFF
--- a/.agents/skills/create-stint/SKILL.md
+++ b/.agents/skills/create-stint/SKILL.md
@@ -149,21 +149,23 @@ If a GitHub issue should be created for this work, create it in Step 6. If one a
 
 ## Step 5 -- Write the Task File
 
-Find the next available ID:
+Reserve the ID atomically and capture it once:
 
 ```bash
-ls .stint/tasks/ | grep -oE '^[0-9]+' | sort -n | tail -1
+ID="$(stint reserve)"
 ```
 
-Increment by 1, zero-pad to 4 digits. Confirm no collision.
+Use `$ID` for the filename and frontmatter below. The reservation remains
+spent, so never derive an ID by listing task files or call `stint reserve`
+again for the same task.
 
-File path: `.stint/tasks/<NNNN>-<kebab-slug>.md`
+File path: `.stint/tasks/$ID-<kebab-slug>.md`
 
 Template:
 
 ```markdown
 ---
-id: "<NNNN>"
+id: "$ID"
 title: "<title>"
 status: todo
 priority: <p0-p4>


### PR DESCRIPTION
Closes stint task `0670` for the PLEXI skill half.

Replace the manual max-plus-one shell pipeline in `create-stint` with one captured `stint reserve` call. The returned ID is used for the file and frontmatter; the skill explicitly forbids recomputing or re-reserving it.

## Release/install prerequisite

Do not merge this PR until the companion CLI PR [ianjamesburke/stint#13](https://github.com/ianjamesburke/stint/pull/13) has merged, received its required patch release, and that released `stint` binary has been installed. This skill references `stint reserve`, which does not exist in older installed versions.

## Verification

Documentation-only diff reviewed: the legacy `ls | grep | sort | tail -1` allocation instruction is absent and the one reservation command is present. Per worker brief, no PLEXI build, install, host boot, or GUI validation was run.