### PR TITLE
fix: polish sidebar context rows (stint 0700)

### DIFF
--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3,6 +3,7 @@
 use super::{ClickFlash, PlexiApp};
 use crate::app_protocol::AgentState;
 use crate::spatial::tiling::{PaneId, PlexiBehavior};
+use crate::ui::style;
 use egui::{Color32, CornerRadius, Stroke, StrokeKind, Vec2};
 use egui_tiles::{Tile, TileId};
 use std::collections::HashMap;
@@ -187,7 +188,7 @@ impl PlexiApp {
                 }
             });
             egui::Panel::left("sidebar")
-                .default_size(220.0)
+                .default_size(style::SIDEBAR_DEFAULT_W)
                 .size_range(140.0..=400.0)
                 .resizable(true)
                 .show_separator_line(false)

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3,7 +3,6 @@
 use super::{ClickFlash, PlexiApp};
 use crate::app_protocol::AgentState;
 use crate::spatial::tiling::{PaneId, PlexiBehavior};
-use crate::ui::style;
 use egui::{Color32, CornerRadius, Stroke, StrokeKind, Vec2};
 use egui_tiles::{Tile, TileId};
 use std::collections::HashMap;
@@ -187,10 +186,12 @@ impl PlexiApp {
                     }
                 }
             });
+            // This review-only width is held in egui's per-session temp data:
+            // switching it never writes user configuration or persisted panel state.
             egui::Panel::left("sidebar")
-                .default_size(style::SIDEBAR_DEFAULT_W)
                 .size_range(140.0..=400.0)
-                .resizable(true)
+                .exact_size(crate::ui::sidebar::sidebar_width_preview(&ctx))
+                .resizable(false)
                 .show_separator_line(false)
                 .frame(
                     egui::Frame::new()

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -3,6 +3,7 @@
 use super::{ClickFlash, PlexiApp};
 use crate::app_protocol::AgentState;
 use crate::spatial::tiling::{PaneId, PlexiBehavior};
+use crate::ui::style;
 use egui::{Color32, CornerRadius, Stroke, StrokeKind, Vec2};
 use egui_tiles::{Tile, TileId};
 use std::collections::HashMap;
@@ -186,12 +187,10 @@ impl PlexiApp {
                     }
                 }
             });
-            // This review-only width is held in egui's per-session temp data:
-            // switching it never writes user configuration or persisted panel state.
             egui::Panel::left("sidebar")
+                .default_size(style::SIDEBAR_DEFAULT_W)
                 .size_range(140.0..=400.0)
