### PR TITLE
fix(ui/sidebar): single-context sidebar inflates to max width with a dead gap strip and un-resizable panel (stint 0715)

### DIFF
--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -6932,3 +6932,44 @@ fn logic_drains_run_without_panic_visible_and_hidden() {
         "hidden frame pass must still run every logic drain and end at logic_complete"
     );
 }
+
+/// Stint 0715: the sidebar's context row used to allocate `available_width`
+/// plus one unbudgeted `item_spacing.x`. egui stores a panel's *content* rect
+/// as that panel's size, so the overflow was read back as the panel width on
+/// the next frame and re-overflowed — a monotonic ramp (+8pt/frame here) that
+/// pinned the sidebar at its `size_range` maximum and undid any user resize.
+/// The first-run state, exactly one context, is the one that showed it.
+#[cfg(test)]
+mod sidebar_panel_width_tests {
+    use super::*;
+
+    fn sidebar_width(h: &HostHarness) -> f32 {
+        egui::containers::panel::PanelState::load(&h.ctx, egui::Id::new("sidebar"))
+            .expect("sidebar panel state must exist after a frame")
+            .rect
+            .width()
+    }
+
+    #[test]
+    fn single_context_sidebar_settles_at_default_width() {
+        let mut h = HostHarness::new();
+        h.app.sidebar_visible = true;
+        assert_eq!(h.app.router.len(), 1, "setup: first-run is one context");
+
+        h.run_frames(2);
+        let settled = sidebar_width(&h);
+        assert_eq!(
+            settled,
+            crate::ui::style::SIDEBAR_DEFAULT_W,
+            "a single-context sidebar must settle at SIDEBAR_DEFAULT_W"
+        );
+
+        h.run_frames(20);
+        assert_eq!(
+            sidebar_width(&h),
+            settled,
+            "the sidebar must not grow frame over frame — a widening panel means \
+             the context row is again allocating more than the panel's width"
+        );
+    }
+}

--- a/src/ui/AGENTS.md
+++ b/src/ui/AGENTS.md
@@ -9,7 +9,7 @@ Host overlays should use these instead of raw egui layout wherever a primitive e
 - `overlay::ModalShell` for modal frame, scrim, title, body, scroll body, and dismissal.
 - `typography` for modal titles, section labels, body text, captions, and muted text.
 - `list::ListRow`, `row`, `text_field::TextField`, `button`, `hints::HintBar`, and `surface` for repeated chrome.
-- `sidebar_row::SidebarRow` for context-list rows — index gutter, badge slot, close action, and per-window pane-pip capsules. It resolves every slot rect in one `measure` pass; never hand-place a piece of a sidebar row.
+- `sidebar_row::SidebarRow` for context-list rows. Two tiers, the same convention `ListRow` uses for a secondary line: identity on top (index gutter, name, close action), pane state below (per-window pip capsules, overflow count, notification badge, root path). It resolves every slot rect in one `measure` pass; never hand-place a piece of a sidebar row.
 
 ## Design Tokens (`src/style.rs`)
 

--- a/src/ui/AGENTS.md
+++ b/src/ui/AGENTS.md
@@ -9,6 +9,7 @@ Host overlays should use these instead of raw egui layout wherever a primitive e
 - `overlay::ModalShell` for modal frame, scrim, title, body, scroll body, and dismissal.
 - `typography` for modal titles, section labels, body text, captions, and muted text.
 - `list::ListRow`, `row`, `text_field::TextField`, `button`, `hints::HintBar`, and `surface` for repeated chrome.
+- `sidebar_row::SidebarRow` for context-list rows — index gutter, badge slot, close action, and per-window pane-pip capsules. It resolves every slot rect in one `measure` pass; never hand-place a piece of a sidebar row.
 
 ## Design Tokens (`src/style.rs`)
 

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,7 +1,7 @@
 use crate::host::context::WindowMenuAction;
 use crate::ui::button;
 use crate::ui::list::ListDropdownHeader;
-use crate::ui::sidebar_row::{ContextItem, PaneDots, SidebarAction};
+use crate::ui::sidebar_row::{PaneDots, SidebarAction, SidebarRow};
 use crate::workspace::router::ContextMove;
 use egui::{Align, CornerRadius, Layout, Rect, RichText, Stroke, Vec2};
 use egui_tiles::Tile;
