### PR TITLE
host: arbitrate Cargo builds with host-owned leases (stint 0690)

### DIFF
--- a/.agents/skills/babysitter/RUN_CONFIG.toml
+++ b/.agents/skills/babysitter/RUN_CONFIG.toml
@@ -37,5 +37,5 @@ prewarm_release_build = false    # OFF 2026-07-31: OOMed the machine at ~10 conc
 
 [limits]
 max_concurrent_lanes = 4
-max_concurrent_cargo_builds = 1
+max_concurrent_cargo_consumers = 1
 on_cap = "pause"                 # pause new lanes over queueing more panes

--- a/.agents/skills/implement-stint/SKILL.md
+++ b/.agents/skills/implement-stint/SKILL.md
@@ -54,7 +54,7 @@ This skill is not complete when the worktree exists. Completion means the task w
 - **The gate is automated + headless only.** Never install, boot, foreground, or drive the GUI host — even when a task's Done-When asks for live validation; the tester round satisfies that requirement. Headless renders (`just scene` / `just scene-live` → PNG) are allowed. A worker told to foreground the host can wedge in AppKit activation long after its code is green (proven live).
 - **Run every suite env-stripped.** Worker panes run inside a live Plexi host, so `PLEXI_CHANNEL` / `PLEXI_CONTEXT_*` / `PLEXI_SOCKET` leak into `cargo test`, which resolves workspace/config state to the host's real channel profile and produces flaky `.plexi-<channel>` / `config_dir` / `temp_dir` failures that look like the diff's own. Always run:
   ```bash
-  env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID cargo test --bin plexi
+  bash scripts/cargo-with-lease.sh env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID cargo test --bin plexi
   ```
   When the diff touches the Python SDK or generated docs, also run `mypy sdk/python/plexi_sdk/ --ignore-missing-imports --check-untyped-defs --exclude testing.py` and every `just gen-*-docs` / `just check-*-docs` generator the diff touches, committing regenerated output.
 - **Memory watchdog on every suite run.** `ulimit -v` does not work on macOS — XNU does not enforce `RLIMIT_AS`, so a `( ulimit -v ...; cargo test )` wrap constrains nothing (proven live). Instead, run the suite alongside a background poller that kills any `target/debug/deps/plexi-*` process exceeding ~8 GB RSS, sampling `top -l 1 -o mem -n 5 -stats mem,pid,command` every 15 s. A multi-GB test balloon is a real bug in the diff (unbounded queue, wake feedback loop, an accumulating test adapter) — never flake to re-run.
@@ -276,8 +276,8 @@ Spawn **Sub-agent I** with the spec from Phase 3 and the worktree path. Sub-agen
 >
 > Rules:
 > - Write tests before implementation for host logic. New `AppRequest` or `HostEffect` behavior needs a `HostHarness` test first.
-> - Always run `cargo build` after edits.
-> - Run the narrower relevant test command: `cargo test --bin plexi <test_name>` (adjust filter as needed).
+> - Always run `bash scripts/cargo-with-lease.sh cargo build` after edits.
+> - Run the narrower relevant test command through `bash scripts/cargo-with-lease.sh cargo test --bin plexi <test_name>` (adjust filter as needed).
 - After tests pass, run a Codex review against alpha (maximum 2 runs; iterate on findings between runs). Write output to a tmp file; only read it if findings are present:
 >   ```bash
 >   CODEX_OUT="/tmp/plexi-codex-review-$$.txt"

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -50,8 +50,8 @@ A diff can hit multiple layers; produce evidence for each.
 Run the test modules nearest the touched code, then the full bin suite:
 
 ```bash
-cargo test --bin plexi <module_filter>
-cargo test --bin plexi
+bash scripts/cargo-with-lease.sh cargo test --bin plexi <module_filter>
+bash scripts/cargo-with-lease.sh cargo test --bin plexi
 ```
 
 Record pass/fail counts and the module filters used. New `AppRequest`/`HostEffect` handlers must have a `HostHarness` test (`src/testing/mod.rs`) — written first, per repo discipline.
@@ -69,7 +69,7 @@ and against which diff it ran.
 ```bash
 just scene tests/scenes/<name>.toml              # run one scene; PNGs + SceneReport JSON to /tmp/plexi-scenes
 just scene <file> /tmp/out 0                     # state-only: skip screenshot steps
-cargo test --bin plexi scene_suite               # all committed scenes (suite = true)
+bash scripts/cargo-with-lease.sh cargo test --bin plexi scene_suite               # all committed scenes (suite = true)
 ```
 
 For a new or changed overlay/widget/pane type: **add a committed scene file** under `tests/scenes/` — it is automatically a regression test. Scenes that spawn real app processes set `suite = false` and run via `just scene`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ Document failures in the issue **body** under `## Prior Attempts`, not in commen
 - **Orient from the document, not the issues.** The PRM IS the plan.
 - **Never serialize issue reads.** Use `gh issue list --search` with filters.
 - **Context is a budget.** Before fetching, ask: do I already have enough?
+- **Checkpoint before another audit.** Once a coherent implementation slice has passed its targeted validation, commit it before starting a fresh review or broad suite. Fix review findings in that next slice, then commit; do not run repeated review cycles against one uncommitted pile unless the user explicitly asks for an adversarial audit.
 - **Pipeline phases flow inline.** implement → open-pr → validate → merge. No stopping to ask.
 - **Match user energy.** When the user says "do it," start building.
 - **Sequential sub-agents only.** Never parallel in one worktree.

--- a/justfile
+++ b/justfile
@@ -24,7 +24,8 @@ wasm-python-shim:
     bash scripts/build-wasm-python-shim.sh
 
 dev:
-    cargo run
+    bash scripts/cargo-with-lease.sh cargo build
+    target/debug/plexi
 
 # Run the website dev server at http://localhost:4321
 web:
@@ -38,7 +39,7 @@ website-deploy:
 # under website/public/registry/v1/. Republishing after an app fix is one
 # command. Builds the binary first so packaging uses the current tree.
 website-registry:
-    cargo build --bin plexi
+    bash scripts/cargo-with-lease.sh cargo build --bin plexi
     python3 website/scripts/build-registry.py
 
 # Smoke-check production: pages, install redirect, registry index + artifact checksums.
@@ -47,12 +48,12 @@ website-smoke:
 
 # Run the full test suite — HostHarness regression tests + unit tests.
 test:
-    env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID cargo test
+    bash scripts/cargo-with-lease.sh env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID cargo test
 
 # Resolve every ROADMAP.toml evidence entry and execute every resolved proof.
 # This includes scenes that opt out of scene_suite.
 roadmap-evidence:
-    env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID python3 scripts/roadmap-evidence.py
+    python3 scripts/roadmap-evidence.py
 
 roadmap-evidence-fixtures:
     python3 scripts/test-roadmap-evidence.py
@@ -62,49 +63,49 @@ roadmap-evidence-fixtures:
 # apps/wasm-poc/* source. Requires cargo-component + the wasm32-wasip2 target.
 # Note: cargo-component emits the adapted component under the wasip1 path.
 wasm-fixtures:
-    cd apps/wasm-poc/sysmon && cargo component build --release --target wasm32-wasip2
+    cd apps/wasm-poc/sysmon && bash ../../../scripts/cargo-with-lease.sh cargo component build --release --target wasm32-wasip2
     cp target/wasm32-wasip1/release/sysmon.wasm tests/wasm-fixtures/sysmon.wasm
-    cd apps/wasm-poc/audio-synth && cargo component build --release --target wasm32-wasip2
+    cd apps/wasm-poc/audio-synth && bash ../../../scripts/cargo-with-lease.sh cargo component build --release --target wasm32-wasip2
     cp target/wasm32-wasip1/release/audio_synth.wasm tests/wasm-fixtures/audio-synth.wasm
-    cd apps/wasm-poc/pong && cargo component build --release --target wasm32-wasip2
+    cd apps/wasm-poc/pong && bash ../../../scripts/cargo-with-lease.sh cargo component build --release --target wasm32-wasip2
     cp target/wasm32-wasip1/release/pong.wasm tests/wasm-fixtures/pong.wasm
-    cd apps/wasm-poc/counter && cargo component build --release --target wasm32-wasip2
+    cd apps/wasm-poc/counter && bash ../../../scripts/cargo-with-lease.sh cargo component build --release --target wasm32-wasip2
     cp target/wasm32-wasip1/release/counter.wasm tests/wasm-fixtures/counter.wasm
-    cd apps/wasm-poc/daw-engine && cargo component build --release --target wasm32-wasip2
+    cd apps/wasm-poc/daw-engine && bash ../../../scripts/cargo-with-lease.sh cargo component build --release --target wasm32-wasip2
     cp target/wasm32-wasip1/release/daw_engine_poc.wasm tests/wasm-fixtures/daw-engine.wasm
