### PR TITLE
feat: QuickNote font and image drops (stints 0617, 0698)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -275,6 +275,10 @@ pub struct PlexiApp {
     pub(crate) modal_input_buffer: String,
     /// Text being composed in the quick note modal.
     pub(crate) quick_note_text: String,
+    /// Local images staged by the QuickNote modal. They are copied into the
+    /// Notes collection only when the user saves, so discard never leaves
+    /// unattached assets behind.
+    pub(crate) quick_note_attachments: Vec<PathBuf>,
     /// Context captured at the time the quick note modal was opened.
     pub(crate) quick_note_ctx: QuickNoteCtx,
     /// Notes picker: inbox notes first, then workspace notes sorted by mtime.
@@ -1428,6 +1432,7 @@ impl PlexiApp {
                     modal_focused_option: 0,
                     modal_input_buffer: String::new(),
                     quick_note_text: String::new(),
+                    quick_note_attachments: Vec::new(),
                     quick_note_ctx: QuickNoteCtx::default(),
                     notes_picker_entries: Vec::new(),
                     notes_picker_selected: 0,
@@ -1691,6 +1696,7 @@ impl PlexiApp {
             modal_focused_option: 0,
             modal_input_buffer: String::new(),
             quick_note_text: String::new(),
+            quick_note_attachments: Vec::new(),
             quick_note_ctx: QuickNoteCtx::default(),
             notes_picker_entries: Vec::new(),
             notes_picker_selected: 0,
@@ -2009,7 +2015,18 @@ impl PlexiApp {
         ctx: egui::Context,
         frame_tick: crate::platform::logging::FrameTick,
     ) -> (Self, ui_mailbox::UiMailbox<crate::app_protocol::AppRequest>) {
-        let config = config::PlexiConfig::default();
+        Self::new_for_test_with_config(ctx, frame_tick, config::PlexiConfig::default())
+    }
+
+    /// Construct the isolated headless host with an explicit already-loaded
+    /// configuration. Tests that exercise config plumbing load it through an
+    /// isolated profile before calling this helper.
+    #[cfg(test)]
+    pub fn new_for_test_with_config(
+        ctx: egui::Context,
+        frame_tick: crate::platform::logging::FrameTick,
+        config: config::PlexiConfig,
+    ) -> (Self, ui_mailbox::UiMailbox<crate::app_protocol::AppRequest>) {
         let key_bindings = crate::host::keys::build_key_bindings(config.keybindings.as_ref());
         let theme_cfg = Self::resolve_theme_config(&config);
         let colors = Colors::from_config(&theme_cfg);
@@ -2052,7 +2069,7 @@ impl PlexiApp {
                 scheduler: crate::host::scheduler::Scheduler::new(),
                 theme: theme::terminal_theme(&theme_cfg),
                 colors,
-                default_font_size: theme::FONT_SIZE,
+                default_font_size: config.font_size.unwrap_or(theme::FONT_SIZE),
                 ctx,
                 router: crate::workspace::router::WorkspaceRouter::new(
                     vec![crate::host::context::Context {
@@ -2139,6 +2156,7 @@ impl PlexiApp {
                 modal_focused_option: 0,
                 modal_input_buffer: String::new(),
                 quick_note_text: String::new(),
+                quick_note_attachments: Vec::new(),
                 quick_note_ctx: QuickNoteCtx::default(),
                 notes_picker_entries: Vec::new(),
                 notes_picker_selected: 0,

--- a/src/overlays/quick_note.rs
+++ b/src/overlays/quick_note.rs
@@ -11,8 +11,29 @@ impl PlexiApp {
         if esc {
             self.pop_focus_layer(&crate::app::FocusKind::QuickNote);
             self.quick_note_text.clear();
+            self.quick_note_attachments.clear();
             log::info!("QuickNote: modal dismissed");
             return;
+        }
+
+        // The modal owns raw file drops before tiled panes render. Taking the
+        // events here routes Cmd+0 drops through the same egui host input that
+        // production window drops use, without leaking them into a pane behind
+        // the modal.
+        let dropped_files = ctx.input_mut(|i| std::mem::take(&mut i.raw.dropped_files));
+        for file in dropped_files {
+            match file.path {
+                Some(path) => match self.stage_quick_note_image(path.clone()) {
+                    Ok(()) => log::info!("QuickNote: drop accepted source={}", path.display()),
+                    Err(error) => {
+                        log::info!(
+                            "QuickNote: drop rejected source={} reason={error}",
+                            path.display()
+                        );
+                    }
+                },
+                None => log::info!("QuickNote: drop rejected reason=missing_local_path"),
+            }
         }
 
         // Explicitly consume paste events before the TextEdit renders.
@@ -73,11 +94,14 @@ impl PlexiApp {
                 false
             }
         });
-        if commit && !self.quick_note_text.trim().is_empty() {
+        if commit
+            && (!self.quick_note_text.trim().is_empty() || !self.quick_note_attachments.is_empty())
+        {
             let text = self.quick_note_text.clone();
             if self.commit_quick_note_to_inbox(&text) {
                 self.pop_focus_layer(&crate::app::FocusKind::QuickNote);
                 self.quick_note_text.clear();
+                self.quick_note_attachments.clear();
                 log::info!("QuickNote: committed to inbox");
             }
             return;
@@ -88,7 +112,8 @@ impl PlexiApp {
         // Modal — grows from ~25% to ~80% of screen height as the user types.
         let modal_w = (screen_rect.width() * 0.72).clamp(480.0, 864.0);
         let max_text_h = (screen_rect.height() * 0.8).max(80.0);
-        let line_h = style::TEXT_BODY + 4.0;
+        let font = self.quick_note_font();
+        let line_h = font.size + 4.0;
         let initial_rows = ((screen_rect.height() * 0.25) / line_h).round() as usize;
         let initial_rows = initial_rows.max(3);
         let colors = self.colors;
@@ -103,21 +128,37 @@ impl PlexiApp {
                                 "Enter to save  ·  Shift+Enter for new line  ·  Esc to discard",
                             )
                             .color(self.colors.text_dim.linear_multiply(0.5))
-                            .size(style::TEXT_HINT)
-                            .family(egui::FontFamily::Monospace),
+                            .font(font.clone()),
                         );
                         ui.add_space(style::SPACE_SM);
 
+                        if !self.quick_note_attachments.is_empty() {
+                            ui.label(
+                                RichText::new(format!(
+                                    "{} image{} attached",
+                                    self.quick_note_attachments.len(),
+                                    if self.quick_note_attachments.len() == 1 {
+                                        ""
+                                    } else {
+                                        "s"
+                                    }
+                                ))
+                                .color(self.colors.text_dim.linear_multiply(0.7))
+                                .font(font.clone()),
+                            );
+                            ui.add_space(style::SPACE_SM);
+                        }
+
                         crate::ui::text_field::TextArea::multiline(
                             egui::Id::new("quick_note_text"),
-                            RichText::new("What's on your mind?").size(style::TEXT_BODY),
+                            RichText::new("What's on your mind?").font(font.clone()),
                         )
                         .surface(crate::ui::focus::SurfaceKey::Overlay(
                             crate::app::input_owner::OverlaySurface::Layer(
                                 crate::app::FocusKind::QuickNote,
                             ),
                         ))
-                        .monospace(style::TEXT_BODY)
+                        .font(font.clone())
                         .text_color(self.colors.text_primary)
                         .hint_color(self.colors.text_dim.linear_multiply(0.3))
                         .rows(initial_rows)
@@ -131,8 +172,15 @@ impl PlexiApp {
         if response.dismissed {
             self.pop_focus_layer(&crate::app::FocusKind::QuickNote);
             self.quick_note_text.clear();
+            self.quick_note_attachments.clear();
             log::info!("QuickNote: modal dismissed via click-away");
         }
+    }
+
+    /// The configured shared terminal family at the current application font
+    /// size. Every QuickNote text surface uses this exact `FontId`.
+    pub(crate) fn quick_note_font(&self) -> egui::FontId {
+        egui::FontId::monospace(self.default_font_size)
     }
 
     pub(crate) fn quick_note_handle_key(

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1738,7 +1738,7 @@ impl PlexiApp {
             context_root: Some(self.router.active().root.clone()),
         };
         let dir = crate::config::config_dir().join("notes").join("inbox");
-        let Some(path) = Self::write_inbox_note("", "scratchpad", &dir, &ctx) else {
+        let Some(path) = Self::write_inbox_note("", "scratchpad", &dir, &ctx, &[]) else {
             log::warn!("scratchpad: failed to create scratch note in {:?}", dir);
             return;
         };
@@ -1783,6 +1783,7 @@ impl PlexiApp {
         let workspace_root = crate::config::active_workspace_root();
         let context_root = Some(self.router.active().root.clone());
         self.quick_note_text = String::new();
+        self.quick_note_attachments.clear();
         self.quick_note_ctx = crate::app::QuickNoteCtx {
             cwd,
             workspace_root,
@@ -1800,8 +1801,42 @@ impl PlexiApp {
     pub(crate) fn commit_quick_note_to_inbox(&mut self, text: &str) -> bool {
         let ctx = self.quick_note_ctx.clone();
         let dir = crate::config::config_dir().join("notes").join("inbox");
-        log::info!("QuickNote: committing to notes/inbox/");
-        Self::write_inbox_note(text, "quick-note", &dir, &ctx).is_some()
+        log::info!(
+            "QuickNote: committing to notes/inbox/ attachments={}",
+            self.quick_note_attachments.len()
+        );
+        Self::write_inbox_note(
+            text,
+            "quick-note",
+            &dir,
+            &ctx,
+            &self.quick_note_attachments,
+        )
+        .is_some()
+    }
+
+    /// Validate and stage one local image for the open QuickNote modal. The
+    /// file remains at its original path until the note is saved, preventing
+    /// discarded modals from creating unattached collection assets.
+    pub(crate) fn stage_quick_note_image(&mut self, source: PathBuf) -> Result<(), String> {
+        let bytes = std::fs::read(&source)
+            .map_err(|e| format!("failed to read dropped image {}: {e}", source.display()))?;
+        image::load_from_memory(&bytes)
+            .map_err(|e| format!("not a decodable image ({}): {e}", source.display()))?;
+        if self.quick_note_attachments.iter().any(|path| path == &source) {
+            log::info!(
+                "QuickNote: drop already staged source={}",
+                source.display()
+            );
+            return Ok(());
+        }
+        log::info!(
+            "QuickNote: staged image source={} bytes={}",
+            source.display(),
+            bytes.len()
+        );
+        self.quick_note_attachments.push(source);
+        Ok(())
     }
 
     /// Write a timestamped note with capture-context frontmatter into `dir`.
@@ -1811,6 +1846,7 @@ impl PlexiApp {
         source: &str,
         dir: &PathBuf,
         ctx: &crate::app::QuickNoteCtx,
+        attachments: &[PathBuf],
     ) -> Option<PathBuf> {
         use chrono::Utc;
         let now = Utc::now();
@@ -1833,9 +1869,29 @@ impl PlexiApp {
         let frontmatter = format!(
             "---\ntitle: \"\"\ncaptured_at: \"{captured_at}\"\nsource: \"{source}\"\ncwd: \"{cwd_str}\"\nworkspace: \"{workspace}\"\ncontext_root: \"{context_root_str}\"\n---\n\n"
         );
-        let content = format!("{frontmatter}{}\n", text.trim());
+        let persisted_attachments = match persist_quick_note_attachments(attachments, dir) {
+            Ok(attachments) => attachments,
+            Err(e) => {
+                log::error!("QuickNote: failed to persist staged image: {e}");
+                return None;
+            }
+        };
+        let attachment_markdown = persisted_attachments
+            .references
+            .iter()
+            .map(|reference| format!("![]({reference})"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let body = match (text.trim(), attachment_markdown.is_empty()) {
+            ("", true) => String::new(),
+            ("", false) => attachment_markdown,
+            (body, true) => body.to_string(),
+            (body, false) => format!("{body}\n\n{attachment_markdown}"),
+        };
+        let content = format!("{frontmatter}{body}\n");
 
         if let Err(e) = std::fs::create_dir_all(dir) {
+            rollback_quick_note_assets(&persisted_attachments.newly_written);
             log::error!(
                 "QuickNote: failed to create inbox dir {}: {e}",
                 dir.display()
@@ -1865,6 +1921,7 @@ impl PlexiApp {
                             // a partial write doesn't leave a ghost file blocking
                             // any future attempt at the same path.
                             let _ = std::fs::remove_file(&path);
+                            rollback_quick_note_assets(&persisted_attachments.newly_written);
                             log::error!("QuickNote: save failed {}: {e}", path.display());
                             return None;
                         }
@@ -1875,11 +1932,166 @@ impl PlexiApp {
                     n += 1;
                 }
                 Err(e) => {
+                    rollback_quick_note_assets(&persisted_attachments.newly_written);
                     log::error!("QuickNote: save failed {}: {e}", path.display());
                     return None;
                 }
             }
         }
+    }
+}
+
+/// Persist QuickNote attachments into the collection-level `notes/assets/`
+/// directory. Inbox notes live under `notes/inbox/`, so their Markdown paths
+/// are always relative `../assets/<name>` references.
+struct PersistedQuickNoteAttachments {
+    references: Vec<String>,
+    newly_written: Vec<PathBuf>,
+}
+
+fn persist_quick_note_attachments(
+    attachments: &[PathBuf],
+    inbox_dir: &Path,
+) -> Result<PersistedQuickNoteAttachments, String> {
+    if attachments.is_empty() {
+        return Ok(PersistedQuickNoteAttachments {
+            references: Vec::new(),
+            newly_written: Vec::new(),
+        });
+    }
+    let notes_dir = inbox_dir.parent().ok_or_else(|| {
+        format!(
+            "inbox directory has no notes parent: {}",
+            inbox_dir.display()
+        )
+    })?;
+    let assets_dir = notes_dir.join("assets");
+    std::fs::create_dir_all(&assets_dir)
+        .map_err(|e| format!("failed to create {}: {e}", assets_dir.display()))?;
+
+    let mut references = Vec::with_capacity(attachments.len());
+    let mut newly_written = Vec::new();
+    for source in attachments {
+        let bytes = match std::fs::read(source) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                rollback_quick_note_assets(&newly_written);
+                return Err(format!(
+                    "failed to read staged image {}: {e}",
+                    source.display()
+                ));
+            }
+        };
+        if let Err(e) = image::load_from_memory(&bytes) {
+            rollback_quick_note_assets(&newly_written);
+            return Err(format!("not a decodable image ({}): {e}", source.display()));
+        }
+        let format = match image::guess_format(&bytes) {
+            Ok(format) => format,
+            Err(e) => {
+                rollback_quick_note_assets(&newly_written);
+                return Err(format!(
+                    "unrecognized image container ({}): {e}",
+                    source.display()
+                ));
+            }
+        };
+        let ext = format.extensions_str().first().copied().unwrap_or("img");
+        let hash = quick_note_asset_hash(&bytes);
+        let stem = quick_note_asset_stem(source);
+        let mut name = format!("{stem}-{hash:016x}.{ext}");
+        let mut suffix = 2usize;
+        let deduped = loop {
+            let candidate = assets_dir.join(&name);
+            if !candidate.exists() {
+                if let Err(e) = std::fs::write(&candidate, &bytes) {
+                    if let Err(cleanup_error) = std::fs::remove_file(&candidate) {
+                        if cleanup_error.kind() != std::io::ErrorKind::NotFound {
+                            log::error!(
+                                "QuickNote: failed to remove partially written image asset {} after save failure: {cleanup_error}",
+                                candidate.display()
+                            );
+                        }
+                    }
+                    rollback_quick_note_assets(&newly_written);
+                    return Err(format!("failed to save {}: {e}", candidate.display()));
+                }
+                newly_written.push(candidate);
+                break false;
+            }
+            match std::fs::read(&candidate) {
+                Ok(existing) if existing == bytes => break true,
+                Ok(_) => {
+                    name = format!("{stem}-{hash:016x}-{suffix}.{ext}");
+                    suffix += 1;
+                }
+                Err(e) => {
+                    rollback_quick_note_assets(&newly_written);
+                    return Err(format!(
+                        "failed to inspect existing asset {}: {e}",
+                        candidate.display()
+                    ));
+                }
+            }
+        };
+        let reference = format!("../assets/{name}");
+        log::info!(
+            "QuickNote: persisted image asset={reference} bytes={} hash={hash:016x} deduped={deduped}",
+            bytes.len()
+        );
+        references.push(reference);
+    }
+    Ok(PersistedQuickNoteAttachments {
+        references,
+        newly_written,
+    })
+}
+
+fn rollback_quick_note_assets(paths: &[PathBuf]) {
+    if paths.is_empty() {
+        return;
+    }
+    log::info!(
+        "QuickNote: rolling back {} newly persisted image assets",
+        paths.len()
+    );
+    for path in paths {
+        if let Err(e) = std::fs::remove_file(path) {
+            log::error!(
+                "QuickNote: failed to roll back image asset {}: {e}",
+                path.display()
+            );
+        }
+    }
+}
+
+fn quick_note_asset_hash(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0xcbf2_9ce4_8422_2325_u64, |hash, byte| {
+        (hash ^ u64::from(*byte)).wrapping_mul(0x0000_0100_0000_01b3)
+    })
+}
+
+fn quick_note_asset_stem(source: &Path) -> String {
+    let raw = source
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .filter(|stem| !stem.is_empty())
+        .unwrap_or("image");
+    let sanitized: String = raw
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let stem = sanitized.trim_matches('-');
+    if stem.is_empty() {
+        "image".to_string()
+    } else {
+        stem.to_string()
     }
 }
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -1936,6 +1936,133 @@ fn quick_note_paste_consumed_from_queue() {
     });
 }
 
+/// The QuickNote editor must lay out with the configured shared font size,
+/// rather than egui's default body style.
+#[test]
+fn quick_note_editor_galley_uses_configured_font_size() {
+    let profile = tempfile::tempdir().expect("isolated config profile");
+    let _profile_guard = crate::config::set_test_profile_dir(profile.path().to_path_buf());
+    std::fs::write(crate::config::config_path(), "font_size = 27.0\n")
+        .expect("write isolated config override");
+    let config = crate::config::PlexiConfig::load();
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _mailbox) =
+        crate::app::PlexiApp::new_for_test_with_config(ctx.clone(), frame_tick, config);
+    use eframe::App as _;
+    let _ = ctx.run_ui(
+        egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(1280.0, 800.0),
+            )),
+            ..Default::default()
+        },
+        |ui| {
+            app.logic(ui.ctx(), &mut eframe::Frame::_new_kittest());
+            app.ui(ui, &mut eframe::Frame::_new_kittest());
+        },
+    );
+
+    let font = app.quick_note_font();
+    let galley = app.ctx.fonts_mut(|fonts| {
+        fonts.layout_no_wrap(
+            "configured quick note".to_owned(),
+            font.clone(),
+            app.colors.text_primary,
+        )
+    });
+
+    assert_eq!(font.size, 27.0);
+    assert!(
+        galley.rows[0].rect().height() >= 27.0,
+        "QuickNote galley must use the configured 27pt font, got {:?}",
+        galley.rows[0].rect()
+    );
+}
+
+/// A real raw host drop while Cmd+0 QuickNote is focused stages the image,
+/// persists it into the collection assets directory on save, and writes the
+/// inbox-relative Markdown reference into the new note.
+#[test]
+fn quick_note_raw_image_drop_stages_and_persists_collection_asset_on_save() {
+    let mut h = HostHarness::new();
+    h.app.open_quick_note_modal();
+    h.run_frames(2);
+
+    let source =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/notes-drop.png");
+    h.frame(egui::RawInput {
+        screen_rect: Some(egui::Rect::from_min_size(
+            egui::Pos2::ZERO,
+            egui::vec2(1280.0, 800.0),
+        )),
+        dropped_files: vec![egui::DroppedFile {
+            path: Some(source),
+            ..Default::default()
+        }],
+        ..Default::default()
+    });
+
+    assert_eq!(h.app.quick_note_attachments.len(), 1);
+    let text = "image attached from QuickNote".to_string();
+    h.app.quick_note_text = text.clone();
+    assert!(h.app.commit_quick_note_to_inbox(&text));
+
+    let notes_dir = crate::config::config_dir().join("notes");
+    let inbox = notes_dir.join("inbox");
+    let saved = std::fs::read_dir(&inbox)
+        .expect("QuickNote must create inbox")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|path| path.extension().is_some_and(|ext| ext == "md"))
+        .expect("QuickNote must save an inbox note");
+    let content = std::fs::read_to_string(saved).expect("saved QuickNote must be readable");
+    assert!(content.contains("image attached from QuickNote"));
+    assert!(content.contains("![](../assets/notes-drop-"), "{content}");
+    assert!(
+        std::fs::read_dir(notes_dir.join("assets"))
+            .expect("QuickNote must create collection assets")
+            .next()
+            .is_some(),
+        "staged image must persist beside inbox, in notes/assets"
+    );
+}
+
+/// A failed inbox write after attachment persistence must not strand an asset
+/// that no saved note can reference.
+#[test]
+fn quick_note_attachment_rolls_back_new_asset_when_inbox_write_fails() {
+    let mut h = HostHarness::new();
+    let source =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/notes-drop.png");
+    h.app
+        .stage_quick_note_image(source)
+        .expect("fixture must be a valid image");
+
+    let notes_dir = crate::config::config_dir().join("notes");
+    let inbox = notes_dir.join("inbox");
+    std::fs::create_dir_all(&notes_dir).expect("create notes directory");
+    std::fs::write(&inbox, "block inbox directory creation")
+        .expect("make the later inbox write fail after asset persistence");
+
+    assert!(
+        !h.app
+            .commit_quick_note_to_inbox("this note cannot be written"),
+        "a file where notes/inbox belongs must prevent creating the note"
+    );
+
+    let assets_dir = notes_dir.join("assets");
+    assert!(
+        !assets_dir.exists()
+            || std::fs::read_dir(&assets_dir)
+                .expect("assets directory must remain readable")
+                .next()
+                .is_none(),
+        "failed QuickNote save must roll back newly persisted assets"
+    );
+}
+
 // -- Layer 2 post-CentralPanel focus guard (#1601) -------------------------
 
 /// Helper: simulate a CentralPanel pane widget stealing egui focus between two frames.

--- a/src/ui/text_field.rs
+++ b/src/ui/text_field.rs
@@ -328,11 +328,6 @@ impl<'a> TextArea<'a> {
         self
     }
 
-    pub(crate) fn monospace(mut self, size: f32) -> Self {
-        self.font_id = egui::FontId::monospace(size);
-        self
-    }
-
     pub(crate) fn text_color(mut self, text_color: egui::Color32) -> Self {
         self.text_color = Some(text_color);
         self

--- a/tests/scenes/quick-note.toml
+++ b/tests/scenes/quick-note.toml
@@ -1,0 +1,21 @@
+# Cmd+0 QuickNote with a realistic multi-line capture. This is the visual
+# regression surface for its configured FontId and attachment status text.
+size = [1168.0, 720.0]
+
+[[steps]]
+key = { target = "host", value = "cmd+0" }
+
+[[steps]]
+run_steps = 2
+
+[[steps]]
+text = { target = "host", value = "Follow up with the design team about the image-drop flow.\n\nInclude the screenshots and persistence notes in tomorrow's review." }
+
+[[steps]]
+run_steps = 2
+
+[[steps]]
+assert_label = { target = "host", label = "Enter to save  ·  Shift+Enter for new line  ·  Esc to discard" }
+
+[[steps]]
+shot = "quick-note.png"


### PR DESCRIPTION
## Summary

Implements stints 0617 and 0698.

- Applies the configured QuickNote font size to the editor, hint, count, and attachment text.
- Accepts raw image drops, validates and stages them until save, then persists them in collection-level `notes/assets/` with inbox references at `../assets/<name>`.
- Rolls back newly written assets if the inbox-note save fails.

## Validation

- Focused `cargo test --bin plexi quick_note_ -- --test-threads=1`: 5 passed.
- Headless QuickNote scene (`tests/scenes/quick-note.toml`): passed; seeded screenshot reviewed visually and deleted.
- `cargo build`: passed.
- Full local `cargo test --bin plexi` did not reach a final verdict across repeated attempts while the machine was under competing build contention; attempts were killed mid-suite with no assertion failure. Per the head ruling, CI's test job on a clean runner is the full-suite proof of record for this PR.

## Tester boundary

A separate tester pane on the installed build owns the interactive behavior gate (Cmd+0 modal, raw file drop, and persisted note/assets behavior). No installed-build validation was performed in this worker lane.