@@ -227,7 +227,7 @@ impl PlexiApp {
             let ctx_id = self.router.get(i).context_id;
             let pane_dots = self.sidebar_pane_dots(ctx_id, is_active);
 
-            // --- Renaming: special-cased before ContextItem path ---
+            // --- Renaming: special-cased before the SidebarRow path ---
             if is_renaming {
                 let fill = if is_active {
                     self.colors.bg_active
@@ -295,7 +295,7 @@ impl PlexiApp {
                 continue;
             }
 
-            // --- Normal row via ContextItem ---
+            // --- Normal row via SidebarRow ---
             let ctx_name = self.router.get(i).name.clone();
             let badge_count = if is_active {
                 self.visible_notification_count()
@@ -304,7 +304,7 @@ impl PlexiApp {
             };
             let subtitle = Some(self.router.get(i).root.display().to_string());
 
-            let (action, response) = ContextItem {
+            let (action, response) = SidebarRow {
                 is_active,
                 is_dragging,
                 any_dragging,
@@ -316,7 +316,7 @@ impl PlexiApp {
                 pane_dots,
                 draggable: true,
             }
-            .draw(ui, egui::Id::new(("ctx", i)), &self.colors);
+            .show(ui, egui::Id::new(("ctx", i)), &self.colors);
 
             active_rects.push(response.rect);
 
@@ -442,7 +442,7 @@ impl PlexiApp {
 
                     let pane_dots = self.sidebar_pane_dots(ctx_id, false);
 
-                    let (action, response) = ContextItem {
+                    let (action, response) = SidebarRow {
                         is_active: false,
                         is_dragging: self.drag_context == Some(i),
                         any_dragging: self.drag_context.is_some(),
@@ -454,7 +454,7 @@ impl PlexiApp {
                         pane_dots,
                         draggable: true,
                     }
-                    .draw(ui, egui::Id::new(("parked_ctx", i)), &self.colors);
+                    .show(ui, egui::Id::new(("parked_ctx", i)), &self.colors);
 
                     parked_rects.push(response.rect);
 

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -6,6 +6,12 @@
 //! gutter aligned to the title, a numeric badge slot distinct from the trailing
 //! action, drag-reorder sensing, and pane pips grouped into per-window capsules.
 //!
+//! The row is two tiers, the same convention [`crate::ui::list::ListRow`] uses
+//! when it has a secondary line: identity on top (index gutter, context name,
+//! and the close action pinned to the row's top-right corner), pane state
+//! below (per-window pip capsules, the overflow count, the notification badge,
+//! and the root path filling whatever is left).
+//!
 //! Geometry is resolved exactly once, by [`RowGeometry::measure`], into explicit
 //! slot rects in row-local space; [`RowGeometry::translated`] moves the whole set
 //! onto the allocated rect. Painting and hit testing both read those rects, so no
@@ -25,21 +31,27 @@ const ROW_INDENT: f32 = 4.0;
 const GUTTER_W: f32 = 18.0;
 /// Top and bottom padding added inside each row for vertical breathing room.
 const ROW_PAD_V: f32 = 7.0;
-/// Right margin for row content that has no trailing slot in front of it.
-const ROW_PAD_RIGHT: f32 = style::SPACE_SM;
-/// Vertical gap between the title line and the path line.
-const TITLE_SUBTITLE_GAP: f32 = 2.0;
+/// Right margin for row content, measured from the row edge. The selection
+/// card insets by `SPACE_XS`, so this leaves visible air inside its outline.
+const ROW_PAD_RIGHT: f32 = style::SPACE_MD;
+/// Vertical gap between the identity tier and the pane-state tier.
+const TIER_GAP: f32 = 3.0;
 
-/// Trailing slot widths. The two slots sit at fixed offsets from the row's
-/// right edge, in this order, so they can never swap or overlap.
-const CLOSE_SLOT_W: f32 = 22.0;
-const BADGE_SLOT_W: f32 = 18.0;
-const TRAILING_SLOT_GAP: f32 = style::SPACE_SM;
-/// Gap between the context name and the pane-pip strip on the title line.
+/// The close action is the row's card-level dismiss, pinned to the top-right
+/// corner of the identity tier — a touch larger than body chrome so it reads
+/// as closing the whole card, not editing a field.
+const CLOSE_SLOT_W: f32 = 26.0;
+const CLOSE_GLYPH_SIZE: f32 = style::TEXT_TITLE;
+/// Gap between the pip strip and the notification badge. The badge is a
+/// separate kind of thing from the pips and must never look glued to them.
+const PIP_BADGE_GAP: f32 = style::SPACE_SM;
+/// Gap before the root path, which fills whatever the pane state leaves.
+const PATH_GAP: f32 = style::SPACE_SM;
+/// Below this the path is dropped rather than elided down to a stub — pane
+/// state is the tier's job, and "/pro…" is noise, not information.
+const PATH_MIN_W: f32 = 48.0;
+/// Gap between the last capsule and the "+N" overflow count.
 const PIP_TEXT_GAP: f32 = style::SPACE_XS;
-/// The name never gives up more than this to the pip strip — a row whose
-/// context is unreadable is worse than one showing fewer pane dots.
-const TITLE_MIN_W: f32 = 56.0;
 
 /// Status-pip radius. Shared with the portal minimap so activity dots are the
 /// same size everywhere they appear (sidebar rows + portal previews).
@@ -136,9 +148,9 @@ pub struct SidebarRow {
     pub ctx_name: String,
     pub ctx_index: Option<usize>,
     pub badge_count: usize,
-    /// Root path shown on its own line below the title line.
+    /// Root path, trailing the pane-state tier.
     pub subtitle: Option<String>,
-    /// Pane pips shown on the title line, right of the name.
+    /// Pane pips, leading the pane-state tier.
     pub pane_dots: Option<PaneDots>,
     /// Whether this row supports drag reordering. When false, hover shows
     /// PointingHand instead of Grab and drag actions are suppressed.
@@ -265,105 +277,132 @@ struct RowGeometry {
     gutter: Rect,
     title: Rect,
     title_galley: std::sync::Arc<egui::Galley>,
-    subtitle: Option<(Rect, std::sync::Arc<egui::Galley>)>,
+    /// Close action, pinned to the identity tier's right edge.
+    close: Option<Rect>,
     /// Strip origin (left edge, vertical center) plus its measured layout.
     pips: Option<(Pos2, PipLayout)>,
-    badge: Option<Rect>,
-    close: Option<Rect>,
+    /// Badge pill and its centered count text.
+    badge: Option<(Rect, std::sync::Arc<egui::Galley>)>,
+    /// Root path, right-aligned in whatever the pane-state tier has left.
+    path: Option<(Rect, std::sync::Arc<egui::Galley>)>,
 }
 
 impl RowGeometry {
     fn measure(ui: &egui::Ui, row: &SidebarRow, width: f32) -> Self {
         let content_left = ROW_INDENT + GUTTER_W;
+        let content_right = width - ROW_PAD_RIGHT;
 
-        // Trailing slots are laid out right to left at fixed widths, so their
-        // positions depend on nothing but which of them are present.
-        let close = row
-            .action_enabled
-            .then_some((width - CLOSE_SLOT_W, CLOSE_SLOT_W));
-        let badge_right = close.map_or(width, |(left, _)| left - TRAILING_SLOT_GAP);
-        let badge = (row.badge_count > 0).then_some((badge_right - BADGE_SLOT_W, BADGE_SLOT_W));
-        // With no trailing slot to sit behind, content still keeps the row's
-        // right margin so text never kisses the selection card's outline.
-        let content_right = badge
-            .or(close)
-            .map_or(width - ROW_PAD_RIGHT, |(left, _)| left)
-            .max(content_left);
+        // ── Identity tier: gutter, name, close ────────────────────────────
+        // The close action is the only thing that shares this line, so the
+        // name's budget is one subtraction and does not vary with pane state.
+        let close_left = row.action_enabled.then_some(content_right - CLOSE_SLOT_W);
+        let title_max = (close_left.unwrap_or(content_right) - content_left).max(0.0);
+        let title_galley = elided_galley(
+            ui,
+            &row.ctx_name,
+            egui::FontId::proportional(style::TEXT_SIDEBAR_TITLE),
+            title_max,
+        );
+        // The close slot is a hit target, not a text line: it is centered on
+        // the title and allowed to overhang into the row's padding rather than
+        // stretching the tier and bulking up every row.
+        let identity_h = title_galley.size().y;
+        let identity_top = ROW_PAD_V;
+        let identity_center_y = identity_top + identity_h / 2.0;
 
-        // The name owns the content lane; the pip strip may take what is left
-        // above the name's floor, and shrinks to fit it. Nothing here depends
-        // on the panel width beyond that one subtraction, so the row has one
-        // shape at every size instead of one per combination of slots.
+        // ── Pane-state tier: pips, badge, path ────────────────────────────
+        // Laid out left to right with fixed reservations, so the path is the
+        // only elastic element and no two of them can ever collide.
         let lane = (content_right - content_left).max(0.0);
+        let badge_galley = (row.badge_count > 0).then(|| {
+            let label = if row.badge_count > 9 {
+                "9+".to_string()
+            } else {
+                row.badge_count.to_string()
+            };
+            ui.fonts_mut(|f| {
+                f.layout_no_wrap(
+                    label,
+                    egui::FontId::proportional(style::TEXT_META),
+                    Color32::PLACEHOLDER,
+                )
+            })
+        });
+        let badge_size = badge_galley.as_ref().map(|galley| {
+            let h = galley.size().y + style::BADGE_PAD_V * 2.0;
+            Vec2::new((galley.size().x + style::BADGE_PAD_H * 2.0).max(h), h)
+        });
+        let badge_reserved = badge_size.map_or(0.0, |size| size.x + PIP_BADGE_GAP);
+
         let pips = row
             .pane_dots
             .as_ref()
-            .and_then(|dots| PipLayout::measure(dots, lane - TITLE_MIN_W - PIP_TEXT_GAP));
-        let pip_reserved = pips
-            .as_ref()
-            .map_or(0.0, |layout| layout.width + PIP_TEXT_GAP);
-
-        let title_font = egui::FontId::proportional(style::TEXT_SIDEBAR_TITLE);
-        let title_max = (content_right - content_left - pip_reserved).max(0.0);
-        let title_galley = elided_galley(ui, &row.ctx_name, title_font, title_max);
-
-        let subtitle_galley = row.subtitle.as_ref().map(|path| {
-            elided_galley(
-                ui,
-                &shorten_path(path),
-                egui::FontId::proportional(style::TEXT_META),
-                (content_right - content_left).max(0.0),
-            )
+            .and_then(|dots| PipLayout::measure(dots, lane - badge_reserved));
+        let mut state_x = content_left + pips.as_ref().map_or(0.0, |layout| layout.width);
+        let badge_left = badge_size.map(|size| {
+            let left = if pips.is_some() {
+                state_x + PIP_BADGE_GAP
+            } else {
+                state_x
+            };
+            state_x = left + size.x;
+            left
         });
 
-        let title_line_h = title_galley
-            .size()
-            .y
-            .max(pips.as_ref().map_or(0.0, |layout| layout.height));
-        let subtitle_h = subtitle_galley.as_ref().map_or(0.0, |g| g.size().y);
-        let height = ROW_PAD_V * 2.0
-            + title_line_h
-            + if subtitle_galley.is_some() {
-                TITLE_SUBTITLE_GAP + subtitle_h
-            } else {
-                0.0
-            };
-        let title_top = ROW_PAD_V;
-        let title_center_y = title_top + title_line_h / 2.0;
+        let path_avail = (content_right - state_x - PATH_GAP).max(0.0);
+        let path_galley = row
+            .subtitle
+            .as_ref()
+            .filter(|_| path_avail >= PATH_MIN_W)
+            .map(|path| {
+                elided_galley(
+                    ui,
+                    &shorten_path(path),
+                    egui::FontId::proportional(style::TEXT_META),
+                    path_avail,
+                )
+            });
 
-        let slot_rect = |(left, w): (f32, f32)| {
-            Rect::from_min_size(Pos2::new(left, title_top), Vec2::new(w, title_line_h))
+        let state_h = pips
+            .as_ref()
+            .map_or(0.0, |layout| layout.height)
+            .max(badge_size.map_or(0.0, |size| size.y))
+            .max(path_galley.as_ref().map_or(0.0, |g| g.size().y));
+        // A row with no pane state at all is one tier tall, gap included.
+        let state_top = identity_top + identity_h + if state_h > 0.0 { TIER_GAP } else { 0.0 };
+        let state_center_y = state_top + state_h / 2.0;
+        let height = state_top + state_h + ROW_PAD_V;
+
+        let centered = |left: f32, size: Vec2| {
+            Rect::from_min_size(Pos2::new(left, state_center_y - size.y / 2.0), size)
         };
 
         Self {
             rect: Rect::from_min_size(Pos2::ZERO, Vec2::new(width, height)),
             gutter: Rect::from_min_size(
-                Pos2::new(ROW_INDENT, title_top),
-                Vec2::new(GUTTER_W, title_line_h),
+                Pos2::new(ROW_INDENT, identity_top),
+                Vec2::new(GUTTER_W, identity_h),
             ),
             title: Rect::from_min_size(
-                Pos2::new(content_left, title_center_y - title_galley.size().y / 2.0),
+                Pos2::new(content_left, identity_center_y - identity_h / 2.0),
                 title_galley.size(),
             ),
             title_galley,
-            subtitle: subtitle_galley.map(|galley| {
+            close: close_left.map(|left| {
+                Rect::from_center_size(
+                    Pos2::new(left + CLOSE_SLOT_W / 2.0, identity_center_y),
+                    Vec2::splat(CLOSE_SLOT_W),
+                )
+            }),
+            pips: pips.map(|layout| (Pos2::new(content_left, state_center_y), layout)),
+            badge: badge_galley
+                .zip(badge_left)
+                .zip(badge_size)
+                .map(|((galley, left), size)| (centered(left, size), galley)),
+            path: path_galley.map(|galley| {
                 let size = galley.size();
-                (
-                    Rect::from_min_size(
-                        Pos2::new(content_left, title_top + title_line_h + TITLE_SUBTITLE_GAP),
-                        size,
-                    ),
-                    galley,
-                )
+                (centered(content_right - size.x, size), galley)
             }),
-            pips: pips.map(|layout| {
-                (
-                    Pos2::new(content_right - layout.width, title_center_y),
-                    layout,
-                )
-            }),
-            badge: badge.map(slot_rect),
-            close: close.map(slot_rect),
         }
     }
 
@@ -373,12 +412,14 @@ impl RowGeometry {
             gutter: self.gutter.translate(offset),
             title: self.title.translate(offset),
             title_galley: self.title_galley,
-            subtitle: self
-                .subtitle
-                .map(|(rect, galley)| (rect.translate(offset), galley)),
-            pips: self.pips.map(|(origin, layout)| (origin + offset, layout)),
-            badge: self.badge.map(|rect| rect.translate(offset)),
             close: self.close.map(|rect| rect.translate(offset)),
+            pips: self.pips.map(|(origin, layout)| (origin + offset, layout)),
+            badge: self
+                .badge
+                .map(|(rect, galley)| (rect.translate(offset), galley)),
+            path: self
+                .path
+                .map(|(rect, galley)| (rect.translate(offset), galley)),
         }
     }
 }
@@ -513,16 +554,17 @@ fn paint_pips(
     }
 
     if let Some(hidden) = layout.overflow {
-        // A focused pane that has no dot of its own is the one the overflow
-        // count stands in for, so the count carries its highlight.
-        let overflow_color = if dots
+        // The overflow count stands in for dots, so it is painted in a dot's
+        // own color — never the accent the notification badge owns, which is
+        // what made a collapsed pip strip read as a badge. A focused pane with
+        // no dot of its own is the one this count represents, so it takes the
+        // focused dot color.
+        let collapsed_is_focused = dots
             .focused_idx
-            .is_some_and(|idx| layout.dot_center_x(idx).is_none())
-        {
-            with_alpha(colors.accent, row_alpha)
-        } else {
-            with_alpha(colors.text_dim, 0.5)
-        };
+            .is_some_and(|idx| layout.dot_center_x(idx).is_none());
+        let overflow_color =
+            crate::ui::activity::pip_color(None, collapsed_is_focused, colors, t, 0)
+                .gamma_multiply(row_alpha);
         crate::ui::snap::text_snapped(
             painter,
             Pos2::new(origin.x + layout.width - PIP_OVERFLOW_W, cy),
@@ -622,14 +664,6 @@ impl SidebarRow {
             geom.title_galley.clone(),
             title_color,
         );
-        if let Some((subtitle_rect, galley)) = &geom.subtitle {
-            crate::ui::snap::galley_snapped(
-                ui.painter(),
-                subtitle_rect.min,
-                galley.clone(),
-                with_alpha(colors.text_dim, row_alpha),
-            );
-        }
 
         // --- Pips -------------------------------------------------------------
         if let (Some(dots), Some((origin, layout))) = (&self.pane_dots, &geom.pips) {
@@ -645,19 +679,34 @@ impl SidebarRow {
         }
 
         // --- Badge ------------------------------------------------------------
-        if let Some(badge_rect) = geom.badge {
-            let label = if self.badge_count > 9 {
-                "9+".to_string()
-            } else {
-                self.badge_count.to_string()
-            };
-            crate::ui::snap::text_snapped(
-                ui.painter(),
-                Pos2::new(badge_rect.right(), badge_rect.center().y),
-                egui::Align2::RIGHT_CENTER,
-                label,
-                egui::FontId::proportional(style::TEXT_META),
+        // A filled accent pill: taller than a pip, a different shape, and a
+        // different color family, so a notification count can never be
+        // mistaken for a collapsed pip strip sitting next to it.
+        if let Some((badge_rect, galley)) = &geom.badge {
+            let text_color = with_alpha(colors.text_on(colors.accent), row_alpha);
+            ui.painter().rect_filled(
+                *badge_rect,
+                style::RADIUS_BADGE,
                 with_alpha(colors.accent, row_alpha),
+            );
+            crate::ui::snap::galley_snapped(
+                ui.painter(),
+                Pos2::new(
+                    badge_rect.center().x - galley.size().x / 2.0,
+                    badge_rect.center().y - galley.size().y / 2.0,
+                ),
+                galley.clone(),
+                text_color,
+            );
+        }
+
+        // --- Path ---------------------------------------------------------
+        if let Some((path_rect, galley)) = &geom.path {
+            crate::ui::snap::galley_snapped(
+                ui.painter(),
+                path_rect.min,
+                galley.clone(),
+                with_alpha(colors.text_dim, row_alpha),
             );
         }
 
@@ -672,7 +721,7 @@ impl SidebarRow {
                 paint_text_centered(
                     ui,
                     "\u{2715}",
-                    egui::FontId::proportional(style::TEXT_SIDEBAR_TITLE),
+                    egui::FontId::proportional(CLOSE_GLYPH_SIZE),
                     with_alpha(
                         if in_close {
                             colors.text_primary
@@ -820,12 +869,12 @@ mod tests {
         }
     }
 
-    /// The three trailing slots are distinct zones at fixed offsets from the
-    /// row's right edge: close outermost, badge inside it, pips inside that.
-    /// None of them may overlap, and none may move past another as the panel
-    /// narrows or content appears.
+    /// The two tiers each hold their own things and nothing crosses between
+    /// them: the close action owns the identity tier's right edge, and the
+    /// pane-state tier lays pips, badge, and path out left to right without
+    /// any pair ever overlapping, at every panel width.
     #[test]
-    fn trailing_slots_never_overlap_at_any_width() {
+    fn tiers_never_overlap_at_any_width() {
         for &panel_w in &[140.0_f32, 180.0, 220.0, 320.0, 480.0] {
             for &action_enabled in &[false, true] {
                 for &badge_count in &[0_usize, 4, 42] {
@@ -837,37 +886,53 @@ mod tests {
                                 "panel_w={panel_w} action={action_enabled} \
                                  badge={badge_count} panes={pane_count}"
                             );
-                            if let (Some(badge), Some(close)) = (geom.badge, geom.close) {
+
+                            // Identity tier.
+                            if let Some(close) = geom.close {
                                 assert!(
-                                    badge.right() <= close.left(),
-                                    "badge overlaps close ({label})"
+                                    geom.title.right() <= close.left() + f32::EPSILON,
+                                    "name runs into the close action ({label})"
+                                );
+                                assert!(
+                                    close.right() <= geom.rect.right(),
+                                    "close escapes the row ({label})"
+                                );
+                                assert!(
+                                    close.center().y < geom.rect.center().y,
+                                    "close must sit on the identity tier ({label})"
                                 );
                             }
-                            let trailing_left = geom
-                                .badge
-                                .or(geom.close)
-                                .map_or(geom.rect.right(), |slot| slot.left());
-                            if let Some((origin, layout)) = &geom.pips {
-                                assert!(
-                                    origin.x + layout.width <= trailing_left + f32::EPSILON,
-                                    "pips overlap the trailing slots ({label})"
-                                );
-                                assert!(
-                                    geom.title.right() <= origin.x + f32::EPSILON,
-                                    "title overlaps the pips ({label})"
-                                );
-                            } else {
-                                assert!(
-                                    geom.title.right() <= trailing_left + f32::EPSILON,
-                                    "title overlaps the trailing slots ({label})"
-                                );
-                            }
-                            assert!(
-                                geom.close.is_none_or(
-                                    |close| close.right() <= geom.rect.right() + f32::EPSILON
+
+                            // Pane-state tier, left to right.
+                            let mut cursor = geom.gutter.right();
+                            for (name, rect) in [
+                                (
+                                    "pips",
+                                    geom.pips.as_ref().map(|(origin, layout)| {
+                                        Rect::from_min_size(
+                                            Pos2::new(origin.x, origin.y - layout.height / 2.0),
+                                            Vec2::new(layout.width, layout.height),
+                                        )
+                                    }),
                                 ),
-                                "close escapes the row ({label})"
-                            );
+                                ("badge", geom.badge.as_ref().map(|(rect, _)| *rect)),
+                                ("path", geom.path.as_ref().map(|(rect, _)| *rect)),
+                            ] {
+                                let Some(rect) = rect else { continue };
+                                assert!(
+                                    rect.left() >= cursor - f32::EPSILON,
+                                    "{name} overlaps what precedes it ({label})"
+                                );
+                                assert!(
+                                    rect.right() <= geom.rect.right() + f32::EPSILON,
+                                    "{name} escapes the row ({label})"
+                                );
+                                assert!(
+                                    rect.center().y > geom.title.bottom(),
+                                    "{name} must sit below the identity tier ({label})"
+                                );
+                                cursor = rect.right();
+                            }
                         });
                     }
                 }
@@ -876,7 +941,7 @@ mod tests {
     }
 
     /// The index number shares the title's optical center, not the whole
-    /// row's — a row with a path line underneath would otherwise read with the
+    /// row's — with a pane-state tier underneath, row-centering reads as the
     /// number sitting low beside the name.
     #[test]
     fn index_gutter_is_centered_on_the_title_line() {
@@ -884,8 +949,8 @@ mod tests {
             let item = row(true, 3, 4);
             let geom = RowGeometry::measure(ui, &item, 220.0);
             assert!(
-                geom.subtitle.is_some(),
-                "setup: this row has a path line below the title"
+                geom.pips.is_some(),
+                "setup: this row has a pane-state tier below the title"
             );
             assert!(
                 (geom.gutter.center().y - geom.title.center().y).abs() < 0.01,
@@ -895,14 +960,40 @@ mod tests {
             );
             assert!(
                 geom.gutter.center().y < geom.rect.center().y,
-                "a two-line row's title sits above the row center, so the \
+                "a two-tier row's title sits above the row center, so the \
                  number must too"
             );
         });
     }
 
-    /// The pip strip's width is measured once and reused: the budget the title
-    /// is elided against is the same number the capsules are painted with.
+    /// The badge cannot be mistaken for a collapsed pip strip: it is a taller
+    /// filled pill, and it is separated from the pips by a visible gap rather
+    /// than butted against them.
+    #[test]
+    fn badge_is_visually_distinct_from_collapsed_pips() {
+        in_frame(220.0, |ui| {
+            let item = row(true, 4, PANE_DOT_MAX + 3);
+            let geom = RowGeometry::measure(ui, &item, 220.0);
+            let (pip_origin, layout) = geom.pips.as_ref().expect("many panes render pips");
+            let (badge, _) = geom.badge.as_ref().expect("a badge count renders a badge");
+            assert!(
+                layout.overflow.is_some(),
+                "setup: this many panes must collapse into an overflow count"
+            );
+            assert!(
+                badge.left() - (pip_origin.x + layout.width) >= PIP_BADGE_GAP - 0.01,
+                "the badge must not read as glued to the pip strip"
+            );
+            assert!(
+                badge.height() > PANE_DOT_RADIUS * 2.0 + 1.0,
+                "the badge pill must be taller than a pip so the two never \
+                 read as the same kind of thing"
+            );
+        });
+    }
+
+    /// The pip strip's width is measured once and reused: the budget the tier
+    /// is laid out against is the same number the capsules are painted with.
     #[test]
     fn pip_strip_width_is_measured_once() {
         in_frame(320.0, |ui| {
@@ -915,8 +1006,8 @@ mod tests {
                 "capsules must fill exactly the width the strip reserved"
             );
             assert!(
-                (origin.x + layout.width - geom.rect.right() + CLOSE_SLOT_W).abs() < 0.01,
-                "the strip must end exactly where the trailing slots begin"
+                (origin.x - geom.gutter.right()).abs() < 0.01,
+                "the strip must start at the content lane, under the name"
             );
         });
     }

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -22,6 +22,8 @@ const WINDOW_GROUP_PAD_X: f32 = 5.0;
 const WINDOW_GROUP_PAD_Y: f32 = 4.0;
 const WINDOW_GROUP_GAP: f32 = 5.0;
 const SIDEBAR_BADGE_W: f32 = 18.0;
+/// Gap between the context name and the pane-pip strip on the headline.
+const PIP_TEXT_GAP: f32 = 4.0;
 
 pub(crate) fn with_alpha(c: Color32, alpha: f32) -> Color32 {
     Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), (c.a() as f32 * alpha) as u8)
@@ -369,6 +371,17 @@ impl ContextItem {
                         // --- Name row ---
                         let name_y_before = ui.cursor().min.y;
                         ui.horizontal(|ui| {
+                            // Every horizontal gap on this row is budgeted
+                            // explicitly below, so implicit item spacing must be
+                            // off: an unbudgeted gap makes the row wider than
+                            // the panel, egui stores that overflowed content
+                            // rect as the panel's size, and the panel re-reads
+                            // it as its width next frame — a feedback loop that
+                            // ramps the sidebar to its size_range maximum and
+                            // swallows any user resize (stint 0715).
+                            let gap = ui.spacing().item_spacing.x;
+                            ui.spacing_mut().item_spacing.x = 0.0;
+
                             // Compute pip strip width so we can budget the name text.
                             let pip_strip_w = if let Some(ref dots) = pane_dots {
                                 if dots.count > 0 {
@@ -385,7 +398,7 @@ impl ContextItem {
                                     if dots.count > PANE_DOT_MAX {
                                         w += 20.0;
                                     }
-                                    w + 4.0 // gap between name text and dots
+                                    w + PIP_TEXT_GAP
                                 } else {
                                     0.0
                                 }
@@ -403,8 +416,18 @@ impl ContextItem {
                             } else {
                                 0.0
                             };
+                            // The trailing block keeps normal item spacing
+                            // between the close zone and the badge, so that gap
+                            // is part of its budget too.
+                            let trailing_w = badge_w
+                                + close_w
+                                + if badge_w > 0.0 && close_w > 0.0 {
+                                    gap
+                                } else {
+                                    0.0
+                                };
                             let text_max =
-                                (ui.available_width() - badge_w - close_w - pip_strip_w).max(0.0);
+                                (ui.available_width() - trailing_w - pip_strip_w).max(0.0);
 
                             let title_width = ui
                                 .scope(|ui| {
@@ -427,10 +450,16 @@ impl ContextItem {
                             // the pips and overlap the count.
                             ui.add_space((text_max - title_width).max(0.0));
 
-                            // Pips stay beside the headline, before the trailing state.
+                            // Pips stay beside the headline, before the trailing
+                            // state. `pip_strip_w` budgeted this gap; with
+                            // implicit spacing off it has to be added by hand.
+                            if pip_strip_w > 0.0 {
+                                ui.add_space(PIP_TEXT_GAP);
+                            }
                             draw_pips(ui, &pane_dots, colors, row_alpha, is_dragging);
 
                             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                                ui.spacing_mut().item_spacing.x = gap;
                                 // The close target follows the count at the physical trailing edge.
                                 if action_enabled {
                                     let (rect, _) = ui.allocate_exact_size(
@@ -623,6 +652,77 @@ impl ContextItem {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Lay one context row out in a `panel_w`-wide viewport and return the
+    /// width the row actually claimed.
+    fn measure_row(
+        panel_w: f32,
+        action_enabled: bool,
+        badge_count: usize,
+        pane_count: usize,
+    ) -> f32 {
+        let colors = Colors::from_config(&crate::config::ThemeConfig::default());
+        let mut pane_dots = (pane_count > 0).then(|| PaneDots {
+            count: pane_count,
+            focused_idx: Some(0),
+            hidden_set: std::collections::HashSet::new(),
+            activities: vec![None; pane_count],
+            windows: vec![PaneDotWindow {
+                start: 0,
+                count: pane_count,
+                is_return_target: true,
+                is_active: true,
+            }],
+        });
+        let input = egui::RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                Vec2::new(panel_w, 600.0),
+            )),
+            ..Default::default()
+        };
+        let ctx = egui::Context::default();
+        let mut row_w = 0.0_f32;
+        let _ = ctx.run_ui(input, |ui| {
+            let (_, response) = ContextItem {
+                is_active: true,
+                is_dragging: false,
+                any_dragging: false,
+                action_enabled,
+                ctx_name: "Default".to_string(),
+                ctx_index: Some(0),
+                badge_count,
+                subtitle: Some("/Users/someone/code/project".to_string()),
+                pane_dots: pane_dots.take(),
+                draggable: true,
+            }
+            .draw(ui, Id::new("row"), &colors);
+            row_w = response.rect.width();
+        });
+        row_w
+    }
+
+    /// Stint 0715: a row wider than the space it was given inflates the
+    /// enclosing panel, because egui stores a panel's content rect as the
+    /// panel's size and reads it back as the width on the next frame. No
+    /// combination of badge, pips, and close zone may exceed the budget.
+    #[test]
+    fn context_row_never_exceeds_available_width() {
+        for &panel_w in &[160.0_f32, 220.0, 320.0, 400.0] {
+            for &action_enabled in &[false, true] {
+                for &badge_count in &[0_usize, 3, 42] {
+                    for &pane_count in &[0_usize, 1, PANE_DOT_MAX + 3] {
+                        let row_w = measure_row(panel_w, action_enabled, badge_count, pane_count);
+                        assert!(
+                            row_w <= panel_w,
+                            "row overflowed: panel_w={panel_w} row_w={row_w} \
+                             action_enabled={action_enabled} badge={badge_count} panes={pane_count}"
+                        );
+                    }
+                }
+            }
+        }
+    }
 
     /// Regression: session restore can leave focus on a pane past PANE_DOT_MAX
     /// (dot_centers len == 8, focused_idx == 8). The pin must be skipped, not

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -30,12 +30,14 @@ const ROW_INDENT: f32 = 4.0;
 /// Fixed-width left gutter that holds the context index number.
 const GUTTER_W: f32 = 18.0;
 /// Top and bottom padding added inside each row for vertical breathing room.
-const ROW_PAD_V: f32 = 7.0;
+const ROW_PAD_V: f32 = style::SPACE_MD;
 /// Right margin for row content, measured from the row edge. The selection
 /// card insets by `SPACE_XS`, so this leaves visible air inside its outline.
 const ROW_PAD_RIGHT: f32 = style::SPACE_MD;
-/// Vertical gap between the identity tier and the pane-state tier.
-const TIER_GAP: f32 = 3.0;
+/// Vertical gap between the identity tier and the pane-state tier. The two
+/// tiers are separate readings of the row, so the gap has to be wide enough
+/// that they do not scan as one wrapped line.
+const TIER_GAP: f32 = style::SPACE_SM;
 
 /// The close action is the row's card-level dismiss, pinned to the top-right
 /// corner of the identity tier — a touch larger than body chrome so it reads
@@ -51,15 +53,16 @@ const PATH_GAP: f32 = style::SPACE_SM;
 /// state is the tier's job, and "/pro…" is noise, not information.
 const PATH_MIN_W: f32 = 48.0;
 /// Gap between the last capsule and the "+N" overflow count.
-const PIP_TEXT_GAP: f32 = style::SPACE_XS;
+const PIP_TEXT_GAP: f32 = style::SPACE_SM;
 
 /// Status-pip radius. Shared with the portal minimap so activity dots are the
 /// same size everywhere they appear (sidebar rows + portal previews).
 pub(crate) const PANE_DOT_RADIUS: f32 = 4.0;
 const PANE_DOT_SPACING: f32 = 11.0;
 const PANE_DOT_MAX: usize = 8;
-const WINDOW_GROUP_PAD_X: f32 = 5.0;
-const WINDOW_GROUP_PAD_Y: f32 = 4.0;
+/// Air between the dots and the capsule's stroke, on each axis.
+const WINDOW_GROUP_PAD_X: f32 = 7.0;
+const WINDOW_GROUP_PAD_Y: f32 = 6.0;
 const WINDOW_GROUP_GAP: f32 = 5.0;
 const WINDOW_GROUP_RADIUS: CornerRadius = CornerRadius::same(4);
 /// Width reserved for the "+N" label when the pane count exceeds the cap.
@@ -67,11 +70,12 @@ const PIP_OVERFLOW_W: f32 = 20.0;
 const GROUP_STROKE_W: f32 = 1.0;
 const GROUP_STROKE_W_RETURN: f32 = 1.5;
 /// Return-target marker: a small triangle whose base sits flush on the
-/// capsule's inner top edge and whose tip points down at the dots. Its height
-/// is one point short of the capsule's vertical padding, so the tip always
-/// stops clear of the dot row without any clamping.
+/// capsule's inner top edge and whose tip points down at the dots. It is a
+/// fixed size rather than a fraction of the capsule's padding — the marker
+/// should not grow when the capsule gets roomier — and the assertion below is
+/// what keeps its tip clear of the dot row.
 const PIN_HALF_W: f32 = 2.5;
-const PIN_H: f32 = WINDOW_GROUP_PAD_Y - 1.0;
+const PIN_H: f32 = 3.0;
 const _: () = assert!(
     PIN_H > 0.0 && PIN_H < WINDOW_GROUP_PAD_Y,
     "the pin must fit inside the capsule's top padding without touching the dot row"

--- a/src/ui/sidebar_row.rs
+++ b/src/ui/sidebar_row.rs
@@ -1,17 +1,45 @@
-use crate::ui::list::{paint_selection, paint_text_centered};
+//! The sidebar context row.
+//!
+//! `SidebarRow` is the context list's counterpart to [`crate::ui::list::ListRow`]:
+//! same shared internals (selection painting, text elision, pixel snapping),
+//! plus the affordances a list row has no business carrying — a leading index
+//! gutter aligned to the title, a numeric badge slot distinct from the trailing
+//! action, drag-reorder sensing, and pane pips grouped into per-window capsules.
+//!
+//! Geometry is resolved exactly once, by [`RowGeometry::measure`], into explicit
+//! slot rects in row-local space; [`RowGeometry::translated`] moves the whole set
+//! onto the allocated rect. Painting and hit testing both read those rects, so no
+//! position is ever reconstructed from a captured height after the fact, and the
+//! row's width is a fixed budget that cannot exceed what the panel offered.
+
+use crate::ui::list::{elide_to_width, paint_selection, paint_text_centered, selection_inset};
 use crate::ui::style;
 use crate::ui::theme::Colors;
 use egui::emath::GuiRounding;
-use egui::{Align, Color32, CornerRadius, CursorIcon, Id, Layout, Rect, Sense, Vec2};
+use egui::{Color32, CornerRadius, CursorIcon, Id, Pos2, Rect, Sense, Stroke, StrokeKind, Vec2};
 
-pub const ACTION_ZONE_WIDTH: f32 = 22.0;
-
+/// Left inset before the index gutter. Every sidebar row is a top-level
+/// context, so there is no nesting level to indent for.
+const ROW_INDENT: f32 = 4.0;
 /// Fixed-width left gutter that holds the context index number.
 const GUTTER_W: f32 = 18.0;
-const ROW_INDENT: f32 = 4.0;
-
 /// Top and bottom padding added inside each row for vertical breathing room.
 const ROW_PAD_V: f32 = 7.0;
+/// Right margin for row content that has no trailing slot in front of it.
+const ROW_PAD_RIGHT: f32 = style::SPACE_SM;
+/// Vertical gap between the title line and the path line.
+const TITLE_SUBTITLE_GAP: f32 = 2.0;
+
+/// Trailing slot widths. The two slots sit at fixed offsets from the row's
+/// right edge, in this order, so they can never swap or overlap.
+const CLOSE_SLOT_W: f32 = 22.0;
+const BADGE_SLOT_W: f32 = 18.0;
+const TRAILING_SLOT_GAP: f32 = style::SPACE_SM;
+/// Gap between the context name and the pane-pip strip on the title line.
+const PIP_TEXT_GAP: f32 = style::SPACE_XS;
+/// The name never gives up more than this to the pip strip — a row whose
+/// context is unreadable is worse than one showing fewer pane dots.
+const TITLE_MIN_W: f32 = 56.0;
 
 /// Status-pip radius. Shared with the portal minimap so activity dots are the
 /// same size everywhere they appear (sidebar rows + portal previews).
@@ -21,9 +49,25 @@ const PANE_DOT_MAX: usize = 8;
 const WINDOW_GROUP_PAD_X: f32 = 5.0;
 const WINDOW_GROUP_PAD_Y: f32 = 4.0;
 const WINDOW_GROUP_GAP: f32 = 5.0;
-const SIDEBAR_BADGE_W: f32 = 18.0;
-/// Gap between the context name and the pane-pip strip on the headline.
-const PIP_TEXT_GAP: f32 = 4.0;
+const WINDOW_GROUP_RADIUS: CornerRadius = CornerRadius::same(4);
+/// Width reserved for the "+N" label when the pane count exceeds the cap.
+const PIP_OVERFLOW_W: f32 = 20.0;
+const GROUP_STROKE_W: f32 = 1.0;
+const GROUP_STROKE_W_RETURN: f32 = 1.5;
+/// Return-target marker: a small triangle whose base sits flush on the
+/// capsule's inner top edge and whose tip points down at the dots. Its height
+/// is one point short of the capsule's vertical padding, so the tip always
+/// stops clear of the dot row without any clamping.
+const PIN_HALF_W: f32 = 2.5;
+const PIN_H: f32 = WINDOW_GROUP_PAD_Y - 1.0;
+const _: () = assert!(
+    PIN_H > 0.0 && PIN_H < WINDOW_GROUP_PAD_Y,
+    "the pin must fit inside the capsule's top padding without touching the dot row"
+);
+const _: () = assert!(
+    PIN_HALF_W * 2.0 < PANE_DOT_SPACING,
+    "the pin must not reach the neighbouring dot"
+);
 
 pub(crate) fn with_alpha(c: Color32, alpha: f32) -> Color32 {
     Color32::from_rgba_unmultiplied(c.r(), c.g(), c.b(), (c.a() as f32 * alpha) as u8)
@@ -84,7 +128,7 @@ pub struct PaneDotWindow {
     pub is_active: bool,
 }
 
-pub struct ContextItem {
+pub struct SidebarRow {
     pub is_active: bool,
     pub is_dragging: bool,
     pub any_dragging: bool,
@@ -92,43 +136,276 @@ pub struct ContextItem {
     pub ctx_name: String,
     pub ctx_index: Option<usize>,
     pub badge_count: usize,
-    /// Root path shown on its own line below the name row.
+    /// Root path shown on its own line below the title line.
     pub subtitle: Option<String>,
-    /// Dots rendered below the name row representing panes.
+    /// Pane pips shown on the title line, right of the name.
     pub pane_dots: Option<PaneDots>,
     /// Whether this row supports drag reordering. When false, hover shows
     /// PointingHand instead of Grab and drag actions are suppressed.
     pub draggable: bool,
 }
 
-/// Render pane-indicator dots into the current horizontal layout position.
-/// Shared by both the subtitle+pips path and the pips-only fallback path.
-fn draw_pips(
-    ui: &mut egui::Ui,
-    pane_dots: &Option<PaneDots>,
+/// One window's capsule inside the pip strip, in strip-local coordinates.
+struct PipGroup {
+    /// Dot range this capsule covers, already clamped to the visible cap.
+    start: usize,
+    end: usize,
+    is_return_target: bool,
+    is_active: bool,
+    x: f32,
+    width: f32,
+}
+
+/// The measured pip strip: the single source of truth for its width, used both
+/// to budget the title text and to paint the capsules.
+struct PipLayout {
+    width: f32,
+    height: f32,
+    groups: Vec<PipGroup>,
+    /// Number of panes past the visible cap, when there are any.
+    overflow: Option<usize>,
+}
+
+impl PipLayout {
+    /// The widest strip that fits `max_width`. The visible dot count shrinks
+    /// until it does — panes past it fold into the "+N" overflow — so a narrow
+    /// panel loses dots rather than pushing the strip under the context name.
+    fn measure(dots: &PaneDots, max_width: f32) -> Option<Self> {
+        let mut cap = dots.count.min(PANE_DOT_MAX);
+        loop {
+            match Self::at_cap(dots, cap) {
+                Some(layout) if layout.width <= max_width => return Some(layout),
+                _ if cap == 0 => return None,
+                _ => cap -= 1,
+            }
+        }
+    }
+
+    fn at_cap(dots: &PaneDots, capped: usize) -> Option<Self> {
+        if dots.count == 0 {
+            return None;
+        }
+        // A context always reports its spatial windows; a caller that supplies
+        // none still gets one capsule, so there is exactly one layout path.
+        let ranges: Vec<(usize, usize, bool, bool)> = if capped == 0 {
+            Vec::new()
+        } else if dots.windows.is_empty() {
+            vec![(0, capped, false, false)]
+        } else {
+            dots.windows
+                .iter()
+                .filter(|window| window.count > 0 && window.start < capped)
+                .map(|window| {
+                    (
+                        window.start,
+                        (window.start + window.count).min(capped),
+                        window.is_return_target,
+                        window.is_active,
+                    )
+                })
+                .collect()
+        };
+
+        let mut groups = Vec::with_capacity(ranges.len());
+        let mut x = 0.0_f32;
+        for (i, &(start, end, is_return_target, is_active)) in ranges.iter().enumerate() {
+            let width = (end - start).saturating_sub(1) as f32 * PANE_DOT_SPACING
+                + PANE_DOT_RADIUS * 2.0
+                + WINDOW_GROUP_PAD_X * 2.0;
+            groups.push(PipGroup {
+                start,
+                end,
+                is_return_target,
+                is_active,
+                x,
+                width,
+            });
+            x += width;
+            if i + 1 < ranges.len() {
+                x += WINDOW_GROUP_GAP;
+            }
+        }
+
+        let overflow = (dots.count > capped).then(|| dots.count - capped);
+        if overflow.is_some() {
+            if !groups.is_empty() {
+                x += PIP_TEXT_GAP;
+            }
+            x += PIP_OVERFLOW_W;
+        }
+
+        Some(Self {
+            width: x,
+            height: PANE_DOT_RADIUS * 2.0 + WINDOW_GROUP_PAD_Y * 2.0,
+            groups,
+            overflow,
+        })
+    }
+
+    /// Center x of dot `idx`, in strip-local coordinates.
+    fn dot_center_x(&self, idx: usize) -> Option<f32> {
+        self.groups
+            .iter()
+            .find(|group| (group.start..group.end).contains(&idx))
+            .map(|group| {
+                group.x
+                    + WINDOW_GROUP_PAD_X
+                    + PANE_DOT_RADIUS
+                    + (idx - group.start) as f32 * PANE_DOT_SPACING
+            })
+    }
+}
+
+/// Every rect the row paints or hit tests. Measured in row-local space (origin
+/// at the row's top-left), then translated onto the allocated rect.
+struct RowGeometry {
+    rect: Rect,
+    /// Index-number cell. Its center y is the title's center y, so the number
+    /// shares the name's optical baseline instead of the whole row's.
+    gutter: Rect,
+    title: Rect,
+    title_galley: std::sync::Arc<egui::Galley>,
+    subtitle: Option<(Rect, std::sync::Arc<egui::Galley>)>,
+    /// Strip origin (left edge, vertical center) plus its measured layout.
+    pips: Option<(Pos2, PipLayout)>,
+    badge: Option<Rect>,
+    close: Option<Rect>,
+}
+
+impl RowGeometry {
+    fn measure(ui: &egui::Ui, row: &SidebarRow, width: f32) -> Self {
+        let content_left = ROW_INDENT + GUTTER_W;
+
+        // Trailing slots are laid out right to left at fixed widths, so their
+        // positions depend on nothing but which of them are present.
+        let close = row
+            .action_enabled
+            .then_some((width - CLOSE_SLOT_W, CLOSE_SLOT_W));
+        let badge_right = close.map_or(width, |(left, _)| left - TRAILING_SLOT_GAP);
+        let badge = (row.badge_count > 0).then_some((badge_right - BADGE_SLOT_W, BADGE_SLOT_W));
+        // With no trailing slot to sit behind, content still keeps the row's
+        // right margin so text never kisses the selection card's outline.
+        let content_right = badge
+            .or(close)
+            .map_or(width - ROW_PAD_RIGHT, |(left, _)| left)
+            .max(content_left);
+
+        // The name owns the content lane; the pip strip may take what is left
+        // above the name's floor, and shrinks to fit it. Nothing here depends
+        // on the panel width beyond that one subtraction, so the row has one
+        // shape at every size instead of one per combination of slots.
+        let lane = (content_right - content_left).max(0.0);
+        let pips = row
+            .pane_dots
+            .as_ref()
+            .and_then(|dots| PipLayout::measure(dots, lane - TITLE_MIN_W - PIP_TEXT_GAP));
+        let pip_reserved = pips
+            .as_ref()
+            .map_or(0.0, |layout| layout.width + PIP_TEXT_GAP);
+
+        let title_font = egui::FontId::proportional(style::TEXT_SIDEBAR_TITLE);
+        let title_max = (content_right - content_left - pip_reserved).max(0.0);
+        let title_galley = elided_galley(ui, &row.ctx_name, title_font, title_max);
+
+        let subtitle_galley = row.subtitle.as_ref().map(|path| {
+            elided_galley(
+                ui,
+                &shorten_path(path),
+                egui::FontId::proportional(style::TEXT_META),
+                (content_right - content_left).max(0.0),
+            )
+        });
+
+        let title_line_h = title_galley
+            .size()
+            .y
+            .max(pips.as_ref().map_or(0.0, |layout| layout.height));
+        let subtitle_h = subtitle_galley.as_ref().map_or(0.0, |g| g.size().y);
+        let height = ROW_PAD_V * 2.0
+            + title_line_h
+            + if subtitle_galley.is_some() {
+                TITLE_SUBTITLE_GAP + subtitle_h
+            } else {
+                0.0
+            };
+        let title_top = ROW_PAD_V;
+        let title_center_y = title_top + title_line_h / 2.0;
+
+        let slot_rect = |(left, w): (f32, f32)| {
+            Rect::from_min_size(Pos2::new(left, title_top), Vec2::new(w, title_line_h))
+        };
+
+        Self {
+            rect: Rect::from_min_size(Pos2::ZERO, Vec2::new(width, height)),
+            gutter: Rect::from_min_size(
+                Pos2::new(ROW_INDENT, title_top),
+                Vec2::new(GUTTER_W, title_line_h),
+            ),
+            title: Rect::from_min_size(
+                Pos2::new(content_left, title_center_y - title_galley.size().y / 2.0),
+                title_galley.size(),
+            ),
+            title_galley,
+            subtitle: subtitle_galley.map(|galley| {
+                let size = galley.size();
+                (
+                    Rect::from_min_size(
+                        Pos2::new(content_left, title_top + title_line_h + TITLE_SUBTITLE_GAP),
+                        size,
+                    ),
+                    galley,
+                )
+            }),
+            pips: pips.map(|layout| {
+                (
+                    Pos2::new(content_right - layout.width, title_center_y),
+                    layout,
+                )
+            }),
+            badge: badge.map(slot_rect),
+            close: close.map(slot_rect),
+        }
+    }
+
+    fn translated(self, offset: Vec2) -> Self {
+        Self {
+            rect: self.rect.translate(offset),
+            gutter: self.gutter.translate(offset),
+            title: self.title.translate(offset),
+            title_galley: self.title_galley,
+            subtitle: self
+                .subtitle
+                .map(|(rect, galley)| (rect.translate(offset), galley)),
+            pips: self.pips.map(|(origin, layout)| (origin + offset, layout)),
+            badge: self.badge.map(|rect| rect.translate(offset)),
+            close: self.close.map(|rect| rect.translate(offset)),
+        }
+    }
+}
+
+fn elided_galley(
+    ui: &egui::Ui,
+    text: &str,
+    font_id: egui::FontId,
+    max_width: f32,
+) -> std::sync::Arc<egui::Galley> {
+    let text = elide_to_width(ui, text, font_id.clone(), max_width);
+    // PLACEHOLDER defers the color to paint time, so measurement never has to
+    // know which of the row's alpha-modulated tones this text will end up in.
+    ui.fonts_mut(|f| f.layout_no_wrap(text, font_id, Color32::PLACEHOLDER))
+}
+
+/// Paint the pip strip: one capsule per spatial window, the dots inside them,
+/// the return-target pin, and the overflow count.
+fn paint_pips(
+    ui: &egui::Ui,
+    dots: &PaneDots,
+    origin: Pos2,
+    layout: &PipLayout,
     colors: &Colors,
     row_alpha: f32,
     is_dragging: bool,
 ) {
-    let Some(dots) = pane_dots else { return };
-    if dots.count == 0 {
-        return;
-    }
-    let capped = dots.count.min(PANE_DOT_MAX);
-    let groups: Vec<&PaneDotWindow> = dots
-        .windows
-        .iter()
-        .filter(|group| group.count > 0 && group.start < capped)
-        .collect();
-    let group_count = groups.len().max(1);
-    let mut dot_area_width = (capped as f32) * PANE_DOT_SPACING
-        + (group_count as f32) * WINDOW_GROUP_PAD_X * 2.0
-        + (group_count.saturating_sub(1) as f32) * WINDOW_GROUP_GAP;
-    if dots.count > PANE_DOT_MAX {
-        dot_area_width += 20.0;
-    }
-    let dot_size = Vec2::new(dot_area_width, PANE_DOT_RADIUS * 2.0 + 4.0);
-    let (rect, _) = ui.allocate_exact_size(dot_size, Sense::hover());
     let t = ui.input(|i| i.time);
     let has_working = dots
         .activities
@@ -141,167 +418,124 @@ fn draw_pips(
         ui.ctx()
             .request_repaint_after(std::time::Duration::from_millis(100));
     }
+
     let painter = ui.painter();
-    let cy = rect
-        .center()
-        .y
-        .round_to_pixel_center(painter.pixels_per_point());
-    let mut dot_centers = vec![0.0; capped];
-    let mut group_rects = Vec::with_capacity(groups.len());
-    let mut cursor_x = rect.min.x;
-    if groups.is_empty() {
-        for (dot_i, center) in dot_centers.iter_mut().enumerate() {
-            *center = (cursor_x + WINDOW_GROUP_PAD_X + PANE_DOT_RADIUS)
-                .round_to_pixel_center(painter.pixels_per_point());
-            cursor_x += PANE_DOT_SPACING;
-            if dot_i + 1 == capped {
-                let group_rect = egui::Rect::from_min_max(
-                    egui::pos2(rect.min.x, cy - PANE_DOT_RADIUS - WINDOW_GROUP_PAD_Y),
-                    egui::pos2(
-                        cursor_x - PANE_DOT_SPACING
-                            + PANE_DOT_RADIUS * 2.0
-                            + WINDOW_GROUP_PAD_X * 2.0,
-                        cy + PANE_DOT_RADIUS + WINDOW_GROUP_PAD_Y,
-                    ),
-                )
-                .round_to_pixels(painter.pixels_per_point());
-                painter.rect_filled(
-                    group_rect,
-                    egui::CornerRadius::same(4),
-                    with_alpha(colors.bg_hover, 0.7 * row_alpha),
-                );
-            }
-        }
-    } else {
-        for (group_i, group) in groups.iter().enumerate() {
-            let start = group.start;
-            let end = (group.start + group.count).min(capped);
-            let group_width = (end - start - 1) as f32 * PANE_DOT_SPACING
-                + PANE_DOT_RADIUS * 2.0
-                + WINDOW_GROUP_PAD_X * 2.0;
-            let group_rect = egui::Rect::from_min_size(
-                egui::pos2(cursor_x, cy - PANE_DOT_RADIUS - WINDOW_GROUP_PAD_Y),
-                egui::vec2(
-                    group_width,
-                    PANE_DOT_RADIUS * 2.0 + WINDOW_GROUP_PAD_Y * 2.0,
-                ),
-            )
-            .round_to_pixels(painter.pixels_per_point());
-            let fill = if group.is_active {
-                with_alpha(colors.accent, 0.16 * row_alpha)
-            } else {
-                // Keep group fill darker than a hovered row, so hover remains
-                // a row-level wash instead of erasing window boundaries.
-                with_alpha(colors.bg_darkest, 0.3 * row_alpha)
-            };
-            let stroke = if group.is_active {
-                egui::Stroke::new(1.0_f32, with_alpha(colors.accent, row_alpha))
-            } else if group.is_return_target {
-                egui::Stroke::new(
-                    1.5_f32,
-                    // `border` is the theme's quiet structural outline; the
-                    // previous high-contrast text color made this capsule
-                    // compete with the context name and activity dots.
-                    with_alpha(colors.border, row_alpha),
-                )
-            } else {
-                egui::Stroke::new(1.0_f32, with_alpha(colors.text_dim, 0.72 * row_alpha))
-            };
-            painter.rect_filled(group_rect, egui::CornerRadius::same(4), fill);
-            painter.rect_stroke(
-                group_rect,
-                egui::CornerRadius::same(4),
-                stroke,
-                egui::StrokeKind::Inside,
-            );
-            group_rects.push((group, group_rect));
-            for (dot_i, center) in dot_centers
-                .iter_mut()
-                .enumerate()
-                .take(end)
-                .skip(start)
-            {
-                *center = (cursor_x
-                    + WINDOW_GROUP_PAD_X
-                    + PANE_DOT_RADIUS
-                    + (dot_i - start) as f32 * PANE_DOT_SPACING)
-                    .round_to_pixel_center(painter.pixels_per_point());
-            }
-            cursor_x += group_width;
-            if group_i + 1 < groups.len() {
-                cursor_x += WINDOW_GROUP_GAP;
-            }
-        }
-    }
-    for (dot_i, &cx) in dot_centers.iter().enumerate().take(capped) {
-        let is_hidden = dots.hidden_set.contains(&dot_i);
-        let agent_state = dots.activities.get(dot_i).and_then(|s| s.as_ref());
-        let focused = dots.focused_idx == Some(dot_i);
-        let mut color = crate::ui::activity::pip_color(agent_state, focused, colors, t, dot_i)
-            .gamma_multiply(row_alpha);
-        if is_dragging && agent_state.is_none() && !focused {
-            color = color.gamma_multiply(0.4);
-        }
-        let center = egui::pos2(cx, cy).round_to_pixel_center(painter.pixels_per_point());
-        if is_hidden {
-            painter.circle_stroke(center, PANE_DOT_RADIUS, egui::Stroke::new(1.0_f32, color));
+    let ppp = painter.pixels_per_point();
+    let cy = origin.y.round_to_pixel_center(ppp);
+
+    for group in &layout.groups {
+        let group_rect = Rect::from_min_size(
+            Pos2::new(origin.x + group.x, cy - layout.height / 2.0),
+            Vec2::new(group.width, layout.height),
+        )
+        .round_to_pixels(ppp);
+        let fill = if group.is_active {
+            with_alpha(colors.accent, 0.16 * row_alpha)
         } else {
-            painter.circle_filled(center, PANE_DOT_RADIUS, color);
-        }
-    }
-    // The pin is intentionally neutral: dot color describes agent activity,
-    // while this tiny direction marker describes where a context will return.
-    if let Some(focused_idx) = dots.focused_idx {
-        if let Some((group, group_rect)) = group_rects.iter().find(|(group, _)| {
-            group.is_return_target
-                && (group.start..group.start + group.count).contains(&focused_idx)
-        }) {
-            // `focused_idx` indexes the full pane list, but `dot_centers` is
-            // capped at PANE_DOT_MAX. A focused pane past the cap has no dot in
-            // the strip — it is represented by the "+N" overflow label (which
-            // highlights via `overflow_color` below), so the pin is skipped.
-            if let Some(&cx) = dot_centers.get(focused_idx) {
-                let tip_y = (cy - PANE_DOT_RADIUS - 0.5).max(group_rect.min.y + 2.0);
-                let pin_color = with_alpha(
-                    colors.text_primary,
-                    if group.is_active {
-                        row_alpha
-                    } else {
-                        0.78 * row_alpha
-                    },
-                );
-                painter.add(egui::Shape::convex_polygon(
-                    vec![
-                        egui::pos2(cx - 2.5, group_rect.min.y + 1.5),
-                        egui::pos2(cx + 2.5, group_rect.min.y + 1.5),
-                        egui::pos2(cx, tip_y),
-                    ],
-                    pin_color,
-                    egui::Stroke::NONE,
-                ));
+            // Keep group fill darker than a hovered row, so hover remains a
+            // row-level wash instead of erasing window boundaries.
+            with_alpha(colors.bg_darkest, 0.3 * row_alpha)
+        };
+        let stroke = if group.is_active {
+            Stroke::new(GROUP_STROKE_W, with_alpha(colors.accent, row_alpha))
+        } else if group.is_return_target {
+            // `border` is the theme's quiet structural outline; a
+            // high-contrast text color made this capsule compete with the
+            // context name and the activity dots.
+            Stroke::new(GROUP_STROKE_W_RETURN, with_alpha(colors.border, row_alpha))
+        } else {
+            Stroke::new(
+                GROUP_STROKE_W,
+                with_alpha(colors.text_dim, 0.72 * row_alpha),
+            )
+        };
+        painter.rect_filled(group_rect, WINDOW_GROUP_RADIUS, fill);
+        painter.rect_stroke(group_rect, WINDOW_GROUP_RADIUS, stroke, StrokeKind::Inside);
+
+        for dot_i in group.start..group.end {
+            let cx = origin.x
+                + group.x
+                + WINDOW_GROUP_PAD_X
+                + PANE_DOT_RADIUS
+                + (dot_i - group.start) as f32 * PANE_DOT_SPACING;
+            let agent_state = dots.activities.get(dot_i).and_then(|s| s.as_ref());
+            let focused = dots.focused_idx == Some(dot_i);
+            let mut color = crate::ui::activity::pip_color(agent_state, focused, colors, t, dot_i)
+                .gamma_multiply(row_alpha);
+            if is_dragging && agent_state.is_none() && !focused {
+                color = color.gamma_multiply(0.4);
+            }
+            let center = Pos2::new(cx, cy).round_to_pixel_center(ppp);
+            if dots.hidden_set.contains(&dot_i) {
+                painter.circle_stroke(center, PANE_DOT_RADIUS, Stroke::new(1.0_f32, color));
+            } else {
+                painter.circle_filled(center, PANE_DOT_RADIUS, color);
             }
         }
+
+        // The pin is intentionally neutral: dot color describes agent activity,
+        // while this direction marker describes where a context will return.
+        // Its base sits on the capsule's inner top edge — the stroke is drawn
+        // inside the rect, so that edge is `min.y + stroke.width` — and both are
+        // on the same pixel grid, leaving no seam.
+        if group.is_return_target {
+            let Some(focused_idx) = dots.focused_idx else {
+                continue;
+            };
+            // A focused pane past the visible cap has no dot; the overflow
+            // label carries the highlight instead.
+            let Some(local_cx) = layout
+                .dot_center_x(focused_idx)
+                .filter(|_| (group.start..group.end).contains(&focused_idx))
+            else {
+                continue;
+            };
+            let cx = (origin.x + local_cx).round_to_pixel_center(ppp);
+            let base_y = (group_rect.min.y + stroke.width).round_to_pixels(ppp);
+            let pin_color = with_alpha(
+                colors.text_primary,
+                if group.is_active {
+                    row_alpha
+                } else {
+                    0.78 * row_alpha
+                },
+            );
+            painter.add(egui::Shape::convex_polygon(
+                vec![
+                    Pos2::new(cx - PIN_HALF_W, base_y),
+                    Pos2::new(cx + PIN_HALF_W, base_y),
+                    Pos2::new(cx, base_y + PIN_H),
+                ],
+                pin_color,
+                Stroke::NONE,
+            ));
+        }
     }
-    if dots.count > PANE_DOT_MAX {
-        let overflow_x = cursor_x + PANE_DOT_RADIUS * 0.5;
-        let overflow_color = if dots.focused_idx.is_some_and(|idx| idx >= PANE_DOT_MAX) {
+
+    if let Some(hidden) = layout.overflow {
+        // A focused pane that has no dot of its own is the one the overflow
+        // count stands in for, so the count carries its highlight.
+        let overflow_color = if dots
+            .focused_idx
+            .is_some_and(|idx| layout.dot_center_x(idx).is_none())
+        {
             with_alpha(colors.accent, row_alpha)
         } else {
             with_alpha(colors.text_dim, 0.5)
         };
         crate::ui::snap::text_snapped(
             painter,
-            egui::pos2(overflow_x, cy),
+            Pos2::new(origin.x + layout.width - PIP_OVERFLOW_W, cy),
             egui::Align2::LEFT_CENTER,
-            format!("+{}", dots.count - PANE_DOT_MAX),
+            format!("+{hidden}"),
             egui::FontId::proportional(style::TEXT_META),
             overflow_color,
         );
     }
 }
 
-impl ContextItem {
-    pub fn draw(
+impl SidebarRow {
+    pub fn show(
         self,
         ui: &mut egui::Ui,
         id: Id,
@@ -309,318 +543,160 @@ impl ContextItem {
     ) -> (SidebarAction, egui::Response) {
         let row_alpha = if self.is_dragging { 0.4_f32 } else { 1.0_f32 };
 
-        // Reserve background shape slot before rendering content.
-        let bg_idx = ui.painter().add(egui::Shape::Noop);
+        // The row claims exactly the width it was offered, never more: egui
+        // stores a panel's content rect as the panel's size and reads it back
+        // as the width next frame, so an overflowing row ramps the sidebar to
+        // its `size_range` maximum and swallows user resizes (stint 0715).
+        let width = ui.available_width();
+        let geom = RowGeometry::measure(ui, &self, width);
+        let (rect, _) = ui.allocate_exact_size(geom.rect.size(), Sense::hover());
+        let geom = geom.translated(rect.min.to_vec2());
 
-        // Every sidebar row is a top-level context, so the gutter is a fixed
-        // There is no nesting level to indent for, so the compact inset leaves
-        // room for the primary label rather than a second visual gutter.
-        let indent = ROW_INDENT;
+        let response = ui.interact(rect, id, Sense::click_and_drag());
+        // The row paints its own text, so nothing else puts the context name
+        // into the accessibility tree that scene `assert_label` and
+        // `host_has_label` read. The full name is reported even when the
+        // painted title is elided.
+        response.widget_info(|| {
+            egui::WidgetInfo::selected(
+                egui::WidgetType::Button,
+                true,
+                self.is_active,
+                &self.ctx_name,
+            )
+        });
+        let hovered = response.hovered();
 
-        let is_active = self.is_active;
-        let is_dragging = self.is_dragging;
-        let any_dragging = self.any_dragging;
-        let action_enabled = self.action_enabled;
-        let ctx_name = self.ctx_name.clone();
-        let ctx_index = self.ctx_index;
-        let badge_count = self.badge_count;
-        let subtitle = self.subtitle.clone();
-        let pane_dots = self.pane_dots;
-        let accent_color = colors.accent;
-        let text_primary = colors.text_primary;
-        let text_dim = colors.text_dim;
-        let bg_active = colors.bg_active;
-        let bg_hover = colors.bg_hover;
+        // --- Background ---------------------------------------------------
+        // A 4pt horizontal inset gives the pill breathing room from the
+        // sidebar edges, matching the visual weight of palette rows.
+        let card = Rect::from_min_max(
+            Pos2::new(rect.min.x + style::SPACE_XS, rect.min.y),
+            Pos2::new(rect.max.x - style::SPACE_XS, rect.max.y),
+        );
+        if self.is_active {
+            if row_alpha < 1.0 {
+                // Dragging: a dim solid fill, no outline.
+                ui.painter().rect_filled(
+                    rect,
+                    CornerRadius::ZERO,
+                    with_alpha(colors.bg_active, row_alpha),
+                );
+            } else {
+                paint_selection(ui.painter(), card, colors);
+            }
+        } else if hovered && !self.is_dragging {
+            ui.painter().rect_filled(
+                selection_inset(card),
+                style::RADIUS_SM,
+                with_alpha(colors.bg_hover, row_alpha),
+            );
+        }
 
+        // --- Index gutter ---------------------------------------------------
+        if let Some(idx) = self.ctx_index.filter(|idx| *idx < 9) {
+            paint_text_centered(
+                ui,
+                format!("{}", idx + 1),
+                egui::FontId::proportional(style::TEXT_HINT),
+                with_alpha(colors.text_dim, row_alpha),
+                geom.gutter.center(),
+            );
+        }
+
+        // --- Title + path ---------------------------------------------------
         // Context names are primary labels: inactive rows read constantly, so
         // they get the contrast-floored secondary tone, not raw `text_dim`
         // (stint 0528).
-        let text_color = with_alpha(
-            if is_active {
-                text_primary
+        let title_color = with_alpha(
+            if self.is_active {
+                colors.text_primary
             } else {
                 colors.text_secondary(colors.bg_sidebar)
             },
             row_alpha,
         );
-
-        let scope_out = ui.scope(|ui| {
-            ui.set_width(ui.available_width());
-
-            ui.add_space(ROW_PAD_V);
-
-            // --- Outer row: left gutter (index number) + content column ---
-            let y_before = ui.cursor().min.y;
-            // name_row_h and close_rect are captured from inside the horizontal
-            // closure so the number and delete hit target stay on the headline,
-            // not the full two-line row.
-            let mut name_row_h_capture = 0.0_f32;
-            let mut close_rect_capture = None;
-            ui.horizontal(|ui| {
-                ui.add_space(indent);
-
-                // Gutter: fixed-width column for the 1-9 index number.
-                // Width is reserved here; the number is painted post-scope
-                // centered across the full row height.
-                ui.add_space(GUTTER_W);
-
-                // Content column: name row + optional path row.
-                // Pips live on the name row, right-aligned before the action zone.
-                let name_row_h = ui
-                    .vertical(|ui| {
-                        // --- Name row ---
-                        let name_y_before = ui.cursor().min.y;
-                        ui.horizontal(|ui| {
-                            // Every horizontal gap on this row is budgeted
-                            // explicitly below, so implicit item spacing must be
-                            // off: an unbudgeted gap makes the row wider than
-                            // the panel, egui stores that overflowed content
-                            // rect as the panel's size, and the panel re-reads
-                            // it as its width next frame — a feedback loop that
-                            // ramps the sidebar to its size_range maximum and
-                            // swallows any user resize (stint 0715).
-                            let gap = ui.spacing().item_spacing.x;
-                            ui.spacing_mut().item_spacing.x = 0.0;
-
-                            // Compute pip strip width so we can budget the name text.
-                            let pip_strip_w = if let Some(ref dots) = pane_dots {
-                                if dots.count > 0 {
-                                    let capped = dots.count.min(PANE_DOT_MAX);
-                                    let group_count = dots
-                                        .windows
-                                        .iter()
-                                        .filter(|group| group.count > 0 && group.start < capped)
-                                        .count()
-                                        .max(1);
-                                    let mut w = (capped as f32) * PANE_DOT_SPACING
-                                        + (group_count as f32) * WINDOW_GROUP_PAD_X * 2.0
-                                        + (group_count.saturating_sub(1) as f32) * WINDOW_GROUP_GAP;
-                                    if dots.count > PANE_DOT_MAX {
-                                        w += 20.0;
-                                    }
-                                    w + PIP_TEXT_GAP
-                                } else {
-                                    0.0
-                                }
-                            } else {
-                                0.0
-                            };
-
-                            let badge_w = if badge_count > 0 {
-                                SIDEBAR_BADGE_W
-                            } else {
-                                0.0
-                            };
-                            let close_w = if action_enabled {
-                                ACTION_ZONE_WIDTH
-                            } else {
-                                0.0
-                            };
-                            // The trailing block keeps normal item spacing
-                            // between the close zone and the badge, so that gap
-                            // is part of its budget too.
-                            let trailing_w = badge_w
-                                + close_w
-                                + if badge_w > 0.0 && close_w > 0.0 {
-                                    gap
-                                } else {
-                                    0.0
-                                };
-                            let text_max =
-                                (ui.available_width() - trailing_w - pip_strip_w).max(0.0);
-
-                            let title_width = ui
-                                .scope(|ui| {
-                                    ui.set_max_width(text_max);
-                                    ui.add(
-                                        egui::Label::new(
-                                            egui::RichText::new(&ctx_name)
-                                                .size(style::TEXT_SIDEBAR_TITLE)
-                                                .color(text_color),
-                                        )
-                                        .selectable(false)
-                                        .truncate(),
-                                    )
-                                    .rect
-                                    .width()
-                                })
-                                .inner;
-                            // Keep the trailing layout at the budget boundary
-                            // even for short names, so it cannot begin after
-                            // the pips and overlap the count.
-                            ui.add_space((text_max - title_width).max(0.0));
-
-                            // Pips stay beside the headline, before the trailing
-                            // state. `pip_strip_w` budgeted this gap; with
-                            // implicit spacing off it has to be added by hand.
-                            if pip_strip_w > 0.0 {
-                                ui.add_space(PIP_TEXT_GAP);
-                            }
-                            draw_pips(ui, &pane_dots, colors, row_alpha, is_dragging);
-
-                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                                ui.spacing_mut().item_spacing.x = gap;
-                                // The close target follows the count at the physical trailing edge.
-                                if action_enabled {
-                                    let (rect, _) = ui.allocate_exact_size(
-                                        Vec2::new(ACTION_ZONE_WIDTH, ui.spacing().interact_size.y),
-                                        Sense::hover(),
-                                    );
-                                    close_rect_capture = Some(rect);
-                                }
-                                if badge_count > 0 {
-                                    let badge_text = if badge_count > 9 {
-                                        "9+".to_string()
-                                    } else {
-                                        badge_count.to_string()
-                                    };
-                                    ui.add_sized(
-                                        Vec2::new(SIDEBAR_BADGE_W, 0.0),
-                                        egui::Label::new(
-                                            egui::RichText::new(badge_text)
-                                                .size(style::TEXT_META)
-                                                .color(with_alpha(accent_color, row_alpha)),
-                                        )
-                                        .halign(Align::RIGHT),
-                                    );
-                                }
-                            });
-                        });
-                        // Capture name-row height before the subtitle row is added.
-                        let name_h = ui.cursor().min.y - name_y_before;
-
-                        // --- Path row (subtitle only, no pips) ---
-                        if let Some(ref path) = subtitle {
-                            ui.horizontal(|ui| {
-                                let path_max = (ui.available_width() - style::SPACE_SM).max(0.0);
-                                ui.scope(|ui| {
-                                    ui.set_max_width(path_max);
-                                    ui.add(
-                                        egui::Label::new(
-                                            egui::RichText::new(shorten_path(path))
-                                                .size(style::TEXT_META)
-                                                .color(with_alpha(text_dim, row_alpha)),
-                                        )
-                                        .selectable(false)
-                                        .truncate(),
-                                    );
-                                });
-                            });
-                        }
-
-                        name_h
-                    })
-                    .inner;
-                name_row_h_capture = name_row_h;
-            });
-
-            ui.add_space(ROW_PAD_V);
-
-            (
-                ui.cursor().min.y - y_before,
-                name_row_h_capture,
-                close_rect_capture,
-            )
-        });
-
-        let row_rect = scope_out.response.rect;
-        let (_total_h, name_row_h, close_rect) = scope_out.inner;
-
-        let response = ui.interact(row_rect, id, Sense::click_and_drag());
-        let hovered = response.hovered();
-
-        // Selection: use paint_selection (inset tinted pill + soft outline) to
-        // match palette/picker rows. Hover keeps the flat sidebar fill.
-        if is_active {
-            // Clear the bg placeholder — paint_selection draws its own rect.
-            ui.painter().set(bg_idx, egui::Shape::Noop);
-            if row_alpha < 1.0 {
-                // Dragging: just a dim solid fill, no outline.
-                ui.painter().rect_filled(
-                    row_rect,
-                    CornerRadius::ZERO,
-                    with_alpha(bg_active, row_alpha),
-                );
-            } else {
-                // 4px horizontal inset gives the pill breathing room from the
-                // sidebar edges, matching the visual weight of palette rows.
-                let pill_rect = Rect::from_min_max(
-                    egui::pos2(row_rect.min.x + 4.0, row_rect.min.y),
-                    egui::pos2(row_rect.max.x - 4.0, row_rect.max.y),
-                );
-                paint_selection(ui.painter(), pill_rect, colors);
-            }
-        } else {
-            let fill = if hovered && !is_dragging {
-                with_alpha(bg_hover, row_alpha)
-            } else {
-                Color32::TRANSPARENT
-            };
-            let hover_rect = crate::ui::list::selection_inset(Rect::from_min_max(
-                egui::pos2(row_rect.min.x + 4.0, row_rect.min.y),
-                egui::pos2(row_rect.max.x - 4.0, row_rect.max.y),
-            ));
-            ui.painter().set(
-                bg_idx,
-                egui::Shape::rect_filled(hover_rect, crate::ui::style::RADIUS_SM, fill),
+        crate::ui::snap::galley_snapped(
+            ui.painter(),
+            geom.title.min,
+            geom.title_galley.clone(),
+            title_color,
+        );
+        if let Some((subtitle_rect, galley)) = &geom.subtitle {
+            crate::ui::snap::galley_snapped(
+                ui.painter(),
+                subtitle_rect.min,
+                galley.clone(),
+                with_alpha(colors.text_dim, row_alpha),
             );
         }
 
-        // Paint the index number centered on the title line. Rows can include
-        // subtitle/pip content below the title, so full-row centering makes the
-        // number read as too low beside the context name.
-        if let Some(idx) = ctx_index {
-            if idx < 9 {
-                let title_center_y = row_rect.min.y + ROW_PAD_V + name_row_h / 2.0;
-                let gutter_rect = Rect::from_min_size(
-                    egui::pos2(row_rect.min.x + indent, row_rect.min.y),
-                    Vec2::new(GUTTER_W, ROW_PAD_V + name_row_h),
-                );
-                paint_text_centered(
-                    ui,
-                    format!("{}", idx + 1),
-                    egui::FontId::proportional(style::TEXT_HINT),
-                    with_alpha(text_dim, row_alpha),
-                    egui::pos2(gutter_rect.center().x, title_center_y),
-                );
-            }
+        // --- Pips -------------------------------------------------------------
+        if let (Some(dots), Some((origin, layout))) = (&self.pane_dots, &geom.pips) {
+            paint_pips(
+                ui,
+                dots,
+                *origin,
+                layout,
+                colors,
+                row_alpha,
+                self.is_dragging,
+            );
         }
 
-        let in_action = close_rect.is_some_and(|rect| ui.rect_contains_pointer(rect));
+        // --- Badge ------------------------------------------------------------
+        if let Some(badge_rect) = geom.badge {
+            let label = if self.badge_count > 9 {
+                "9+".to_string()
+            } else {
+                self.badge_count.to_string()
+            };
+            crate::ui::snap::text_snapped(
+                ui.painter(),
+                Pos2::new(badge_rect.right(), badge_rect.center().y),
+                egui::Align2::RIGHT_CENTER,
+                label,
+                egui::FontId::proportional(style::TEXT_META),
+                with_alpha(colors.accent, row_alpha),
+            );
+        }
 
-        if let Some(close_rect) = close_rect {
-            if hovered && !is_dragging {
-                let glyph_color =
-                    with_alpha(if in_action { text_primary } else { text_dim }, row_alpha);
+        // --- Close ------------------------------------------------------------
+        // The glyph is centered in the same rect the pointer is tested against,
+        // so the target is exactly where the X appears.
+        let in_close = geom
+            .close
+            .is_some_and(|close| ui.rect_contains_pointer(close));
+        if let Some(close) = geom.close {
+            if hovered && !self.is_dragging {
                 paint_text_centered(
                     ui,
                     "\u{2715}",
                     egui::FontId::proportional(style::TEXT_SIDEBAR_TITLE),
-                    glyph_color,
-                    close_rect.center(),
+                    with_alpha(
+                        if in_close {
+                            colors.text_primary
+                        } else {
+                            colors.text_dim
+                        },
+                        row_alpha,
+                    ),
+                    close.center(),
                 );
             }
         }
 
-        if in_action {
+        if in_close {
             response.clone().on_hover_text("Delete context");
-        }
-
-        if in_action {
             ui.ctx().set_cursor_icon(CursorIcon::PointingHand);
         } else {
-            let content_max_x = if action_enabled {
-                row_rect.max.x - ACTION_ZONE_WIDTH
-            } else {
-                row_rect.max.x
-            };
-            let in_content = ui.rect_contains_pointer(Rect::from_min_max(
-                row_rect.min,
-                egui::pos2(content_max_x, row_rect.max.y),
-            ));
-            if in_content || is_dragging {
+            let content = Rect::from_min_max(
+                rect.min,
+                Pos2::new(geom.close.map_or(rect.max.x, |c| c.left()), rect.max.y),
+            );
+            if ui.rect_contains_pointer(content) || self.is_dragging {
                 ui.ctx().set_cursor_icon(if self.draggable {
-                    if any_dragging {
+                    if self.any_dragging {
                         CursorIcon::Grabbing
                     } else {
                         CursorIcon::Grab
@@ -637,7 +713,7 @@ impl ContextItem {
             SidebarAction::DragStart
         } else if self.draggable && response.drag_stopped() {
             SidebarAction::DragEnd
-        } else if response.clicked() && in_action && hovered {
+        } else if response.clicked() && in_close && hovered {
             SidebarAction::Delete
         } else if response.clicked() {
             SidebarAction::Activate
@@ -653,6 +729,57 @@ impl ContextItem {
 mod tests {
     use super::*;
 
+    fn test_dots(pane_count: usize, windows: Vec<PaneDotWindow>) -> PaneDots {
+        PaneDots {
+            count: pane_count,
+            focused_idx: Some(0),
+            hidden_set: std::collections::HashSet::new(),
+            activities: vec![None; pane_count],
+            windows,
+        }
+    }
+
+    fn one_window(pane_count: usize) -> Vec<PaneDotWindow> {
+        vec![PaneDotWindow {
+            start: 0,
+            count: pane_count,
+            is_return_target: true,
+            is_active: true,
+        }]
+    }
+
+    fn row(action_enabled: bool, badge_count: usize, pane_count: usize) -> SidebarRow {
+        SidebarRow {
+            is_active: true,
+            is_dragging: false,
+            any_dragging: false,
+            action_enabled,
+            ctx_name: "Default".to_string(),
+            ctx_index: Some(0),
+            badge_count,
+            subtitle: Some("/Users/someone/code/project".to_string()),
+            pane_dots: (pane_count > 0).then(|| test_dots(pane_count, one_window(pane_count))),
+            draggable: true,
+        }
+    }
+
+    /// Run `f` inside a real egui frame at `panel_w` points wide.
+    fn in_frame<R>(panel_w: f32, f: impl FnOnce(&mut egui::Ui) -> R) -> R {
+        let input = egui::RawInput {
+            screen_rect: Some(Rect::from_min_size(Pos2::ZERO, Vec2::new(panel_w, 600.0))),
+            ..Default::default()
+        };
+        let ctx = egui::Context::default();
+        let mut f = Some(f);
+        let mut out = None;
+        let _ = ctx.run_ui(input, |ui| {
+            if let Some(f) = f.take() {
+                out = Some(f(ui));
+            }
+        });
+        out.expect("frame body ran")
+    }
+
     /// Lay one context row out in a `panel_w`-wide viewport and return the
     /// width the row actually claimed.
     fn measure_row(
@@ -662,44 +789,13 @@ mod tests {
         pane_count: usize,
     ) -> f32 {
         let colors = Colors::from_config(&crate::config::ThemeConfig::default());
-        let mut pane_dots = (pane_count > 0).then(|| PaneDots {
-            count: pane_count,
-            focused_idx: Some(0),
-            hidden_set: std::collections::HashSet::new(),
-            activities: vec![None; pane_count],
-            windows: vec![PaneDotWindow {
-                start: 0,
-                count: pane_count,
-                is_return_target: true,
-                is_active: true,
-            }],
-        });
-        let input = egui::RawInput {
-            screen_rect: Some(egui::Rect::from_min_size(
-                egui::Pos2::ZERO,
-                Vec2::new(panel_w, 600.0),
-            )),
-            ..Default::default()
-        };
-        let ctx = egui::Context::default();
-        let mut row_w = 0.0_f32;
-        let _ = ctx.run_ui(input, |ui| {
-            let (_, response) = ContextItem {
-                is_active: true,
-                is_dragging: false,
-                any_dragging: false,
-                action_enabled,
-                ctx_name: "Default".to_string(),
-                ctx_index: Some(0),
-                badge_count,
-                subtitle: Some("/Users/someone/code/project".to_string()),
-                pane_dots: pane_dots.take(),
-                draggable: true,
-            }
-            .draw(ui, Id::new("row"), &colors);
-            row_w = response.rect.width();
-        });
-        row_w
+        in_frame(panel_w, |ui| {
+            row(action_enabled, badge_count, pane_count)
+                .show(ui, Id::new("row"), &colors)
+                .1
+                .rect
+                .width()
+        })
     }
 
     /// Stint 0715: a row wider than the space it was given inflates the
@@ -724,29 +820,171 @@ mod tests {
         }
     }
 
-    /// Regression: session restore can leave focus on a pane past PANE_DOT_MAX
-    /// (dot_centers len == 8, focused_idx == 8). The pin must be skipped, not
-    /// index out of bounds.
+    /// The three trailing slots are distinct zones at fixed offsets from the
+    /// row's right edge: close outermost, badge inside it, pips inside that.
+    /// None of them may overlap, and none may move past another as the panel
+    /// narrows or content appears.
     #[test]
-    fn draw_pips_focused_pane_past_dot_cap_does_not_panic() {
-        let dots = Some(PaneDots {
-            count: PANE_DOT_MAX + 1,
-            focused_idx: Some(PANE_DOT_MAX),
-            hidden_set: std::collections::HashSet::new(),
-            activities: vec![None; PANE_DOT_MAX + 1],
-            windows: vec![PaneDotWindow {
-                start: 0,
-                count: PANE_DOT_MAX + 1,
-                is_return_target: true,
-                is_active: true,
-            }],
+    fn trailing_slots_never_overlap_at_any_width() {
+        for &panel_w in &[140.0_f32, 180.0, 220.0, 320.0, 480.0] {
+            for &action_enabled in &[false, true] {
+                for &badge_count in &[0_usize, 4, 42] {
+                    for &pane_count in &[0_usize, 1, 5, PANE_DOT_MAX + 3] {
+                        in_frame(panel_w, |ui| {
+                            let item = row(action_enabled, badge_count, pane_count);
+                            let geom = RowGeometry::measure(ui, &item, panel_w);
+                            let label = format!(
+                                "panel_w={panel_w} action={action_enabled} \
+                                 badge={badge_count} panes={pane_count}"
+                            );
+                            if let (Some(badge), Some(close)) = (geom.badge, geom.close) {
+                                assert!(
+                                    badge.right() <= close.left(),
+                                    "badge overlaps close ({label})"
+                                );
+                            }
+                            let trailing_left = geom
+                                .badge
+                                .or(geom.close)
+                                .map_or(geom.rect.right(), |slot| slot.left());
+                            if let Some((origin, layout)) = &geom.pips {
+                                assert!(
+                                    origin.x + layout.width <= trailing_left + f32::EPSILON,
+                                    "pips overlap the trailing slots ({label})"
+                                );
+                                assert!(
+                                    geom.title.right() <= origin.x + f32::EPSILON,
+                                    "title overlaps the pips ({label})"
+                                );
+                            } else {
+                                assert!(
+                                    geom.title.right() <= trailing_left + f32::EPSILON,
+                                    "title overlaps the trailing slots ({label})"
+                                );
+                            }
+                            assert!(
+                                geom.close.is_none_or(
+                                    |close| close.right() <= geom.rect.right() + f32::EPSILON
+                                ),
+                                "close escapes the row ({label})"
+                            );
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    /// The index number shares the title's optical center, not the whole
+    /// row's — a row with a path line underneath would otherwise read with the
+    /// number sitting low beside the name.
+    #[test]
+    fn index_gutter_is_centered_on_the_title_line() {
+        in_frame(220.0, |ui| {
+            let item = row(true, 3, 4);
+            let geom = RowGeometry::measure(ui, &item, 220.0);
+            assert!(
+                geom.subtitle.is_some(),
+                "setup: this row has a path line below the title"
+            );
+            assert!(
+                (geom.gutter.center().y - geom.title.center().y).abs() < 0.01,
+                "gutter center {} must match title center {}",
+                geom.gutter.center().y,
+                geom.title.center().y
+            );
+            assert!(
+                geom.gutter.center().y < geom.rect.center().y,
+                "a two-line row's title sits above the row center, so the \
+                 number must too"
+            );
         });
+    }
+
+    /// The pip strip's width is measured once and reused: the budget the title
+    /// is elided against is the same number the capsules are painted with.
+    #[test]
+    fn pip_strip_width_is_measured_once() {
+        in_frame(320.0, |ui| {
+            let item = row(true, 0, 5);
+            let geom = RowGeometry::measure(ui, &item, 320.0);
+            let (origin, layout) = geom.pips.as_ref().expect("five panes render pips");
+            let last = layout.groups.last().expect("one capsule per window");
+            assert!(
+                (last.x + last.width - layout.width).abs() < 0.01,
+                "capsules must fill exactly the width the strip reserved"
+            );
+            assert!(
+                (origin.x + layout.width - geom.rect.right() + CLOSE_SLOT_W).abs() < 0.01,
+                "the strip must end exactly where the trailing slots begin"
+            );
+        });
+    }
+
+    /// Regression: session restore can leave focus on a pane past PANE_DOT_MAX
+    /// (the strip caps at 8 dots, focused_idx == 8). The pin must be skipped,
+    /// not index out of bounds.
+    #[test]
+    fn pips_focused_pane_past_dot_cap_does_not_panic() {
+        let dots = PaneDots {
+            focused_idx: Some(PANE_DOT_MAX),
+            ..test_dots(PANE_DOT_MAX + 1, one_window(PANE_DOT_MAX + 1))
+        };
+        let layout = PipLayout::measure(&dots, 200.0).expect("nine panes render pips");
+        assert_eq!(layout.overflow, Some(1));
+        assert!(layout.dot_center_x(PANE_DOT_MAX).is_none());
+
         let colors = Colors::from_config(&crate::config::ThemeConfig::default());
         let ctx = egui::Context::default();
         let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
             egui::CentralPanel::default().show_inside(ui, |ui| {
-                draw_pips(ui, &dots, &colors, 1.0, false);
+                paint_pips(
+                    ui,
+                    &dots,
+                    Pos2::new(10.0, 20.0),
+                    &layout,
+                    &colors,
+                    1.0,
+                    false,
+                );
             });
         });
+    }
+
+    /// Multi-window contexts get one capsule per window, in order, separated by
+    /// a visible gap — the boundary is what tells a user which panes will come
+    /// back together.
+    #[test]
+    fn each_spatial_window_gets_its_own_capsule() {
+        let dots = test_dots(
+            5,
+            vec![
+                PaneDotWindow {
+                    start: 0,
+                    count: 2,
+                    is_return_target: true,
+                    is_active: true,
+                },
+                PaneDotWindow {
+                    start: 2,
+                    count: 3,
+                    is_return_target: false,
+                    is_active: false,
+                },
+            ],
+        );
+        let layout = PipLayout::measure(&dots, 200.0).expect("five panes render pips");
+        assert_eq!(layout.groups.len(), 2);
+        assert!(
+            (layout.groups[1].x - (layout.groups[0].x + layout.groups[0].width))
+                >= WINDOW_GROUP_GAP - 0.01,
+            "capsules must be separated by the window gap"
+        );
+        for idx in 0..5 {
+            assert!(
+                layout.dot_center_x(idx).is_some(),
+                "every visible dot belongs to a capsule"
+            );
+        }
     }
 }

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1441,6 +1441,204 @@ mod tests {
             .expect("render failed");
     }
 
+    /// Push a second spatial window onto `context_id` and return its index, so
+    /// a sidebar row can be seeded with more than one pip capsule.
+    fn push_window_for_context(
+        h: &mut PlexiUiHarness,
+        context_id: u64,
+        grid_x: u32,
+        path: &str,
+    ) -> usize {
+        h.with_app_mut(|app| {
+            let window_id = app.next_window_id;
+            app.next_window_id += 1;
+            app.windows.push(crate::host::context::Window {
+                name: String::new(),
+                path: std::path::PathBuf::from(path),
+                tree: egui_tiles::Tree::empty("sidebar-row-states"),
+                panes: std::collections::HashMap::new(),
+                focused_pane: None,
+                zoomed_pane: None,
+                grid_x,
+                grid_y: 0,
+                window_id,
+                context_id,
+            });
+            app.windows.len() - 1
+        })
+    }
+
+    /// Fill `window_index` with `count` app panes wired into one horizontal
+    /// container, so the window's tree really reports every pane — inserting
+    /// panes without attaching them to the root leaves them invisible to the
+    /// spatial walk the sidebar pips are built from.
+    fn fill_window_with_panes(h: &mut PlexiUiHarness, window_index: usize, count: usize) {
+        let browser_root = h.workspace.path().to_path_buf();
+        h.with_app_mut(|app| {
+            let mut tiles = Vec::with_capacity(count);
+            for _ in 0..count {
+                let pane_id = app.host.alloc_pane_id();
+                let app_pane = AppPane {
+                    pip_status: None,
+                    id: pane_id,
+                    runtime: AppRuntime::Builtin(Box::new(
+                        crate::file_browser::FileBrowserApp::new(browser_root.clone()),
+                    )),
+                    workspace_root: browser_root.clone(),
+                    permissions: AppPermissions::builtin(),
+                    manifest_id: "test".to_string(),
+                    name: "Test App".to_string(),
+                    pane_group: None,
+                    linked_pane_id: None,
+                    overlay_replaced: None,
+                    hidden: false,
+                    agent: None,
+                    slots: std::collections::HashMap::new(),
+                    semantic_state: Default::default(),
+                };
+                let win = &mut app.windows[window_index];
+                win.panes.insert(pane_id, Pane::App(Box::new(app_pane)));
+                tiles.push(win.tree.tiles.insert_pane(pane_id));
+            }
+            let win = &mut app.windows[window_index];
+            let container = win.tree.tiles.insert_horizontal_tile(tiles.clone());
+            win.tree.root = Some(container);
+            win.focused_pane = tiles.first().copied();
+        });
+    }
+
+    /// Seed a context with a name, a root path, and its own window, returning
+    /// `(router index, context id, window index)`.
+    fn push_sidebar_context(h: &mut PlexiUiHarness, name: &str, root: &str) -> (usize, u64, usize) {
+        let (idx, context_id) = h.with_app_mut(|app| {
+            let context_id = app.next_window_id;
+            app.next_window_id += 1;
+            app.router.push(crate::host::context::Context {
+                name: name.to_string(),
+                root: std::path::PathBuf::from(root),
+                description: None,
+                context_id,
+                parent_id: None,
+                depth: 0,
+                parked: false,
+            });
+            (app.router.len() - 1, context_id)
+        });
+        let window_idx = push_window_for_context(h, context_id, 0, root);
+        (idx, context_id, window_idx)
+    }
+
+    fn seeded_notification(
+        notify_id: &str,
+        source_context_id: u64,
+        source_window_id: u64,
+    ) -> crate::app::PendingNotification {
+        crate::app::PendingNotification {
+            notify_id: notify_id.to_string(),
+            sender_pane_id: 0,
+            source_context_id,
+            source_window_id,
+            title: "Preview badge".to_string(),
+            body: "Seeded sidebar notification".to_string(),
+            kind: crate::app_protocol::NotifyKind::Message,
+            options: vec![],
+            input_prompt: None,
+            required: false,
+            scope: crate::app_protocol::NotifyScope::Context,
+            image_inline: None,
+            image_pipe_id: None,
+            response_file: None,
+            timeout_secs: None,
+            on_dismiss: None,
+            enqueued_at: std::time::Instant::now(),
+            tombstoned: false,
+            deliver_after: None,
+        }
+    }
+
+    /// Stint 0717: the whole vocabulary of the rebuilt context row in one
+    /// frame, at HiDPI — index numbers beside their names, per-window pip
+    /// capsules with the return-target pin on the active window, agent
+    /// activity colors, pip overflow past the visible cap, notification badges
+    /// inboard of the close slot, an active row, and a hovered row showing its
+    /// close glyph. Read the PNG: the number must sit on the name's optical
+    /// center, no two trailing slots may touch, and the capsule's top edge must
+    /// be unbroken except where the pin meets it.
+    #[test]
+    fn screenshot_sidebar_row_states() {
+        const SHOT_PPP: f32 = 2.0;
+        let mut h = PlexiUiHarness::new_sized_ppp(1100.0, 700.0, SHOT_PPP);
+        h.step();
+
+        let (active_context_id, active_window_id) = h.with_app_mut(|app| {
+            app.sidebar_visible = true;
+            let idx = app.router.active_idx();
+            app.router.get_mut(idx).name = "PLEXI Workspace".to_string();
+            app.router.get_mut(idx).root = std::path::PathBuf::from("/projects/PLEXI");
+            (
+                app.router.get(idx).context_id,
+                app.windows[app.active_window].window_id,
+            )
+        });
+
+        // Active context: two spatial windows, so the row carries two capsules
+        // and the pin marks the one activation will return to.
+        let active_window = h.with_app(|app| app.active_window);
+        fill_window_with_panes(&mut h, active_window, 3);
+        let second_window =
+            push_window_for_context(&mut h, active_context_id, 1, "/projects/PLEXI");
+        fill_window_with_panes(&mut h, second_window, 2);
+
+        // A long name that must elide, and enough panes to overflow the cap.
+        let (_, narrator_id, narrator_window) = push_sidebar_context(
+            &mut h,
+            "Narrator Video Production Workspace",
+            "/projects/narrator-site",
+        );
+        fill_window_with_panes(&mut h, narrator_window, 11);
+        let narrator_window_id = h.with_app(|app| app.windows[narrator_window].window_id);
+
+        let (_, _, scratch_window) = push_sidebar_context(&mut h, "scratch", "/tmp/scratch");
+        fill_window_with_panes(&mut h, scratch_window, 1);
+
+        // Agent activity across the pips, and badges on two rows.
+        h.with_app_mut(|app| {
+            let statuses = [
+                crate::app_protocol::PipStatus::Yellow,
+                crate::app_protocol::PipStatus::Green,
+                crate::app_protocol::PipStatus::Red,
+            ];
+            for (i, pane) in app.windows[0].panes.values_mut().enumerate() {
+                if let Pane::App(app_pane) = pane {
+                    app_pane.pip_status = Some(statuses[i % statuses.len()]);
+                }
+            }
+            app.pending_notifications.extend([
+                seeded_notification("active-one", active_context_id, active_window_id),
+                seeded_notification("active-two", active_context_id, active_window_id),
+                seeded_notification("active-three", active_context_id, active_window_id),
+                seeded_notification("narrator-one", narrator_id, narrator_window_id),
+                seeded_notification("narrator-two", narrator_id, narrator_window_id),
+            ]);
+        });
+        h.run_steps(3);
+
+        // Hover the inactive "scratch" row so one row shows its close glyph
+        // while the active row shows its badge — the two states that used to
+        // share a single trailing zone.
+        // kittest reports node rects in physical pixels; pointer events are in
+        // points, so the HiDPI scale has to come back out.
+        let scratch_row = h.harness().get_by_label("scratch").rect().center() / SHOT_PPP;
+        h.harness()
+            .input_mut()
+            .events
+            .push(egui::Event::PointerMoved(scratch_row));
+        h.step();
+
+        h.save_screenshot("/tmp/plexi-0717-sidebar-row-states.png")
+            .expect("render failed");
+    }
+
     /// Stint 0605: `NextContext`/`PrevContext` cycle the same enumeration the
     /// sidebar draws. Against a live router carrying a real subcontext wedged
     /// between two masters, cycling steps master → master and wraps, so it can

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1424,6 +1424,23 @@ mod tests {
             .expect("render failed");
     }
 
+    /// Stint 0715: visual review surface for the first-run sidebar — exactly
+    /// one context, so the close zone is suppressed and the row is at its
+    /// widest text budget. This is the state that used to ramp the panel to
+    /// its `size_range` maximum, clip the row card, and leave a dead strip
+    /// between the sidebar and the central pane.
+    #[test]
+    fn screenshot_single_context_sidebar() {
+        let mut h = PlexiUiHarness::new_sized_ppp(1280.0, 800.0, 2.0);
+        h.with_app_mut(|app| app.sidebar_visible = true);
+        h.run_steps(6);
+        h.with_app(|app| {
+            assert_eq!(app.router.len(), 1, "first-run is a single context");
+        });
+        h.save_screenshot("/tmp/plexi-0715-single-context-sidebar.png")
+            .expect("render failed");
+    }
+
     /// Stint 0605: `NextContext`/`PrevContext` cycle the same enumeration the
     /// sidebar draws. Against a live router carrying a real subcontext wedged
     /// between two masters, cycling steps master → master and wraps, so it can

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1556,14 +1556,15 @@ mod tests {
         }
     }
 
-    /// Stint 0717: the whole vocabulary of the rebuilt context row in one
-    /// frame, at HiDPI — index numbers beside their names, per-window pip
-    /// capsules with the return-target pin on the active window, agent
-    /// activity colors, pip overflow past the visible cap, notification badges
-    /// inboard of the close slot, an active row, and a hovered row showing its
-    /// close glyph. Read the PNG: the number must sit on the name's optical
-    /// center, no two trailing slots may touch, and the capsule's top edge must
-    /// be unbroken except where the pin meets it.
+    /// Stint 0717: the whole vocabulary of the rebuilt two-tier context row in
+    /// one frame, at HiDPI. Identity tier — index number, context name, and
+    /// the close action pinned top-right. Pane-state tier — per-window pip
+    /// capsules with the return-target pin and agent activity colors, the
+    /// overflow count, the notification badge, and the root path trailing.
+    /// Read the PNG: the number must sit on the name's optical center; the
+    /// badge must read as a different kind of thing from the collapsed pips
+    /// beside it; the capsule's top edge must be unbroken except where the pin
+    /// meets it; and nothing on either tier may touch its neighbour.
     #[test]
     fn screenshot_sidebar_row_states() {
         const SHOT_PPP: f32 = 2.0;


### PR DESCRIPTION
Closes stint **0715** — *fix(ui/sidebar): single-context sidebar inflates to max width with a dead gap strip and un-resizable panel*. No linked GitHub issue; stint is authoritative.

## Root cause (measured, not assumed)

The stint left the root cause open. A frame-over-frame probe pinned it exactly:

```
[row] outer_avail=198 text_max=198 title_w=29.6 pip=0 badge=0 close=0 min_rect_w=206 spacing=8
[probe] frame=0 panel_w=228   frame=1 236   frame=2 244 ... +8pt every frame
```

`ContextItem`'s headline lays out `label → pad-to-budget → pips → trailing block` and budgets each of their **widths**, but never egui's implicit `item_spacing.x` between them. The row allocated `available_width + 8`.

That alone would just clip. What made it compound: egui stores a panel's **content** rect as the panel's size (`PanelState { rect }.store` on the frame's response rect), and `PanelSizer::get_size_from_state_or_default` reads that back as the panel's width next frame. So the overflow fed itself — a monotonic ramp to the `size_range` 400-point cap, which also explains the un-resizable handle (a drag is overwritten the very next frame) and the dead strip (the panel's `clip_rect` stays at `panel_rect` while `cursor.min.x` for the central panel is advanced to the wider content rect, so the difference is painted by neither).

**Why a second context "fixed" it** (the stint's other open question): it does not. Two contexts enable the close zone, which shifts 22pt out of the text budget but leaves the same single unbudgeted 8pt gap — it still overflows. What changes is that the ramp starts from an already-clamped state in the reporter's session; the geometry test in this PR shows a 2+-context row overflowing pre-fix too (`panel_w=160 row_w=168` with `action_enabled=true`). So this was never a single-context-only defect; the first-run state is simply where it is most visible, because a lone context suppresses the close zone and gives the name its widest budget.

## Fix

Turn implicit item spacing off on the headline row and budget every gap explicitly:

- the pip/text gap becomes a named `PIP_TEXT_GAP` and an explicit `add_space`, matching what `pip_strip_w` already reserved;
- the trailing right-to-left block keeps normal spacing internally, and that gap is now part of `trailing_w`.

Row width now equals the panel's available width exactly, for every combination of close zone, badge, and pip count. Visual design from stint 0700 is unchanged.

Out of scope, as the stint specifies: the narrow-window responsive clamp / content-area floor (stint 0713).

## Test evidence

- **`ui::sidebar_row::tests::context_row_never_exceeds_available_width`** — sweeps panel width × close zone × badge count × pip count and asserts the row never claims more than it was given.
- **`testing::harness_tests::sidebar_panel_width_tests::single_context_sidebar_settles_at_default_width`** — first-run state settles at `SIDEBAR_DEFAULT_W` (220) and does not grow across 20 further frames.
- **Falsified**: both go red with the fix reverted — `row overflowed: panel_w=160 row_w=168`, and `left: 236.0 right: 220.0`.
- **`ui_tests::tests::screenshot_single_context_sidebar`** — visual review surface at ppp 2.0. Rendered and inspected: sidebar at 220pt, row card fully inside the panel with its 4pt inset, no dead strip between sidebar and central pane. PNG deleted after review per TESTING.md.
- **Full suite**: `cargo test --bin plexi` — 2243 passed, 3 failed. All 3 (`cargo_lease_serializes_concurrent_invocations`, `cargo_lease_sigkilled_wrapped_command_reports_137`, `wasm_python::headless_frame_fails_fast_when_the_guest_dies_at_import`) are self-interference from running the suite *inside* `scripts/cargo-with-lease.sh` plus load-sensitive timeouts; re-run outside the wrapper all 7 in that filter pass. Unrelated to this diff.
- **Codex review** (`--base alpha`): clean, no findings.
- **Conclusion**: install skippable — the geometry invariant, the frame-over-frame settling behavior, and the rendered pixels are all covered headlessly. A `just pr-install` pass is still worth it if a human wants to confirm the resize handle feels right by hand, since drag feel is the one thing the harness does not reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)