### PR TITLE
File-backed app state + `plexi app state get/set` (stints 0644, 0645)

### DIFF
--- a/sdk/protocol/pgap.schema.json
+++ b/sdk/protocol/pgap.schema.json
@@ -4226,6 +4226,36 @@
           "type": "object"
         },
         {
+          "description": "A state scope's backing file changed outside the app's own persist\nflow — an external edit, or a persist the app lost to a concurrent\nexternal write (disk wins; the dropped persist is answered with this\nevent). `payload` is the scope's full on-disk value set; the SDK\nreplaces the scope wholesale (deleted keys vanish — never a merge).\n`error` is set when the file exists but could not be decoded; the\nprevious values are kept in that case and persists to the scope are\nblocked until a successful re-read.",
+          "properties": {
+            "error": {
+              "default": null,
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "payload": true,
+            "scope": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "type": {
+              "const": "state_changed",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "scope",
+            "payload",
+            "source"
+          ],
+          "type": "object"
+        },
+        {
           "description": "DEPRECATED: superseded by the `state` field on Init.\nKept for backwards compatibility with older SDK versions. The headless\nrenderer no longer sends this event.",
           "properties": {
             "payload": true,

--- a/sdk/python/AUTHORING.md
+++ b/sdk/python/AUTHORING.md
@@ -381,13 +381,35 @@ scopes = ["global", "context"]
 ```
 
 Omitting `[state]` gives `["global"]`. The host owns path construction:
-`global` state lives in `~/.plexi/app_states/<app_id>.json` (channel-neutral,
+`global` state lives in `~/.plexi/app_states/<app_id>.<ext>` (channel-neutral,
 cross-project), `context` state in `<context_root>/.plexi/app_states/`,
 resolved against the pane's context root at call time — so
 `plexi context set-root` immediately redirects where context-scoped state
 lands. Context-scoped state is gitignored by the host (`.plexi/.gitignore`
 gains `app_states/` automatically): app state is personal, single-user, local
 data — never committed. An unknown or empty scope list fails install loudly.
+
+`[state] format` selects the on-disk shape: `"json"` (default, `.json`
+extension) or `"markdown"` (`.md`). Markdown keeps the host format-blind:
+your state must carry the whole document as a string under the single key
+`document` — `PersistState({"document": text})` writes those bytes verbatim
+(a non-string `document` is a loud error and nothing is written), and reads
+arrive back as `{"document": "<file text>"}`. For checklist documents use
+the blessed codec in `plexi_sdk.state_format` (`ChecklistItem`,
+`parse_checklist`, `render_checklist`): tolerant reader, canonical writer.
+An unknown format fails install loudly.
+
+State files are shared with the outside world — the CLI, agents, and editors
+write them too. The contract is **disk wins**: every write (host and CLI) is
+atomic temp+rename, and the host read-backs before writing — a `PersistState`
+that loses to a concurrent external write is dropped, the on-disk state is
+reloaded, and your app is told via the `events.StateChanged` event
+(re-apply your change from there; never assume a persist landed). External
+edits also arrive as `StateChanged`: the scope's values are replaced
+wholesale before `update()` runs — deleted keys vanish, never a merge — and
+`event.error` is set when the file exists but cannot be decoded (previous
+values are kept and persists to that scope are blocked until the file is
+fixed).
 
 ## Dev / Test Loop
 

--- a/sdk/python/plexi_sdk/__init__.py
+++ b/sdk/python/plexi_sdk/__init__.py
@@ -42,3 +42,8 @@ from .ui import (
     TextEdit as TextEdit,
 )
 from ._theme import theme, Theme, AppPalette
+from .state_format import (
+    ChecklistItem as ChecklistItem,
+    parse_checklist as parse_checklist,
+    render_checklist as render_checklist,
+)

--- a/sdk/python/plexi_sdk/_v3_runtime.py
+++ b/sdk/python/plexi_sdk/_v3_runtime.py
@@ -233,6 +233,37 @@ class V3AppRuntime:
             if isinstance(payload, dict):
                 self._default_values().update(payload)
                 self._set_state(in_view=False)
+        elif t == "state_changed":
+            self._handle_state_changed(ev)
+
+    def _handle_state_changed(self, ev: dict) -> None:
+        """A scope's backing file changed outside our own persist flow.
+
+        Replaces the scope's values WHOLESALE (deleted keys must vanish —
+        never a merge), then dispatches ``events.StateChanged`` through the
+        normal update path so ``update()`` runs against the fresh snapshot
+        and a render is scheduled. On a decode error the host kept the
+        previous values, so we keep ours too and only surface the error.
+        """
+        scope = ev.get("scope") or self._scopes[0]
+        if scope not in self._scoped_values:
+            _host_log(
+                "error",
+                f"state_changed for undeclared scope '{scope}' ignored "
+                f"(declared: {self._scopes})",
+            )
+            return
+        payload = ev.get("payload")
+        error = ev.get("error")
+        values = dict(payload) if isinstance(payload, dict) else {}
+        if error is None:
+            self._scoped_values[scope] = values
+        self._dispatch(events.StateChanged(
+            scope=scope,
+            values=dict(self._scoped_values[scope]),
+            source=str(ev.get("source", "external")),
+            error=error,
+        ))
 
     def _handle_init(self, ev: dict) -> None:
         self._app_id = ev.get("app_id", "")

--- a/sdk/python/plexi_sdk/effects.py
+++ b/sdk/python/plexi_sdk/effects.py
@@ -20,7 +20,14 @@ class PersistState:
     to disk. The host owns path construction: ``global`` state lives in
     ``~/.plexi/app_states/``, ``context`` state in
     ``<context_root>/.plexi/app_states/`` — resolved against the pane's
-    context root at call time. ``scope=None`` targets the default scope."""
+    context root at call time. ``scope=None`` targets the default scope.
+
+    Read-back rule (disk wins): the host checks the file before writing. A
+    persist that loses to a concurrent external write is dropped — the host
+    reloads the on-disk state instead and answers with an
+    ``events.StateChanged``, so re-apply your change from that event rather
+    than assuming the persist landed. Writes are atomic (temp + rename) in
+    both directions; a reader never sees a partial file."""
     data: dict
     scope: str | None = None
 

--- a/sdk/python/plexi_sdk/events.py
+++ b/sdk/python/plexi_sdk/events.py
@@ -256,6 +256,26 @@ class PipeError:
 
 
 @dataclass
+class StateChanged:
+    """A state scope's backing file changed outside this app's own persist
+    flow — an external edit (CLI, agent, editor), or a persist this app lost
+    to a concurrent external write (disk wins: the dropped persist is
+    answered with this event).
+
+    ``values`` is the scope's full value set after the change; the runtime
+    has already replaced the scope wholesale (deleted keys are gone — never a
+    merge) before dispatching this event, so ``state.get`` reads are fresh
+    inside ``update()``. When ``error`` is set the file could not be decoded:
+    the previous values are kept and persists to the scope are blocked until
+    a successful re-read.
+    """
+    scope: str
+    values: dict
+    source: str = "external"
+    error: Optional[str] = None
+
+
+@dataclass
 class CapabilityGranted:
     name: str
 

--- a/sdk/python/plexi_sdk/state_format.py
+++ b/sdk/python/plexi_sdk/state_format.py
@@ -1,0 +1,57 @@
+"""Blessed codecs for markdown-format app state (``[state] format = "markdown"``).
+
+A markdown state file is a plain document the host round-trips verbatim under
+a single ``document`` key — humans and agents edit it directly, so the reader
+must be tolerant of what they write while the writer emits one canonical
+shape (otherwise every app save churns the user's formatting).
+
+Checklist convention:
+
+- Reader (:func:`parse_checklist`) accepts ``- [ ]`` / ``- [x]`` / ``* [x]``,
+  case-insensitive ``x``, loose whitespace; every non-matching line is
+  skipped.
+- Writer (:func:`render_checklist`) emits exactly ``- [ ] text`` /
+  ``- [x] text`` lines with a trailing newline.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+@dataclass
+class ChecklistItem:
+    text: str
+    done: bool
+
+
+# Tolerant line shape: bullet (- or *), brackets holding an optional x,
+# whitespace anywhere humans put it.
+_ITEM_RE = re.compile(r"^\s*[-*]\s*\[\s*([xX]?)\s*\]\s*(.*)$")
+
+
+def parse_checklist(text: str) -> list[ChecklistItem]:
+    """Read every checklist item out of a markdown document.
+
+    Non-matching lines (headings, prose, blanks) are skipped, not errors —
+    a checklist may live inside a larger document.
+    """
+    items: list[ChecklistItem] = []
+    for line in text.splitlines():
+        match = _ITEM_RE.match(line)
+        if match is None:
+            continue
+        items.append(
+            ChecklistItem(text=match.group(2).rstrip(), done=match.group(1) != "")
+        )
+    return items
+
+
+def render_checklist(items: list[ChecklistItem]) -> str:
+    """Write items in the canonical shape: ``- [ ] `` / ``- [x] `` per line,
+    trailing newline. An empty list renders as an empty document."""
+    if not items:
+        return ""
+    return "".join(
+        f"- [{'x' if item.done else ' '}] {item.text}\n" for item in items
+    )

--- a/sdk/python/tests/test_state_changed_event.py
+++ b/sdk/python/tests/test_state_changed_event.py
@@ -1,0 +1,105 @@
+"""`state_changed` host event handling in the v3 runtime (stint 0644).
+
+The host sends `state_changed` when a scope's backing file changed outside
+the app's own persist flow (external edit, or a persist the app lost to a
+concurrent external write). The runtime must replace the scope's values
+wholesale — deleted keys vanish, never a merge — then dispatch
+`events.StateChanged` through the normal update path so `update()` runs
+against the fresh snapshot. A decode error is surfaced on the event while
+the previous values are kept.
+"""
+
+import textwrap
+from pathlib import Path
+
+from test_state_scopes import _init_scoped
+from test_v3_runtime_regression import (
+    _collect_until,
+    _find_events,
+    _send_event,
+    _spawn_v3_app,
+)
+
+
+def _write_probe_app(tmp_path: Path) -> Path:
+    app = tmp_path / "app.py"
+    app.write_text(textwrap.dedent("""
+        import json
+
+        from plexi_sdk import state
+        from plexi_sdk.effects import SetStatus
+        from plexi_sdk.events import StateChanged
+        from plexi_sdk.ui import Text
+
+        def init(size, args):
+            return []
+
+        def update(event):
+            if isinstance(event, StateChanged):
+                return [SetStatus(
+                    "changed scope=%s source=%s error=%r a=%r b=%r values=%s" % (
+                        event.scope,
+                        event.source,
+                        event.error,
+                        state.get("a"),
+                        state.get("b"),
+                        json.dumps(event.values, sort_keys=True),
+                    )
+                )]
+            return []
+
+        def view():
+            return Text("probe")
+    """))
+    return app
+
+
+def _send_state_changed(proc, payload, error=None, scope="global"):
+    _send_event(proc, {
+        "type": "state_changed",
+        "scope": scope,
+        "payload": payload,
+        "error": error,
+        "source": "external",
+    })
+    # `_dispatch` emits effects first, then schedule_render — collecting to
+    # the render marker captures both.
+    return _collect_until(proc, "schedule_render")
+
+
+def test_state_changed_replaces_scope_and_dispatches_update(tmp_path):
+    proc = _spawn_v3_app(_write_probe_app(tmp_path))
+    try:
+        _init_scoped(proc, scopes=["global"], states={"global": {"a": 1, "b": 2}})
+
+        # External write dropped key "b" — it must vanish from state reads.
+        events = _send_state_changed(proc, {"a": 9})
+        statuses = _find_events(events, "status_summary")
+        assert len(statuses) == 1, f"update() must run exactly once, got {events}"
+        text = statuses[0]["text"]
+        assert "scope=global" in text
+        assert "source=external" in text
+        assert "error=None" in text
+        assert "a=9" in text, f"fresh value must be visible inside update(): {text}"
+        assert "b=None" in text, f"deleted key must vanish (replace, not merge): {text}"
+        assert '"b"' not in text.split("values=")[1], "event.values must not carry b"
+
+        # A render is scheduled through the normal update path.
+        assert _find_events(events, "schedule_render"), events
+    finally:
+        proc.kill()
+
+
+def test_state_changed_error_is_surfaced_and_values_kept(tmp_path):
+    proc = _spawn_v3_app(_write_probe_app(tmp_path))
+    try:
+        _init_scoped(proc, scopes=["global"], states={"global": {"a": 1}})
+
+        events = _send_state_changed(proc, {"a": 1}, error="parse state JSON: boom")
+        statuses = _find_events(events, "status_summary")
+        assert len(statuses) == 1
+        text = statuses[0]["text"]
+        assert "error='parse state JSON: boom'" in text
+        assert "a=1" in text, f"previous values must be kept on error: {text}"
+    finally:
+        proc.kill()

--- a/sdk/python/tests/test_state_format.py
+++ b/sdk/python/tests/test_state_format.py
@@ -1,0 +1,55 @@
+"""Blessed markdown checklist codec (stint 0644).
+
+Tolerant reader, strict canonical writer — human/agent edits parse, app
+writes converge to one shape.
+"""
+
+from plexi_sdk.state_format import ChecklistItem, parse_checklist, render_checklist
+
+
+def test_round_trip_is_stable():
+    items = [
+        ChecklistItem(text="buy milk", done=False),
+        ChecklistItem(text="ship stint 0644", done=True),
+    ]
+    rendered = render_checklist(items)
+    assert parse_checklist(rendered) == items
+    # Canonical output is a fixed point: render(parse(render(x))) == render(x).
+    assert render_checklist(parse_checklist(rendered)) == rendered
+
+
+def test_tolerant_reader_accepts_human_variants():
+    text = (
+        "# My list\n"
+        "\n"
+        "some prose that is not an item\n"
+        "- [ ] plain unchecked\n"
+        "- [x] plain checked\n"
+        "* [X] star bullet, capital X\n"
+        "  -  [ ]   indented and loosely spaced\n"
+        "- [] empty brackets count as unchecked\n"
+        "-[x] no space after bullet\n"
+    )
+    items = parse_checklist(text)
+    assert items == [
+        ChecklistItem(text="plain unchecked", done=False),
+        ChecklistItem(text="plain checked", done=True),
+        ChecklistItem(text="star bullet, capital X", done=True),
+        ChecklistItem(text="indented and loosely spaced", done=False),
+        ChecklistItem(text="empty brackets count as unchecked", done=False),
+        ChecklistItem(text="no space after bullet", done=True),
+    ]
+
+
+def test_non_matching_lines_are_skipped_not_errors():
+    assert parse_checklist("just prose\n\n## heading\n") == []
+    assert parse_checklist("") == []
+
+
+def test_canonical_writer_shape():
+    out = render_checklist(
+        [ChecklistItem(text="a", done=False), ChecklistItem(text="b", done=True)]
+    )
+    assert out == "- [ ] a\n- [x] b\n"
+    assert out.endswith("\n"), "canonical output carries a trailing newline"
+    assert render_checklist([]) == ""

--- a/skills/plexi-cli/SKILL.md
+++ b/skills/plexi-cli/SKILL.md
@@ -29,6 +29,11 @@ CLI or app SDK; do not inspect Plexi profile files directly.
   sub-contexts: `plexi context --help`.
 - **Apps** — scaffold, check, test, open, package, install, and inspect apps:
   `plexi app --help`.
+- **App state** — read or replace a file-backed app's state document, so a human
+  and an agent can drive the same app: `plexi app state --help`. Only apps that
+  declare a `[state]` section are addressable; the path is resolved from the
+  manifest and the calling context, never passed in. A running app picks the
+  write up on its own event loop.
 - **Notifications** — show scoped information to the person using the host:
   `plexi notify --help`.
 - **Workspace tools** — initialize a workspace, run named commands, and manage

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -2724,6 +2724,19 @@ impl PlexiApp {
                     "pane_ipc: kind=set_context_root root={} context_id={context_id:?}",
                     root.display()
                 );
+                // Standing ruling: every path that establishes a context root
+                // ensures app_states/ is gitignored there (personal local
+                // data, never committed). Non-fatal; guarded so a bad root
+                // never gains directories as a side effect.
+                if root.is_dir() {
+                    if let Err(error) = crate::workspace::secrets::ensure_app_state_gitignore(root)
+                    {
+                        log::warn!(
+                            "could not ensure {}/.plexi/.gitignore covers app_states/: {error}",
+                            root.display()
+                        );
+                    }
+                }
                 self.set_context_root(root.clone(), *context_id);
                 self.save_workspace();
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -348,6 +348,13 @@ pub struct PlexiApp {
     /// existing `AppPane` envelope.
     pub(crate) hot_reload: crate::host::hot_reload::HotReloadWatcher,
     pub(crate) hot_reload_rx: ui_mailbox::MailboxReceiver<crate::host::hot_reload::ReloadRequest>,
+    /// App state file watcher (stint 0644). Watches each file-backed app
+    /// pane's state files for external writes; `state_watch_rx` is drained
+    /// each `logic` pass (never `ui` — occluded-window trap) and each notice
+    /// triggers `apply_external_state` on the matching pane.
+    pub(crate) state_watch: crate::host::state_watch::StateWatcher,
+    pub(crate) state_watch_rx:
+        ui_mailbox::MailboxReceiver<crate::host::state_watch::StateChangedNotice>,
     /// Config file watcher (#1115). Watches `config.toml` for saves and fires
     /// a signal so `reload_config()` runs automatically.
     pub(crate) _config_watcher: Option<crate::config::watcher::ConfigWatcher>,
@@ -1033,6 +1040,13 @@ impl PlexiApp {
         let (hr_watcher2, hr_rx2) =
             crate::host::hot_reload::HotReloadWatcher::new(std::sync::Arc::clone(&ui_wake));
 
+        // App state file watcher (stint 0644). Same two-branch shadow-name
+        // pattern as hot_reload above.
+        let (sw_watcher, sw_rx) =
+            crate::host::state_watch::StateWatcher::new(std::sync::Arc::clone(&ui_wake));
+        let (sw_watcher2, sw_rx2) =
+            crate::host::state_watch::StateWatcher::new(std::sync::Arc::clone(&ui_wake));
+
         // Config file watcher (#1115). Watches config.toml for saves so the
         // host can hot-reload theme/font/notification settings automatically.
         let (mut cfg_watcher, mut cfg_reload_rx) = match crate::config::watcher::start(
@@ -1450,6 +1464,8 @@ impl PlexiApp {
                     directed_pipes: HashMap::new(),
                     hot_reload: hr_watcher,
                     hot_reload_rx: hr_rx,
+                    state_watch: sw_watcher,
+                    state_watch_rx: sw_rx,
                     _config_watcher: cfg_watcher.take(),
                     config_reload_rx: cfg_reload_rx.take(),
                     _registry_watcher: reg_watcher.take(),
@@ -1594,6 +1610,19 @@ impl PlexiApp {
             };
 
         let agent_host = crate::agent::AgentHost::production(config.ai.clone());
+        // Standing ruling: a context root must gitignore its app_states dir
+        // (personal local data, never committed). Guarded so constructing a
+        // Context never creates directories as a side effect.
+        if default_root.is_dir() {
+            if let Err(error) =
+                crate::workspace::secrets::ensure_app_state_gitignore(&default_root)
+            {
+                log::warn!(
+                    "could not ensure {}/.plexi/.gitignore covers app_states/: {error}",
+                    default_root.display()
+                );
+            }
+        }
         let mut app = Self {
             pty_event_rx: rx,
             pty_event_tx: tx,
@@ -1713,6 +1742,8 @@ impl PlexiApp {
             directed_pipes: HashMap::new(),
             hot_reload: hr_watcher2,
             hot_reload_rx: hr_rx2,
+            state_watch: sw_watcher2,
+            state_watch_rx: sw_rx2,
             _config_watcher: cfg_watcher.take(),
             config_reload_rx: cfg_reload_rx.take(),
             _registry_watcher: default_reg_watcher.take(),
@@ -2025,9 +2056,20 @@ impl PlexiApp {
         let (tx, rx) = mpsc::channel();
         let (hr_watcher, hr_rx) =
             crate::host::hot_reload::HotReloadWatcher::new(std::sync::Arc::clone(&ui_wake));
+        let (sw_watcher, sw_rx) =
+            crate::host::state_watch::StateWatcher::new(std::sync::Arc::clone(&ui_wake));
         let path =
             std::env::temp_dir().join(format!("plexi-test-workspace-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&path).expect("create isolated test workspace");
+        // Standing ruling: a context root must gitignore its app_states dir.
+        if path.is_dir() {
+            if let Err(error) = crate::workspace::secrets::ensure_app_state_gitignore(&path) {
+                log::warn!(
+                    "could not ensure {}/.plexi/.gitignore covers app_states/: {error}",
+                    path.display()
+                );
+            }
+        }
         let features = crate::features::FeatureFlags::from_config(&config);
         let (pane_ipc_tx, pane_ipc_rx) =
             ui_mailbox::UiMailbox::<crate::app_protocol::AppRequest>::channel(
@@ -2170,6 +2212,8 @@ impl PlexiApp {
                 directed_pipes: HashMap::new(),
                 hot_reload: hr_watcher,
                 hot_reload_rx: hr_rx,
+                state_watch: sw_watcher,
+                state_watch_rx: sw_rx,
                 _config_watcher: None,
                 config_reload_rx: None,
                 _registry_watcher: None,
@@ -3396,6 +3440,12 @@ impl eframe::App for PlexiApp {
         // dropped (sending Shutdown + reaping the child) and replaced with
         // a fresh subprocess. Idempotent if the pane was closed since.
         self.drain_hot_reload_requests();
+
+        // App state files (stint 0644): drain external-change notices and
+        // re-read the affected scope on the matching pane. Lives in `logic`,
+        // never `ui` — external CLI/agent edits must land even when the host
+        // window is hidden or occluded.
+        self.drain_state_change_requests();
 
         // Crash-resilient dev reload (#1055): auto-restart watched panes that
         // have crashed, after a 2s delay so the developer can read the traceback.

--- a/src/app/registry.rs
+++ b/src/app/registry.rs
@@ -88,6 +88,11 @@ pub struct StateSection {
     /// Required within the section: a present-but-empty `[state]` table is a
     /// manifest error, not a default.
     pub scopes: Vec<String>,
+    /// Optional `[state] format` — `"json"` (default) or `"markdown"`.
+    /// Validated at install and launch via [`AppManifest::state_format`];
+    /// an unknown value fails loudly.
+    #[serde(default)]
+    pub format: Option<String>,
 }
 
 impl AppManifest {
@@ -97,6 +102,16 @@ impl AppManifest {
         match &self.state {
             Some(section) => crate::host::state_scope::parse_scopes(&section.scopes),
             None => Ok(crate::host::state_scope::default_scopes()),
+        }
+    }
+
+    /// The validated `[state] format`. Omitted → JSON. An unknown value is a
+    /// loud install/launch error, never a silent fallback to JSON.
+    pub fn state_format(&self) -> Result<crate::host::state_scope::StateFormat, String> {
+        match self.state.as_ref().and_then(|s| s.format.as_deref()) {
+            Some(raw) => crate::host::state_scope::StateFormat::parse(raw)
+                .map_err(|error| format!("manifest [state] format: {error}")),
+            None => Ok(crate::host::state_scope::StateFormat::default()),
         }
     }
 }
@@ -456,6 +471,16 @@ pub struct InstalledApp {
     /// For `LocalApp`/`LocalAgent` entries: the workspace root they belong to.
     /// `None` for global entries.
     pub workspace_root: Option<PathBuf>,
+    /// Validated `[state] scopes` from the manifest, ordered; the first entry
+    /// is the app's default scope. The default scope list when `[state]` is
+    /// omitted.
+    pub state_scopes: Vec<crate::host::state_scope::StateScope>,
+    /// Validated `[state] format` from the manifest; JSON when omitted.
+    pub state_format: crate::host::state_scope::StateFormat,
+    /// Whether the manifest declared a `[state]` section at all — lets
+    /// tooling distinguish an explicit `scopes = ["global"]` from the
+    /// implicit default.
+    pub state_declared: bool,
 }
 
 pub struct AppRegistry {
@@ -565,7 +590,7 @@ impl AppRegistry {
                 Ok(installed) => {
                     let id = installed.manifest.id.clone();
                     log::debug!(
-                        "AppRegistry: contract id={} target={:?} world={:?} python_compat={:?} min_sdk={:?} watch={:?} background={} keyboard_capture={} min_size={:?}x{:?} widths={:?}/{:?} startup={:?} secrets={}",
+                        "AppRegistry: contract id={} target={:?} world={:?} python_compat={:?} min_sdk={:?} watch={:?} background={} keyboard_capture={} min_size={:?}x{:?} widths={:?}/{:?} startup={:?} secrets={} state_scopes={:?} state_format={} state_declared={}",
                         id,
                         installed.runtime.target,
                         installed.runtime.world,
@@ -580,6 +605,9 @@ impl AppRegistry {
                         installed.launch.regular,
                         installed.launch.startup_message,
                         installed.secrets.len(),
+                        installed.state_scopes,
+                        installed.state_format.as_str(),
+                        installed.state_declared,
                     );
                     if let Some(existing) = self.apps.get(&id) {
                         if source != existing.source {
@@ -698,12 +726,14 @@ impl AppRegistry {
             }
         }
 
-        // An invalid `[state] scopes` declaration fails install loudly, same
-        // discipline as capabilities and on_launch above: a typo silently
-        // creating an unreachable scope would orphan the app's data. The
-        // launch path re-reads the manifest and re-validates in
+        // An invalid `[state]` declaration (scopes or format) fails install
+        // loudly, same discipline as capabilities and on_launch above: a typo
+        // silently creating an unreachable scope would orphan the app's data.
+        // The launch path re-reads the manifest and re-validates in
         // `PythonLaunchConfig::from_manifest_file`.
-        manifest.state_scopes()?;
+        let state_scopes = manifest.state_scopes()?;
+        let state_format = manifest.state_format()?;
+        let state_declared = manifest.state.is_some();
 
         let bin_path = resolve_entry(app_dir, &manifest.app.entry, manifest.app.manifest_type)?;
 
@@ -726,6 +756,9 @@ impl AppRegistry {
             // Placeholders — `scan_dir` overwrites both with real values.
             source: RegistrySource::Global,
             workspace_root: None,
+            state_scopes,
+            state_format,
+            state_declared,
         })
     }
 
@@ -1566,6 +1599,57 @@ entry = "run.sh"
         assert!(
             registry.get("empty-scope-app").is_none(),
             "a present-but-empty [state] scopes must refuse to install"
+        );
+    }
+
+    #[test]
+    fn installed_app_carries_declared_scopes_format_and_declared_flag() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        write_app_with_state_section(
+            global.path(),
+            "md-app",
+            "\n[state]\nscopes = [\"context\"]\nformat = \"markdown\"\n",
+        );
+        write_app_with_state_section(global.path(), "plain-app", "");
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+
+        let md = registry.get("md-app").expect("markdown app installs");
+        assert_eq!(
+            md.state_scopes,
+            vec![crate::host::state_scope::StateScope::Context]
+        );
+        assert_eq!(
+            md.state_format,
+            crate::host::state_scope::StateFormat::Markdown
+        );
+        assert!(md.state_declared, "explicit [state] must set the flag");
+
+        let plain = registry.get("plain-app").expect("plain app installs");
+        assert_eq!(
+            plain.state_scopes,
+            crate::host::state_scope::default_scopes()
+        );
+        assert_eq!(
+            plain.state_format,
+            crate::host::state_scope::StateFormat::Json
+        );
+        assert!(!plain.state_declared, "omitted [state] must clear the flag");
+    }
+
+    #[test]
+    fn manifest_with_unknown_state_format_fails_install_loudly() {
+        let global = tempfile::tempdir().unwrap();
+        let bare = tempfile::tempdir().unwrap();
+        write_app_with_state_section(
+            global.path(),
+            "typo-format-app",
+            "\n[state]\nscopes = [\"global\"]\nformat = \"yaml\"\n",
+        );
+        let registry = AppRegistry::load_with_global(bare.path(), global.path());
+        assert!(
+            registry.get("typo-format-app").is_none(),
+            "an unknown state format must refuse to install, never silently fall back to json"
         );
     }
 

--- a/src/cli/app_check.rs
+++ b/src/cli/app_check.rs
@@ -54,6 +54,7 @@ pub(crate) fn python_launch_config_from_parts(
         // Headless one-shot renders never persist state; the default scope
         // list and an app-dir anchor are inert here.
         state_scopes: crate::host::state_scope::default_scopes(),
+        state_format: crate::host::state_scope::StateFormat::Json,
         context_root: app_dir.to_path_buf(),
     }
 }

--- a/src/cli/app_state.rs
+++ b/src/cli/app_state.rs
@@ -1,0 +1,541 @@
+//! `plexi app state get/set` — the sanctioned surface for reading and writing
+//! a file-backed app's state (stint 0645).
+//!
+//! An agent could write the state file directly once stint 0644 landed; the
+//! file is on disk. These verbs exist to make that *correct*: they resolve the
+//! app's declared state path so no caller ever hardcodes one, they validate the
+//! document in the app's declared format before it reaches disk, they write
+//! through the same atomic path the app's own writes use, and every attempt is
+//! traced. Direct file writes stay possible and stay unsupported.
+//!
+//! The commands are **disk-direct and host-independent** — no socket, no
+//! `AppRequest`. A running app picks the write up through the 0644 state
+//! watcher within one debounce window; a not-running app sees it on next load.
+//!
+//! Entitlement here is structural, not checked: there is no path argument and
+//! no `--context` flag, so the only reachable files are the calling context's
+//! own state files for an app that declared `[state]`.
+
+use crate::host::state_scope::{StateFormat, StateScope};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+/// Everything resolving an invocation produced: which file, in which format,
+/// under which scope.
+#[derive(Debug)]
+struct ResolvedState {
+    path: PathBuf,
+    scope: StateScope,
+    format: StateFormat,
+    context_root: PathBuf,
+}
+
+/// Who is driving. Only used for the log line — a caller that exports neither
+/// pane nor context identity is `external`, which is a normal case (a plain
+/// shell outside any pane), not an error.
+fn caller_label() -> String {
+    let pane = std::env::var("PLEXI_PANE_ID")
+        .ok()
+        .filter(|v| !v.is_empty());
+    let context = std::env::var("PLEXI_CONTEXT_ID")
+        .ok()
+        .filter(|v| !v.is_empty());
+    match (pane, context) {
+        (Some(pane), Some(context)) => format!("pane={pane} context={context}"),
+        (Some(pane), None) => format!("pane={pane}"),
+        (None, Some(context)) => format!("context={context}"),
+        (None, None) => "external".to_string(),
+    }
+}
+
+/// The context root this invocation addresses. Mirrors `notes::cli_context_root`
+/// — `PLEXI_CONTEXT_ROOT` when a pane exports it, else the active workspace
+/// root. A root that does not exist is an error rather than something to
+/// create: creating it would silently manufacture a context the user never
+/// established.
+fn cli_context_root() -> Result<PathBuf, String> {
+    let root = match std::env::var_os("PLEXI_CONTEXT_ROOT").filter(|v| !v.is_empty()) {
+        Some(root) => PathBuf::from(root),
+        None => crate::config::active_workspace_root()
+            .ok_or_else(|| "no context root — this shell is not inside a Plexi context and no active workspace root is set".to_string())?,
+    };
+    if !root.is_dir() {
+        return Err(format!(
+            "context root {} does not exist — refusing to create it",
+            root.display()
+        ));
+    }
+    Ok(root)
+}
+
+/// Resolve `app_id` + an optional `--scope` to a concrete state file.
+///
+/// Rejects, each with a named reason: an unknown app, an app that declared no
+/// `[state]` section, a scope the app did not declare, an app id that is not a
+/// safe file stem, and a resolved path whose parent is not really the scope's
+/// state directory (a symlinked `.plexi/` or `app_states/`).
+fn resolve(
+    app_id: &str,
+    scope_raw: Option<&str>,
+    registry: &crate::app::registry::AppRegistry,
+) -> Result<ResolvedState, String> {
+    let installed = registry.get(app_id).ok_or_else(|| {
+        format!("app '{app_id}' not found — run `plexi app list` to see installed apps")
+    })?;
+    if !installed.state_declared {
+        return Err(format!(
+            "app '{app_id}' declares no [state] section — it has no file-backed state to address"
+        ));
+    }
+    let declared = &installed.state_scopes;
+    let scope = match scope_raw {
+        Some(raw) => {
+            let requested = StateScope::parse(raw)?;
+            if !declared.contains(&requested) {
+                return Err(format!(
+                    "app '{app_id}' does not declare the '{}' scope — it declares: {}",
+                    requested.as_str(),
+                    declared
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            requested
+        }
+        // No flag reaches us as absent (src/cli/AGENTS.md) — the default is the
+        // app's own first declared scope, never a CLI-side constant.
+        None => *declared
+            .first()
+            .ok_or_else(|| format!("app '{app_id}' declares an empty scope list"))?,
+    };
+    let format = installed.state_format;
+    let context_root = match scope {
+        StateScope::Context => cli_context_root()?,
+        StateScope::Global => PathBuf::new(),
+    };
+    let path = crate::host::state_scope::state_file(scope, app_id, format, &context_root)?;
+    crate::host::state_scope::assert_within_scope(&path, scope, &context_root)?;
+    Ok(ResolvedState {
+        path,
+        scope,
+        format,
+        context_root,
+    })
+}
+
+/// The document an app with no state file yet should read as. A missing file is
+/// first launch, not an error — the same rule the host's loader follows.
+fn empty_document(format: StateFormat) -> &'static str {
+    match format {
+        StateFormat::Json => "{}\n",
+        StateFormat::Markdown => "",
+    }
+}
+
+/// `plexi app state get <app> [--scope ...]`
+pub fn get(app_id: &str, scope: Option<&str>) -> i32 {
+    let registry =
+        crate::app::registry::AppRegistry::load(&std::env::current_dir().unwrap_or_default());
+    let resolved = match resolve(app_id, scope, &registry) {
+        Ok(resolved) => resolved,
+        Err(error) => {
+            log::info!(
+                "app_state: get app={app_id} caller={} rejected — {error}",
+                caller_label()
+            );
+            eprintln!("error: {error}");
+            return 1;
+        }
+    };
+    match std::fs::read(&resolved.path) {
+        Ok(bytes) => {
+            // Read-back proves the file is decodable in the declared format;
+            // a corrupted file is surfaced, never printed as if it were state.
+            if let Err(error) = crate::host::wasm_python::decode_state_file(&bytes, resolved.format)
+            {
+                log::info!(
+                    "app_state: get app={app_id} scope={} caller={} path={} rejected — {error}",
+                    resolved.scope.as_str(),
+                    caller_label(),
+                    resolved.path.display()
+                );
+                eprintln!(
+                    "error: state file {} is not valid {}: {error}",
+                    resolved.path.display(),
+                    resolved.format.as_str()
+                );
+                return 1;
+            }
+            log::info!(
+                "app_state: get app={app_id} scope={} format={} caller={} path={} accepted bytes={}",
+                resolved.scope.as_str(),
+                resolved.format.as_str(),
+                caller_label(),
+                resolved.path.display(),
+                bytes.len()
+            );
+            print!("{}", String::from_utf8_lossy(&bytes));
+            0
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            log::info!(
+                "app_state: get app={app_id} scope={} format={} caller={} path={} accepted (no file yet)",
+                resolved.scope.as_str(),
+                resolved.format.as_str(),
+                caller_label(),
+                resolved.path.display()
+            );
+            print!("{}", empty_document(resolved.format));
+            0
+        }
+        Err(error) => {
+            log::info!(
+                "app_state: get app={app_id} scope={} caller={} path={} rejected — read failed: {error}",
+                resolved.scope.as_str(),
+                caller_label(),
+                resolved.path.display()
+            );
+            eprintln!("error: read {}: {error}", resolved.path.display());
+            1
+        }
+    }
+}
+
+/// `plexi app state set <app> [FILE] [--scope ...]`
+///
+/// Replaces the document wholesale. Reads `FILE` when given, else stdin. There
+/// is deliberately no partial/merge update — get/set proves the capability, and
+/// the right merge semantics are clearer once something real is using it.
+pub fn set(app_id: &str, file: Option<&Path>, scope: Option<&str>) -> i32 {
+    let input: Box<dyn Read> = match file {
+        Some(path) => match std::fs::File::open(path) {
+            Ok(file) => Box::new(file),
+            Err(error) => {
+                eprintln!("error: open {}: {error}", path.display());
+                return 1;
+            }
+        },
+        None => Box::new(std::io::stdin()),
+    };
+    let registry =
+        crate::app::registry::AppRegistry::load(&std::env::current_dir().unwrap_or_default());
+    set_from(app_id, input, scope, &registry)
+}
+
+/// `set` with its input factored out so tests can drive it without a real stdin.
+fn set_from(
+    app_id: &str,
+    mut input: impl Read,
+    scope: Option<&str>,
+    registry: &crate::app::registry::AppRegistry,
+) -> i32 {
+    let resolved = match resolve(app_id, scope, registry) {
+        Ok(resolved) => resolved,
+        Err(error) => {
+            log::info!(
+                "app_state: set app={app_id} caller={} rejected — {error}",
+                caller_label()
+            );
+            eprintln!("error: {error}");
+            return 1;
+        }
+    };
+    let mut bytes = Vec::new();
+    if let Err(error) = input.read_to_end(&mut bytes) {
+        log::info!(
+            "app_state: set app={app_id} scope={} caller={} rejected — read input: {error}",
+            resolved.scope.as_str(),
+            caller_label()
+        );
+        eprintln!("error: read input: {error}");
+        return 1;
+    }
+    // Validate before writing: a rejected document must never reach disk, or
+    // the app wakes to a corrupt file it did not cause.
+    if let Err(error) = crate::host::wasm_python::decode_state_file(&bytes, resolved.format) {
+        log::info!(
+            "app_state: set app={app_id} scope={} format={} caller={} path={} rejected — {error}",
+            resolved.scope.as_str(),
+            resolved.format.as_str(),
+            caller_label(),
+            resolved.path.display()
+        );
+        eprintln!(
+            "error: input is not valid {} state: {error}",
+            resolved.format.as_str()
+        );
+        return 1;
+    }
+    if resolved.scope == StateScope::Context {
+        // A user must never be able to accidentally commit their app state with
+        // a project — same standing ruling the host's own write path follows.
+        if let Err(error) =
+            crate::workspace::secrets::ensure_app_state_gitignore(&resolved.context_root)
+        {
+            log::warn!(
+                "app_state: could not ensure {}/.plexi/.gitignore covers app_states/: {error}",
+                resolved.context_root.display()
+            );
+        }
+    }
+    match crate::host::state_scope::atomic_write(&resolved.path, &bytes) {
+        Ok(()) => {
+            log::info!(
+                "app_state: set app={app_id} scope={} format={} caller={} path={} accepted bytes={}",
+                resolved.scope.as_str(),
+                resolved.format.as_str(),
+                caller_label(),
+                resolved.path.display(),
+                bytes.len()
+            );
+            0
+        }
+        Err(error) => {
+            log::info!(
+                "app_state: set app={app_id} scope={} caller={} path={} rejected — write failed: {error}",
+                resolved.scope.as_str(),
+                caller_label(),
+                resolved.path.display()
+            );
+            eprintln!("error: write {}: {error}", resolved.path.display());
+            1
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Install a minimal app into a staged global apps dir and return a registry
+    /// that sees it. Same hermetic seam `src/app/registry.rs`'s own tests use —
+    /// no chdir, which is process-global and would race the rest of the suite.
+    fn install_app(
+        state_section: Option<&str>,
+    ) -> (tempfile::TempDir, crate::app::registry::AppRegistry) {
+        let apps = tempdir().expect("apps dir");
+        let app_dir = apps.path().join("test.state");
+        std::fs::create_dir_all(&app_dir).expect("app dir");
+        std::fs::write(app_dir.join("run.sh"), "#!/bin/sh\nexit 0\n").expect("entry");
+        let manifest = format!(
+            "schema_version = 1\n\n[app]\nid = \"test.state\"\ntype = \"app\"\n\
+             name = \"State Test\"\nversion = \"0.0.1\"\nentry = \"run.sh\"\n{}",
+            state_section.unwrap_or("")
+        );
+        std::fs::write(app_dir.join("manifest.toml"), manifest).expect("manifest");
+        let bare = tempdir().expect("bare cwd");
+        let registry =
+            crate::app::registry::AppRegistry::load_with_global(bare.path(), apps.path());
+        (apps, registry)
+    }
+
+    /// Point the resolver at this context root for the duration of one test.
+    /// The CLI has no path argument by design, so tests steer it exactly the way
+    /// a real caller does: through the context-root environment.
+    fn with_context_root<T>(root: &Path, body: impl FnOnce() -> T) -> T {
+        let previous = std::env::var_os("PLEXI_CONTEXT_ROOT");
+        // SAFETY: every reader of this variable in-process is serialized behind
+        // `env_guard`, which each test in this module holds for its duration.
+        unsafe { std::env::set_var("PLEXI_CONTEXT_ROOT", root) };
+        let out = body();
+        match previous {
+            Some(value) => unsafe { std::env::set_var("PLEXI_CONTEXT_ROOT", value) },
+            None => unsafe { std::env::remove_var("PLEXI_CONTEXT_ROOT") },
+        }
+        out
+    }
+
+    /// Serializes the env-mutating tests in this module against each other.
+    fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    const CONTEXT_ONLY: &str = "\n[state]\nscopes = [\"context\"]\n";
+
+    #[test]
+    fn set_writes_the_document_to_the_apps_declared_state_file() {
+        let _guard = env_guard();
+        let (_apps, registry) = install_app(Some(CONTEXT_ONLY));
+        let root = tempdir().expect("context root");
+        with_context_root(root.path(), || {
+            assert_eq!(
+                set_from(
+                    "test.state",
+                    &br#"{"items":["buy milk"]}"#[..],
+                    None,
+                    &registry
+                ),
+                0,
+                "a valid document must be accepted"
+            );
+        });
+        let written =
+            std::fs::read_to_string(root.path().join(".plexi/app_states/test.state.json"))
+                .expect("state file written");
+        assert!(written.contains("buy milk"));
+    }
+
+    #[test]
+    fn an_app_without_a_state_section_is_not_addressable() {
+        let _guard = env_guard();
+        let (_apps, registry) = install_app(None);
+        let root = tempdir().expect("context root");
+        with_context_root(root.path(), || {
+            assert_eq!(
+                set_from("test.state", &b"{}"[..], None, &registry),
+                1,
+                "an app that declared no [state] must be refused"
+            );
+            let error = resolve("test.state", None, &registry).expect_err("must be refused");
+            assert!(
+                error.contains("declares no [state] section"),
+                "the refusal must name the reason, got: {error}"
+            );
+        });
+    }
+
+    #[test]
+    fn an_undeclared_scope_is_refused_rather_than_silently_redirected() {
+        let _guard = env_guard();
+        let (_apps, registry) = install_app(Some(CONTEXT_ONLY));
+        let root = tempdir().expect("context root");
+        with_context_root(root.path(), || {
+            let error =
+                resolve("test.state", Some("global"), &registry).expect_err("must be refused");
+            assert!(
+                error.contains("does not declare the 'global' scope"),
+                "the refusal must name the declared set, got: {error}"
+            );
+            assert_eq!(
+                set_from("test.state", &b"{}"[..], Some("global"), &registry),
+                1
+            );
+        });
+    }
+
+    #[test]
+    fn a_malformed_document_never_reaches_disk() {
+        let _guard = env_guard();
+        let (_apps, registry) = install_app(Some(CONTEXT_ONLY));
+        let root = tempdir().expect("context root");
+        with_context_root(root.path(), || {
+            assert_eq!(
+                set_from("test.state", &b"not json at all"[..], None, &registry),
+                1
+            );
+            // A JSON array parses, but a state document is an object.
+            assert_eq!(set_from("test.state", &b"[1,2,3]"[..], None, &registry), 1);
+        });
+        assert!(
+            !root
+                .path()
+                .join(".plexi/app_states/test.state.json")
+                .exists(),
+            "a rejected document must leave no file behind"
+        );
+    }
+
+    #[test]
+    fn a_traversal_or_absolute_app_id_cannot_address_a_file_outside_the_scope() {
+        let _guard = env_guard();
+        let (_apps, registry) = install_app(Some(CONTEXT_ONLY));
+        let root = tempdir().expect("context root");
+        with_context_root(root.path(), || {
+            assert_eq!(
+                set_from("../../etc/passwd", &b"{}"[..], None, &registry),
+                1,
+                "a traversal app id must never be writable"
+            );
+        });
+        // The id gate is the load-bearing part: even for a declared app, such an
+        // id never resolves to a path at all.
+        for hostile in ["../../etc/passwd", "/etc/passwd", "a/b"] {
+            assert!(
+                crate::host::state_scope::state_file(
+                    StateScope::Context,
+                    hostile,
+                    StateFormat::Json,
+                    root.path()
+                )
+                .is_err(),
+                "app id {hostile:?} must never resolve to a state path"
+            );
+        }
+    }
+
+    #[test]
+    fn a_missing_context_root_errors_instead_of_being_created() {
+        let _guard = env_guard();
+        let (_apps, registry) = install_app(Some(CONTEXT_ONLY));
+        let root = tempdir().expect("context root");
+        let missing = root.path().join("no-such-context");
+        with_context_root(&missing, || {
+            assert_eq!(set_from("test.state", &b"{}"[..], None, &registry), 1);
+        });
+        assert!(
+            !missing.exists(),
+            "a context root that does not exist must never be conjured by a state write"
+        );
+    }
+
+    #[test]
+    fn markdown_state_passes_through_verbatim() {
+        let _guard = env_guard();
+        let (_apps, registry) = install_app(Some(
+            "\n[state]\nscopes = [\"context\"]\nformat = \"markdown\"\n",
+        ));
+        let root = tempdir().expect("context root");
+        let document = "- [ ] buy milk\n- [x] ship 0645\n";
+        with_context_root(root.path(), || {
+            assert_eq!(
+                set_from("test.state", document.as_bytes(), None, &registry),
+                0
+            );
+        });
+        let written = std::fs::read_to_string(root.path().join(".plexi/app_states/test.state.md"))
+            .expect("markdown state file");
+        assert_eq!(
+            written, document,
+            "markdown state must reach disk byte-for-byte — the host is format-blind"
+        );
+    }
+
+    #[test]
+    fn a_symlinked_app_states_dir_is_refused() {
+        let _guard = env_guard();
+        let (_apps, registry) = install_app(Some(CONTEXT_ONLY));
+        let root = tempdir().expect("context root");
+        let elsewhere = tempdir().expect("escape target");
+        let plexi_dir = root.path().join(".plexi");
+        std::fs::create_dir_all(&plexi_dir).expect("plexi dir");
+        std::os::unix::fs::symlink(elsewhere.path(), plexi_dir.join("app_states"))
+            .expect("symlink app_states");
+        with_context_root(root.path(), || {
+            assert_eq!(
+                set_from("test.state", &b"{}"[..], None, &registry),
+                1,
+                "a redirected app_states directory must be refused, not followed"
+            );
+        });
+        assert!(
+            !elsewhere.path().join("test.state.json").exists(),
+            "nothing may be written through the symlink"
+        );
+    }
+
+    #[test]
+    fn get_on_an_app_with_no_state_file_yet_prints_the_empty_document() {
+        let _guard = env_guard();
+        let (_apps, registry) = install_app(Some(CONTEXT_ONLY));
+        let root = tempdir().expect("context root");
+        with_context_root(root.path(), || {
+            let resolved = resolve("test.state", None, &registry).expect("resolves");
+            assert!(!resolved.path.exists(), "fixture starts with no state file");
+            assert_eq!(empty_document(resolved.format), "{}\n");
+        });
+    }
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -666,6 +666,15 @@ pub enum AppCmd {
     },
     /// Show details about an installed app: id, name, version, and available tools.
     Info { id: String },
+    /// Read or replace a file-backed app's state document (stint 0645).
+    ///
+    /// Only apps that declare a `[state]` section are addressable. The state
+    /// path is resolved from the manifest and the calling context — callers
+    /// never pass a path, and there is no flag to address another context.
+    State {
+        #[command(subcommand)]
+        cmd: AppStateCmd,
+    },
     /// Create a new app from a template.
     ///
     /// Scaffolds the folder structure and files you need to build a Plexi app:
@@ -1283,6 +1292,30 @@ pub enum PaneCmd {
     Slot {
         #[command(subcommand)]
         cmd: PaneSlotCmd,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AppStateCmd {
+    /// Print an app's current state document to stdout.
+    Get {
+        /// App id (from `plexi app list`)
+        app: String,
+        /// Which declared scope to read. Defaults to the app's first declared
+        /// scope; a scope the app did not declare is an error.
+        #[arg(long, value_parser = ["global", "context"])]
+        scope: Option<String>,
+    },
+    /// Replace an app's state document, reading from a file or stdin.
+    Set {
+        /// App id (from `plexi app list`)
+        app: String,
+        /// File to read the new document from. Reads stdin when omitted.
+        file: Option<std::path::PathBuf>,
+        /// Which declared scope to write. Defaults to the app's first declared
+        /// scope; a scope the app did not declare is an error.
+        #[arg(long, value_parser = ["global", "context"])]
+        scope: Option<String>,
     },
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -211,6 +211,7 @@ pub mod agent;
 pub mod ai;
 pub mod app;
 pub mod app_check;
+pub mod app_state;
 pub mod completions;
 pub mod config_cli;
 pub mod context_cli;

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -26,6 +26,7 @@ pub mod scheduler;
 pub mod services;
 pub mod shell;
 pub mod state_scope;
+pub mod state_watch;
 pub mod typed_pipes;
 pub mod wasm_app;
 pub mod wasm_frame;

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -906,6 +906,25 @@ impl AppRuntime {
         }
     }
 
+    /// Every state file this runtime persists to, resolved against its live
+    /// context root. Only file-backed runtimes (Python today) have any.
+    pub fn state_paths(&self) -> Vec<(crate::host::state_scope::StateScope, std::path::PathBuf)> {
+        match self {
+            AppRuntime::Python(app) => app.state_paths(),
+            AppRuntime::Builtin(_) | AppRuntime::Wasm(_) => Vec::new(),
+        }
+    }
+
+    /// Re-read one scope's state file after an external change (see
+    /// `LivePythonPane::apply_external_state`). No-op for runtimes without
+    /// file-backed state.
+    pub fn apply_external_state(&mut self, scope: crate::host::state_scope::StateScope) {
+        match self {
+            AppRuntime::Python(app) => app.apply_external_state(scope),
+            AppRuntime::Builtin(_) | AppRuntime::Wasm(_) => {}
+        }
+    }
+
     pub fn queue_outbound_event(&mut self, event: crate::app_protocol::PlexiEvent) {
         match self {
             AppRuntime::Builtin(app) => app.queue_outbound_event(event),

--- a/src/host/state_scope.rs
+++ b/src/host/state_scope.rs
@@ -63,9 +63,193 @@ impl StateScope {
     }
 }
 
+/// The on-disk format of an app's state file. Declared in the manifest
+/// (`[state] format`); the host is format-blind for anything but JSON — a
+/// markdown file's bytes pass through verbatim under a single `document` key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum StateFormat {
+    /// Pretty-printed JSON object — the default.
+    #[default]
+    Json,
+    /// A plain-text markdown document; the host never parses it.
+    Markdown,
+}
+
+impl StateFormat {
+    /// Manifest / wire spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Markdown => "markdown",
+        }
+    }
+
+    /// State-file extension, without the dot.
+    pub fn ext(self) -> &'static str {
+        match self {
+            Self::Json => "json",
+            Self::Markdown => "md",
+        }
+    }
+
+    /// Parse a manifest format name. Unknown values are a loud error, never a
+    /// silent fallback to JSON.
+    pub fn parse(raw: &str) -> Result<Self, String> {
+        match raw {
+            "json" => Ok(Self::Json),
+            "markdown" => Ok(Self::Markdown),
+            other => Err(format!(
+                "unknown state format '{other}' — valid formats: json, markdown"
+            )),
+        }
+    }
+}
+
 /// The scopes an app that omits `[state]` gets.
 pub fn default_scopes() -> Vec<StateScope> {
     vec![StateScope::Global]
+}
+
+/// Validate an app id before it is used as a state-file name component.
+/// The id becomes `<dir>/<app_id>.<ext>` on disk, so anything that could
+/// escape the state directory (separators, traversal, hidden-file prefixes)
+/// is rejected loudly.
+pub fn validate_app_id(app_id: &str) -> Result<(), String> {
+    if app_id.is_empty() {
+        return Err("app id is empty — cannot resolve a state file".to_string());
+    }
+    if app_id.starts_with('.') {
+        return Err(format!(
+            "app id '{app_id}' starts with '.' — state file names must not be hidden or traversal paths"
+        ));
+    }
+    if app_id.contains("..") {
+        return Err(format!(
+            "app id '{app_id}' contains '..' — path traversal is not allowed in state file names"
+        ));
+    }
+    if let Some(bad) = app_id
+        .chars()
+        .find(|c| !(c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')))
+    {
+        return Err(format!(
+            "app id '{app_id}' contains invalid character '{bad}' — allowed: A-Z a-z 0-9 . _ -"
+        ));
+    }
+    Ok(())
+}
+
+/// Resolve a scope + format to the concrete state file for `app_id`,
+/// validating the app id first. New callers route through this; `state_path`
+/// stays as the raw two-rule resolver.
+pub fn state_file(
+    scope: StateScope,
+    app_id: &str,
+    format: StateFormat,
+    context_root: &Path,
+) -> Result<PathBuf, String> {
+    validate_app_id(app_id)?;
+    Ok(state_path(scope, app_id, format.ext(), context_root))
+}
+
+/// Assert that `path`'s parent directory really is the scope's state
+/// directory, resolving symlinks. Catches a symlinked `.plexi/` or
+/// `app_states/` that would silently redirect writes outside the scope.
+///
+/// The comparison anchors on the scope's trusted *base* (the context root, or
+/// the home dir for global scope): the base is canonicalized, the
+/// `.plexi/app_states` tail is appended literally, and the actual parent's
+/// fully-resolved form must match exactly. Components of the parent that do
+/// not exist yet (first write) cannot hide a symlink and are appended
+/// literally too.
+pub fn assert_within_scope(
+    path: &Path,
+    scope: StateScope,
+    context_root: &Path,
+) -> Result<(), String> {
+    let (base, plexi_dir) = match scope {
+        StateScope::Global => (
+            dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")),
+            ".plexi",
+        ),
+        StateScope::Context => (context_root.to_path_buf(), ".plexi"),
+    };
+    let expected = resolve_existing_prefix(&base)
+        .map_err(|error| format!("resolve scope base {}: {error}", base.display()))?
+        .join(plexi_dir)
+        .join(APP_STATES_DIR);
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("state path {} has no parent directory", path.display()))?;
+    let actual = resolve_existing_prefix(parent)
+        .map_err(|error| format!("resolve state dir {}: {error}", parent.display()))?;
+    if actual != expected {
+        return Err(format!(
+            "state path {} escapes its scope: parent resolves to {} but the {} scope \
+             directory is {} — refusing to follow a redirected app_states directory",
+            path.display(),
+            actual.display(),
+            scope.as_str(),
+            expected.display()
+        ));
+    }
+    Ok(())
+}
+
+/// Fully resolve `path` by canonicalizing its nearest existing ancestor and
+/// re-appending the not-yet-existing tail components literally (they cannot
+/// contain symlinks because they do not exist).
+fn resolve_existing_prefix(path: &Path) -> Result<PathBuf, String> {
+    let mut probe = path;
+    let mut tail: Vec<std::ffi::OsString> = Vec::new();
+    while !probe.exists() {
+        let name = probe
+            .file_name()
+            .ok_or_else(|| format!("no existing ancestor for {}", path.display()))?;
+        tail.push(name.to_os_string());
+        probe = probe
+            .parent()
+            .ok_or_else(|| format!("no existing ancestor for {}", path.display()))?;
+    }
+    let mut resolved = probe
+        .canonicalize()
+        .map_err(|error| format!("canonicalize {}: {error}", probe.display()))?;
+    for name in tail.iter().rev() {
+        resolved.push(name);
+    }
+    Ok(resolved)
+}
+
+/// Write `bytes` to `path` atomically: sibling temp file, fsync, rename.
+/// A reader never observes a partial file; a crash leaves at worst an
+/// orphaned `.{name}.tmp-{uuid}` sibling. Pattern shared with
+/// `crate::assistant::store`.
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    use std::io::Write;
+
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("write {}: missing parent", path.display()))?;
+    std::fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
+    let temp = parent.join(format!(
+        ".{}.tmp-{}",
+        path.file_name().unwrap_or_default().to_string_lossy(),
+        uuid::Uuid::new_v4()
+    ));
+    let result = (|| {
+        let mut file =
+            std::fs::File::create(&temp).map_err(|e| format!("create {}: {e}", temp.display()))?;
+        file.write_all(bytes)
+            .map_err(|e| format!("write {}: {e}", temp.display()))?;
+        file.sync_all()
+            .map_err(|e| format!("sync {}: {e}", temp.display()))?;
+        std::fs::rename(&temp, path)
+            .map_err(|e| format!("rename {} to {}: {e}", temp.display(), path.display()))
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result
 }
 
 /// Validate a manifest `[state] scopes` list. Rules (fail loud, no silent
@@ -137,11 +321,9 @@ mod tests {
         assert!(parse_scopes(&["workspace".to_string()])
             .unwrap_err()
             .contains("unknown state scope 'workspace'"));
-        assert!(
-            parse_scopes(&["global".to_string(), "global".to_string()])
-                .unwrap_err()
-                .contains("more than once")
-        );
+        assert!(parse_scopes(&["global".to_string(), "global".to_string()])
+            .unwrap_err()
+            .contains("more than once"));
     }
 
     #[test]
@@ -160,6 +342,106 @@ mod tests {
             !global.starts_with(root),
             "global scope must ignore the context root"
         );
+    }
+
+    #[test]
+    fn validate_app_id_rejects_traversal_separators_and_empties() {
+        assert!(validate_app_id("").unwrap_err().contains("empty"));
+        assert!(validate_app_id(".hidden").unwrap_err().contains("'.'"));
+        assert!(validate_app_id("a..b").unwrap_err().contains(".."));
+        assert!(validate_app_id("a/b")
+            .unwrap_err()
+            .contains("invalid character"));
+        assert!(validate_app_id("a\\b")
+            .unwrap_err()
+            .contains("invalid character"));
+        assert!(validate_app_id("a b")
+            .unwrap_err()
+            .contains("invalid character"));
+        assert!(validate_app_id("todo").is_ok());
+        assert!(validate_app_id("acme.todo-2").is_ok());
+    }
+
+    #[test]
+    fn state_file_refuses_bad_app_ids_and_uses_format_ext() {
+        let root = Path::new("/projects/demo");
+        assert!(state_file(StateScope::Context, "../todo", StateFormat::Json, root).is_err());
+        assert!(state_file(StateScope::Context, "a/b", StateFormat::Json, root).is_err());
+        assert_eq!(
+            state_file(StateScope::Context, "todo", StateFormat::Markdown, root).unwrap(),
+            PathBuf::from("/projects/demo/.plexi/app_states/todo.md")
+        );
+        assert_eq!(
+            state_file(StateScope::Context, "todo", StateFormat::Json, root).unwrap(),
+            PathBuf::from("/projects/demo/.plexi/app_states/todo.json")
+        );
+    }
+
+    #[test]
+    fn state_format_parses_and_defaults() {
+        assert_eq!(StateFormat::parse("json").unwrap(), StateFormat::Json);
+        assert_eq!(
+            StateFormat::parse("markdown").unwrap(),
+            StateFormat::Markdown
+        );
+        assert!(StateFormat::parse("yaml")
+            .unwrap_err()
+            .contains("valid formats: json, markdown"));
+        assert_eq!(StateFormat::default(), StateFormat::Json);
+        assert_eq!(StateFormat::Markdown.ext(), "md");
+        assert_eq!(StateFormat::Markdown.as_str(), "markdown");
+    }
+
+    #[test]
+    fn assert_within_scope_rejects_a_symlinked_app_states_dir() {
+        let root = tempfile::tempdir().expect("context root");
+        let elsewhere = tempfile::tempdir().expect("attacker-controlled dir");
+        let plexi_dir = root.path().join(".plexi");
+        std::fs::create_dir_all(&plexi_dir).expect("create .plexi");
+        std::os::unix::fs::symlink(elsewhere.path(), plexi_dir.join(APP_STATES_DIR))
+            .expect("symlink app_states elsewhere");
+
+        let path = state_file(StateScope::Context, "todo", StateFormat::Json, root.path())
+            .expect("resolve state file");
+        let err = assert_within_scope(&path, StateScope::Context, root.path())
+            .expect_err("a symlinked app_states dir must be rejected");
+        assert!(err.contains("escapes its scope"), "unexpected error: {err}");
+
+        // A genuine directory passes.
+        let honest = tempfile::tempdir().expect("honest root");
+        let honest_dir = context_state_dir(honest.path());
+        std::fs::create_dir_all(&honest_dir).expect("create app_states");
+        let honest_path = state_file(
+            StateScope::Context,
+            "todo",
+            StateFormat::Json,
+            honest.path(),
+        )
+        .expect("resolve state file");
+        assert_within_scope(&honest_path, StateScope::Context, honest.path())
+            .expect("real app_states dir is within scope");
+
+        // Not-yet-created app_states dir is fine too (first write).
+        let fresh = tempfile::tempdir().expect("fresh root");
+        let fresh_path = state_file(StateScope::Context, "todo", StateFormat::Json, fresh.path())
+            .expect("resolve state file");
+        assert_within_scope(&fresh_path, StateScope::Context, fresh.path())
+            .expect("missing app_states dir is within scope before first write");
+    }
+
+    #[test]
+    fn atomic_write_leaves_no_temp_residue() {
+        let dir = tempfile::tempdir().expect("dir");
+        let path = dir.path().join("app_states").join("todo.json");
+        atomic_write(&path, b"{\"k\":1}").expect("atomic write");
+        assert_eq!(std::fs::read(&path).expect("read back"), b"{\"k\":1}");
+        let residue: Vec<_> = std::fs::read_dir(path.parent().unwrap())
+            .expect("read dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains(".tmp-"))
+            .collect();
+        assert!(residue.is_empty(), "temp residue left behind: {residue:?}");
     }
 
     #[test]

--- a/src/host/state_watch.rs
+++ b/src/host/state_watch.rs
@@ -1,0 +1,488 @@
+//! App state file watcher (stint 0644) — watches each Python pane's state
+//! files for *external* writes (CLI, agents, editors) and emits a debounced
+//! `StateChangedNotice` per `(pane, scope)`.
+//!
+//! # Design
+//!
+//! Modelled on `crate::host::hot_reload`, with two deliberate differences:
+//!
+//! - **The watch target is the state file's PARENT DIRECTORY, non-recursive**,
+//!   never the file itself. Everything writing state uses atomic temp+rename,
+//!   which replaces the inode — a single-file watch dies after the first
+//!   replacement. Events are filtered by file name instead.
+//! - **The watched dirs are shared** (`~/.plexi/app_states/` holds every
+//!   app's global state), so filename filtering is mandatory: without it,
+//!   every app's save would fire every other app's watcher.
+//!
+//! Same 250ms debounce-thread pattern as hot_reload; one debouncer thread per
+//! watched pane coalesces a burst into one notice per scope. Self-write
+//! echoes are suppressed downstream by `LivePythonPane::apply_external_state`
+//! via the cached `(mtime, len)` identity — the watcher itself cannot tell
+//! who wrote.
+//!
+//! # Invariants
+//!
+//! - `unwatch(pane_id)` is idempotent.
+//! - Notices arrive exclusively through the channel handed out by
+//!   `StateWatcher::new`. No other side effects.
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver, TryRecvError};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use crate::app::ui_mailbox::{MailboxReceiver, UiMailbox, UiWake};
+use crate::host::state_scope::StateScope;
+use crate::spatial::tiling::PaneId;
+
+/// Debounce window — bursts of writes to the same state file within this much
+/// of each other coalesce into a single notice.
+pub const DEBOUNCE_MS: u64 = 250;
+
+/// Sent on each debounced state-file change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StateChangedNotice {
+    pub pane_id: PaneId,
+    pub scope: StateScope,
+}
+
+/// Owns the lifetime of one pane's watchers + debouncer thread.
+struct WatcherHandle {
+    /// Cancellation flag — set to true to signal the debouncer thread to exit.
+    cancel: Arc<Mutex<bool>>,
+    /// Debouncer thread join handle. Joined on drop best-effort.
+    thread: Option<JoinHandle<()>>,
+    /// One notify watcher per watched parent directory. Held for drop.
+    _watchers: Vec<RecommendedWatcher>,
+    /// The exact `(scope, path)` set registered, so callers can detect when a
+    /// pane's resolved paths drift (e.g. `plexi context set-root`) and
+    /// re-register.
+    entries: Vec<(StateScope, PathBuf)>,
+}
+
+impl Drop for WatcherHandle {
+    fn drop(&mut self) {
+        if let Ok(mut c) = self.cancel.lock() {
+            *c = true;
+        }
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+        // _watchers drop here, releasing FS resources.
+    }
+}
+
+/// Manages per-pane state-file watchers. The host owns one of these, registers
+/// each file-backed app pane at launch, re-syncs registrations when a pane's
+/// resolved state paths change, and unwatches on pane close.
+pub struct StateWatcher {
+    watchers: HashMap<PaneId, WatcherHandle>,
+    /// Mailbox shared with every debouncer thread; each send wakes the UI
+    /// thread so an external edit is never stranded on an idle host.
+    sender: UiMailbox<StateChangedNotice>,
+}
+
+impl StateWatcher {
+    /// Construct the watcher set + matching receiver. The host stores the
+    /// receiver and drains it each `logic` pass.
+    pub fn new(wake: Arc<dyn UiWake>) -> (Self, MailboxReceiver<StateChangedNotice>) {
+        let (tx, rx) = UiMailbox::channel(wake, "state_watch");
+        (
+            Self {
+                watchers: HashMap::new(),
+                sender: tx,
+            },
+            rx,
+        )
+    }
+
+    /// The `(scope, path)` set currently registered for `pane_id`. Empty when
+    /// the pane is not watched. Used by the drain pass to detect a context
+    /// root change without extra bookkeeping.
+    pub fn watched_entries(&self, pane_id: PaneId) -> &[(StateScope, PathBuf)] {
+        self.watchers
+            .get(&pane_id)
+            .map(|handle| handle.entries.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Begin watching `entries` (each a declared scope's resolved state file)
+    /// for `pane_id`. Replaces any existing registration for the pane.
+    pub fn watch(&mut self, pane_id: PaneId, entries: &[(StateScope, PathBuf)]) {
+        // Replace any existing registration (idempotent).
+        self.watchers.remove(&pane_id);
+        if entries.is_empty() {
+            return;
+        }
+
+        let cancel = Arc::new(Mutex::new(false));
+        let cancel_thread = Arc::clone(&cancel);
+        let sender = self.sender.clone();
+
+        // Internal channel: every notify watcher → the pane's debouncer.
+        // Carries the matched scope so the debouncer never re-derives paths.
+        let (raw_tx, raw_rx) = mpsc::channel::<StateScope>();
+
+        let mut watchers = Vec::new();
+        for (scope, path) in entries {
+            let Some(parent) = path.parent().map(Path::to_path_buf) else {
+                log::error!(
+                    "state_watch: state path {} has no parent — cannot watch (pane {pane_id})",
+                    path.display()
+                );
+                continue;
+            };
+            let Some(file_name) = path.file_name().map(|n| n.to_os_string()) else {
+                log::error!(
+                    "state_watch: state path {} has no file name — cannot watch (pane {pane_id})",
+                    path.display()
+                );
+                continue;
+            };
+            // The parent may not exist before the first persist; create it so
+            // the watch can arm now and catch that first external write.
+            if let Err(error) = std::fs::create_dir_all(&parent) {
+                log::error!(
+                    "state_watch: create state dir {} for pane {pane_id}: {error}",
+                    parent.display()
+                );
+                continue;
+            }
+            let scope = *scope;
+            let tx = raw_tx.clone();
+            let mut watcher =
+                match notify::recommended_watcher(move |res: notify::Result<Event>| {
+                    match res {
+                        Ok(ev) => {
+                            // Content changes only; macOS FSEvents reports
+                            // `Any` for many save flows — accept those too.
+                            if !matches!(
+                                ev.kind,
+                                EventKind::Modify(_)
+                                    | EventKind::Create(_)
+                                    | EventKind::Remove(_)
+                                    | EventKind::Any
+                            ) {
+                                return;
+                            }
+                            // Shared dir: only this app's file counts. An
+                            // atomic rename reports the destination path, so
+                            // matching the final file name is sufficient.
+                            if ev
+                                .paths
+                                .iter()
+                                .any(|p| p.file_name() == Some(file_name.as_os_str()))
+                            {
+                                let _ = tx.send(scope);
+                            }
+                        }
+                        Err(e) => log::warn!("state_watch: watcher error: {e}"),
+                    }
+                }) {
+                    Ok(w) => w,
+                    Err(e) => {
+                        log::error!(
+                            "state_watch: failed to create watcher for pane {pane_id} at {}: {e}",
+                            parent.display()
+                        );
+                        continue;
+                    }
+                };
+            // NonRecursive parent-dir watch: survives atomic rename (which
+            // replaces the file's inode) and never descends into siblings.
+            if let Err(e) = watcher.watch(&parent, RecursiveMode::NonRecursive) {
+                log::error!(
+                    "state_watch: failed to begin watching {} for pane {pane_id}: {e}",
+                    parent.display()
+                );
+                continue;
+            }
+            log::info!(
+                "state_watch: watching {} (scope={}) for pane {pane_id}",
+                path.display(),
+                scope.as_str()
+            );
+            watchers.push(watcher);
+        }
+        drop(raw_tx);
+        if watchers.is_empty() {
+            return;
+        }
+
+        let thread = thread::spawn(move || {
+            debounce_loop(pane_id, raw_rx, sender, cancel_thread);
+        });
+
+        self.watchers.insert(
+            pane_id,
+            WatcherHandle {
+                cancel,
+                thread: Some(thread),
+                _watchers: watchers,
+                entries: entries.to_vec(),
+            },
+        );
+    }
+
+    /// Stop watching `pane_id`. Idempotent — closing a pane that was never
+    /// watched is a no-op.
+    pub fn unwatch(&mut self, pane_id: PaneId) {
+        if self.watchers.remove(&pane_id).is_some() {
+            log::info!("state_watch: stopped watching pane {pane_id}");
+        }
+    }
+}
+
+/// Debounce loop: collect per-scope events into a window, emit one
+/// `StateChangedNotice` per changed scope when the window closes (no new
+/// events within `DEBOUNCE_MS`). Polls every 50ms so cancellation is observed
+/// promptly even when the watchers are silent.
+fn debounce_loop(
+    pane_id: PaneId,
+    rx: Receiver<StateScope>,
+    sender: UiMailbox<StateChangedNotice>,
+    cancel: Arc<Mutex<bool>>,
+) {
+    let mut pending: HashMap<StateScope, Instant> = HashMap::new();
+    let debounce = Duration::from_millis(DEBOUNCE_MS);
+    let poll = Duration::from_millis(50);
+
+    loop {
+        if cancel.lock().map(|g| *g).unwrap_or(true) {
+            return;
+        }
+
+        match rx.try_recv() {
+            Ok(scope) => {
+                pending.insert(scope, Instant::now());
+            }
+            Err(TryRecvError::Disconnected) => {
+                // All watchers dropped — exit cleanly.
+                return;
+            }
+            Err(TryRecvError::Empty) => {
+                let due: Vec<StateScope> = pending
+                    .iter()
+                    .filter(|(_, t)| t.elapsed() >= debounce)
+                    .map(|(scope, _)| *scope)
+                    .collect();
+                for scope in due {
+                    pending.remove(&scope);
+                    log::info!(
+                        "state_watch: debounced state change for pane {pane_id} scope={}",
+                        scope.as_str()
+                    );
+                    if sender.send(StateChangedNotice { pane_id, scope }).is_err() {
+                        // Host receiver dropped — nothing more to do.
+                        return;
+                    }
+                }
+                thread::sleep(poll);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::ui_mailbox::RecordingWake;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn poll_for_notice(
+        rx: &MailboxReceiver<StateChangedNotice>,
+        base_timeout: Duration,
+    ) -> Option<StateChangedNotice> {
+        let deadline = Instant::now() + crate::testing::load_aware_timeout(base_timeout);
+        while Instant::now() < deadline {
+            if let Ok(notice) = rx.try_recv() {
+                return Some(notice);
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        None
+    }
+
+    fn arm_delay() {
+        // Give FSEvents a moment to arm before mutating.
+        thread::sleep(crate::testing::load_aware_timeout(Duration::from_millis(
+            150,
+        )));
+    }
+
+    #[test]
+    fn fires_on_external_write() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("todo.json");
+        fs::write(&file, "{}\n").unwrap();
+
+        let wake = Arc::new(RecordingWake::new());
+        let (mut watcher, rx) = StateWatcher::new(wake.clone());
+        watcher.watch(42, &[(StateScope::Global, file.clone())]);
+        arm_delay();
+
+        fs::write(&file, "{\"k\":1}\n").unwrap();
+
+        let got = poll_for_notice(&rx, Duration::from_secs(3));
+        assert_eq!(
+            got,
+            Some(StateChangedNotice {
+                pane_id: 42,
+                scope: StateScope::Global
+            }),
+            "external write should yield a debounced notice"
+        );
+        assert!(
+            wake.sources().contains(&"state_watch"),
+            "state change must wake the UI thread"
+        );
+    }
+
+    #[test]
+    fn survives_atomic_rename_replacement() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("todo.json");
+        fs::write(&file, "{}\n").unwrap();
+
+        let (mut watcher, rx) = StateWatcher::new(Arc::new(RecordingWake::new()));
+        watcher.watch(7, &[(StateScope::Context, file.clone())]);
+        arm_delay();
+
+        // First replacement (new inode).
+        crate::host::state_scope::atomic_write(&file, b"{\"v\":1}\n").unwrap();
+        let first = poll_for_notice(&rx, Duration::from_secs(3));
+        assert!(first.is_some(), "first atomic replacement must fire");
+        // Drain any stragglers from the first burst before the second write.
+        thread::sleep(crate::testing::load_aware_timeout(Duration::from_millis(
+            400,
+        )));
+        while rx.try_recv().is_ok() {}
+
+        // Second replacement — a single-file watch would be dead by now
+        // because the first rename replaced the watched inode.
+        crate::host::state_scope::atomic_write(&file, b"{\"v\":2}\n").unwrap();
+        let second = poll_for_notice(&rx, Duration::from_secs(3));
+        assert_eq!(
+            second,
+            Some(StateChangedNotice {
+                pane_id: 7,
+                scope: StateScope::Context
+            }),
+            "watch must survive inode replacement (parent-dir watch, not file watch)"
+        );
+    }
+
+    #[test]
+    fn debounces_burst_to_single_event() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("burst.json");
+        fs::write(&file, "{}\n").unwrap();
+
+        let (mut watcher, rx) = StateWatcher::new(Arc::new(RecordingWake::new()));
+        watcher.watch(9, &[(StateScope::Global, file.clone())]);
+        arm_delay();
+
+        for i in 0..6 {
+            fs::write(&file, format!("{{\"v\":{i}}}\n")).unwrap();
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let first = poll_for_notice(&rx, Duration::from_secs(3));
+        assert!(first.is_some(), "expected at least one notice");
+
+        // With a 250ms debounce the burst should coalesce — at most one
+        // extra is OK (FSEvents occasionally splits a burst).
+        let mut extras = 0;
+        let deadline =
+            Instant::now() + crate::testing::load_aware_timeout(Duration::from_millis(600));
+        while Instant::now() < deadline {
+            if rx.try_recv().is_ok() {
+                extras += 1;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            extras <= 1,
+            "burst of 6 writes should debounce to 1–2 notices, got {extras} extras"
+        );
+    }
+
+    #[test]
+    fn ignores_sibling_app_files() {
+        let dir = tempdir().unwrap();
+        let mine = dir.path().join("mine.json");
+        let sibling = dir.path().join("other-app.json");
+        fs::write(&mine, "{}\n").unwrap();
+        fs::write(&sibling, "{}\n").unwrap();
+
+        let (mut watcher, rx) = StateWatcher::new(Arc::new(RecordingWake::new()));
+        watcher.watch(11, &[(StateScope::Global, mine.clone())]);
+        arm_delay();
+        // FSEvents can replay the pre-watch creation of mine.json once the
+        // watch arms — drain that echo so only the sibling write is under test.
+        thread::sleep(crate::testing::load_aware_timeout(Duration::from_millis(
+            600,
+        )));
+        while rx.try_recv().is_ok() {}
+
+        // Only the sibling changes — the shared dir fires FS events, but the
+        // filename filter must drop them.
+        fs::write(&sibling, "{\"other\":1}\n").unwrap();
+        let got = poll_for_notice(&rx, Duration::from_millis(800));
+        assert!(
+            got.is_none(),
+            "a sibling app's state file must not fire this pane's watcher, got {got:?}"
+        );
+    }
+
+    #[test]
+    fn unwatch_stops_delivery_and_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("stop.json");
+        fs::write(&file, "{}\n").unwrap();
+
+        let (mut watcher, rx) = StateWatcher::new(Arc::new(RecordingWake::new()));
+        watcher.watch(13, &[(StateScope::Global, file.clone())]);
+        arm_delay();
+
+        watcher.unwatch(13);
+        // Drain any in-flight event from before the unwatch.
+        thread::sleep(crate::testing::load_aware_timeout(Duration::from_millis(
+            400,
+        )));
+        while rx.try_recv().is_ok() {}
+
+        fs::write(&file, "{\"v\":1}\n").unwrap();
+        let got = poll_for_notice(&rx, Duration::from_millis(800));
+        assert!(
+            got.is_none(),
+            "no notice should be delivered after unwatch, got {got:?}"
+        );
+
+        // Idempotent: unwatching again (and an unknown pane) is a no-op.
+        watcher.unwatch(13);
+        watcher.unwatch(999);
+        assert!(watcher.watched_entries(13).is_empty());
+    }
+
+    #[test]
+    fn watched_entries_reports_registration() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("app.json");
+        fs::write(&file, "{}\n").unwrap();
+
+        let (mut watcher, _rx) = StateWatcher::new(Arc::new(RecordingWake::new()));
+        assert!(watcher.watched_entries(21).is_empty());
+        watcher.watch(21, &[(StateScope::Global, file.clone())]);
+        assert_eq!(
+            watcher.watched_entries(21),
+            &[(StateScope::Global, file.clone())]
+        );
+        watcher.unwatch(21);
+        assert!(watcher.watched_entries(21).is_empty());
+    }
+}

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -328,6 +328,11 @@ pub struct PythonLaunchConfig {
     /// Validated `[state] scopes` from the manifest. Ordered; the first entry
     /// is the app's default scope. See `crate::host::state_scope`.
     pub state_scopes: Vec<crate::host::state_scope::StateScope>,
+    /// Validated `[state] format` from the manifest. JSON unless the app
+    /// declared `format = "markdown"`, in which case the host is
+    /// format-blind: the file's bytes round-trip verbatim under a single
+    /// `document` key.
+    pub state_format: crate::host::state_scope::StateFormat,
     /// The root of the launching pane's context, used to seed the pane's live
     /// `context_root` (which the host refreshes every frame). State paths
     /// resolve against the live value at call time — never against
@@ -360,6 +365,9 @@ impl PythonLaunchConfig {
         let state_scopes = manifest
             .state_scopes()
             .map_err(WasmPythonError::StateScopes)?;
+        let state_format = manifest
+            .state_format()
+            .map_err(WasmPythonError::StateScopes)?;
 
         let entry = manifest.app.entry;
         if !(entry.ends_with(".py") || entry.ends_with(".pyc")) {
@@ -389,6 +397,7 @@ impl PythonLaunchConfig {
             )
             .to_theme_map(),
             state_scopes,
+            state_format,
             context_root: app_dir.to_path_buf(),
         }))
     }
@@ -773,7 +782,10 @@ pub struct LivePythonPane {
     perf_ui_render: std::time::Duration,
     perf_canvas_render: std::time::Duration,
     /// Per-scope in-memory copy of persisted state, keyed by declared scope.
-    persisted_states: HashMap<crate::host::state_scope::StateScope, serde_json::Map<String, Value>>,
+    /// Each entry also caches the backing file's `(mtime, len)` from the last
+    /// successful read/write so a persist can detect an external write that
+    /// landed since (disk wins — see `save_state`).
+    persisted_states: HashMap<crate::host::state_scope::StateScope, ScopeState>,
     /// The root of this pane's context, refreshed by the host on every `ui`
     /// pass. State paths resolve against this at persist time, so
     /// `plexi context set-root` redirects where context-scoped state lands
@@ -1268,15 +1280,29 @@ impl PythonFrameScheduler {
     }
 }
 
+/// One scope's in-memory state plus the file identity it was last synced
+/// against. `(mtime, len)` are `None` until the backing file has been seen on
+/// disk; `error` is set when the file exists but could not be decoded — the
+/// scope then refuses to persist until an external read clears it, so a
+/// corrupt file is never silently reset to `{}`.
+#[derive(Debug, Clone, Default)]
+struct ScopeState {
+    values: serde_json::Map<String, Value>,
+    mtime: Option<std::time::SystemTime>,
+    len: Option<u64>,
+    error: Option<String>,
+}
+
 /// Resolve one declared scope to its state file, against the pane's context
 /// root *at call time*. The host owns path construction — see
-/// `crate::host::state_scope` for the two rules.
+/// `crate::host::state_scope` for the two rules. Validates the app id.
 fn python_state_path(
     app_id: &str,
     scope: crate::host::state_scope::StateScope,
+    format: crate::host::state_scope::StateFormat,
     context_root: &Path,
-) -> PathBuf {
-    crate::host::state_scope::state_path(scope, app_id, "json", context_root)
+) -> Result<PathBuf, String> {
+    crate::host::state_scope::state_file(scope, app_id, format, context_root)
 }
 
 #[cfg(test)]
@@ -1303,92 +1329,126 @@ fn ensure_python_state_gitignore(config: &PythonLaunchConfig) {
     }
 }
 
-fn write_python_state_atomic(path: &Path, bytes: &[u8]) -> Result<(), std::io::Error> {
-    use std::io::Write;
-    use std::sync::atomic::{AtomicU64, Ordering};
-
-    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(1);
-
-    let parent = path.parent().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("state path has no parent: {}", path.display()),
-        )
-    })?;
-    let file_name = path.file_name().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("state path has no file name: {}", path.display()),
-        )
-    })?;
-    let mut temp_path = None;
-    let mut temp_file = None;
-    for _ in 0..16 {
-        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
-        let candidate = parent.join(format!(
-            ".{}.{}.{id}.tmp",
-            file_name.to_string_lossy(),
-            std::process::id()
-        ));
-        match std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&candidate)
-        {
-            Ok(file) => {
-                temp_path = Some(candidate);
-                temp_file = Some(file);
-                break;
-            }
-            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(error),
+/// Encode a scope's values for disk in the app's declared format.
+///
+/// JSON is pretty-printed. Markdown keeps the host format-blind: the app's
+/// `document` value (which must be a string) is written verbatim — no JSON
+/// envelope, no escaping.
+fn encode_state_file(
+    values: &serde_json::Map<String, Value>,
+    format: crate::host::state_scope::StateFormat,
+) -> Result<Vec<u8>, String> {
+    match format {
+        crate::host::state_scope::StateFormat::Json => {
+            serde_json::to_vec_pretty(&Value::Object(values.clone()))
+                .map_err(|error| format!("serialize state JSON: {error}"))
         }
-    }
-    let (temp_path, mut temp_file) = match (temp_path, temp_file) {
-        (Some(path), Some(file)) => (path, file),
-        _ => {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::AlreadyExists,
-                format!("could not allocate state temp file beside {}", path.display()),
-            ));
-        }
-    };
-    let write_result = temp_file
-        .write_all(bytes)
-        .and_then(|()| temp_file.sync_all())
-        .and_then(|()| std::fs::rename(&temp_path, path));
-    if write_result.is_err() {
-        if let Err(error) = std::fs::remove_file(&temp_path) {
-            log::warn!(
-                "could not clean up failed app-state temp file {}: {error}",
-                temp_path.display()
-            );
-        }
-    }
-    write_result
-}
-
-fn read_python_state_file(app_id: &str, path: &Path) -> serde_json::Map<String, Value> {
-    match std::fs::read(path) {
-        Ok(bytes) => match serde_json::from_slice::<Value>(&bytes) {
-            Ok(Value::Object(state)) => state,
-            Ok(_) => {
-                log::warn!(
-                    "app::{app_id}: state {} is not a JSON object",
-                    path.display()
-                );
-                serde_json::Map::new()
-            }
-            Err(error) => {
-                log::warn!("app::{app_id}: parse state {}: {error}", path.display());
-                serde_json::Map::new()
+        crate::host::state_scope::StateFormat::Markdown => match values.get("document") {
+            Some(Value::String(document)) => Ok(document.as_bytes().to_vec()),
+            Some(other) => Err(format!(
+                "markdown state requires a string 'document' value, got {}",
+                match other {
+                    Value::Null => "null",
+                    Value::Bool(_) => "a bool",
+                    Value::Number(_) => "a number",
+                    Value::Array(_) => "an array",
+                    Value::Object(_) => "an object",
+                    Value::String(_) => unreachable!(),
+                }
+            )),
+            None => {
+                Err("markdown state requires a 'document' key carrying the file text".to_string())
             }
         },
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => serde_json::Map::new(),
-        Err(error) => {
-            log::warn!("app::{app_id}: read state {}: {error}", path.display());
-            serde_json::Map::new()
+    }
+}
+
+/// Decode a state file's bytes in the app's declared format. The inverse of
+/// [`encode_state_file`]: markdown text arrives as `{"document": "<file text>"}`.
+pub(crate) fn decode_state_file(
+    bytes: &[u8],
+    format: crate::host::state_scope::StateFormat,
+) -> Result<serde_json::Map<String, Value>, String> {
+    match format {
+        crate::host::state_scope::StateFormat::Json => {
+            match serde_json::from_slice::<Value>(bytes) {
+                Ok(Value::Object(state)) => Ok(state),
+                Ok(other) => Err(format!(
+                    "state file is not a JSON object (got {})",
+                    match other {
+                        Value::Null => "null",
+                        Value::Bool(_) => "a bool",
+                        Value::Number(_) => "a number",
+                        Value::String(_) => "a string",
+                        Value::Array(_) => "an array",
+                        Value::Object(_) => unreachable!(),
+                    }
+                )),
+                Err(error) => Err(format!("parse state JSON: {error}")),
+            }
         }
+        crate::host::state_scope::StateFormat::Markdown => {
+            let text = String::from_utf8(bytes.to_vec())
+                .map_err(|error| format!("markdown state is not valid UTF-8: {error}"))?;
+            let mut map = serde_json::Map::new();
+            map.insert("document".to_string(), Value::String(text));
+            Ok(map)
+        }
+    }
+}
+
+/// Read one scope's state file into a [`ScopeState`]. A missing file is an
+/// empty map — indistinguishable from first launch by design. A file that
+/// exists but fails to decode sets `error` and leaves `values` empty; the
+/// caller decides whether to keep previously-known values.
+fn read_python_state_file(
+    app_id: &str,
+    path: &Path,
+    format: crate::host::state_scope::StateFormat,
+) -> ScopeState {
+    let (mtime, len) = stat_state_file(path);
+    match std::fs::read(path) {
+        Ok(bytes) => match decode_state_file(&bytes, format) {
+            Ok(values) => ScopeState {
+                values,
+                mtime,
+                len,
+                error: None,
+            },
+            Err(error) => {
+                log::error!(
+                    "app::{app_id}: state {} is unreadable ({error}) — state is NOT reset; \
+                     persists are blocked until the file is fixed",
+                    path.display()
+                );
+                ScopeState {
+                    values: serde_json::Map::new(),
+                    mtime,
+                    len,
+                    error: Some(error),
+                }
+            }
+        },
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => ScopeState::default(),
+        Err(error) => {
+            let message = format!("read state {}: {error}", path.display());
+            log::error!("app::{app_id}: {message} — state is NOT reset");
+            ScopeState {
+                values: serde_json::Map::new(),
+                mtime,
+                len,
+                error: Some(message),
+            }
+        }
+    }
+}
+
+/// Stat a state file's `(mtime, len)` identity pair. `(None, None)` when the
+/// file does not exist (or cannot be statted).
+fn stat_state_file(path: &Path) -> (Option<std::time::SystemTime>, Option<u64>) {
+    match std::fs::metadata(path) {
+        Ok(meta) => (meta.modified().ok(), Some(meta.len())),
+        Err(_) => (None, None),
     }
 }
 
@@ -1408,7 +1468,8 @@ fn load_python_state(
         .first()
         .copied()
         .unwrap_or(crate::host::state_scope::StateScope::Global);
-    let path = python_state_path(&config.app_id, scope, &config.context_root);
+    let path = python_state_path(&config.app_id, scope, config.state_format, &config.context_root)
+        .expect("resolve state path");
     match read_python_state_bytes(&path)? {
         Some(bytes) => parse_python_state(&path, &bytes),
         None => Ok(serde_json::Map::new()),
@@ -1466,13 +1527,31 @@ fn parse_python_state(
 /// indistinguishable from first launch by design.
 fn load_python_states(
     config: &PythonLaunchConfig,
-) -> HashMap<crate::host::state_scope::StateScope, serde_json::Map<String, Value>> {
+) -> HashMap<crate::host::state_scope::StateScope, ScopeState> {
     config
         .state_scopes
         .iter()
         .map(|&scope| {
-            let path = python_state_path(&config.app_id, scope, &config.context_root);
-            (scope, read_python_state_file(&config.app_id, &path))
+            let state = match python_state_path(
+                &config.app_id,
+                scope,
+                config.state_format,
+                &config.context_root,
+            ) {
+                Ok(path) => read_python_state_file(&config.app_id, &path, config.state_format),
+                Err(error) => {
+                    log::error!(
+                        "app::{}: cannot resolve state path for scope {}: {error}",
+                        config.app_id,
+                        scope.as_str()
+                    );
+                    ScopeState {
+                        error: Some(error),
+                        ..ScopeState::default()
+                    }
+                }
+            };
+            (scope, state)
         })
         .collect()
 }
@@ -2380,7 +2459,7 @@ impl LivePythonPane {
     fn default_scope_state(&self) -> serde_json::Map<String, Value> {
         self.persisted_states
             .get(&self.default_scope())
-            .cloned()
+            .map(|state| state.values.clone())
             .unwrap_or_default()
     }
 
@@ -2393,12 +2472,140 @@ impl LivePythonPane {
                     (
                         scope.as_str().to_string(),
                         Value::Object(
-                            self.persisted_states.get(scope).cloned().unwrap_or_default(),
+                            self.persisted_states
+                                .get(scope)
+                                .map(|state| state.values.clone())
+                                .unwrap_or_default(),
                         ),
                     )
                 })
                 .collect(),
         )
+    }
+
+    /// Every declared scope's state file, resolved against the *current*
+    /// context root. The watcher registration in `pane_ops::create` re-syncs
+    /// against this each drain pass, so `plexi context set-root` follows.
+    pub fn state_paths(&self) -> Vec<(crate::host::state_scope::StateScope, PathBuf)> {
+        self.config
+            .state_scopes
+            .iter()
+            .filter_map(|&scope| {
+                match python_state_path(
+                    &self.app_id,
+                    scope,
+                    self.config.state_format,
+                    &self.context_root,
+                ) {
+                    Ok(path) => Some((scope, path)),
+                    Err(error) => {
+                        log::error!(
+                            "app::{}: cannot resolve state path for scope {}: {error}",
+                            self.app_id,
+                            scope.as_str()
+                        );
+                        None
+                    }
+                }
+            })
+            .collect()
+    }
+
+    /// Tell the runtime a scope's state changed outside its own persist flow
+    /// (an external edit, or a persist that lost to one). The SDK replaces
+    /// the scope's values wholesale and dispatches `events.StateChanged`.
+    fn send_state_changed(
+        &self,
+        scope: crate::host::state_scope::StateScope,
+        values: &serde_json::Map<String, Value>,
+        error: Option<&str>,
+    ) {
+        self.send_to_runtime(&json!({
+            "type": "state_changed",
+            "scope": scope.as_str(),
+            "payload": Value::Object(values.clone()),
+            "error": error,
+            "source": "external",
+        }));
+    }
+
+    /// Re-read one scope's state file after an external change notification.
+    ///
+    /// No-ops when the file's `(mtime, len)` identity matches the cached pair
+    /// — this is what suppresses watcher echoes of our own atomic writes. On
+    /// a real change the on-disk values replace the scope's values wholesale
+    /// (disk wins; deleted keys vanish) and the app is notified via
+    /// `state_changed`. On a decode failure the previous values are kept, the
+    /// scope's `error` is set (blocking persists), and the app is notified
+    /// with the error attached.
+    pub fn apply_external_state(&mut self, scope: crate::host::state_scope::StateScope) {
+        if !self.config.state_scopes.contains(&scope) {
+            log::warn!(
+                "app::{}: external state change for undeclared scope '{}' ignored",
+                self.app_id,
+                scope.as_str()
+            );
+            return;
+        }
+        let path = match python_state_path(
+            &self.app_id,
+            scope,
+            self.config.state_format,
+            &self.context_root,
+        ) {
+            Ok(path) => path,
+            Err(error) => {
+                log::error!(
+                    "app::{}: cannot resolve state path for scope {}: {error}",
+                    self.app_id,
+                    scope.as_str()
+                );
+                return;
+            }
+        };
+        let (mtime, len) = stat_state_file(&path);
+        let cached = self.persisted_states.entry(scope).or_default();
+        let unchanged_existing = mtime.is_some() && mtime == cached.mtime && len == cached.len;
+        let still_absent = mtime.is_none() && cached.mtime.is_none() && cached.error.is_none();
+        if unchanged_existing || still_absent {
+            log::debug!(
+                "app::{}: external state notification for scope {} matches cached identity — \
+                 self-write echo, ignoring",
+                self.app_id,
+                scope.as_str()
+            );
+            return;
+        }
+        let fresh = read_python_state_file(&self.app_id, &path, self.config.state_format);
+        match &fresh.error {
+            None => {
+                log::info!(
+                    "app::{}: state scope={} changed on disk ({}) — replacing in-memory state \
+                     and notifying app",
+                    self.app_id,
+                    scope.as_str(),
+                    path.display()
+                );
+                *cached = fresh;
+                let values = cached.values.clone();
+                self.send_state_changed(scope, &values, None);
+            }
+            Some(error) => {
+                log::error!(
+                    "app::{}: external change to state scope={} ({}) is unreadable: {error} — \
+                     keeping previous values; persists blocked until the file is fixed",
+                    self.app_id,
+                    scope.as_str(),
+                    path.display()
+                );
+                cached.error = Some(error.clone());
+                cached.mtime = fresh.mtime;
+                cached.len = fresh.len;
+                let values = cached.values.clone();
+                let message = error.clone();
+                self.send_state_changed(scope, &values, Some(&message));
+            }
+        }
     }
 
     fn save_state(&mut self, scope_raw: Option<&Value>, payload: Option<&Value>) {
@@ -2431,8 +2638,78 @@ impl LivePythonPane {
             );
             return;
         }
-        self.persisted_states.insert(scope, payload.clone());
-        let path = python_state_path(&self.app_id, scope, &self.context_root);
+        if let Some(error) = self
+            .persisted_states
+            .get(&scope)
+            .and_then(|state| state.error.as_ref())
+        {
+            log::error!(
+                "app::{}: save_app_state refused — scope '{}' has an unresolved file error \
+                 ({error}); fix the file on disk, a successful re-read clears this",
+                self.app_id,
+                scope.as_str()
+            );
+            return;
+        }
+        let path = match python_state_path(
+            &self.app_id,
+            scope,
+            self.config.state_format,
+            &self.context_root,
+        ) {
+            Ok(path) => path,
+            Err(error) => {
+                log::error!(
+                    "app::{}: save_app_state rejected — {error}; state NOT persisted",
+                    self.app_id
+                );
+                return;
+            }
+        };
+        // Read-back-before-write (disk wins): if the file changed since we
+        // last synced with it, an external writer got there first — drop
+        // this persist, reload from disk, and tell the app so it can
+        // re-apply its change on top of the fresh state.
+        let (disk_mtime, disk_len) = stat_state_file(&path);
+        let cached_identity = self
+            .persisted_states
+            .get(&scope)
+            .map(|state| (state.mtime, state.len))
+            .unwrap_or((None, None));
+        if disk_mtime.is_some() && (disk_mtime, disk_len) != cached_identity {
+            log::warn!(
+                "app::{}: state scope={} ({}) changed on disk since load — reloading instead \
+                 of overwriting; persist dropped",
+                self.app_id,
+                scope.as_str(),
+                path.display()
+            );
+            let fresh = read_python_state_file(&self.app_id, &path, self.config.state_format);
+            let error = fresh.error.clone();
+            let values = fresh.values.clone();
+            self.persisted_states.insert(scope, fresh);
+            self.send_state_changed(scope, &values, error.as_deref());
+            return;
+        }
+        let bytes = match encode_state_file(payload, self.config.state_format) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                log::error!(
+                    "app::{}: save_app_state rejected — {error}; state NOT persisted",
+                    self.app_id
+                );
+                return;
+            }
+        };
+        if let Err(error) =
+            crate::host::state_scope::assert_within_scope(&path, scope, &self.context_root)
+        {
+            log::error!(
+                "app::{}: save_app_state rejected — {error}; state NOT persisted",
+                self.app_id
+            );
+            return;
+        }
         if scope == crate::host::state_scope::StateScope::Context {
             // A user must never be able to accidentally commit their app
             // state with a project (standing ruling; personal local data).
@@ -2446,26 +2723,29 @@ impl LivePythonPane {
                 );
             }
         }
-        if let Some(parent) = path.parent() {
-            if let Err(error) = std::fs::create_dir_all(parent) {
-                log::error!(
-                    "app::{}: create state dir {}: {error}",
-                    self.app_id,
-                    parent.display()
+        match crate::host::state_scope::atomic_write(&path, &bytes) {
+            Ok(()) => {
+                // Re-stat AFTER the rename so the cached identity is the
+                // file we just produced — statting before the rename would
+                // make every self-write look external and loop reloads.
+                let (mtime, len) = stat_state_file(&path);
+                self.persisted_states.insert(
+                    scope,
+                    ScopeState {
+                        values: payload.clone(),
+                        mtime,
+                        len,
+                        error: None,
+                    },
                 );
-                return;
+                log::info!(
+                    "app::{}: persisted state scope={} format={} to {}",
+                    self.app_id,
+                    scope.as_str(),
+                    self.config.state_format.as_str(),
+                    path.display()
+                );
             }
-        }
-        match serde_json::to_vec_pretty(payload)
-            .map_err(std::io::Error::other)
-            .and_then(|bytes| write_python_state_atomic(&path, &bytes))
-        {
-            Ok(()) => log::info!(
-                "app::{}: persisted state scope={} to {}",
-                self.app_id,
-                scope.as_str(),
-                path.display()
-            ),
             Err(error) => log::error!(
                 "app::{}: write state {}: {error}",
                 self.app_id,
@@ -4612,6 +4892,7 @@ mod tests {
             // `StateScope::Context`'s contract — `Global` would ignore the
             // root entirely and defeat the premise of every test here.
             state_scopes: vec![crate::host::state_scope::StateScope::Context],
+            state_format: crate::host::state_scope::StateFormat::Json,
             context_root: workspace_root.to_path_buf(),
         }
     }
@@ -4627,7 +4908,13 @@ mod tests {
             .first()
             .copied()
             .unwrap_or(crate::host::state_scope::StateScope::Global);
-        super::python_state_path(&config.app_id, scope, &config.context_root)
+        super::python_state_path(
+            &config.app_id,
+            scope,
+            config.state_format,
+            &config.context_root,
+        )
+        .expect("resolve state path")
     }
 
     #[test]
@@ -4701,7 +4988,7 @@ mod tests {
         first_state.insert("items".to_string(), json!(["buy milk"]));
         let path = python_state_path_for_config(&first);
         std::fs::create_dir_all(path.parent().expect("state parent")).expect("mkdir");
-        write_python_state_atomic(
+        crate::host::state_scope::atomic_write(
             &path,
             &serde_json::to_vec_pretty(&first_state).expect("serialize"),
         )
@@ -4713,7 +5000,7 @@ mod tests {
 
         // The second instance persists anything at all — a draft keystroke is
         // enough — and writes the empty item list it has held since launch.
-        write_python_state_atomic(
+        crate::host::state_scope::atomic_write(
             &path,
             &serde_json::to_vec_pretty(&second_state).expect("serialize"),
         )
@@ -4741,7 +5028,7 @@ mod tests {
 
         let path_a = python_state_path_for_config(&under_a);
         std::fs::create_dir_all(path_a.parent().expect("state parent")).expect("mkdir");
-        write_python_state_atomic(&path_a, br#"{"items":["buy milk"]}"#).expect("persist under A");
+        crate::host::state_scope::atomic_write(&path_a, br#"{"items":["buy milk"]}"#).expect("persist under A");
 
         assert_eq!(
             load_python_state(&under_a).expect("load under A")["items"],
@@ -4851,7 +5138,7 @@ mod tests {
 
         fn seed_items(address: &Path, items: &serde_json::Value) {
             std::fs::create_dir_all(address.parent().expect("state parent")).expect("mkdir");
-            write_python_state_atomic(
+            crate::host::state_scope::atomic_write(
                 address,
                 &serde_json::to_vec_pretty(&serde_json::json!({ "items": items }))
                     .expect("serialize"),
@@ -5046,7 +5333,7 @@ mod tests {
         let path = workspace.path().join("todo.json");
         std::fs::write(&path, br#"{"version":"old"}"#).expect("seed");
 
-        write_python_state_atomic(&path, br#"{"version":"new"}"#).expect("atomic replace");
+        crate::host::state_scope::atomic_write(&path, br#"{"version":"new"}"#).expect("atomic replace");
 
         assert_eq!(
             std::fs::read(&path).expect("state"),
@@ -5956,6 +6243,7 @@ mod tests {
                 crate::host::state_scope::StateScope::Global,
                 crate::host::state_scope::StateScope::Context,
             ],
+            state_format: crate::host::state_scope::StateFormat::Json,
             context_root: root_a.path().to_path_buf(),
         };
         let mut pane = LivePythonPane::launch(config).expect("launch pane");
@@ -6010,6 +6298,7 @@ mod tests {
             )
             .to_theme_map(),
             state_scopes: crate::host::state_scope::default_scopes(),
+            state_format: crate::host::state_scope::StateFormat::Json,
             context_root: undeclared_root.path().to_path_buf(),
         };
         let mut global_pane = LivePythonPane::launch(global_only).expect("launch global-only");
@@ -6020,6 +6309,280 @@ mod tests {
                 .join(".plexi/app_states/test.global-only.json")
                 .exists(),
             "an undeclared scope must not persist anything"
+        );
+    }
+
+    /// Shared scaffolding for the file-backed state tests (stint 0644):
+    /// a trivial app + a context-scoped launch config against a fresh root.
+    fn file_state_config(
+        app_dir: &Path,
+        app_id: &str,
+        context_root: &Path,
+        format: crate::host::state_scope::StateFormat,
+    ) -> PythonLaunchConfig {
+        std::fs::write(
+            app_dir.join("main.py"),
+            "def init(size, args): return []\ndef update(event): return []\ndef view():\n    from plexi_sdk.ui import Text\n    return Text('x')\n",
+        )
+        .expect("write app");
+        PythonLaunchConfig {
+            app_id: app_id.to_string(),
+            app_dir: app_dir.to_path_buf(),
+            entry: app_dir.join("main.py"),
+            module_name: "main".to_string(),
+            launch_args: Vec::new(),
+            workspace_root: app_dir.to_path_buf(),
+            capabilities: Vec::new(),
+            allowed_hosts: Vec::new(),
+            state_scopes: vec![crate::host::state_scope::StateScope::Context],
+            state_format: format,
+            theme: crate::ui::theme::colors_from_config(&crate::config::PlexiConfig::default())
+                .to_theme_map(),
+            context_root: context_root.to_path_buf(),
+        }
+    }
+
+    fn context_state_file(root: &Path, app_id: &str, ext: &str) -> PathBuf {
+        root.join(".plexi/app_states")
+            .join(format!("{app_id}.{ext}"))
+    }
+
+    #[test]
+    fn persist_does_not_clobber_a_file_changed_since_load() {
+        let app = tempdir().expect("app dir");
+        let root = tempdir().expect("context root");
+        let file = context_state_file(root.path(), "test.no-clobber", "json");
+        std::fs::create_dir_all(file.parent().unwrap()).expect("state dir");
+        std::fs::write(&file, serde_json::to_vec_pretty(&json!({"a": 1})).unwrap())
+            .expect("seed state");
+
+        let config = file_state_config(
+            app.path(),
+            "test.no-clobber",
+            root.path(),
+            crate::host::state_scope::StateFormat::Json,
+        );
+        let mut pane = LivePythonPane::launch(config).expect("launch pane");
+
+        // External writer lands after load. Different byte length guarantees
+        // the (mtime, len) pair differs even at 1s mtime granularity.
+        std::fs::write(
+            &file,
+            serde_json::to_vec_pretty(&json!({"external": "winner", "padding": 12345})).unwrap(),
+        )
+        .expect("external write");
+
+        pane.save_state(
+            Some(&json!("context")),
+            Some(&json!({"app": "would-clobber"})),
+        );
+
+        let on_disk: Value =
+            serde_json::from_slice(&std::fs::read(&file).expect("read state")).expect("json");
+        assert_eq!(
+            on_disk,
+            json!({"external": "winner", "padding": 12345}),
+            "disk wins: the app's persist must be dropped, not overwrite the external write"
+        );
+        let scope_state = pane
+            .persisted_states
+            .get(&crate::host::state_scope::StateScope::Context)
+            .expect("scope state");
+        assert_eq!(
+            Value::Object(scope_state.values.clone()),
+            json!({"external": "winner", "padding": 12345}),
+            "the on-disk values must replace (not merge into) the in-memory scope"
+        );
+
+        // A follow-up persist now syncs cleanly (identity was re-cached).
+        pane.save_state(Some(&json!("context")), Some(&json!({"app": "retry"})));
+        let retried: Value =
+            serde_json::from_slice(&std::fs::read(&file).expect("read state")).expect("json");
+        assert_eq!(retried, json!({"app": "retry"}));
+    }
+
+    #[test]
+    fn persist_is_atomic_and_leaves_no_partial_file() {
+        let app = tempdir().expect("app dir");
+        let root = tempdir().expect("context root");
+        let config = file_state_config(
+            app.path(),
+            "test.atomic",
+            root.path(),
+            crate::host::state_scope::StateFormat::Json,
+        );
+        let mut pane = LivePythonPane::launch(config).expect("launch pane");
+        pane.save_state(Some(&json!("context")), Some(&json!({"k": 1})));
+
+        let file = context_state_file(root.path(), "test.atomic", "json");
+        let on_disk: Value =
+            serde_json::from_slice(&std::fs::read(&file).expect("read state")).expect("json");
+        assert_eq!(on_disk, json!({"k": 1}));
+        let residue: Vec<String> = std::fs::read_dir(file.parent().unwrap())
+            .expect("read state dir")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|name| name.contains(".tmp-"))
+            .collect();
+        assert!(residue.is_empty(), "temp residue left behind: {residue:?}");
+    }
+
+    #[test]
+    fn malformed_state_file_surfaces_error_and_does_not_reset() {
+        let app = tempdir().expect("app dir");
+        let root = tempdir().expect("context root");
+        let file = context_state_file(root.path(), "test.malformed", "json");
+        std::fs::create_dir_all(file.parent().unwrap()).expect("state dir");
+        std::fs::write(&file, b"{not json at all").expect("seed corrupt state");
+
+        let config = file_state_config(
+            app.path(),
+            "test.malformed",
+            root.path(),
+            crate::host::state_scope::StateFormat::Json,
+        );
+        let mut pane = LivePythonPane::launch(config).expect("launch pane");
+        let scope = crate::host::state_scope::StateScope::Context;
+        assert!(
+            pane.persisted_states
+                .get(&scope)
+                .and_then(|s| s.error.as_ref())
+                .is_some(),
+            "a corrupt state file must surface as a scope error"
+        );
+
+        // Persists are refused while the error stands — the corrupt file is
+        // never silently replaced with `{}` or the app's payload.
+        pane.save_state(Some(&json!("context")), Some(&json!({"k": 1})));
+        assert_eq!(
+            std::fs::read(&file).expect("read state"),
+            b"{not json at all",
+            "a corrupt state file must not be overwritten"
+        );
+
+        // Fixing the file externally and re-reading clears the error.
+        std::fs::write(
+            &file,
+            serde_json::to_vec_pretty(&json!({"fixed": true})).unwrap(),
+        )
+        .expect("fix state file");
+        pane.apply_external_state(scope);
+        let scope_state = pane.persisted_states.get(&scope).expect("scope state");
+        assert!(
+            scope_state.error.is_none(),
+            "successful re-read clears the error"
+        );
+        assert_eq!(
+            Value::Object(scope_state.values.clone()),
+            json!({"fixed": true})
+        );
+        pane.save_state(Some(&json!("context")), Some(&json!({"k": 2})));
+        let on_disk: Value =
+            serde_json::from_slice(&std::fs::read(&file).expect("read state")).expect("json");
+        assert_eq!(
+            on_disk,
+            json!({"k": 2}),
+            "persists resume once the error clears"
+        );
+    }
+
+    #[test]
+    fn apply_external_state_replaces_rather_than_merges() {
+        let app = tempdir().expect("app dir");
+        let root = tempdir().expect("context root");
+        let file = context_state_file(root.path(), "test.replace", "json");
+        std::fs::create_dir_all(file.parent().unwrap()).expect("state dir");
+        std::fs::write(
+            &file,
+            serde_json::to_vec_pretty(&json!({"a": 1, "b": 2})).unwrap(),
+        )
+        .expect("seed state");
+
+        let config = file_state_config(
+            app.path(),
+            "test.replace",
+            root.path(),
+            crate::host::state_scope::StateFormat::Json,
+        );
+        let mut pane = LivePythonPane::launch(config).expect("launch pane");
+        let scope = crate::host::state_scope::StateScope::Context;
+
+        // External write drops key "b"; longer content keeps (mtime, len)
+        // distinct without relying on mtime granularity.
+        std::fs::write(
+            &file,
+            serde_json::to_vec_pretty(&json!({"a": 99, "padding": "xxxxxxxxxxxx"})).unwrap(),
+        )
+        .expect("external write");
+        pane.apply_external_state(scope);
+
+        let scope_state = pane.persisted_states.get(&scope).expect("scope state");
+        assert_eq!(
+            Value::Object(scope_state.values.clone()),
+            json!({"a": 99, "padding": "xxxxxxxxxxxx"}),
+            "external state must replace wholesale — deleted keys must vanish, never merge"
+        );
+    }
+
+    #[test]
+    fn markdown_format_writes_document_verbatim() {
+        let app = tempdir().expect("app dir");
+        let root = tempdir().expect("context root");
+        let config = file_state_config(
+            app.path(),
+            "test.markdown",
+            root.path(),
+            crate::host::state_scope::StateFormat::Markdown,
+        );
+        let mut pane = LivePythonPane::launch(config).expect("launch pane");
+
+        let document = "# Checklist\n\n- [ ] first\n- [x] second\n";
+        pane.save_state(
+            Some(&json!("context")),
+            Some(&json!({"document": document})),
+        );
+
+        let file = context_state_file(root.path(), "test.markdown", "md");
+        assert!(file.exists(), "markdown state must use the .md extension");
+        assert_eq!(
+            std::fs::read(&file).expect("read markdown state"),
+            document.as_bytes(),
+            "markdown bytes must round-trip verbatim — no JSON envelope, no escaping"
+        );
+
+        // Read-back is the inverse: {"document": "<file text>"}.
+        let external = "# Edited outside\n";
+        std::fs::write(&file, external).expect("external markdown write");
+        pane.apply_external_state(crate::host::state_scope::StateScope::Context);
+        let scope_state = pane
+            .persisted_states
+            .get(&crate::host::state_scope::StateScope::Context)
+            .expect("scope state");
+        assert_eq!(
+            Value::Object(scope_state.values.clone()),
+            json!({"document": external})
+        );
+    }
+
+    #[test]
+    fn markdown_format_rejects_non_string_document() {
+        let app = tempdir().expect("app dir");
+        let root = tempdir().expect("context root");
+        let config = file_state_config(
+            app.path(),
+            "test.markdown-bad",
+            root.path(),
+            crate::host::state_scope::StateFormat::Markdown,
+        );
+        let mut pane = LivePythonPane::launch(config).expect("launch pane");
+
+        pane.save_state(Some(&json!("context")), Some(&json!({"document": 42})));
+        pane.save_state(Some(&json!("context")), Some(&json!({"not_document": "x"})));
+
+        let file = context_state_file(root.path(), "test.markdown-bad", "md");
+        assert!(
+            !file.exists(),
+            "a non-string (or missing) document must be a loud error with NO write"
         );
     }
 
@@ -6045,6 +6608,7 @@ mod tests {
             )
             .to_theme_map(),
             state_scopes: crate::host::state_scope::default_scopes(),
+            state_format: crate::host::state_scope::StateFormat::Json,
             context_root: app.path().to_path_buf(),
         };
         let mut runtime = WasmPythonRuntime::launch(&config).expect("launch CPython WASM");
@@ -6170,6 +6734,7 @@ mod tests {
             )
             .to_theme_map(),
             state_scopes: crate::host::state_scope::default_scopes(),
+            state_format: crate::host::state_scope::StateFormat::Json,
             context_root: app.path().to_path_buf(),
         };
         let colors = crate::ui::theme::colors_from_config(&crate::config::PlexiConfig::default());
@@ -6259,6 +6824,7 @@ mod tests {
             )
             .to_theme_map(),
             state_scopes: crate::host::state_scope::default_scopes(),
+            state_format: crate::host::state_scope::StateFormat::Json,
             context_root: app.path().to_path_buf(),
         };
         let err = run_headless_frame(&config, (480.0, 320.0), None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,10 +241,9 @@ fn main() -> eframe::Result {
         })
         .collect();
     use crate::cli::args::{
-        AccountCmd, AgentCmd, AiCmd, AppCmd, Cli, Commands, ConfigCmd, ContextCmd, DescriptorCmd,
-        EventsCmd, HookAction, HostCmd, NotesCmd, NotifyCmd, PaneCmd, PaneSlotCmd,
-        RegistryCmd,
-        RoutineCmd, SecretCmd, UpdateCmd, WorkspaceCmd,
+        AccountCmd, AgentCmd, AiCmd, AppCmd, AppStateCmd, Cli, Commands, ConfigCmd, ContextCmd,
+        DescriptorCmd, EventsCmd, HookAction, HostCmd, NotesCmd, NotifyCmd, PaneCmd, PaneSlotCmd,
+        RegistryCmd, RoutineCmd, SecretCmd, UpdateCmd, WorkspaceCmd,
     };
     use clap::Parser;
     let args = cli::args::normalize_config_scope_aliases(args);
@@ -601,6 +600,14 @@ fn main() -> eframe::Result {
                                 std::process::exit(cli::app_test_cli(&path, snapshot));
                             }
                             AppCmd::Info { id } => std::process::exit(cli::app_info(&id)),
+                            AppCmd::State { cmd } => match cmd {
+                                AppStateCmd::Get { app, scope } => std::process::exit(
+                                    cli::app_state::get(&app, scope.as_deref()),
+                                ),
+                                AppStateCmd::Set { app, file, scope } => std::process::exit(
+                                    cli::app_state::set(&app, file.as_deref(), scope.as_deref()),
+                                ),
+                            },
                             AppCmd::Validate { path } => {
                                 log::info!("app_validate:cli: path={path}");
                                 std::process::exit(cli::validate_cli(&path));

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -531,6 +531,9 @@ impl PlexiApp {
         let app_id = config.app_id.clone();
         let runtime = crate::host::wasm_python::LivePythonPane::launch(config)
             .map_err(|error| error.to_string())?;
+        // Captured before the runtime moves into the pane closure; the drain
+        // pass re-syncs these if the pane's context root changes later.
+        let state_paths = runtime.state_paths();
         let manifest_id = app_id.clone();
         let name = app_id.clone();
         let new_id = self
@@ -560,6 +563,9 @@ impl PlexiApp {
             )
             .ok_or_else(|| format!("overlay launch target unavailable for {app_id}"))?;
         self.hot_reload.watch(new_id, app_dir);
+        // State files (stint 0644): watch for external writes so CLI/agent
+        // edits reach the running app without a relaunch.
+        self.state_watch.watch(new_id, &state_paths);
         crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
             app_id: app_id.clone(),
             type_id: "python-wasm".to_string(),
@@ -812,6 +818,67 @@ impl PlexiApp {
     pub(crate) fn drain_hot_reload_requests(&mut self) {
         while let Ok(req) = self.hot_reload_rx.try_recv() {
             self.reload_app_pane(req.pane_id, "watcher");
+        }
+    }
+
+    /// Drain pending `StateChangedNotice`s from the state watcher and re-read
+    /// the affected scope on the matching pane (stint 0644). In the same pass,
+    /// re-sync every live Python pane's watcher registration against its
+    /// currently-resolved state paths — `plexi context set-root` moves
+    /// context-scoped paths without any pane event, and this drain is the one
+    /// place that observes both sides. Called once per `logic` pass.
+    pub(crate) fn drain_state_change_requests(&mut self) {
+        while let Ok(notice) = self.state_watch_rx.try_recv() {
+            let mut found = false;
+            for window in &mut self.windows {
+                if let Some(app_pane) = window
+                    .panes
+                    .get_mut(&notice.pane_id)
+                    .and_then(|pane| pane.as_app_mut())
+                {
+                    log::info!(
+                        "state_watch: external change → pane {} app {} scope={}",
+                        notice.pane_id,
+                        app_pane.manifest_id,
+                        notice.scope.as_str()
+                    );
+                    app_pane.runtime.apply_external_state(notice.scope);
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                // Pane closed between the notice and the drain — the unwatch
+                // on close already tore the watcher down; nothing to do.
+                log::debug!(
+                    "state_watch: notice for unknown pane {} dropped (pane closed)",
+                    notice.pane_id
+                );
+            }
+        }
+
+        // Registration re-sync: covers context-root moves.
+        let mut stale: Vec<(
+            PaneId,
+            Vec<(crate::host::state_scope::StateScope, std::path::PathBuf)>,
+        )> = Vec::new();
+        for window in &self.windows {
+            for pane in window.panes.values() {
+                let Some(app_pane) = pane.as_app() else {
+                    continue;
+                };
+                let current = app_pane.runtime.state_paths();
+                if current.is_empty() {
+                    continue;
+                }
+                if self.state_watch.watched_entries(app_pane.id) != current.as_slice() {
+                    stale.push((app_pane.id, current));
+                }
+            }
+        }
+        for (pane_id, entries) in stale {
+            log::info!("state_watch: re-registering pane {pane_id} — resolved state paths changed");
+            self.state_watch.watch(pane_id, &entries);
         }
     }
 

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -906,6 +906,8 @@ impl PlexiApp {
             // Hot reload (#83): drop any active watcher for this pane.
             // Idempotent — no-op when the pane wasn't being watched.
             self.hot_reload.unwatch(pane_id);
+            // State watch (stint 0644): same lifecycle, same idempotence.
+            self.state_watch.unwatch(pane_id);
             // Tombstone any notifications this pane posted — they stay visible but
             // their action buttons are hidden since the app can no longer respond.
             self.tombstone_pane_notifications(pane_id);

--- a/src/protocol/events.rs
+++ b/src/protocol/events.rs
@@ -203,6 +203,21 @@ pub enum PlexiEvent {
     /// Sent at startup with persisted app state (workspace if available, else global).
     /// Also usable from `pgap_test_harness` to seed deterministic state.
     InjectState { payload: serde_json::Value },
+    /// A state scope's backing file changed outside the app's own persist
+    /// flow — an external edit, or a persist the app lost to a concurrent
+    /// external write (disk wins; the dropped persist is answered with this
+    /// event). `payload` is the scope's full on-disk value set; the SDK
+    /// replaces the scope wholesale (deleted keys vanish — never a merge).
+    /// `error` is set when the file exists but could not be decoded; the
+    /// previous values are kept in that case and persists to the scope are
+    /// blocked until a successful re-read.
+    StateChanged {
+        scope: String,
+        payload: serde_json::Value,
+        #[serde(default)]
+        error: Option<String>,
+        source: String,
+    },
     /// DEPRECATED: superseded by the `state` field on Init.
     /// Kept for backwards compatibility with older SDK versions. The headless
     /// renderer no longer sends this event.

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -457,6 +457,7 @@ Manage your Plexi apps — open, install, list, scaffold, and inspect
 | `check` | Check a local app with manifest, scaffold metadata, SDK, and render-size checks |
 | `test` | Run an app's AppHarness tests with `uv run pytest tests/` |
 | `info` | Show details about an installed app: id, name, version, and available tools |
+| `state` | Read or replace a file-backed app's state document (stint 0645) |
 | `init` | Create a new app from a template |
 | `validate` | Check a Plexi app directory or .plexipkg package for errors before publishing or installing |
 | `inspect` | Show the trust sheet for a local app directory or .plexipkg package |
@@ -578,6 +579,36 @@ Show details about an installed app: id, name, version, and available tools
 | Flag / Arg | Type | Required | Description |
 |---|---|---|---|
 | `<id>` | string | yes |  |
+
+### `plexi app state`
+
+Read or replace a file-backed app's state document (stint 0645).
+
+Only apps that declare a `[state]` section are addressable. The state path is resolved from the manifest and the calling context — callers never pass a path, and there is no flag to address another context.
+
+| Subcommand | Description |
+|---|---|
+| `get` | Print an app's current state document to stdout |
+| `set` | Replace an app's state document, reading from a file or stdin |
+
+#### `plexi app state get`
+
+Print an app's current state document to stdout
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<app>` | string | yes | App id (from `plexi app list`) |
+| `--scope` | string | no | Which declared scope to read. Defaults to the app's first declared scope; a scope the app did not declare is an error |
+
+#### `plexi app state set`
+
+Replace an app's state document, reading from a file or stdin
+
+| Flag / Arg | Type | Required | Description |
+|---|---|---|---|
+| `<app>` | string | yes | App id (from `plexi app list`) |
+| `<file>` | string | no | File to read the new document from. Reads stdin when omitted |
+| `--scope` | string | no | Which declared scope to write. Defaults to the app's first declared scope; a scope the app did not declare is an error |
 
 ### `plexi app init`
 

--- a/website/src/content/docs/pgap.md
+++ b/website/src/content/docs/pgap.md
@@ -1284,6 +1284,17 @@ Drop a JSON payload into the app's `on_inject` hook. Sent at startup with persis
 |-------|------|----------|
 | `payload` | `any` | yes |
 
+### `state_changed`
+
+A state scope's backing file changed outside the app's own persist flow — an external edit, or a persist the app lost...
+
+| Field | Type | Required |
+|-------|------|----------|
+| `error` | `string?` | no |
+| `payload` | `any` | yes |
+| `scope` | `string` | yes |
+| `source` | `string` | yes |
+
 ### `render_seed`
 
 DEPRECATED: superseded by the `state` field on Init. Kept for backwards compatibility with older SDK versions. The he...

--- a/website/src/content/docs/sdk.md
+++ b/website/src/content/docs/sdk.md
@@ -48,6 +48,13 @@ to disk. The host owns path construction: ``global`` state lives in
 ``<context_root>/.plexi/app_states/`` — resolved against the pane's
 context root at call time. ``scope=None`` targets the default scope.
 
+Read-back rule (disk wins): the host checks the file before writing. A
+persist that loses to a concurrent external write is dropped — the host
+reloads the on-disk state instead and answers with an
+``events.StateChanged``, so re-apply your change from that event rather
+than assuming the persist landed. Writes are atomic (temp + rename) in
+both directions; a reader never sees a partial file.
+
 ### `SetSchedulerMode`
 
 ```python
@@ -444,6 +451,24 @@ PipeClosed(handle: int)
 ```python
 PipeError(handle: int, error: str)
 ```
+
+### `StateChanged`
+
+```python
+StateChanged(scope: str, values: dict, source: str = 'external', error: Optional[str] = None)
+```
+
+A state scope's backing file changed outside this app's own persist
+flow — an external edit (CLI, agent, editor), or a persist this app lost
+to a concurrent external write (disk wins: the dropped persist is
+answered with this event).
+
+``values`` is the scope's full value set after the change; the runtime
+has already replaced the scope wholesale (deleted keys are gone — never a
+merge) before dispatching this event, so ``state.get`` reads are fresh
+inside ``update()``. When ``error`` is set the file could not be decoded:
+the previous values are kept and persists to the scope are blocked until
+a successful re-read.
 
 ### `CapabilityGranted`
 


### PR DESCRIPTION
Resumes the branch parked overnight on 2026-07-31. It was stacked on the
then-unmerged #2536; this rebases it onto the merged 0652 on alpha, reconciles
it with alpha's later fix round, and finishes stint 0645, which had not been
started.

## What this makes true

An app's state is a file, and anything with permission can write it. A human
types an item in a pane while an agent writes three more from the CLI, and both
see the same list.

## 0644 — host + SDK

The write path already existed (`PersistState` → `save_state`). Read-back did
not, so a live pane silently destroyed any external write on its next persist.
That was the actual defect.

- `save_state` re-stats before writing. On conflict **disk wins**: the persist
  is dropped, disk is reloaded, and the app is notified via a new
  `state_changed` event. The re-stat happens *after* the rename — the other
  order makes every self-write look external and loops reloads.
- Conflict detection is the `(mtime, len)` pair, not mtime alone; mtime
  granularity can be a full second.
- A malformed or externally-corrupted file surfaces an error and keeps the
  previous values. Losing a user's list to a script writing bad JSON is the
  failure mode designed against first.
- `StateWatcher` watches each state file's **parent dir** filtered by filename —
  single-file watches die on atomic rename, and the shared global dir needs
  sibling-app filtering. Drained in `App::logic`, never `ui`, so an occluded
  window still services it.
- Markdown format keeps the host format-blind: the app's `document` string is
  written verbatim, read back as `{"document": text}`. The SDK ships a blessed
  checklist codec so apps don't each invent serialization.
- Context-scoped state is gitignored at context establishment — personal local
  data, never committed.

## 0645 — the CLI surface

`plexi app state get|set <app> [--scope global|context]`

Disk-direct and host-independent: no socket, no `AppRequest`. A running app
picks the write up through the 0644 watcher within one debounce window.

- Only apps that explicitly declare `[state]` are addressable. After 0652 every
  app *defaults* to `["global"]`, so "has file-backed state" has to mean
  "declared it" — hence `state_declared`.
- `--scope` defaults to the app's own first declared scope, never a CLI-side
  constant. An undeclared scope is a nonzero exit naming the declared set.
- `set` reads a file argument or stdin, and validates in the declared format
  **before** writing — a rejected document never reaches disk.
- Entitlement is structural, not checked: there is no path argument and no
  `--context` flag, so the only reachable files are the calling context's.
- Every attempt traces app, scope, caller, path, and verdict at info level.

Partial/merge updates are deliberately out of scope — get/set proves the
capability, and the right merge semantics are clearer once something real uses
it. MCP remains the destination for *semantic* manipulation; it sits on top of
this state model rather than replacing it.

## Merge notes

Alpha's 0652 fix round and the parked branch both grew code in this area:

- `write_python_state_atomic` (alpha) and `state_scope::atomic_write` (parked)
  were duplicate atomic writers. The resolver-owned one survives; alpha's tests
  were migrated onto it.
- Alpha's `PendingNotification` lost `level`/`priority` to stint 0711; a seeded
  fixture on this branch still set them.
- `sdk/python/uv.lock` was stale (0.2.3 vs pyproject's 0.2.5), picked up
  incidentally by running the SDK suite. That drift turned out to be a release
  script bug and is **not** part of this PR: it is fixed on alpha in
  `bbf867ce`, which re-locks on bump and adds a `check-sdk-lock` gate.

## Testing

- `cargo test --bin plexi`: **2240 passed, 0 failed**, re-run after rebasing onto
  alpha `fcb8e0e5`. The `scene_suite` failures this PR previously reported as
  pre-existing (`notes-image-drop`, `notes-live-preview`) are gone, fixed by
  #2568's scene `/tmp` state cleanup — confirming they were never this branch's.
- SDK: `270 passed, 1 skipped`. `mypy` clean.
- All docs gates green: CLI, config, SDK, capability, coverage, authoring,
  schema. Generated artifacts regenerated from their generators, never by hand.
- New security tests assert the escapes fail: traversal and absolute app ids, a
  symlinked `app_states` dir, an undeclared scope, a malformed document, and a
  `PLEXI_CONTEXT_ROOT` pointing at a missing dir (errors, never creates).

Converting the todo app is stint 0646 and is deliberately **not** folded in.

