### PR TITLE
Eliminate recurring and quit-path UI stalls (stints 0705, 0694)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -178,6 +178,7 @@ pub struct PlexiApp {
     pub(crate) welcome_delete_press_count: u8,
     pub(crate) welcome_delete_last_press: Option<std::time::Instant>,
     pub(crate) frame_tick: crate::platform::logging::FrameTick,
+    pub(crate) ui_phase: crate::platform::logging::UiPhaseTracker,
     /// Repaint-cause diagnostics sample window (#2019): start instant and
     /// frame count. `None` until the first frame opens a window.
     pub(crate) frame_diag_window: Option<(std::time::Instant, u32)>,
@@ -976,6 +977,7 @@ impl PlexiApp {
         cc: &eframe::CreationContext<'_>,
         frame_tick: crate::platform::logging::FrameTick,
         heartbeat_ctx: crate::platform::logging::HeartbeatCtxSlot,
+        ui_phase: crate::platform::logging::UiPhaseTracker,
     ) -> Self {
         // Hand the egui context to the heartbeat watchdog so it can tell
         // healthy zero-frame idle apart from a genuine UI freeze.
@@ -1395,6 +1397,7 @@ impl PlexiApp {
                     pending_close: false,
                     pending_context_close: None,
                     frame_tick,
+                    ui_phase: ui_phase.clone(),
                     frame_diag_window: None,
                     pending_screenshots: Vec::new(),
                     pending_slot_waits: Vec::new(),
@@ -1659,6 +1662,7 @@ impl PlexiApp {
             pending_close: false,
             pending_context_close: None,
             frame_tick,
+            ui_phase,
             frame_diag_window: None,
             pending_screenshots: Vec::new(),
             pending_slot_waits: Vec::new(),
@@ -2116,6 +2120,7 @@ impl PlexiApp {
                 pending_close: false,
                 pending_context_close: None,
                 frame_tick,
+                ui_phase: crate::platform::logging::new_ui_phase_tracker(),
                 frame_diag_window: None,
                 pending_screenshots: Vec::new(),
                 pending_slot_waits: Vec::new(),
@@ -2581,6 +2586,10 @@ impl eframe::App for PlexiApp {
     }
 
     fn logic(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::Logic,
+        );
         // Everything that services external clients — pane IPC, spawn queue,
         // PTY events, shutdown, event-bus subscriptions, agent turns — must
         // run here, not in `ui`. eframe skips `ui` entirely while the window
@@ -2634,10 +2643,18 @@ impl eframe::App for PlexiApp {
         // `service_app_commands`). It runs last in `logic` because the services
         // above may queue work an app command then consumes on this same pass.
         self.service_app_commands(ctx);
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::LogicComplete,
+        );
     }
 
     fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
         let ctx = &ui.ctx().clone();
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::UiRender,
+        );
         self.frame_tick
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         // Repaint-cause diagnostics (#2019): count this frame, attribute
@@ -3443,6 +3460,15 @@ impl eframe::App for PlexiApp {
         //     immediately (no triple-tap for deliberate window close gestures).
         //   - quitting == true → triple-tap completed; save and allow close.
         if ctx.input(|i| i.viewport().close_requested()) {
+            crate::platform::logging::mark_ui_phase(
+                &self.ui_phase,
+                crate::platform::logging::UiPhase::CloseRequest,
+            );
+            log::info!(
+                "quit_phase: close_request quitting={} quit_press_count={}",
+                self.quitting,
+                self.quit_press_count
+            );
             if self.quitting {
                 self.save_workspace();
             } else if self.confirm_quit() && self.quit_press_count > 0 {
@@ -3471,9 +3497,18 @@ impl eframe::App for PlexiApp {
         // widget focus (stint 0429). Everything above may change host focus
         // state; nothing after this may touch egui focus.
         self.reconcile_egui_focus(ctx);
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::RendererPresent,
+        );
     }
 
     fn on_exit(&mut self) {
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::Exit,
+        );
+        log::info!("quit_phase: on_exit begin");
         if let Some((window_id, tile_id)) = self.last_logged_focus {
             let duration_secs = self
                 .focus_started_at
@@ -3489,6 +3524,7 @@ impl eframe::App for PlexiApp {
                 FocusSegmentReason::Shutdown,
             );
         }
+        log::info!("quit_phase: on_exit complete");
     }
 }
 

--- a/src/host/shell.rs
+++ b/src/host/shell.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 use std::io;
+#[cfg(target_os = "macos")]
+use std::os::unix::ffi::OsStrExt;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
@@ -649,20 +651,51 @@ pub fn pid_has_children(pid: u32) -> bool {
 fn get_pid_cwd_uncached(pid: u32) -> Option<PathBuf> {
     #[cfg(target_os = "macos")]
     {
-        let output = Command::new("/usr/sbin/lsof")
-            .args(["-a", "-d", "cwd", "-Fn", "-p", &pid.to_string()])
-            .output()
-            .ok()?;
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        for line in stdout.lines() {
-            if let Some(path) = line.strip_prefix('n') {
-                let p = PathBuf::from(path);
-                if p.is_dir() {
-                    return Some(p);
-                }
-            }
+        static LOG_BACKEND_ONCE: LazyLock<()> = LazyLock::new(|| {
+            log::info!(
+                "pid_cwd: using in-process {} backend",
+                pid_cwd_backend_name()
+            );
+        });
+        LazyLock::force(&LOG_BACKEND_ONCE);
+
+        let mut info = std::mem::MaybeUninit::<libc::proc_vnodepathinfo>::zeroed();
+        let info_size = std::mem::size_of::<libc::proc_vnodepathinfo>();
+        // SAFETY: `info` points to writable storage of exactly the size
+        // requested from libproc. A short result is rejected before init.
+        let bytes = unsafe {
+            libc::proc_pidinfo(
+                pid as libc::c_int,
+                libc::PROC_PIDVNODEPATHINFO,
+                0,
+                info.as_mut_ptr().cast(),
+                info_size as libc::c_int,
+            )
+        };
+        if bytes as usize != info_size {
+            return None;
         }
-        None
+
+        // SAFETY: libproc reported that it initialized the full struct.
+        let info = unsafe { info.assume_init() };
+        let path_ptr = info.pvi_cdir.vip_path.as_ptr().cast::<libc::c_char>();
+        // SAFETY: the slice is bounded to the in-struct MAXPATHLEN array;
+        // unlike CStr::from_ptr this cannot scan beyond it if the kernel ever
+        // returns a malformed record without a trailing NUL.
+        let path_bytes = unsafe {
+            std::slice::from_raw_parts(
+                path_ptr.cast::<u8>(),
+                std::mem::size_of_val(&info.pvi_cdir.vip_path),
+            )
+        };
+        let path_len = path_bytes.iter().position(|byte| *byte == 0)?;
+        if path_len == 0 {
+            return None;
+        }
+        let path = PathBuf::from(std::ffi::OsStr::from_bytes(&path_bytes[..path_len]));
+        // PROC_PIDVNODEPATHINFO's current-directory vnode already guarantees
+        // this is a directory; avoid a filesystem stat on the UI thread.
+        Some(path)
     }
     #[cfg(target_os = "linux")]
     {
@@ -673,6 +706,11 @@ fn get_pid_cwd_uncached(pid: u32) -> Option<PathBuf> {
         let _ = pid;
         None
     }
+}
+
+#[cfg(target_os = "macos")]
+fn pid_cwd_backend_name() -> &'static str {
+    "libproc"
 }
 
 fn ensure_shell_integration() -> io::Result<PathBuf> {
@@ -773,6 +811,16 @@ pub(crate) fn shell_quote(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn pid_cwd_uses_in_process_libproc_backend() {
+        assert_eq!(pid_cwd_backend_name(), "libproc");
+        assert_eq!(
+            get_pid_cwd_uncached(std::process::id()),
+            std::env::current_dir().ok()
+        );
+    }
 
     #[test]
     fn shell_join_plain_args_no_quoting() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1334,7 +1334,12 @@ fn main() -> eframe::Result {
     // Shell probes are done. Start the heartbeat now so it only monitors
     // eframe operation — not pre-startup shell work (#588).
     let heartbeat_ctx = crate::platform::logging::new_heartbeat_ctx_slot();
-    crate::platform::logging::spawn_heartbeat(frame_tick.clone(), heartbeat_ctx.clone());
+    let ui_phase = crate::platform::logging::new_ui_phase_tracker();
+    crate::platform::logging::spawn_heartbeat(
+        frame_tick.clone(),
+        heartbeat_ctx.clone(),
+        ui_phase.clone(),
+    );
 
     log::info!("ui_stack: egui=0.34.3 renderer=wgpu");
 
@@ -1389,7 +1394,14 @@ fn main() -> eframe::Result {
     eframe::run_native(
         env!("CARGO_PKG_NAME"),
         native_options,
-        Box::new(|cc| Ok(Box::new(app::PlexiApp::new(cc, frame_tick, heartbeat_ctx)))),
+        Box::new(|cc| {
+            Ok(Box::new(app::PlexiApp::new(
+                cc,
+                frame_tick,
+                heartbeat_ctx,
+                ui_phase,
+            )))
+        }),
     )
 }
 

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -1838,6 +1838,10 @@ impl PlexiApp {
     }
 
     pub(crate) fn save_workspace(&self) {
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::WorkspaceSave,
+        );
         let mut saved_contexts = Vec::new();
         let mut saved_windows = Vec::new();
 

--- a/src/platform/logging.rs
+++ b/src/platform/logging.rs
@@ -14,7 +14,7 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 /// Live log level for plexi-namespace targets. The fern filter reads this on
@@ -245,6 +245,97 @@ pub fn init(level: log::LevelFilter, retention_days: u32, cli_mode: bool) {
 /// Shared counter bumped by the UI thread each frame so the heartbeat can detect freezes.
 pub type FrameTick = Arc<AtomicU64>;
 
+/// Last host phase reached by the UI thread. The phase and its monotonic
+/// timestamp are packed into one atomic word so the heartbeat can take a
+/// coherent snapshot without contending with the UI thread.
+pub type UiPhaseTracker = Arc<AtomicU64>;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub(crate) enum UiPhase {
+    Startup = 0,
+    Logic = 1,
+    LogicComplete = 2,
+    UiRender = 3,
+    RendererPresent = 4,
+    CloseRequest = 5,
+    WorkspaceSave = 6,
+    Exit = 7,
+}
+
+impl UiPhase {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Startup => "startup",
+            Self::Logic => "logic",
+            Self::LogicComplete => "logic_complete",
+            Self::UiRender => "ui_render",
+            Self::RendererPresent => "renderer_present",
+            Self::CloseRequest => "close_request",
+            Self::WorkspaceSave => "workspace_save",
+            Self::Exit => "exit",
+        }
+    }
+
+    fn from_byte(value: u8) -> Self {
+        match value {
+            1 => Self::Logic,
+            2 => Self::LogicComplete,
+            3 => Self::UiRender,
+            4 => Self::RendererPresent,
+            5 => Self::CloseRequest,
+            6 => Self::WorkspaceSave,
+            7 => Self::Exit,
+            _ => Self::Startup,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct UiPhaseSnapshot {
+    name: &'static str,
+    age: Duration,
+}
+
+static UI_PHASE_EPOCH: LazyLock<Instant> = LazyLock::new(Instant::now);
+
+fn ui_phase_millis() -> u64 {
+    UI_PHASE_EPOCH
+        .elapsed()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX >> 8)
+}
+
+fn pack_ui_phase(phase: UiPhase, millis: u64) -> u64 {
+    (millis.min(u64::MAX >> 8) << 8) | phase as u64
+}
+
+pub fn new_ui_phase_tracker() -> UiPhaseTracker {
+    Arc::new(AtomicU64::new(pack_ui_phase(
+        UiPhase::Startup,
+        ui_phase_millis(),
+    )))
+}
+
+pub(crate) fn mark_ui_phase(tracker: &UiPhaseTracker, phase: UiPhase) {
+    tracker.store(pack_ui_phase(phase, ui_phase_millis()), Ordering::Release);
+}
+
+fn ui_phase_snapshot(tracker: &UiPhaseTracker) -> UiPhaseSnapshot {
+    let packed = tracker.load(Ordering::Acquire);
+    unpack_ui_phase(packed, ui_phase_millis())
+}
+
+fn unpack_ui_phase(packed: u64, now_ms: u64) -> UiPhaseSnapshot {
+    let phase = UiPhase::from_byte(packed as u8);
+    let marked_at_ms = packed >> 8;
+    UiPhaseSnapshot {
+        name: phase.name(),
+        age: Duration::from_millis(now_ms.saturating_sub(marked_at_ms)),
+    }
+}
+
 /// Create a new frame tick counter. Pass the clone to `spawn_heartbeat`, store the
 /// original in `PlexiApp` and call `.fetch_add(1, Relaxed)` each frame.
 pub fn new_frame_tick() -> FrameTick {
@@ -281,7 +372,11 @@ pub(crate) fn freeze_verdict(counter_stalled: bool, repaint_pending: Option<bool
 ///
 /// Writes go directly to the file, bypassing the logger, so they survive
 /// even if the logger thread is itself blocked by a freeze.
-pub fn spawn_heartbeat(frame_tick: FrameTick, egui_ctx: HeartbeatCtxSlot) {
+pub fn spawn_heartbeat(
+    frame_tick: FrameTick,
+    egui_ctx: HeartbeatCtxSlot,
+    ui_phase: UiPhaseTracker,
+) {
     let log_path = log_path();
     std::thread::Builder::new()
         .name("plexi-heartbeat".into())
@@ -311,8 +406,11 @@ pub fn spawn_heartbeat(frame_tick: FrameTick, egui_ctx: HeartbeatCtxSlot) {
                         let frozen_secs = last_tick_seen_at.elapsed().as_secs();
                         if frozen_secs >= FREEZE_THRESHOLD_SECS && !freeze_reported {
                             freeze_reported = true;
+                            let phase = ui_phase_snapshot(&ui_phase);
+                            let phase_age_ms = phase.age.as_millis();
                             lines.push_str(&format!(
-                                "[{now}] [WARN] [plexi::heartbeat] [FREEZE] UI thread unresponsive for {frozen_secs}s\n"
+                                "[{now}] [WARN] [plexi::heartbeat] [FREEZE] UI thread unresponsive for {frozen_secs}s phase={} phase_age_ms={phase_age_ms}\n",
+                                phase.name
                             ));
                         }
                     } else if !freeze_reported {
@@ -325,8 +423,11 @@ pub fn spawn_heartbeat(frame_tick: FrameTick, egui_ctx: HeartbeatCtxSlot) {
                     // Frame counter advanced — UI thread is alive.
                     if freeze_reported {
                         let frozen_secs = last_tick_seen_at.elapsed().as_secs();
+                        let phase = ui_phase_snapshot(&ui_phase);
+                        let phase_age_ms = phase.age.as_millis();
                         lines.push_str(&format!(
-                            "[{now}] [INFO] [plexi::heartbeat] [THAW] UI thread resumed after ~{frozen_secs}s\n"
+                            "[{now}] [INFO] [plexi::heartbeat] [THAW] UI thread resumed after ~{frozen_secs}s phase={} phase_age_ms={phase_age_ms}\n",
+                            phase.name
                         ));
                         freeze_reported = false;
                     }
@@ -354,6 +455,15 @@ mod tests {
     use super::*;
     use chrono::NaiveDate;
     use std::fs;
+
+    #[test]
+    fn ui_phase_snapshot_tracks_last_phase_without_locking() {
+        let tracker = Arc::new(AtomicU64::new(pack_ui_phase(UiPhase::Startup, 0)));
+        tracker.store(pack_ui_phase(UiPhase::WorkspaceSave, 42), Ordering::Release);
+        let snapshot = unpack_ui_phase(tracker.load(Ordering::Acquire), 100);
+        assert_eq!(snapshot.name, "workspace_save");
+        assert_eq!(snapshot.age, Duration::from_millis(58));
+    }
 
     /// Zero frames with no pending repaint is healthy idle — never a freeze.
     #[test]


### PR DESCRIPTION
## Summary

Implements stint 0705 and stint 0694. No linked GitHub issue — stint is authoritative.

- Replaces macOS terminal-CWD resolution through synchronous `/usr/sbin/lsof` with the in-process `PROC_PIDVNODEPATHINFO` libproc query, removing the external-process wait and follow-up filesystem stat from UI/render/save call sites.
- Adds lock-free UI phase attribution to existing `[FREEZE]` and `[THAW]` records plus quit milestones, so any remaining stall names the last host phase without per-frame log noise.
- Leaves agent-report behavior and renderer dependencies unchanged: live sampling refuted `agent_report:cli` as UI-thread work, while normal `CAMetalLayer::nextDrawable` sampling did not prove a freeze.

## Diagnosis and 0694 relationship

The blocking production boundary is `save_workspace` and ordinary render/query paths calling `host::shell::get_pid_cwd_uncached`, which synchronously waited for a spawned `lsof` process on the UI thread. A live main-thread sample observed those probes; source inspection confirms the same call is reachable during ordinary frames and quit handling. Stint 0694 is therefore provisionally the same defect, but installed quit-path validation remains the acceptance proof.

## Done When

### Stint 0705

- Identify the blocking work by name and remove or make it non-blocking.
- Produce zero new `[FREEZE]` lines during forty minutes of ordinary multi-agent use on the installed PR build.
- Preserve a regression seam and phase-attributed diagnostics.

### Stint 0694

- Quit a workspace with at least three windows on the installed PR build with no `[FREEZE]` line.
- Confirm the shared-defect relationship or report a distinct phase if the new diagnostics falsify it.

## Test evidence

- `cargo test --bin plexi`: 2205 passed, 0 failed, 5 ignored — full bin suite with Plexi runtime environment stripped.
- Focused tests: `pid_cwd_uses_in_process_libproc_backend` passed; `ui_phase_snapshot_tracks_last_phase_without_locking` passed.
- `cargo build`: passed.
- Codex review against `alpha`: clean; orchestrator follow-up removed the remaining UI-thread filesystem stat and corrected macOS-only import gating.
- Conclusion: binary install required — this changes host/runtime and quit behavior that must be proven in the installed bundle.
- PR install: required via `just pr-install <PR>`; validate using `plexi-pr-<PR>`, then run the forty-minute ordinary-use oracle and 3+ window quit oracle above.