### PR TITLE
chore(build): raise cargo jobs throttle 3 -> 6

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,9 @@
 [build]
 target-dir = "target"
 
-# THROTTLE: limits cargo to 3 of 10 logical cores to keep the machine
-# responsive during parallel agent builds. Builds take ~3x longer.
-# When on a faster machine, remove this line and cargo will default to
-# using all available cores.
-jobs = 3
+# THROTTLE: limits cargo to 6 of 10 logical cores so the machine stays
+# responsive during a build. Builds are serialized machine-wide by
+# scripts/cargo-with-lease.sh (kernel flock), so this only needs to leave
+# headroom for one build, not N parallel ones. On a faster machine, remove
+# this line and cargo will default to all available cores.
+jobs = 6

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,12 +37,13 @@ fi
 
 display="Plexi${cap}"
 bundle_id="com.ianjamesburke.plexi${suffix}"
-# Resolve target-dir from cargo metadata so all worktrees share a single build
-# cache. The CARGO_TARGET_DIR env var or a [build] target-dir in .cargo/config.toml
-# points every worktree at <repo-root>/target/ rather than a per-worktree target/.
-# INVARIANT: if you change the target-dir in .cargo/config.toml, update this
-# resolver too. A mismatch causes install to silently skip the binary because the
-# bundle lands in the old path while this script looks in the new one.
+# Resolve target-dir from cargo metadata rather than hardcoding a path. The
+# [build] target-dir in .cargo/config.toml is relative ("target"), so each
+# worktree builds into its own target/ — worktrees do NOT share a build cache
+# (cross-worktree reuse comes from sccache, not a shared target dir).
+# Resolving via cargo metadata keeps this script correct regardless of where
+# target-dir points; a hardcoded path would silently skip the binary because
+# the bundle lands in one place while this script looks in another.
 _target_dir="$(cargo metadata --format-version=1 --no-deps 2>/dev/null | python3 -c 'import sys,json; print(json.load(sys.stdin)["target_directory"])' 2>/dev/null || echo "")"
 
 # Preflight: fail fast if target-dir resolution failed rather than building and


### PR DESCRIPTION
## Why

The `jobs = 3` throttle in `.cargo/config.toml` existed to keep the machine responsive during **parallel** agent builds. Since c828829c, `scripts/cargo-with-lease.sh` serializes every cargo invocation behind a kernel flock — only one build runs at a time, so the throttle only needs headroom for a single build. Every build was paying ~3x wall-clock for protection the flock already provides.

## What

- `.cargo/config.toml`: `jobs = 3` → `jobs = 6` (of 10 logical cores), comment updated to reference the flock serialization.
- `scripts/install.sh`: fix a stale comment claiming all worktrees share a repo-root `target/`. The `target-dir` is relative, so each worktree has its own `target/`; cross-worktree reuse comes from sccache. The `cargo metadata` resolver itself is unchanged and already handles this correctly.

## Validation

- `cargo metadata` parses the new config cleanly from the worktree.
- `bash -n scripts/install.sh` passes; comment-only change, resolver logic untouched.
- No Rust code touched — no host logic or UI surface to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)