-    cd apps/wasm-poc/jukebox && cargo component build --release --target wasm32-wasip2
+    cd apps/wasm-poc/jukebox && bash ../../../scripts/cargo-with-lease.sh cargo component build --release --target wasm32-wasip2
     cp target/wasm32-wasip1/release/jukebox.wasm tests/wasm-fixtures/jukebox.wasm
     bash scripts/build-wasm-python-shim.sh
 
 # Generate an HTML line-coverage report and open it in the browser.
 # Requires: cargo install cargo-llvm-cov && rustup component add llvm-tools-preview
 coverage:
-    cargo llvm-cov --bin plexi --html --open -- --skip "welcome_tab_falls_back_to_home_dir_when_no_root"
+    bash scripts/cargo-with-lease.sh cargo llvm-cov --bin plexi --html --open -- --skip "welcome_tab_falls_back_to_home_dir_when_no_root"
 
 # Print per-file coverage summary to stdout (no browser).
 coverage-summary:
-    cargo llvm-cov --bin plexi --summary-only -- --skip "welcome_tab_falls_back_to_home_dir_when_no_root"
+    bash scripts/cargo-with-lease.sh cargo llvm-cov --bin plexi --summary-only -- --skip "welcome_tab_falls_back_to_home_dir_when_no_root"
 
 # Perf lint gate — run before and after any perf work; must exit clean.
 # Scoped to the perf lint set only (`-A clippy::all` silences unrelated lints);
 # vendored deps/egui_term opts out via crate-level allows in its lib.rs.
 perf-clippy:
-    RUSTC_WRAPPER= RUSTFLAGS= cargo clippy --all-targets --all-features --locked -- -A clippy::all -D clippy::perf -D clippy::redundant_clone -D clippy::needless_collect -D clippy::large_enum_variant -D clippy::clone_on_copy
+    RUSTC_WRAPPER= RUSTFLAGS= bash scripts/cargo-with-lease.sh cargo clippy --all-targets --all-features --locked -- -A clippy::all -D clippy::perf -D clippy::redundant_clone -D clippy::needless_collect -D clippy::large_enum_variant -D clippy::clone_on_copy
 
 build:
-    cargo build --release
+    bash scripts/cargo-with-lease.sh cargo build --release
 
 # Regenerate the canonical PGAP JSON Schema and Python protocol models.
 # Run after any change to src/app_protocol.rs.
 gen-schema:
-    cargo run -p gen_schema > sdk/protocol/pgap.schema.json
+    bash scripts/cargo-with-lease.sh cargo run -p gen_schema > sdk/protocol/pgap.schema.json
     python3 tools/gen_protocol_py.py
     @echo "Schema and Python protocol models regenerated."
 
 # Regenerate the CLI reference docs from the clap Command tree.
 # Run after any change to src/cli_args.rs.
 gen-cli-docs:
-    cargo run -p gen_cli_docs > website/src/content/docs/cli.md
+    bash scripts/cargo-with-lease.sh cargo run -p gen_cli_docs > website/src/content/docs/cli.md
     @echo "CLI reference regenerated."
     git add website/src/content/docs/cli.md
     git diff --cached --quiet || git commit -m "chore(website): regenerate CLI reference docs"
@@ -115,7 +116,7 @@ gen-cli-docs:
 check-cli-docs:
     #!/usr/bin/env bash
     set -euo pipefail
-    cargo run -p gen_cli_docs > /tmp/plexi_check_cli.md
+    bash scripts/cargo-with-lease.sh cargo run -p gen_cli_docs > /tmp/plexi_check_cli.md
     if ! diff -q website/src/content/docs/cli.md /tmp/plexi_check_cli.md > /dev/null; then
         echo "ERROR: website/src/content/docs/cli.md is stale. Run 'just gen-cli-docs'."
         diff website/src/content/docs/cli.md /tmp/plexi_check_cli.md || true
@@ -126,7 +127,7 @@ check-cli-docs:
 # Regenerate the config reference docs from the serde config structs.
 # Run after any change to src/config/mod.rs or scripts/default-config.toml.
 gen-config-docs:
-    cargo run -p gen_config_docs > website/src/content/docs/config.md
+    bash scripts/cargo-with-lease.sh cargo run -p gen_config_docs > website/src/content/docs/config.md
     @echo "Config reference regenerated."
     git add website/src/content/docs/config.md
     git diff --cached --quiet || git commit -m "chore(website): regenerate config reference docs"
@@ -137,7 +138,7 @@ gen-config-docs:
 check-config-docs:
     #!/usr/bin/env bash
     set -euo pipefail
-    cargo run -p gen_config_docs > /tmp/plexi_check_config.md
+    bash scripts/cargo-with-lease.sh cargo run -p gen_config_docs > /tmp/plexi_check_config.md
     if ! diff -q website/src/content/docs/config.md /tmp/plexi_check_config.md > /dev/null; then
         echo "ERROR: website/src/content/docs/config.md is stale. Run 'just gen-config-docs'."
         diff website/src/content/docs/config.md /tmp/plexi_check_config.md || true
@@ -150,7 +151,7 @@ check-config-docs:
 check-schema:
     #!/usr/bin/env bash
     set -euo pipefail
-    cargo run -p gen_schema > /tmp/pgap_check.schema.json
+    bash scripts/cargo-with-lease.sh cargo run -p gen_schema > /tmp/pgap_check.schema.json
     if ! diff -q sdk/protocol/pgap.schema.json /tmp/pgap_check.schema.json > /dev/null; then
         echo "ERROR: sdk/protocol/pgap.schema.json is stale. Run 'just gen-schema'."
         diff sdk/protocol/pgap.schema.json /tmp/pgap_check.schema.json || true
@@ -208,7 +209,8 @@ check-authoring-docs:
 check-docs: check-cli-docs check-config-docs check-sdk-docs check-capability-docs check-docs-coverage check-authoring-docs
 
 run:
-    cargo run --release
+    bash scripts/cargo-with-lease.sh cargo build --release
+    target/release/plexi
 
 # Regenerate generated artifacts only when their source files changed.
 # When adding a new generated artifact, add a stale check here.
@@ -226,15 +228,15 @@ regen-if-stale:
     set -euo pipefail
     if [[ Cargo.toml -nt website/src/content/docs/cli.md || src/cli/args.rs -nt website/src/content/docs/cli.md ]]; then
         echo "CLI docs source changed — regenerating CLI docs..."
-        cargo run -p gen_cli_docs > website/src/content/docs/cli.md
+        bash scripts/cargo-with-lease.sh cargo run -p gen_cli_docs > website/src/content/docs/cli.md
     fi
     if [[ src/config/mod.rs -nt website/src/content/docs/config.md || scripts/default-config.toml -nt website/src/content/docs/config.md ]]; then
         echo "Config source changed — regenerating config docs..."
-        cargo run -p gen_config_docs > website/src/content/docs/config.md
+        bash scripts/cargo-with-lease.sh cargo run -p gen_config_docs > website/src/content/docs/config.md
     fi
     if [[ src/app_protocol.rs -nt sdk/protocol/pgap.schema.json ]]; then
         echo "app_protocol.rs changed — regenerating schema..."
-        cargo run -p gen_schema > sdk/protocol/pgap.schema.json
+        bash scripts/cargo-with-lease.sh cargo run -p gen_schema > sdk/protocol/pgap.schema.json
         python3 tools/gen_protocol_py.py
     fi
 
@@ -278,6 +280,7 @@ pr-install number:
     # pick a worktree that provably contains it, and build from THAT.
     _repo_root="$(git rev-parse --path-format=absolute --git-common-dir)"
     _repo_root="${_repo_root%/.git}"
+    _driver_root="$(git rev-parse --show-toplevel)"
     _head_json="$(gh pr view {{number}} --json headRefName,headRefOid 2>/dev/null || echo "")"
     if [[ -z "$_head_json" ]]; then
       echo "Error: could not resolve PR #{{number}} via gh (gh pr view failed)."
@@ -333,7 +336,15 @@ pr-install number:
     # Pre-install tests and the build both run inside the resolved worktree,
     # never the caller's cwd.
     ( cd "$_wt" && just fetch-python-runtime sdk-smoke )