-                .exact_size(crate::ui::sidebar::sidebar_width_preview(&ctx))
-                .resizable(false)
+                .resizable(true)
                 .show_separator_line(false)
                 .frame(
                     egui::Frame::new()

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,26 +1,34 @@
 use crate::host::context::WindowMenuAction;
 use crate::ui::button;
 use crate::ui::list::ListDropdownHeader;
-use crate::ui::sidebar_row::{CloseAffordance, ContextItem, PaneDots, SidebarAction};
+use crate::ui::sidebar_row::{ContextItem, PaneDots, SidebarAction};
+use crate::ui::style;
 use crate::workspace::router::ContextMove;
 use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 use egui_tiles::Tile;
 
 use crate::app::PlexiApp;
 
-const CLOSE_AFFORDANCE_PREVIEW_ID: &str = "sidebar_close_affordance_preview";
+const SIDEBAR_WIDTH_PREVIEW_ID: &str = "sidebar_width_preview";
+const SIDEBAR_NARROW_W: f32 = 200.0;
 
-fn close_affordance_preview(ctx: &egui::Context) -> CloseAffordance {
+pub(crate) fn sidebar_width_preview(ctx: &egui::Context) -> f32 {
     ctx.data(|data| {
-        data.get_temp(egui::Id::new(CLOSE_AFFORDANCE_PREVIEW_ID))
-            .unwrap_or_default()
+        data.get_temp(egui::Id::new(SIDEBAR_WIDTH_PREVIEW_ID))
+            .unwrap_or(style::SIDEBAR_DEFAULT_W)
     })
 }
 
-fn set_close_affordance_preview(ctx: &egui::Context, affordance: CloseAffordance) {
+fn toggle_sidebar_width_preview(ctx: &egui::Context, width: f32) -> f32 {
+    let next = if width == style::SIDEBAR_DEFAULT_W {
+        SIDEBAR_NARROW_W
+    } else {
+        style::SIDEBAR_DEFAULT_W
+    };
     ctx.data_mut(|data| {
-        data.insert_temp(egui::Id::new(CLOSE_AFFORDANCE_PREVIEW_ID), affordance);
+        data.insert_temp(egui::Id::new(SIDEBAR_WIDTH_PREVIEW_ID), next);
     });
+    next
 }
 
 fn drop_slot_from_rects(rects: &[Rect], mouse_y: f32) -> usize {
@@ -180,7 +188,7 @@ impl PlexiApp {
 impl PlexiApp {
     pub(crate) fn draw_sidebar(&mut self, ui: &mut egui::Ui) {
         let sidebar_width = ui.available_width();
-        let mut close_affordance = close_affordance_preview(ui.ctx());
+        let sidebar_width_preview = sidebar_width_preview(ui.ctx());
 
         // Header
         ui.add_space(8.0);
@@ -199,16 +207,14 @@ impl PlexiApp {
                 }
                 if button::toolbar_button(
                     ui,
-                    close_affordance.preview_label(),
-                    "Switch sidebar close-affordance preview",
+                    format!("Width: {:.0}", sidebar_width_preview),
+                    "Switch sidebar width preview between 220 and 200 points",
                 )
                 .clicked()
                 {
-                    close_affordance = close_affordance.toggled();
-                    set_close_affordance_preview(ui.ctx(), close_affordance);
+                    let next = toggle_sidebar_width_preview(ui.ctx(), sidebar_width_preview);
                     log::info!(
-                        "sidebar: close_affordance_preview={}",
-                        close_affordance.log_name()
+                        "sidebar: width_preview={next:.0}",
                     );
                 }
             });
@@ -345,7 +351,6 @@ impl PlexiApp {
                 badge_count,
                 subtitle,
                 pane_dots,
-                close_affordance,
                 draggable: true,
             }
             .draw(ui, egui::Id::new(("ctx", i)), &self.colors);
@@ -484,7 +489,6 @@ impl PlexiApp {
                         badge_count: 0,
                         subtitle,
                         pane_dots,
-                        close_affordance,
                         draggable: true,
                     }
                     .draw(ui, egui::Id::new(("parked_ctx", i)), &self.colors);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,12 +1,27 @@
 use crate::host::context::WindowMenuAction;
 use crate::ui::button;
 use crate::ui::list::ListDropdownHeader;
-use crate::ui::sidebar_row::{ContextItem, PaneDots, SidebarAction};
+use crate::ui::sidebar_row::{CloseAffordance, ContextItem, PaneDots, SidebarAction};
 use crate::workspace::router::ContextMove;
 use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 use egui_tiles::Tile;
 
 use crate::app::PlexiApp;
+
+const CLOSE_AFFORDANCE_PREVIEW_ID: &str = "sidebar_close_affordance_preview";
+
+fn close_affordance_preview(ctx: &egui::Context) -> CloseAffordance {
+    ctx.data(|data| {
+        data.get_temp(egui::Id::new(CLOSE_AFFORDANCE_PREVIEW_ID))
+            .unwrap_or_default()
+    })
+}
+
+fn set_close_affordance_preview(ctx: &egui::Context, affordance: CloseAffordance) {
+    ctx.data_mut(|data| {
+        data.insert_temp(egui::Id::new(CLOSE_AFFORDANCE_PREVIEW_ID), affordance);
+    });
+}
 
 fn drop_slot_from_rects(rects: &[Rect], mouse_y: f32) -> usize {
     for (i, rect) in rects.iter().enumerate() {
@@ -165,6 +180,7 @@ impl PlexiApp {
 impl PlexiApp {
     pub(crate) fn draw_sidebar(&mut self, ui: &mut egui::Ui) {
         let sidebar_width = ui.available_width();
+        let mut close_affordance = close_affordance_preview(ui.ctx());
 
         // Header
         ui.add_space(8.0);
@@ -180,6 +196,20 @@ impl PlexiApp {
                 ui.add_space(12.0);
                 if button::icon_button(ui, "+", "New context", &self.colors).clicked() {
                     add_clicked = true;
+                }
+                if button::toolbar_button(
+                    ui,
+                    close_affordance.preview_label(),
+                    "Switch sidebar close-affordance preview",
+                )
+                .clicked()
+                {
+                    close_affordance = close_affordance.toggled();
+                    set_close_affordance_preview(ui.ctx(), close_affordance);
+                    log::info!(
+                        "sidebar: close_affordance_preview={}",
+                        close_affordance.log_name()
+                    );
                 }
             });
         });
@@ -315,6 +345,7 @@ impl PlexiApp {
                 badge_count,
                 subtitle,
                 pane_dots,
+                close_affordance,
                 draggable: true,
             }
             .draw(ui, egui::Id::new(("ctx", i)), &self.colors);
@@ -453,6 +484,7 @@ impl PlexiApp {
                         badge_count: 0,
                         subtitle,
                         pane_dots,
+                        close_affordance,
                         draggable: true,
                     }
                     .draw(ui, egui::Id::new(("parked_ctx", i)), &self.colors);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -2,34 +2,11 @@ use crate::host::context::WindowMenuAction;
 use crate::ui::button;
 use crate::ui::list::ListDropdownHeader;
 use crate::ui::sidebar_row::{ContextItem, PaneDots, SidebarAction};
-use crate::ui::style;
 use crate::workspace::router::ContextMove;
 use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 use egui_tiles::Tile;
 
 use crate::app::PlexiApp;
-
-const SIDEBAR_WIDTH_PREVIEW_ID: &str = "sidebar_width_preview";
-const SIDEBAR_NARROW_W: f32 = 200.0;
-
-pub(crate) fn sidebar_width_preview(ctx: &egui::Context) -> f32 {
-    ctx.data(|data| {
-        data.get_temp(egui::Id::new(SIDEBAR_WIDTH_PREVIEW_ID))
-            .unwrap_or(style::SIDEBAR_DEFAULT_W)
-    })
-}
-
-fn toggle_sidebar_width_preview(ctx: &egui::Context, width: f32) -> f32 {
-    let next = if width == style::SIDEBAR_DEFAULT_W {
-        SIDEBAR_NARROW_W
-    } else {
-        style::SIDEBAR_DEFAULT_W
-    };
-    ctx.data_mut(|data| {
-        data.insert_temp(egui::Id::new(SIDEBAR_WIDTH_PREVIEW_ID), next);
-    });
-    next
-}
 
 fn drop_slot_from_rects(rects: &[Rect], mouse_y: f32) -> usize {
     for (i, rect) in rects.iter().enumerate() {
@@ -188,8 +165,6 @@ impl PlexiApp {
 impl PlexiApp {
     pub(crate) fn draw_sidebar(&mut self, ui: &mut egui::Ui) {
         let sidebar_width = ui.available_width();
-        let sidebar_width_preview = sidebar_width_preview(ui.ctx());
-
         // Header
         ui.add_space(8.0);
         let mut add_clicked = false;
@@ -204,18 +179,6 @@ impl PlexiApp {
                 ui.add_space(12.0);
                 if button::icon_button(ui, "+", "New context", &self.colors).clicked() {
                     add_clicked = true;
-                }
-                if button::toolbar_button(
-                    ui,
-                    format!("Width: {:.0}", sidebar_width_preview),
-                    "Switch sidebar width preview between 220 and 200 points",
-                )
-                .clicked()
-                {
-                    let next = toggle_sidebar_width_preview(ui.ctx(), sidebar_width_preview);
-                    log::info!(
-                        "sidebar: width_preview={next:.0}",
-                    );
                 }
             });
         });

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -4,44 +4,11 @@ use crate::ui::theme::Colors;
 use egui::emath::GuiRounding;
 use egui::{Align, Color32, CornerRadius, CursorIcon, Id, Layout, Rect, Sense, Vec2};
 
-pub const ACTION_ZONE_WIDTH: f32 = 30.0;
-
-/// Temporary presentation choices for the sidebar close affordance. The host
-/// owns deletion; this only chooses where its existing hit target is drawn.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum CloseAffordance {
-    /// Keep the notification count and delete control together at the end.
-    #[default]
-    TrailingDelete,
-    /// Keep the delete control with the headline/pips and pin the count right.
-    InlineDelete,
-}
-
-impl CloseAffordance {
-    pub(crate) const fn toggled(self) -> Self {
-        match self {
-            Self::TrailingDelete => Self::InlineDelete,
-            Self::InlineDelete => Self::TrailingDelete,
-        }
-    }
-
-    pub(crate) const fn preview_label(self) -> &'static str {
-        match self {
-            Self::TrailingDelete => "X: end",
-            Self::InlineDelete => "X: inline",
-        }
-    }
-
-    pub(crate) const fn log_name(self) -> &'static str {
-        match self {
-            Self::TrailingDelete => "TrailingDelete",
-            Self::InlineDelete => "InlineDelete",
-        }
-    }
-}
+pub const ACTION_ZONE_WIDTH: f32 = 22.0;
 
 /// Fixed-width left gutter that holds the context index number.
-const GUTTER_W: f32 = 24.0;
+const GUTTER_W: f32 = 18.0;
+const ROW_INDENT: f32 = 4.0;
 
 /// Top and bottom padding added inside each row for vertical breathing room.
 const ROW_PAD_V: f32 = 7.0;
@@ -54,7 +21,7 @@ const PANE_DOT_MAX: usize = 8;
 const WINDOW_GROUP_PAD_X: f32 = 5.0;
 const WINDOW_GROUP_PAD_Y: f32 = 4.0;
 const WINDOW_GROUP_GAP: f32 = 5.0;
-const SIDEBAR_BADGE_W: f32 = 26.0;
+const SIDEBAR_BADGE_W: f32 = 18.0;
 
 pub(crate) fn with_alpha(c: Color32, alpha: f32) -> Color32 {
     Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), (c.a() as f32 * alpha) as u8)
@@ -127,7 +94,6 @@ pub struct ContextItem {
     pub subtitle: Option<String>,
     /// Dots rendered below the name row representing panes.
     pub pane_dots: Option<PaneDots>,
-    pub close_affordance: CloseAffordance,
     /// Whether this row supports drag reordering. When false, hover shows
     /// PointingHand instead of Grab and drag actions are suppressed.
     pub draggable: bool,
@@ -345,8 +311,9 @@ impl ContextItem {
         let bg_idx = ui.painter().add(egui::Shape::Noop);
 
         // Every sidebar row is a top-level context, so the gutter is a fixed
-        // 6px inset — there is no nesting level to indent for.
-        let indent = 6.0;
+        // There is no nesting level to indent for, so the compact inset leaves
+        // room for the primary label rather than a second visual gutter.
+        let indent = ROW_INDENT;
 
         let is_active = self.is_active;
         let is_dragging = self.is_dragging;
@@ -357,7 +324,6 @@ impl ContextItem {
         let badge_count = self.badge_count;
         let subtitle = self.subtitle.clone();
         let pane_dots = self.pane_dots;
-        let close_affordance = self.close_affordance;
         let accent_color = colors.accent;
         let text_primary = colors.text_primary;
         let text_dim = colors.text_dim;
@@ -419,7 +385,7 @@ impl ContextItem {
                                     if dots.count > PANE_DOT_MAX {
                                         w += 20.0;
                                     }
-                                    w + 6.0 // gap between name text and dots
+                                    w + 4.0 // gap between name text and dots
                                 } else {
                                     0.0
                                 }
@@ -461,26 +427,12 @@ impl ContextItem {
                             // the pips and overlap the count.
                             ui.add_space((text_max - title_width).max(0.0));
 
-                            // Pips remain beside the headline in both previews.
+                            // Pips stay beside the headline, before the trailing state.
                             draw_pips(ui, &pane_dots, colors, row_alpha, is_dragging);
 
-                            // InlineDelete keeps the close target with the
-                            // headline and pips; the count is rendered by the
-                            // trailing layout below.
-                            if action_enabled && close_affordance == CloseAffordance::InlineDelete {
-                                let (rect, _) = ui.allocate_exact_size(
-                                    Vec2::new(ACTION_ZONE_WIDTH, ui.spacing().interact_size.y),
-                                    Sense::hover(),
-                                );
-                                close_rect_capture = Some(rect);
-                            }
-
                             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                                // TrailingDelete puts the close target after
-                                // the count at the physical trailing edge.
-                                if action_enabled
-                                    && close_affordance == CloseAffordance::TrailingDelete
-                                {
+                                // The close target follows the count at the physical trailing edge.
+                                if action_enabled {
                                     let (rect, _) = ui.allocate_exact_size(
                                         Vec2::new(ACTION_ZONE_WIDTH, ui.spacing().interact_size.y),
                                         Sense::hover(),

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -6,6 +6,40 @@ use egui::{Align, Color32, CornerRadius, CursorIcon, Id, Layout, Rect, Sense, Ve
 
 pub const ACTION_ZONE_WIDTH: f32 = 30.0;
 
+/// Temporary presentation choices for the sidebar close affordance. The host
+/// owns deletion; this only chooses where its existing hit target is drawn.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CloseAffordance {
+    /// Keep the notification count and delete control together at the end.
+    #[default]
+    TrailingDelete,
+    /// Keep the delete control with the headline/pips and pin the count right.
+    InlineDelete,
+}
+
+impl CloseAffordance {
+    pub(crate) const fn toggled(self) -> Self {
+        match self {
+            Self::TrailingDelete => Self::InlineDelete,
+            Self::InlineDelete => Self::TrailingDelete,
+        }
+    }
+
+    pub(crate) const fn preview_label(self) -> &'static str {
+        match self {
+            Self::TrailingDelete => "X: end",
+            Self::InlineDelete => "X: inline",
+        }
+    }
+
+    pub(crate) const fn log_name(self) -> &'static str {
+        match self {
+            Self::TrailingDelete => "TrailingDelete",
+            Self::InlineDelete => "InlineDelete",
+        }
+    }
+}
+
 /// Fixed-width left gutter that holds the context index number.
 const GUTTER_W: f32 = 24.0;
 
@@ -93,6 +127,7 @@ pub struct ContextItem {
     pub subtitle: Option<String>,
     /// Dots rendered below the name row representing panes.
     pub pane_dots: Option<PaneDots>,
+    pub close_affordance: CloseAffordance,
     /// Whether this row supports drag reordering. When false, hover shows
     /// PointingHand instead of Grab and drag actions are suppressed.
     pub draggable: bool,
@@ -322,6 +357,7 @@ impl ContextItem {
         let badge_count = self.badge_count;
         let subtitle = self.subtitle.clone();
         let pane_dots = self.pane_dots;
+        let close_affordance = self.close_affordance;
         let accent_color = colors.accent;
         let text_primary = colors.text_primary;
         let text_dim = colors.text_dim;
@@ -347,10 +383,11 @@ impl ContextItem {
 
             // --- Outer row: left gutter (index number) + content column ---
             let y_before = ui.cursor().min.y;
-            // name_row_h is captured from inside the horizontal closure and
-            // returned as part of the scope inner so the action zone can be
-            // limited to the header line height.
+            // name_row_h and close_rect are captured from inside the horizontal
+            // closure so the number and delete hit target stay on the headline,
+            // not the full two-line row.
             let mut name_row_h_capture = 0.0_f32;
+            let mut close_rect_capture = None;
             ui.horizontal(|ui| {
                 ui.add_space(indent);
 
@@ -363,14 +400,22 @@ impl ContextItem {
                 // Pips live on the name row, right-aligned before the action zone.
                 let name_row_h = ui
                     .vertical(|ui| {
-                        // --- Name row (includes pips right-aligned) ---
+                        // --- Name row ---
                         let name_y_before = ui.cursor().min.y;
                         ui.horizontal(|ui| {
                             // Compute pip strip width so we can budget the name text.
                             let pip_strip_w = if let Some(ref dots) = pane_dots {
                                 if dots.count > 0 {
                                     let capped = dots.count.min(PANE_DOT_MAX);
-                                    let mut w = (capped as f32) * PANE_DOT_SPACING;
+                                    let group_count = dots
+                                        .windows
+                                        .iter()
+                                        .filter(|group| group.count > 0 && group.start < capped)
+                                        .count()
+                                        .max(1);
+                                    let mut w = (capped as f32) * PANE_DOT_SPACING
+                                        + (group_count as f32) * WINDOW_GROUP_PAD_X * 2.0
+                                        + (group_count.saturating_sub(1) as f32) * WINDOW_GROUP_GAP;
                                     if dots.count > PANE_DOT_MAX {
                                         w += 20.0;
                                     }
@@ -382,52 +427,80 @@ impl ContextItem {
                                 0.0
                             };
 
-                            let right_reserve = if action_enabled {
-                                ACTION_ZONE_WIDTH + 4.0
-                            } else {
-                                8.0
-                            };
                             let badge_w = if badge_count > 0 {
                                 SIDEBAR_BADGE_W
                             } else {
                                 0.0
                             };
+                            let close_w = if action_enabled {
+                                ACTION_ZONE_WIDTH
+                            } else {
+                                0.0
+                            };
                             let text_max =
-                                (ui.available_width() - right_reserve - badge_w - pip_strip_w)
-                                    .max(0.0);
+                                (ui.available_width() - badge_w - close_w - pip_strip_w).max(0.0);
 
-                            ui.scope(|ui| {
-                                ui.set_max_width(text_max);
-                                ui.add(
-                                    egui::Label::new(
-                                        egui::RichText::new(&ctx_name)
-                                            .size(style::TEXT_SIDEBAR_TITLE)
-                                            .color(text_color),
+                            let title_width = ui
+                                .scope(|ui| {
+                                    ui.set_max_width(text_max);
+                                    ui.add(
+                                        egui::Label::new(
+                                            egui::RichText::new(&ctx_name)
+                                                .size(style::TEXT_SIDEBAR_TITLE)
+                                                .color(text_color),
+                                        )
+                                        .selectable(false)
+                                        .truncate(),
                                     )
-                                    .selectable(false)
-                                    .truncate(),
-                                );
-                            });
+                                    .rect
+                                    .width()
+                                })
+                                .inner;
+                            // Keep the trailing layout at the budget boundary
+                            // even for short names, so it cannot begin after
+                            // the pips and overlap the count.
+                            ui.add_space((text_max - title_width).max(0.0));
 
-                            // Pips: rendered inline right of the name, before badge/action.
+                            // Pips remain beside the headline in both previews.
                             draw_pips(ui, &pane_dots, colors, row_alpha, is_dragging);
 
+                            // InlineDelete keeps the close target with the
+                            // headline and pips; the count is rendered by the
+                            // trailing layout below.
+                            if action_enabled && close_affordance == CloseAffordance::InlineDelete {
+                                let (rect, _) = ui.allocate_exact_size(
+                                    Vec2::new(ACTION_ZONE_WIDTH, ui.spacing().interact_size.y),
+                                    Sense::hover(),
+                                );
+                                close_rect_capture = Some(rect);
+                            }
+
                             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                                ui.add_space(if action_enabled {
-                                    ACTION_ZONE_WIDTH
-                                } else {
-                                    0.0
-                                });
+                                // TrailingDelete puts the close target after
+                                // the count at the physical trailing edge.
+                                if action_enabled
+                                    && close_affordance == CloseAffordance::TrailingDelete
+                                {
+                                    let (rect, _) = ui.allocate_exact_size(
+                                        Vec2::new(ACTION_ZONE_WIDTH, ui.spacing().interact_size.y),
+                                        Sense::hover(),
+                                    );
+                                    close_rect_capture = Some(rect);
+                                }
                                 if badge_count > 0 {
                                     let badge_text = if badge_count > 9 {
                                         "9+".to_string()
                                     } else {
                                         badge_count.to_string()
                                     };
-                                    ui.label(
-                                        egui::RichText::new(badge_text)
-                                            .size(style::TEXT_META)
-                                            .color(with_alpha(accent_color, row_alpha)),
+                                    ui.add_sized(
+                                        Vec2::new(SIDEBAR_BADGE_W, 0.0),
+                                        egui::Label::new(
+                                            egui::RichText::new(badge_text)
+                                                .size(style::TEXT_META)
+                                                .color(with_alpha(accent_color, row_alpha)),
+                                        )
+                                        .halign(Align::RIGHT),
                                     );
                                 }
                             });
@@ -462,11 +535,15 @@ impl ContextItem {
 
             ui.add_space(ROW_PAD_V);
 
-            (ui.cursor().min.y - y_before, name_row_h_capture)
+            (
+                ui.cursor().min.y - y_before,
+                name_row_h_capture,
+                close_rect_capture,
+            )
         });
 
         let row_rect = scope_out.response.rect;
-        let (_total_h, name_row_h) = scope_out.inner;
+        let (_total_h, name_row_h, close_rect) = scope_out.inner;
 
         let response = ui.interact(row_rect, id, Sense::click_and_drag());
         let hovered = response.hovered();
@@ -528,18 +605,9 @@ impl ContextItem {
             }
         }
 
-        let action_zone = if action_enabled {
-            Some(Rect::from_min_max(
-                egui::pos2(row_rect.max.x - ACTION_ZONE_WIDTH, row_rect.min.y),
-                egui::pos2(row_rect.max.x, row_rect.min.y + name_row_h),
-            ))
-        } else {
-            None
-        };
+        let in_action = close_rect.is_some_and(|rect| ui.rect_contains_pointer(rect));
 
-        let in_action = action_zone.is_some_and(|az| ui.rect_contains_pointer(az));
-
-        if let Some(az) = action_zone {
+        if let Some(close_rect) = close_rect {
             if hovered && !is_dragging {
                 let glyph_color =
                     with_alpha(if in_action { text_primary } else { text_dim }, row_alpha);
@@ -548,7 +616,7 @@ impl ContextItem {
                     "\u{2715}",
                     egui::FontId::proportional(style::TEXT_SIDEBAR_TITLE),
                     glyph_color,
-                    az.center(),
+                    close_rect.center(),
                 );
             }
         }

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -79,6 +79,8 @@ pub const LIST_ROW_GAP: f32 = 8.0;
 /// Monospace line boxes sit optically low inside compact row chips.
 pub const LIST_CHIP_TEXT_OFFSET_Y: f32 = -1.0;
 pub const LIST_DROPDOWN_HEADER_H: f32 = 28.0;
+/// Default width leaves room for a readable context headline beside its state.
+pub const SIDEBAR_DEFAULT_W: f32 = 240.0;
 pub const LIST_DROPDOWN_CHEVRON_W: f32 = 24.0;
 pub const TABLE_HEADER_H: f32 = 28.0;
 

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -80,7 +80,7 @@ pub const LIST_ROW_GAP: f32 = 8.0;
 pub const LIST_CHIP_TEXT_OFFSET_Y: f32 = -1.0;
 pub const LIST_DROPDOWN_HEADER_H: f32 = 28.0;
 /// Default width leaves room for a readable context headline beside its state.
-pub const SIDEBAR_DEFAULT_W: f32 = 240.0;
+pub const SIDEBAR_DEFAULT_W: f32 = 220.0;
 pub const LIST_DROPDOWN_CHEVRON_W: f32 = 24.0;
 pub const TABLE_HEADER_H: f32 = 28.0;
 

--- a/src/ui/style.rs
+++ b/src/ui/style.rs
@@ -37,7 +37,7 @@ pub const SPACE_XL: f32 = 24.0;
 pub const TEXT_HINT: f32 = 11.0; // Keyboard hints, meta labels.
 pub const TEXT_CAPTION: f32 = 12.0; // Secondary info, small labels.
 pub const TEXT_META: f32 = 10.0; // Compact badges and sidebar metadata.
-pub const TEXT_SIDEBAR_TITLE: f32 = 13.0; // Sidebar context row titles.
+pub const TEXT_SIDEBAR_TITLE: f32 = 14.0; // Sidebar context row titles.
 pub const TEXT_BODY: f32 = 14.0; // Default body text, button labels.
 pub const TEXT_TITLE: f32 = 16.0; // Modal/section titles — pair with
                                   // `theme::font_medium` for weight contrast.

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -3212,12 +3212,12 @@ mod tests {
         render_sidebar_pane_dots_pixel_grid(2.0, "/tmp/plexi-0564-sidebar-pips-ppp2.png");
     }
 
-    /// Stint 0700: the Contexts header keeps both close-affordance candidates
-    /// live for visual review. This exercises the real header response, then
-    /// renders realistic names, root paths, pane pips, and notification badges
-    /// in each candidate state.
+    /// Stint 0700: the Contexts header keeps both sidebar-width candidates live
+    /// for visual review. This exercises the real header response, then renders
+    /// realistic names, root paths, pane pips, and notification badges at both
+    /// widths.
     #[test]
-    fn screenshot_sidebar_close_affordance_previews_are_live_switchable() {
+    fn screenshot_sidebar_width_previews_are_live_switchable() {
         let mut h = PlexiUiHarness::new_sized(1100.0, 700.0);
         h.step();
         let inactive_window_idx = h.with_app_mut(|app| {
@@ -3249,7 +3249,7 @@ mod tests {
             app.windows.push(crate::host::context::Window {
                 name: String::new(),
                 path: inactive_root,
-                tree: egui_tiles::Tree::empty("sidebar-close-affordance-preview"),
+                tree: egui_tiles::Tree::empty("sidebar-width-preview"),
                 panes: std::collections::HashMap::new(),
                 focused_pane: None,
                 zoomed_pane: None,
@@ -3297,21 +3297,20 @@ mod tests {
         add_focused_pane_to_window(&mut h, inactive_window_idx);
         h.run_steps(3);
 
-        // The default preview puts the close control after the count. Hover a
-        // sidebar row so the hand-painted close glyph is visible in the PNG.
+        // Hover a sidebar row so the trailing close glyph is visible in the PNG.
         let active_title = h.harness().get_by_label("PLEXI Workspace").rect().center();
         h.harness()
             .input_mut()
             .events
             .push(egui::Event::PointerMoved(active_title));
         h.step();
-        h.harness().get_by_label("X: end");
-        h.save_screenshot("/tmp/plexi-0700-sidebar-trailing-delete.png")
-            .expect("trailing close-affordance render");
+        h.harness().get_by_label("Width: 220");
+        h.save_screenshot("/tmp/plexi-0700-sidebar-x-end.png")
+            .expect("220-point sidebar render");
 
         // Use the actual header widget's semantic rect rather than a guessed
-        // coordinate, then assert the re-rendered UI exposes the other state.
-        let toggle = h.harness().get_by_label("X: end").rect().center();
+        // coordinate, then assert the re-rendered UI exposes the narrow state.
+        let toggle = h.harness().get_by_label("Width: 220").rect().center();
         h.harness()
             .input_mut()
             .events
@@ -3335,10 +3334,10 @@ mod tests {
                 modifiers: egui::Modifiers::NONE,
             });
         h.run_steps(2);
-        h.harness().get_by_label("X: inline");
+        h.harness().get_by_label("Width: 200");
         assert!(
-            !h.host_has_label("X: end"),
-            "clicking the real header toggle must replace the preview state"
+            !h.host_has_label("Width: 220"),
+            "clicking the real header toggle must replace the width preview"
         );
 
         let active_title = h.harness().get_by_label("PLEXI Workspace").rect().center();
@@ -3347,8 +3346,8 @@ mod tests {
             .events
             .push(egui::Event::PointerMoved(active_title));
         h.step();
-        h.save_screenshot("/tmp/plexi-0700-sidebar-inline-delete.png")
-            .expect("inline close-affordance render");
+        h.save_screenshot("/tmp/plexi-0700-sidebar-narrow.png")
+            .expect("200-point sidebar render");
     }
 
     /// Stint 0528 evidence: file browser rows + preview panel at ppp 2.0 —

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -3212,6 +3212,142 @@ mod tests {
         render_sidebar_pane_dots_pixel_grid(2.0, "/tmp/plexi-0564-sidebar-pips-ppp2.png");
     }
 
+    /// Stint 0700: the Contexts header keeps both close-affordance candidates
+    /// live for visual review. This exercises the real header response, then
+    /// renders realistic names, root paths, pane pips, and notification badges
+    /// in each candidate state.
+    #[test]
+    fn screenshot_sidebar_close_affordance_previews_are_live_switchable() {
+        let mut h = PlexiUiHarness::new_sized(1100.0, 700.0);
+        h.step();
+        let inactive_window_idx = h.with_app_mut(|app| {
+            app.sidebar_visible = true;
+            let active_context_idx = app.router.active_idx();
+            let active_context_id = app.router.get(active_context_idx).context_id;
+            let active_window_id = app.windows[app.active_window].window_id;
+            app.router.get_mut(active_context_idx).name = "PLEXI Workspace".to_string();
+            app.router.get_mut(active_context_idx).root =
+                std::path::PathBuf::from("/projects/PLEXI");
+
+            let inactive_context_id = app.next_window_id;
+            app.next_window_id += 1;
+            let inactive_root = std::path::PathBuf::from("/projects/narrator-site");
+            app.router.push(crate::host::context::Context {
+                name: "Narrator Site".to_string(),
+                root: inactive_root.clone(),
+                description: None,
+                context_id: inactive_context_id,
+                parent_id: None,
+                depth: 0,
+                parked: false,
+            });
+            let inactive_window_id = app.next_window_id;
+            app.next_window_id += 1;
+            app.windows.push(crate::host::context::Window {
+                name: String::new(),
+                path: inactive_root,
+                tree: egui_tiles::Tree::empty("sidebar-close-affordance-preview"),
+                panes: std::collections::HashMap::new(),
+                focused_pane: None,
+                zoomed_pane: None,
+                grid_x: 0,
+                grid_y: 0,
+                window_id: inactive_window_id,
+                context_id: inactive_context_id,
+            });
+
+            let notification = |notify_id: &str, source_context_id, source_window_id| {
+                crate::app::PendingNotification {
+                    notify_id: notify_id.to_string(),
+                    sender_pane_id: 0,
+                    source_context_id,
+                    source_window_id,
+                    level: "info".to_string(),
+                    title: "Preview badge".to_string(),
+                    body: "Seeded sidebar notification".to_string(),
+                    kind: crate::app_protocol::NotifyKind::Message,
+                    options: vec![],
+                    input_prompt: None,
+                    required: false,
+                    priority: 0,
+                    scope: crate::app_protocol::NotifyScope::Context,
+                    image_inline: None,
+                    image_pipe_id: None,
+                    response_file: None,
+                    timeout_secs: None,
+                    on_dismiss: None,
+                    enqueued_at: std::time::Instant::now(),
+                    tombstoned: false,
+                    deliver_after: None,
+                }
+            };
+            app.pending_notifications.extend([
+                notification("active-one", active_context_id, active_window_id),
+                notification("active-two", active_context_id, active_window_id),
+                notification("active-three", active_context_id, active_window_id),
+                notification("inactive-one", inactive_context_id, inactive_window_id),
+                notification("inactive-two", inactive_context_id, inactive_window_id),
+            ]);
+            app.windows.len() - 1
+        });
+        add_focused_pane(&mut h);
+        add_focused_pane_to_window(&mut h, inactive_window_idx);
+        h.run_steps(3);
+
+        // The default preview puts the close control after the count. Hover a
+        // sidebar row so the hand-painted close glyph is visible in the PNG.
+        let active_title = h.harness().get_by_label("PLEXI Workspace").rect().center();
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::PointerMoved(active_title));
+        h.step();
+        h.harness().get_by_label("X: end");
+        h.save_screenshot("/tmp/plexi-0700-sidebar-trailing-delete.png")
+            .expect("trailing close-affordance render");
+
+        // Use the actual header widget's semantic rect rather than a guessed
+        // coordinate, then assert the re-rendered UI exposes the other state.
+        let toggle = h.harness().get_by_label("X: end").rect().center();
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::PointerMoved(toggle));
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::PointerButton {
+                pos: toggle,
+                button: egui::PointerButton::Primary,
+                pressed: true,
+                modifiers: egui::Modifiers::NONE,
+            });
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::PointerButton {
+                pos: toggle,
+                button: egui::PointerButton::Primary,
+                pressed: false,
+                modifiers: egui::Modifiers::NONE,
+            });
+        h.run_steps(2);
+        h.harness().get_by_label("X: inline");
+        assert!(
+            !h.host_has_label("X: end"),
+            "clicking the real header toggle must replace the preview state"
+        );
+
+        let active_title = h.harness().get_by_label("PLEXI Workspace").rect().center();
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::PointerMoved(active_title));
+        h.step();
+        h.save_screenshot("/tmp/plexi-0700-sidebar-inline-delete.png")
+            .expect("inline close-affordance render");
+    }
+
     /// Stint 0528 evidence: file browser rows + preview panel at ppp 2.0 —
     /// integer point sizes only (was 9.5/10.5).
     #[test]

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -3233,7 +3233,10 @@ mod tests {
             app.next_window_id += 1;
             let inactive_root = std::path::PathBuf::from("/projects/narrator-site");
             app.router.push(crate::host::context::Context {
-                name: "Narrator Site".to_string(),
+                // Deliberately longer than a normal workspace title: the
+                // screenshot must exercise truncation without making the
+                // ordinary active title a false-positive fixture.
+                name: "Narrator Video Production Workspace".to_string(),
                 root: inactive_root.clone(),
                 description: None,
                 context_id: inactive_context_id,

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -3212,12 +3212,11 @@ mod tests {
         render_sidebar_pane_dots_pixel_grid(2.0, "/tmp/plexi-0564-sidebar-pips-ppp2.png");
     }
 
-    /// Stint 0700: the Contexts header keeps both sidebar-width candidates live
-    /// for visual review. This exercises the real header response, then renders
-    /// realistic names, root paths, pane pips, and notification badges at both
-    /// widths.
+    /// Stint 0700: the 220-point sidebar shows an ordinary context name in full
+    /// while a genuinely long name ellipsizes. The hover makes the sole trailing
+    /// close affordance visible in the evidence image.
     #[test]
-    fn screenshot_sidebar_width_previews_are_live_switchable() {
+    fn screenshot_sidebar_x_end_at_default_width() {
         let mut h = PlexiUiHarness::new_sized(1100.0, 700.0);
         h.step();
         let inactive_window_idx = h.with_app_mut(|app| {
@@ -3249,7 +3248,7 @@ mod tests {
             app.windows.push(crate::host::context::Window {
                 name: String::new(),
                 path: inactive_root,
-                tree: egui_tiles::Tree::empty("sidebar-width-preview"),
+                tree: egui_tiles::Tree::empty("sidebar-x-end-preview"),
                 panes: std::collections::HashMap::new(),
                 focused_pane: None,
                 zoomed_pane: None,
@@ -3300,54 +3299,14 @@ mod tests {
         // Hover a sidebar row so the trailing close glyph is visible in the PNG.
         let active_title = h.harness().get_by_label("PLEXI Workspace").rect().center();
         h.harness()
+            .get_by_label("Narrator Video Production Workspace");
+        h.harness()
             .input_mut()
             .events
             .push(egui::Event::PointerMoved(active_title));
         h.step();
-        h.harness().get_by_label("Width: 220");
         h.save_screenshot("/tmp/plexi-0700-sidebar-x-end.png")
             .expect("220-point sidebar render");
-
-        // Use the actual header widget's semantic rect rather than a guessed
-        // coordinate, then assert the re-rendered UI exposes the narrow state.
-        let toggle = h.harness().get_by_label("Width: 220").rect().center();
-        h.harness()
-            .input_mut()
-            .events
-            .push(egui::Event::PointerMoved(toggle));
-        h.harness()
-            .input_mut()
-            .events
-            .push(egui::Event::PointerButton {
-                pos: toggle,
-                button: egui::PointerButton::Primary,
-                pressed: true,
-                modifiers: egui::Modifiers::NONE,
-            });
-        h.harness()
-            .input_mut()
-            .events
-            .push(egui::Event::PointerButton {
-                pos: toggle,
-                button: egui::PointerButton::Primary,
-                pressed: false,
-                modifiers: egui::Modifiers::NONE,
-            });
-        h.run_steps(2);
-        h.harness().get_by_label("Width: 200");
-        assert!(
-            !h.host_has_label("Width: 220"),
-            "clicking the real header toggle must replace the width preview"
-        );
-
-        let active_title = h.harness().get_by_label("PLEXI Workspace").rect().center();
-        h.harness()
-            .input_mut()
-            .events
-            .push(egui::Event::PointerMoved(active_title));
-        h.step();
-        h.save_screenshot("/tmp/plexi-0700-sidebar-narrow.png")
-            .expect("200-point sidebar render");
     }
 
     /// Stint 0528 evidence: file browser rows + preview panel at ppp 2.0 —


### PR DESCRIPTION
## Summary

Implements stint 0700. No linked GitHub issue; stint is authoritative.

- Aligns the context number with its headline, pins notification counts to the trailing edge, and raises only the headline token to 14 px.
- Ships the close affordance as `X: end`: the X follows the notification count on the active row. The inline candidate and its toggle are deleted.
- Restores the default sidebar width to 220 points. The row finds headline room internally by tightening the number gutter, one-digit count reserve, X hit target, and title-to-pips gap. `PLEXI Workspace` fits at 220; the deliberately long fixture ellipsizes.
- Sidebar text size is not configurable today. The existing terminal font size and pane-title font size do not control sidebar rows; this stint deliberately adds no config key.

## Done When

- Context number aligns with the headline.
- Notification count is trailing-aligned without overlap.
- Headline is larger while subtitle/body text remains unchanged.
- `X: end` is the sole shipped close affordance.

**Test evidence:**

- `env -u PLEXI_SOCKET cargo test --bin plexi screenshot_sidebar_x_end_at_default_width -- --nocapture`: passed.
- Re-rendered current-state evidence: `.stint/evidence/0700-sidebar-x-end.png`. The fixture includes `PLEXI Workspace` and `Narrator Video Production Workspace`.