-    ( cd "$_wt" && bash scripts/pr-clean.sh {{number}} && bash scripts/install.sh "pr-{{number}}" )
+    ( cd "$_wt" && bash scripts/pr-clean.sh {{number}} )
+    if rg -q 'cargo-with-lease\.sh' "$_wt/scripts/install.sh"; then
+      ( cd "$_wt" && bash scripts/install.sh "pr-{{number}}" )
+    else
+      # Older PR heads predate the leaf wrapper. Treat their opaque install
+      # script as the compatibility leaf; newer heads acquire inside their
+      # own bundle invocation and must never acquire twice.
+      ( cd "$_wt" && "$_driver_root/scripts/cargo-with-lease.sh" bash scripts/install.sh "pr-{{number}}" )
+    fi
     # Provenance trace: which head this channel is actually running. Written
     # after install.sh (pr-clean wipes the profile dir); path matches
     # install.sh's profile_dir for channel pr-{{number}}.
@@ -522,7 +533,7 @@ ship +issues:
 scene FILE out="/tmp/plexi-scenes" shots="1":
     PLEXI_SCENE={{FILE}} PLEXI_SCENE_OUT={{out}} \
     {{ if shots == "0" { "PLEXI_SCENE_NO_SHOTS=1" } else { "" } }} \
-    env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID cargo test --bin plexi scene_single -- --ignored --exact scenes::tests::scene_single --nocapture
+    bash scripts/cargo-with-lease.sh env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID cargo test --bin plexi scene_single -- --ignored --exact scenes::tests::scene_single --nocapture
 
 # Run the same TOML scene against an explicit installed host channel.
 # The runner owns and tears down the host unless PLEXI_SCENE_ATTACH=1 is set.

--- a/scripts/build-wasm-python-shim.sh
+++ b/scripts/build-wasm-python-shim.sh
@@ -9,8 +9,8 @@ WASM_OUT="${ROOT}/target/wasm32-wasip1/release/python_shim.wasm"
 FIXTURE_OUT="${ROOT}/tests/wasm-fixtures/python-shim.wasm"
 
 cd "$CRATE_DIR"
-cargo test
-cargo component build --release --target wasm32-wasip2
+bash "$ROOT/scripts/cargo-with-lease.sh" cargo test
+bash "$ROOT/scripts/cargo-with-lease.sh" cargo component build --release --target wasm32-wasip2
 wasm-tools validate "$WASM_OUT"
 
 mkdir -p "$(dirname "$FIXTURE_OUT")"

--- a/scripts/cargo-with-lease.sh
+++ b/scripts/cargo-with-lease.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Run one Cargo leaf under the host's cargo-build lease when a Plexi host is
+# reachable. CI and standalone shells have no host/lane concurrency, so they
+# proceed explicitly unleased; a reachable host that times out is a hard fail.
+set -euo pipefail
+
+lease_name="cargo-build"
+if [[ -z "${PLEXI_SOCKET:-}" ]]; then
+  echo "cargo-lease: proceeding unleased (no Plexi host reachable)" >&2
+  exec "$@"
+fi
+
+# `lock` is intentionally a new command, so first prove that the host itself
+# is reachable through an established verb. A pre-lease shim must not turn an
+# unknown `lock` command into an unleased build.
+set +e
+plexi pane list >/dev/null 2>&1
+probe_rc=$?
+set -e
+if [[ "$probe_rc" -ne 0 ]]; then
+  echo "cargo-lease: proceeding unleased (no Plexi host reachable)" >&2
+  exec "$@"
+fi
+
+set +e
+plexi lock status "$lease_name" >/dev/null 2>&1
+status_rc=$?
+set -e
+if [[ "$status_rc" -ne 0 ]]; then
+  echo "cargo-lease: host reachable but status failed (exit $status_rc); refusing unleased cargo" >&2
+  exit "$status_rc"
+fi
+
+set +e
+plexi lock acquire "$lease_name" --timeout "${PLEXI_CARGO_LEASE_TIMEOUT_SECS:-900}"
+rc=$?
+set -e
+if [[ "$rc" -ne 0 ]]; then
+  echo "cargo-lease: host reachable but acquire failed (exit $rc); refusing unleased cargo" >&2
+  exit "$rc"
+fi
+
+release() {
+  if ! plexi lock release "$lease_name" >/dev/null; then
+    echo "cargo-lease: host reachable but release failed; refusing to hide a held lease" >&2
+    return 1
+  fi
+}
+
+cleanup() {
+  local command_rc=$?
+  trap - EXIT INT TERM
+  release || exit 1
+  exit "$command_rc"
+}
+trap cleanup EXIT INT TERM
+"$@"

--- a/scripts/daw-gate.sh
+++ b/scripts/daw-gate.sh
@@ -132,7 +132,7 @@ echo "daw-gate: started channel=$channel scenes=${#scenes[@]} out=$out_dir"
 core_artifact="${TMPDIR:-/tmp}/plexi-daw-gate/daw-gate-core.json"
 rm -f "$core_artifact"
 echo "daw-gate: running core qualification (cargo test daw_gate core artifact)"
-if ! (cd "$repo_root" && env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID \
+if ! (cd "$repo_root" && bash scripts/cargo-with-lease.sh env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID \
     -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID \
     cargo test --bin plexi daw_gate::daw_gate_core_qualification_artifact \
     > "$out_dir/core-qualification.log" 2>&1); then

--- a/scripts/editor-gate.sh
+++ b/scripts/editor-gate.sh
@@ -116,7 +116,7 @@ echo "editor-gate: started channel=$channel scenes=${#scenes[@]} out=$out_dir"
 core_artifact="${TMPDIR:-/tmp}/plexi-editor-gate/editor-gate-core.json"
 rm -f "$core_artifact"
 echo "editor-gate: running core qualification (cargo test editor::gate)"
-if ! (cd "$repo_root" && env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID \
+if ! (cd "$repo_root" && bash scripts/cargo-with-lease.sh env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID \
     -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID \
     cargo test --bin plexi editor::gate::gate_core_qualification_artifact \
     > "$out_dir/core-qualification.log" 2>&1); then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,9 +80,9 @@ fi
 # for every real channel so an inherited shell variable cannot taint a
 # production build.
 if [[ "$channel" =~ ^pr-[0-9]+$ ]]; then
-  PLEXI_BUILD_TEST_CHANNEL="$channel" cargo bundle --release
+  PLEXI_BUILD_TEST_CHANNEL="$channel" bash scripts/cargo-with-lease.sh cargo bundle --release
 else
-  env -u PLEXI_BUILD_TEST_CHANNEL cargo bundle --release
+  env -u PLEXI_BUILD_TEST_CHANNEL bash scripts/cargo-with-lease.sh cargo bundle --release
 fi
 
 if [[ ! -d "$app_src" ]]; then

--- a/scripts/promote.sh
+++ b/scripts/promote.sh
@@ -160,7 +160,7 @@ check_clean "$MAIN_TREE" "main worktree"
 # tree's own clap tree: every subcommand and flag the skill documents must
 # exist, and plexi_version must match Cargo.toml. See src/cli/skill_surface.rs.
 echo "Verifying agent skill against the release CLI surface..."
-(cd "$BETA_TREE" && cargo test --quiet --bin plexi skill_surface) \
+(cd "$BETA_TREE" && bash scripts/cargo-with-lease.sh cargo test --quiet --bin plexi skill_surface) \
     || die "skill surface gate failed — the skill documents CLI surface this release does not have (src/cli/skill_surface.rs)"
 
 version=$(grep '^version' "$BETA_TREE/Cargo.toml" | head -1 | sed 's/version = "\(.*\)"/\1/')

--- a/scripts/roadmap-evidence.py
+++ b/scripts/roadmap-evidence.py
@@ -18,6 +18,11 @@ import tomllib
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 TEST_RE = re.compile(r"^\s*#\s*\[\s*(?:[\w:]+::)?test[^\]]*\]\s*$")
 FN_RE = re.compile(r"^\s*(?:pub\s+)?(?:async\s+)?fn\s+(\w+)\s*\(")
+CARGO_ENV_STRIP = [
+    "env", "-u", "PLEXI_CHANNEL", "-u", "PLEXI_CONTEXT_ROOT", "-u",
+    "PLEXI_CONTEXT_ID", "-u", "PLEXI_CONTEXT_NAME", "-u", "PLEXI_SOCKET",
+    "-u", "PLEXI_RUNNING", "-u", "PLEXI_PANE_ID",
+]
 
 
 def roadmap_evidence(path: pathlib.Path) -> list[str]:
@@ -73,7 +78,7 @@ def run(command: list[str], cwd: pathlib.Path) -> bool:
 def execute(root: pathlib.Path, resolved: dict[str, pathlib.Path]) -> list[str]:
     failures: list[str] = []
     listing = subprocess.run(
-        ["cargo", "test", "--workspace", "--", "--list"],
+        ["bash", "scripts/cargo-with-lease.sh", *CARGO_ENV_STRIP, "cargo", "test", "--workspace", "--", "--list"],
         cwd=root,
         text=True,
         capture_output=True,
@@ -103,6 +108,9 @@ def execute(root: pathlib.Path, resolved: dict[str, pathlib.Path]) -> list[str]:
     # roadmap evidence and fails reproducibly on clean alpha.
     if not run(
         [
+            "bash",
+            "scripts/cargo-with-lease.sh",
+            *CARGO_ENV_STRIP,
             "cargo",
             "test",
             "--workspace",

--- a/scripts/run-live-scene.sh
+++ b/scripts/run-live-scene.sh
@@ -30,4 +30,4 @@ PLEXI_SCENE_NO_SHOTS=1 \
 PLEXI_SCENE_BACKEND=live \
 PLEXI_SCENE_CHANNEL="$channel" \
 PLEXI_SCENE_OWNER_FILE="$owner_file" \
-cargo test --bin plexi scene_single -- --ignored --exact scenes::tests::scene_single --nocapture
+bash scripts/cargo-with-lease.sh cargo test --bin plexi scene_single -- --ignored --exact scenes::tests::scene_single --nocapture

--- a/scripts/test-roadmap-evidence.py
+++ b/scripts/test-roadmap-evidence.py
@@ -37,6 +37,13 @@ def fixture(name: str, evidence: str) -> tuple[tempfile.TemporaryDirectory[str],
     write(roadmap, f'[[node]]\nid = "fixture"\nevidence = ["{evidence}"]\n')
     bin_dir = root / "bin"
     write(bin_dir / "cargo", "#!/bin/sh\nexit 0\n", True)
+    # The production gate invokes cargo through the host-lease wrapper. Keep
+    # fixture roots hermetic while preserving their fake cargo boundary.
+    write(
+        root / "scripts/cargo-with-lease.sh",
+        "#!/bin/sh\nexec \"$@\"\n",
+        True,
+    )
     return temp, root, roadmap, bin_dir
 
 

--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plexi-cli
 description: Operate a running Plexi host: panes, apps, contexts, notifications, workspace tools, and agent coordination.
-skill_version: "5.0.0"
+skill_version: "5.0.1"
 plexi_version: "0.2.3"
 last_verified: "2026-08-01"
 ---
@@ -25,6 +25,8 @@ CLI or app SDK; do not inspect Plexi profile files directly.
   and `pane new --agent` is the dedicated verb for booting another agent.
 - **Slots** — store a small, named pane result that another pane can inspect or
   wait for: `plexi pane slot --help`.
+- **Locks** — coordinate host-owned named leases between panes with FIFO grants,
+  timeouts, and pane-death cleanup: `plexi lock --help`.
 - **Contexts** — create or enter scoped project spaces, including pre-populated
   sub-contexts: `plexi context --help`.
 - **Apps** — scaffold, check, test, open, package, install, and inspect apps:
@@ -49,6 +51,7 @@ The release gate verifies these feature-map entry points:
 ```
 pane
 pane slot
+lock
 context
 app
 notify

--- a/src/app/build_lease.rs
+++ b/src/app/build_lease.rs
@@ -1,0 +1,451 @@
+//! Host-owned named build leases.
+//!
+//! A lease is held by a pane, rather than by a shell PID: the host can prove
+//! and clean up that identity when the terminal exits or is closed.
+
+use std::collections::{HashMap, VecDeque};
+use std::time::Instant;
+
+use serde::Deserialize;
+
+#[derive(Debug)]
+struct Holder {
+    pane_id: u64,
+}
+
+#[derive(Debug)]
+struct Waiter {
+    pane_id: u64,
+    response_file: String,
+    queued_at: Instant,
+    expires_at: Instant,
+}
+
+#[derive(Debug, Default)]
+struct NamedLease {
+    holders: Vec<Holder>,
+    waiters: VecDeque<Waiter>,
+}
+
+#[derive(Debug)]
+pub(crate) struct BuildLeaseManager {
+    capacity: usize,
+    leases: HashMap<String, NamedLease>,
+}
+
+#[derive(Deserialize)]
+struct RunConfig {
+    limits: RunLimits,
+}
+
+#[derive(Deserialize)]
+struct RunLimits {
+    max_concurrent_cargo_consumers: usize,
+}
+
+impl BuildLeaseManager {
+    pub(crate) fn from_run_config() -> Self {
+        let config: RunConfig = toml::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/.agents/skills/babysitter/RUN_CONFIG.toml"
+        )))
+        .expect("RUN_CONFIG.toml must define limits.max_concurrent_cargo_consumers");
+        Self::new(config.limits.max_concurrent_cargo_consumers)
+    }
+
+    pub(crate) fn new(capacity: usize) -> Self {
+        assert!(capacity > 0, "build lease capacity must be positive");
+        Self {
+            capacity,
+            leases: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn acquire(
+        &mut self,
+        name: &str,
+        pane_id: u64,
+        timeout_secs: f64,
+        response_file: String,
+    ) -> Result<(), String> {
+        if !timeout_secs.is_finite()
+            || !(0.0..=crate::app::pane_wait::MAX_WAIT_TIMEOUT_SECS).contains(&timeout_secs)
+        {
+            return Err(format!(
+                "--timeout must be between 0 and {}, got {timeout_secs}",
+                crate::app::pane_wait::MAX_WAIT_TIMEOUT_SECS
+            ));
+        }
+        let now = Instant::now();
+        let lease = self.leases.entry(name.to_owned()).or_default();
+        if lease.holders.iter().any(|holder| holder.pane_id == pane_id)
+            || lease.waiters.iter().any(|waiter| waiter.pane_id == pane_id)
+        {
+            return Err(format!(
+                "pane {pane_id} already owns or waits for lease {name:?}; leases are non-reentrant"
+            ));
+        }
+        if lease.waiters.is_empty() && lease.holders.len() < self.capacity {
+            if !crate::rpc::write_json_response(
+                &response_file,
+                serde_json::json!({"ok": true, "name": name, "pane_id": pane_id, "wait_secs": 0.0}),
+            ) {
+                return Err(format!(
+                    "could not confirm lease {name:?} grant to pane {pane_id}"
+                ));
+            }
+            lease.holders.push(Holder { pane_id });
+            log::info!("build_lease: granted name={name:?} pane_id={pane_id} wait_secs=0");
+        } else {
+            lease.waiters.push_back(Waiter {
+                pane_id,
+                response_file,
+                queued_at: now,
+                expires_at: now + std::time::Duration::from_secs_f64(timeout_secs),
+            });
+            log::info!(
+                "build_lease: queued name={name:?} pane_id={pane_id} depth={}",
+                lease.waiters.len()
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn release(&mut self, name: &str, pane_id: u64) -> Result<(), String> {
+        let Some(lease) = self.leases.get_mut(name) else {
+            return Err(format!("lease {name:?} is not held"));
+        };
+        let before = lease.holders.len();
+        lease.holders.retain(|holder| holder.pane_id != pane_id);
+        if before == lease.holders.len() {
+            return Err(format!("pane {pane_id} does not hold lease {name:?}"));
+        }
+        log::info!("build_lease: released name={name:?} pane_id={pane_id}");
+        self.grant_waiters(name);
+        Ok(())
+    }
+
+    pub(crate) fn release_pane(&mut self, pane_id: u64, reason: &str) {
+        let names: Vec<String> = self.leases.keys().cloned().collect();
+        for name in names {
+            let Some(lease) = self.leases.get_mut(&name) else {
+                continue;
+            };
+            let held = lease.holders.iter().any(|holder| holder.pane_id == pane_id);
+            lease.holders.retain(|holder| holder.pane_id != pane_id);
+            lease.waiters.retain(|waiter| waiter.pane_id != pane_id);
+            if held {
+                log::info!(
+                    "build_lease: auto_released name={name:?} pane_id={pane_id} reason={reason}"
+                );
+                self.grant_waiters(&name);
+            }
+        }
+    }
+
+    pub(crate) fn status(&self, name: &str) -> serde_json::Value {
+        let now = Instant::now();
+        let Some(lease) = self.leases.get(name) else {
+            return serde_json::json!({"name": name, "holder_pane_id": null, "holder_pane_ids": [], "queue_depth": 0, "wait_secs": 0.0});
+        };
+        let holders: Vec<u64> = lease.holders.iter().map(|holder| holder.pane_id).collect();
+        let wait_secs = lease
+            .waiters
+            .front()
+            .map(|waiter| now.duration_since(waiter.queued_at).as_secs_f64())
+            .unwrap_or(0.0);
+        serde_json::json!({"name": name, "holder_pane_id": holders.first(), "holder_pane_ids": holders, "queue_depth": lease.waiters.len(), "wait_secs": wait_secs})
+    }
+
+    pub(crate) fn service(&mut self, ctx: &egui::Context) {
+        let now = Instant::now();
+        let names: Vec<String> = self.leases.keys().cloned().collect();
+        for name in &names {
+            let mut expired = Vec::new();
+            if let Some(lease) = self.leases.get_mut(name) {
+                lease.waiters.retain(|waiter| {
+                    if now >= waiter.expires_at {
+                        expired.push((waiter.pane_id, waiter.response_file.clone()));
+                        false
+                    } else {
+                        true
+                    }
+                });
+            }
+            for (pane_id, response_file) in expired {
+                log::info!("build_lease: timed_out name={name:?} pane_id={pane_id}");
+                crate::rpc::write_json_response(
+                    &format!("{response_file}.err"),
+                    serde_json::json!({"ok": false, "timeout": true, "error": format!("timed out waiting for lease {name:?}")}),
+                );
+            }
+            self.grant_waiters(name);
+        }
+        if let Some(next) = self
+            .leases
+            .values()
+            .flat_map(|lease| lease.waiters.iter().map(|waiter| waiter.expires_at))
+            .min()
+        {
+            let remaining = next.saturating_duration_since(Instant::now());
+            let predicted =
+                std::time::Duration::from_secs_f32(ctx.input(|input| input.predicted_dt));
+            ctx.request_repaint_after(remaining + predicted);
+        }
+    }
+
+    fn grant_waiters(&mut self, name: &str) {
+        let now = Instant::now();
+        let Some(lease) = self.leases.get_mut(name) else {
+            return;
+        };
+        while lease.holders.len() < self.capacity {
+            let Some(waiter) = lease.waiters.pop_front() else {
+                break;
+            };
+            if now >= waiter.expires_at {
+                crate::rpc::write_json_response(
+                    &format!("{}.err", waiter.response_file),
+                    serde_json::json!({"ok": false, "timeout": true, "error": format!("timed out waiting for lease {name:?}")}),
+                );
+                continue;
+            }
+            let wait_secs = now.duration_since(waiter.queued_at).as_secs_f64();
+            if !crate::rpc::write_json_response(
+                &waiter.response_file,
+                serde_json::json!({"ok": true, "name": name, "pane_id": waiter.pane_id, "wait_secs": wait_secs}),
+            ) {
+                log::error!(
+                    "build_lease: could not confirm grant name={name:?} pane_id={}; dropping waiter",
+                    waiter.pane_id
+                );
+                continue;
+            }
+            lease.holders.push(Holder {
+                pane_id: waiter.pane_id,
+            });
+            log::info!(
+                "build_lease: granted name={name:?} pane_id={} wait_secs={wait_secs:.3}",
+                waiter.pane_id
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    #[test]
+    fn cargo_lease_wrapper_explicitly_proceeds_without_a_host() {
+        let output = Command::new("bash")
+            .arg(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/scripts/cargo-with-lease.sh"
+            ))
+            .arg("/usr/bin/true")
+            .env_remove("PLEXI_SOCKET")
+            .env_remove("PLEXI_CHANNEL")
+            .env_remove("PLEXI_PANE_ID")
+            .output()
+            .expect("cargo lease wrapper must run");
+        assert!(
+            output.status.success(),
+            "unreachable host must not block cargo"
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr)
+                .contains("proceeding unleased (no Plexi host reachable)"),
+            "unreachable host fallback must be explicit"
+        );
+    }
+
+    #[test]
+    fn cargo_lease_wrapper_refuses_a_reachable_host_with_failed_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("bin");
+        std::fs::create_dir(&bin).unwrap();
+        let plexi = bin.join("plexi");
+        std::fs::write(
+            &plexi,
+            "#!/usr/bin/env bash\nif [[ \"$1\" == pane ]]; then exit 0; fi\nexit 2\n",
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&plexi).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&plexi, permissions).unwrap();
+
+        let output = Command::new("bash")
+            .arg(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/scripts/cargo-with-lease.sh"
+            ))
+            .arg("/usr/bin/true")
+            .env("PLEXI_SOCKET", "/tmp/reachable-plexi.sock")
+            .env(
+                "PATH",
+                format!("{}:{}", bin.display(), std::env::var("PATH").unwrap()),
+            )
+            .output()
+            .expect("cargo lease wrapper must run");
+        assert_eq!(output.status.code(), Some(2));
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("host reachable but status failed"),
+            "a configured host that cannot answer status must not run cargo unleased"
+        );
+    }
+
+    #[test]
+    fn cargo_lease_wrapper_surfaces_release_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let bin = dir.path().join("bin");
+        std::fs::create_dir(&bin).unwrap();
+        let plexi = bin.join("plexi");
+        std::fs::write(
+            &plexi,
+            "#!/usr/bin/env bash\ncase \"$1 $2\" in\n  'pane list'|'lock status'|'lock acquire') exit 0 ;;\n  'lock release') exit 2 ;;\nesac\nexit 1\n",
+        )
+        .unwrap();
+        let mut permissions = std::fs::metadata(&plexi).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&plexi, permissions).unwrap();
+
+        let output = Command::new("bash")
+            .arg(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/scripts/cargo-with-lease.sh"
+            ))
+            .arg("/usr/bin/true")
+            .env("PLEXI_SOCKET", "/tmp/reachable-plexi.sock")
+            .env(
+                "PATH",
+                format!("{}:{}", bin.display(), std::env::var("PATH").unwrap()),
+            )
+            .output()
+            .expect("cargo lease wrapper must run");
+        assert_eq!(output.status.code(), Some(1));
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("release failed"),
+            "a failed release must fail the build command rather than strand the holder"
+        );
+    }
+
+    #[test]
+    fn capacity_controls_parallel_holders() {
+        let mut leases = BuildLeaseManager::new(1);
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("first.json");
+        let second = dir.path().join("second.json");
+        leases
+            .acquire("cargo-build", 1, 60.0, first.to_string_lossy().into())
+            .unwrap();
+        leases
+            .acquire("cargo-build", 2, 60.0, second.to_string_lossy().into())
+            .unwrap();
+        assert!(first.exists());
+        assert!(
+            !second.exists(),
+            "capacity one must queue the second holder"
+        );
+        leases.release("cargo-build", 1).unwrap();
+        assert!(second.exists(), "release must grant the FIFO waiter");
+    }
+
+    #[test]
+    fn holder_exit_releases_lease_and_grants_the_fifo_waiter() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut leases = BuildLeaseManager::new(1);
+        let granted = dir.path().join("holder.json");
+        let queued = dir.path().join("waiter.json");
+        leases
+            .acquire("cargo-build", 1, 60.0, granted.to_string_lossy().into())
+            .unwrap();
+        assert!(granted.exists());
+        leases
+            .acquire("cargo-build", 2, 60.0, queued.to_string_lossy().into())
+            .unwrap();
+        assert!(!queued.exists(), "capacity one must queue the second pane");
+        leases.release_pane(1, "pty_exit");
+        assert!(
+            queued.exists(),
+            "PTY death must release the holder and grant FIFO waiter"
+        );
+    }
+
+    #[test]
+    fn saturated_host_returns_a_typed_timeout() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut leases = BuildLeaseManager::new(1);
+        leases
+            .acquire(
+                "cargo-build",
+                1,
+                60.0,
+                dir.path().join("holder.json").to_string_lossy().into(),
+            )
+            .unwrap();
+        let timeout = dir.path().join("timeout.json");
+        leases
+            .acquire("cargo-build", 2, 0.0, timeout.to_string_lossy().into())
+            .unwrap();
+        leases.service(&egui::Context::default());
+        let reply: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(format!("{}.err", timeout.display())).unwrap())
+                .unwrap();
+        assert_eq!(
+            reply["timeout"], true,
+            "reachable saturated host must fail rather than proceed unleased"
+        );
+    }
+
+    #[test]
+    fn failed_grant_response_does_not_create_a_holder() {
+        let dir = tempfile::tempdir().unwrap();
+        let response = dir.path().join("missing/grant.json");
+        let mut manager = BuildLeaseManager::new(1);
+
+        assert!(manager
+            .acquire(
+                "cargo-build",
+                7,
+                1.0,
+                response.to_string_lossy().into_owned()
+            )
+            .is_err());
+        assert_eq!(
+            manager.status("cargo-build")["holder_pane_id"],
+            serde_json::Value::Null,
+            "a client that never receives its grant must not occupy capacity"
+        );
+    }
+
+    #[test]
+    fn later_waiter_times_out_behind_a_live_fifo_waiter() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut leases = BuildLeaseManager::new(1);
+        leases
+            .acquire(
+                "cargo-build",
+                1,
+                60.0,
+                dir.path().join("holder.json").to_string_lossy().into(),
+            )
+            .unwrap();
+        let live = dir.path().join("live.json");
+        let expired = dir.path().join("expired.json");
+        leases
+            .acquire("cargo-build", 2, 60.0, live.to_string_lossy().into())
+            .unwrap();
+        leases
+            .acquire("cargo-build", 3, 0.0, expired.to_string_lossy().into())
+            .unwrap();
+        leases.service(&egui::Context::default());
+        assert!(
+            std::path::Path::new(&format!("{}.err", expired.display())).exists(),
+            "an expired waiter behind a live FIFO waiter must receive the host timeout"
+        );
+        assert_eq!(leases.status("cargo-build")["queue_depth"], 1);
+    }
+}

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -695,6 +695,57 @@ impl PlexiApp {
                         expires_at,
                     });
             }
+            crate::app_protocol::AppRequest::LockAcquire {
+                name,
+                pane_id,
+                timeout_secs,
+                response_file,
+            } => {
+                log::info!("pane_ipc: kind=lock_acquire name={name:?} pane_id={pane_id} timeout_secs={timeout_secs}");
+                if !self
+                    .windows
+                    .iter()
+                    .any(|window| window.panes.contains_key(pane_id))
+                {
+                    crate::rpc::write_json_response(
+                        &format!("{response_file}.err"),
+                        serde_json::json!({"ok": false, "error": format!("pane {pane_id} is not live")}),
+                    );
+                    return;
+                }
+                if let Err(error) =
+                    self.build_leases
+                        .acquire(name, *pane_id, *timeout_secs, response_file.clone())
+                {
+                    crate::rpc::write_json_response(
+                        &format!("{response_file}.err"),
+                        serde_json::json!({"ok": false, "error": error}),
+                    );
+                }
+            }
+            crate::app_protocol::AppRequest::LockRelease {
+                name,
+                pane_id,
+                response_file,
+            } => {
+                log::info!("pane_ipc: kind=lock_release name={name:?} pane_id={pane_id}");
+                match self.build_leases.release(name, *pane_id) {
+                    Ok(()) => crate::rpc::write_json_response(
+                        response_file,
+                        serde_json::json!({"ok": true, "name": name, "pane_id": pane_id}),
+                    ),
+                    Err(error) => crate::rpc::write_json_response(
+                        &format!("{response_file}.err"),
+                        serde_json::json!({"ok": false, "error": error}),
+                    ),
+                };
+            }
+            crate::app_protocol::AppRequest::LockStatus {
+                name,
+                response_file,
+            } => {
+                crate::rpc::write_json_response(response_file, self.build_leases.status(name));
+            }
             crate::app_protocol::AppRequest::SlotRead {
                 pane_id,
                 slot_name,
@@ -3464,6 +3515,7 @@ impl PlexiApp {
             }
             match &event {
                 PtyEvent::Exit => {
+                    self.build_leases.release_pane(id, "pty_exit");
                     for win in &mut self.windows {
                         if let Some(pane) = win.panes.get_mut(&id) {
                             if let Some(t) = pane.as_terminal_mut() {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,6 +2,7 @@ pub mod account;
 pub mod app_trait;
 pub(crate) mod assistant_host_tools;
 pub mod audio_player_app;
+pub(crate) mod build_lease;
 pub(crate) mod canvas_bindings;
 mod dispatch;
 pub mod file_handlers;
@@ -186,6 +187,9 @@ pub struct PlexiApp {
     /// `plexi pane slot wait` requests parked until the watched slot's
     /// value matches, or their caller-supplied deadline passes (stint 0585).
     pub(crate) pending_slot_waits: Vec<crate::app::pane_wait::PendingSlotWait>,
+    /// Host-arbitrated named build leases. Holders are pane ids so close and
+    /// PTY-death paths can release them without trusting a shell cleanup trap.
+    pub(crate) build_leases: crate::app::build_lease::BuildLeaseManager,
     /// `plexi pane new --agent` spawns whose response is withheld until the
     /// agent in the new pane self-reports idle (stint 0584).
     pub(crate) pending_agent_boots: Vec<crate::app::pane_wait::PendingAgentBoot>,
@@ -1390,6 +1394,7 @@ impl PlexiApp {
                     frame_diag_window: None,
                     pending_screenshots: Vec::new(),
                     pending_slot_waits: Vec::new(),
+                    build_leases: crate::app::build_lease::BuildLeaseManager::from_run_config(),
                     pending_agent_boots: Vec::new(),
                     pending_submits: Vec::new(),
                     pane_heartbeats: restored_heartbeats,
@@ -1652,6 +1657,7 @@ impl PlexiApp {
             frame_diag_window: None,
             pending_screenshots: Vec::new(),
             pending_slot_waits: Vec::new(),
+            build_leases: crate::app::build_lease::BuildLeaseManager::from_run_config(),
             pending_agent_boots: Vec::new(),
             pending_submits: Vec::new(),
             pane_heartbeats: HashMap::new(),
@@ -2096,6 +2102,7 @@ impl PlexiApp {
                 frame_diag_window: None,
                 pending_screenshots: Vec::new(),
                 pending_slot_waits: Vec::new(),
+                build_leases: crate::app::build_lease::BuildLeaseManager::from_run_config(),
                 pending_agent_boots: Vec::new(),
                 pending_submits: Vec::new(),
                 pane_heartbeats: HashMap::new(),
@@ -2578,6 +2585,7 @@ impl eframe::App for PlexiApp {
         // host must still expire them on schedule, so the caller sees the
         // host's typed timeout instead of its own (stint 0585).
         self.service_pending_slot_waits(ctx);
+        self.build_leases.service(ctx);
 
         // And for `pane new --agent`, whose reply is owed either an idle
         // report, an expired deadline, or a pane that went away (stint 0584).

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -129,6 +129,12 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: PaneCmd,
     },
+    /// Coordinate a named host-owned lease between panes.
+    #[command(next_help_heading = "Panes")]
+    Lock {
+        #[command(subcommand)]
+        cmd: LockCmd,
+    },
     /// Subscribe to a Plexi app's event streams and receive brokered deliveries.
     ///
     /// Apps declare named event streams (e.g. `probe.tick`) and emit events on them.
@@ -940,6 +946,20 @@ pub enum HostCmd {
         #[arg(long, short = 'o')]
         output: Option<String>,
     },
+}
+
+#[derive(Subcommand)]
+pub enum LockCmd {
+    /// Block until the host grants this pane the named lease.
+    Acquire {
+        name: String,
+        #[arg(long, default_value_t = 900.0)]
+        timeout: f64,
+    },
+    /// Release this pane's named lease.
+    Release { name: String },
+    /// Print holder pane id(s), FIFO queue depth, and oldest wait time.
+    Status { name: String },
 }
 
 /// `plexi account <cmd>` — marketplace account management.

--- a/src/cli/lock.rs
+++ b/src/cli/lock.rs
@@ -1,0 +1,138 @@
+//! CLI surface for host-arbitrated named leases.
+
+use std::time::Duration;
+
+fn pane_id() -> Result<u64, i32> {
+    match std::env::var("PLEXI_PANE_ID")
+        .ok()
+        .and_then(|id| id.parse().ok())
+    {
+        Some(id) => Ok(id),
+        None => {
+            eprintln!("error: PLEXI_PANE_ID is required — run lock commands from a Plexi pane");
+            Err(1)
+        }
+    }
+}
+
+fn reply(response_file: &str, timeout: Duration) -> i32 {
+    match crate::rpc::poll_slot_reply(response_file, Some(timeout)) {
+        Ok(crate::rpc::SlotReply::Data(data)) => {
+            let value: serde_json::Value = match serde_json::from_slice(&data) {
+                Ok(value) => value,
+                Err(error) => {
+                    eprintln!("error: invalid lock response: {error}");
+                    return 1;
+                }
+            };
+            if value.get("ok").and_then(|ok| ok.as_bool()) == Some(true) {
+                0
+            } else {
+                eprintln!("error: {value}");
+                1
+            }
+        }
+        Ok(crate::rpc::SlotReply::Err(data)) => {
+            let value: serde_json::Value = serde_json::from_slice(&data)
+                .unwrap_or_else(|_| serde_json::json!({"error": "invalid lock error"}));
+            eprintln!(
+                "error: {}",
+                value
+                    .get("error")
+                    .and_then(|e| e.as_str())
+                    .unwrap_or("lock request failed")
+            );
+            if value.get("timeout").and_then(|v| v.as_bool()) == Some(true) {
+                2
+            } else {
+                1
+            }
+        }
+        Err(error) => {
+            eprintln!("error: lock host reply failed: {error}");
+            1
+        }
+    }
+}
+
+pub fn acquire(name: &str, timeout_secs: f64) -> i32 {
+    if !timeout_secs.is_finite()
+        || !(0.0..=crate::app::pane_wait::MAX_WAIT_TIMEOUT_SECS).contains(&timeout_secs)
+    {
+        eprintln!("error: invalid --timeout {timeout_secs}");
+        return 1;
+    }
+    let pane_id = match pane_id() {
+        Ok(id) => id,
+        Err(code) => return code,
+    };
+    let response_file = crate::rpc::response_file("lock-acquire", "json");
+    if super::send_to_socket(
+        serde_json::json!({"type":"lock_acquire","name":name,"pane_id":pane_id,"timeout_secs":timeout_secs,"response_file":response_file}),
+    ) != 0
+    {
+        return 1;
+    }
+    reply(
+        &response_file,
+        Duration::from_secs_f64(timeout_secs) + Duration::from_secs(5),
+    )
+}
+
+pub fn release(name: &str) -> i32 {
+    let pane_id = match pane_id() {
+        Ok(id) => id,
+        Err(code) => return code,
+    };
+    let response_file = crate::rpc::response_file("lock-release", "json");
+    if super::send_to_socket(
+        serde_json::json!({"type":"lock_release","name":name,"pane_id":pane_id,"response_file":response_file}),
+    ) != 0
+    {
+        return 1;
+    }
+    reply(&response_file, Duration::from_secs(10))
+}
+
+pub fn status(name: &str) -> i32 {
+    let response_file = crate::rpc::response_file("lock-status", "json");
+    if super::send_to_socket(
+        serde_json::json!({"type":"lock_status","name":name,"response_file":response_file}),
+    ) != 0
+    {
+        return 1;
+    }
+    match crate::rpc::poll_string(&response_file, Some(Duration::from_secs(10))) {
+        Ok(value) => {
+            println!("{value}");
+            0
+        }
+        Err(crate::rpc::PollError::TimedOut) => {
+            eprintln!("error: lock status timed out after the host accepted the request");
+            2
+        }
+        Err(error) => {
+            eprintln!("error: lock status failed: {error}");
+            2
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn typed_host_timeout_exits_nonzero() {
+        let dir = tempfile::tempdir().unwrap();
+        let response = dir.path().join("lock.json");
+        crate::rpc::write_json_response(
+            &format!("{}.err", response.display()),
+            serde_json::json!({"ok": false, "timeout": true, "error": "timed out"}),
+        );
+        assert_eq!(
+            reply(&response.to_string_lossy(), Duration::from_secs(1)),
+            2
+        );
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -222,6 +222,7 @@ pub mod host;
 pub mod install;
 pub mod install_host;
 pub mod list;
+pub mod lock;
 pub mod marketplace;
 pub mod notes;
 pub mod notify;

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,7 +242,8 @@ fn main() -> eframe::Result {
         .collect();
     use crate::cli::args::{
         AccountCmd, AgentCmd, AiCmd, AppCmd, Cli, Commands, ConfigCmd, ContextCmd, DescriptorCmd,
-        EventsCmd, HookAction, HostCmd, NotesCmd, NotifyCmd, PaneCmd, PaneSlotCmd, RegistryCmd,
+        EventsCmd, HookAction, HostCmd, LockCmd, NotesCmd, NotifyCmd, PaneCmd, PaneSlotCmd,
+        RegistryCmd,
         RoutineCmd, SecretCmd, UpdateCmd, WorkspaceCmd,
     };
     use clap::Parser;
@@ -679,6 +680,13 @@ fn main() -> eframe::Result {
                         HostCmd::Screenshot { pane, output } => {
                             std::process::exit(cli::host_screenshot_cli(pane, output.as_deref()))
                         }
+                    },
+                    Commands::Lock { cmd } => match cmd {
+                        LockCmd::Acquire { name, timeout } => {
+                            std::process::exit(cli::lock::acquire(&name, timeout))
+                        }
+                        LockCmd::Release { name } => std::process::exit(cli::lock::release(&name)),
+                        LockCmd::Status { name } => std::process::exit(cli::lock::status(&name)),
                     },
                     Commands::Notify { cmd, post } => {
                         // The caller's own identity, stamped by the pane env.

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -754,7 +754,7 @@ impl PlexiApp {
 
     /// Close a tile in a specific context by its TileId. Handles sibling focus
     /// transfer, container cleanup, and pane removal.
-    pub(super) fn close_tile(&mut self, ctx_idx: usize, tile_id: TileId) {
+    pub(crate) fn close_tile(&mut self, ctx_idx: usize, tile_id: TileId) {
         // Snapshot focus/zoom state before any mutation so Phase 2 guards are accurate.
         let is_focused = self.windows[ctx_idx].focused_pane == Some(tile_id);
         let is_zoomed = self.windows[ctx_idx].zoomed_pane == Some(tile_id);
@@ -890,6 +890,7 @@ impl PlexiApp {
         // without it a closed run would block its routine forever), then park
         // background WASM app runtimes; drop everything else.
         if let Some(pane_id) = closed_pane_id {
+            self.build_leases.release_pane(pane_id, "pane_closed");
             if self.pane_heartbeats.remove(&pane_id).is_some() {
                 log::info!("pane_heartbeat: pane_id={pane_id} removed reason=closed");
             }

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -1051,8 +1051,19 @@ impl PlexiApp {
             &deleted[1..]
         );
 
-        // 3. Remove all windows belonging to any deleted context.
+        // 3. Remove all windows belonging to any deleted context. Release
+        // their pane-owned leases before dropping the panes: a context delete
+        // bypasses close_tile and therefore has no terminal-exit cleanup.
+        let deleted_pane_ids: Vec<crate::spatial::tiling::PaneId> = self
+            .windows
+            .iter()
+            .filter(|window| deleted.contains(&window.context_id))
+            .flat_map(|window| window.panes.keys().copied())
+            .collect();
         self.windows.retain(|c| !deleted.contains(&c.context_id));
+        for pane_id in deleted_pane_ids {
+            self.build_leases.release_pane(pane_id, "context_deleted");
+        }
 
         // 4. Remove Portal tiles in surviving windows that point to any deleted ctx.
         for win in &mut self.windows {

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -461,6 +461,19 @@ pub enum AppRequest {
         response_file: String,
     },
 
+    /// Acquire a host-owned named lease for the calling pane. The reply is
+    /// parked by the host until FIFO capacity grants it or its deadline passes.
+    LockAcquire {
+        name: String,
+        pane_id: u64,
+        timeout_secs: f64,
+        response_file: String,
+    },
+    /// Release a named lease held by the calling pane.
+    LockRelease { name: String, pane_id: u64, response_file: String },
+    /// Report the current holders, queue depth, and oldest queued wait.
+    LockStatus { name: String, response_file: String },
+
     /// List named host-managed pane file slots.
     SlotList { pane_id: u64, response_file: String },
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -66,6 +66,74 @@ fn read_json_response(path: &str) -> serde_json::Value {
 }
 
 #[test]
+fn build_lease_ipc_rejects_dead_panes_and_releases_on_pty_exit_or_close() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut h = HostHarness::new();
+    let terminal = h.add_focused_terminal();
+
+    let rejected = temp_response(tmp.path(), "dead-pane");
+    h.inject_ipc(AppRequest::LockAcquire {
+        name: "cargo-build".into(),
+        pane_id: 999_999,
+        timeout_secs: 1.0,
+        response_file: rejected.clone(),
+    });
+    h.hidden_frame();
+    assert!(
+        read_json_response(&format!("{rejected}.err"))["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("not live")),
+        "a stale PLEXI_PANE_ID must not create an uncollectable holder"
+    );
+
+    let granted = temp_response(tmp.path(), "pty-holder");
+    h.inject_ipc(AppRequest::LockAcquire {
+        name: "cargo-build".into(),
+        pane_id: terminal,
+        timeout_secs: 1.0,
+        response_file: granted.clone(),
+    });
+    h.hidden_frame();
+    assert_eq!(read_json_response(&granted)["ok"], true);
+    h.app
+        .pty_event_tx
+        .send((terminal, egui_term::PtyEvent::Exit))
+        .expect("queue PTY exit");
+    h.hidden_frame();
+    assert_eq!(
+        h.app.build_leases.status("cargo-build")["holder_pane_id"],
+        serde_json::Value::Null,
+        "PTY exit must release through the production lifecycle path"
+    );
+
+    let closing_pane = h.add_test_pane();
+    let closing_grant = temp_response(tmp.path(), "closing-holder");
+    h.inject_ipc(AppRequest::LockAcquire {
+        name: "cargo-build".into(),
+        pane_id: closing_pane,
+        timeout_secs: 1.0,
+        response_file: closing_grant.clone(),
+    });
+    h.hidden_frame();
+    assert_eq!(read_json_response(&closing_grant)["ok"], true);
+    let tile_id = h.app.windows[0]
+        .tree
+        .tiles
+        .iter()
+        .find_map(|(tile_id, tile)| match tile {
+            egui_tiles::Tile::Pane(id) if *id == closing_pane => Some(tile_id),
+            _ => None,
+        })
+        .expect("test pane has a tile");
+    h.app.close_tile(0, *tile_id);
+    assert_eq!(
+        h.app.build_leases.status("cargo-build")["holder_pane_id"],
+        serde_json::Value::Null,
+        "pane close must release through the production close path"
+    );
+}
+
+#[test]
 fn pane_status_request_routes_through_host_and_returns_composite_evidence() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let mut h = HostHarness::new();

--- a/tools/check_docs_coverage.sh
+++ b/tools/check_docs_coverage.sh
@@ -18,6 +18,7 @@ SKIP=(
   "demo"         # self-documenting interactive tutorial
   "doctor"       # diagnostic tool, no standalone docs yet
   "events"       # developer API, covered in sdk-emitter
+  "lock"         # build-recipe primitive; generated CLI reference + plexi-cli skill are canonical
   "note"         # alias for notes, covered in quick-note
   "notify"       # developer API, covered in sdk-emitter
   "registry"     # internal developer tool

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -1045,6 +1045,41 @@ Delete a named pane slot
 | `<name>` | string | yes | Slot name |
 | `<pane_id>` | string | no | Pane id. Defaults to PLEXI_PANE_ID |
 
+## `plexi lock`
+
+Coordinate a named host-owned lease between panes
+
+| Subcommand | Description |
+|---|---|
+| `acquire` | Block until the host grants this pane the named lease |
+| `release` | Release this pane's named lease |
+| `status` | Print holder pane id(s), FIFO queue depth, and oldest wait time |
+
+### `plexi lock acquire`
+
+Block until the host grants this pane the named lease
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<name>` | string | yes |  |
+| `--timeout` | string | no | Default: `900`. |
+
+### `plexi lock release`
+
+Release this pane's named lease
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<name>` | string | yes |  |
+
+### `plexi lock status`
+
+Print holder pane id(s), FIFO queue depth, and oldest wait time
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<name>` | string | yes |  |
+
 ## `plexi events`
 
 Subscribe to a Plexi app's event streams and receive brokered deliveries.


### PR DESCRIPTION
# Stint 0690 cargo lease enumeration

## Ruling requested and now approved

Acquire only at a leaf cargo invocation that can compile Rust. A wrapper that
delegates to another cargo-capable recipe or script holds no lease. The lease
is deliberately non-reentrant: no inherited token and no nested acquisition.
This lets the host queue every actual build in FIFO order without a wrapper
waiting behind its own child. Capacity is `RUN_CONFIG.toml`'s renamed cargo-wide
limit and covers workers, installers/testers, and release paths.

## Must take the lease

Each direct Cargo process below is a leaf and must acquire/release the named
`cargo-build` lease around only that process. The short generators take it too:
they may compile a changed generator or dependency graph, even though their
normal warm-cache runtime is unlike a release bundle.

| Entry path | Cargo work | Lease decision |
|---|---|---|
| `just dev` | `cargo run` | Take: compiles/runs host. |
| `just run` | `cargo run --release` | Take: release compile. |
| `just build` | `cargo build --release` | Take: release compile. |
| `just website-registry` | `cargo build --bin plexi` | Take: host compile before registry packaging. |
| `just test` | `cargo test` | Take: compiles/runs Rust tests. |
| `just scene` | `cargo test --bin plexi scene_single ...` | Take: compiles/runs host scene test. |
| `just coverage`, `just coverage-summary` | `cargo llvm-cov ...` | Take: compiles/runs instrumented tests. |
| `just perf-clippy` | `cargo clippy ...` | Take: compiles analysis targets. |
| `just wasm-fixtures` | six `cargo component build` calls | Take each component-build leaf. |
| `just wasm-python-shim` / `scripts/build-wasm-python-shim.sh` | `cargo test`; `cargo component build` | Take each leaf. `wasm-fixtures` does not acquire around its call to this script. |
| `just gen-schema`, `check-schema` | `cargo run -p gen_schema` | Take: generator can compile. |
| `just gen-cli-docs`, `check-cli-docs` | `cargo run -p gen_cli_docs` | Take: generator can compile. |
| `just gen-config-docs`, `check-config-docs` | `cargo run -p gen_config_docs` | Take: generator can compile. |
| `just regen-if-stale` | conditional generator `cargo run` calls | Take each conditionally reached leaf, not the outer recipe. |
| `just roadmap-evidence` / `scripts/roadmap-evidence.py` | workspace `cargo test --list`; workspace `cargo test` | Take both direct leaves. Its nested `just scene` calls acquire only in `just scene`. |
| `just scene-live` / `scripts/run-live-scene.sh` | `cargo test --bin plexi scene_single ...` | Take: host scene test. |
| `just editor-gate` / `scripts/editor-gate.sh` | targeted `cargo test --bin plexi ...` | Take: core qualification test. |
| `just daw-gate` / `scripts/daw-gate.sh` | targeted `cargo test --bin plexi ...` | Take: core qualification test. |
| `just install`, `just channel-install`, `just pr-install` / `scripts/install.sh` | `cargo bundle --release` | Take at `cargo bundle`. Install wrappers acquire nothing themselves. |
| `just promote` / `scripts/promote.sh` | CLI doc check/generation; `cargo test --bin plexi skill_surface`; optional install | Take each direct leaf. The outer promote wrapper never holds a lease while it calls `just check-cli-docs`, `just gen-cli-docs`, or `just install`. |
| `just bump` / `scripts/release-version.sh` | its nested `just gen-cli-docs` | Take only in the generator leaf; release-version itself does not acquire. |

## Must not take the lease

| Entry path | Why it does not take a lease |
|---|---|
| `scripts/install.sh` `cargo metadata` | Metadata query only: no Rust compilation and no build-capacity hazard. |
| `scripts/release-version.sh` `cargo generate-lockfile` | Dependency resolution only: no Rust compilation and no shared target build hazard. |
| `just install`, `channel-install`, `pr-install` outer recipes | Thin wrappers/dependency coordinators; `regen-if-stale` and `scripts/install.sh` own their individual leaf acquisitions. |
| `just promote` outer recipe | Thin orchestrator; its cargo-capable child recipes and direct skill-surface test acquire exactly once. |
| `just wasm-fixtures` around its `wasm-python-shim` child | The parent acquires for its six direct component builds only; the child owns its two direct Cargo calls. |
| `just roadmap-evidence` around nested `just scene` | The Python runner acquires its two direct workspace test calls; `just scene` owns the nested one. |
| `scripts/bs-validate-setup.sh` | Thin wrapper around `just pr-install`; no second acquire. |
| `bs-start`, `bs-reset`, `bs-merge`, merge, channel cleanup/listing, release-tag, and non-Rust recipes | They do not invoke a Cargo build. |

## Nesting inventory

- `wasm-fixtures` reaches `build-wasm-python-shim.sh` both through the wrapper
  and directly through `just wasm-python-shim`; the script's two Cargo leaves
  are the only acquirers in both routes.
- `install` and `channel-install` run `regen-if-stale` then `install.sh`;
  generators and `cargo bundle` acquire independently.
- `pr-install` invokes `install.sh` after its non-Rust SDK smoke; only
  `cargo bundle` acquires.
- `promote` may invoke CLI-doc recipes and `just install`; direct host test and
  all child leaf paths acquire independently.
- `bump` invokes `just gen-cli-docs`; only that generator acquires.
- `bs-validate-setup` invokes `just pr-install`; only `install.sh`'s bundle
  invocation acquires.
- `roadmap-evidence` invokes `just scene`; its own two workspace test leaves
  acquire separately from the scene leaf.

No path may hold the lease twice. A leaf reached directly and through a wrapper
has the same single acquirer in both routes; this will be called out in the PR
body.

## Implementation

- Adds `plexi lock acquire/release/status` with host-owned FIFO capacity and automatic cleanup on pane close, PTY exit, and context deletion.
- Wraps every approved Cargo-compiling leaf while keeping orchestrators and nested wrappers unleased.
- Changes `just dev` and `just run` to lease only the build phase, then launch the built binary after releasing the lease.

## Test evidence

- `just test`: 2203 passed; 5 ignored.
- `cargo build` passed through the explicit no-host continuation path.
- `just check-docs` and `python3 scripts/test-roadmap-evidence.py` passed.
- Focused lease unit tests and HostHarness lifecycle coverage passed.
- `git diff --check`, `just --list`, and leaf-only rustfmt checks passed.
- Codex Review was not rerun. A later review-invoked Cargo command failed only because sccache returned `Operation not permitted`; the successful project test path is the product evidence.
- Worker scope intentionally excludes host boot, install, and merge.
