### PR TITLE
feat(logging): fine-grained UiPhase instrumentation for logic() freeze (stint 0716)

### DIFF
--- a/.agents/skills/implement-stint-v2/SKILL.md
+++ b/.agents/skills/implement-stint-v2/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: implement-stint-v2
+description: "given a stint (task), implement it into a PR, as one of many commits."
+risk: low
+source: local
+---
+
+you maintain your state using the plexi cli
+
+first see if alpha is clean, if not set state to blocked and send a plexi notification
+
+  plexi notify --title "Error: Implemntenet stint 1234" \
+    --body "stint XYZ failed because alpha branch is dirty." \
+    --choice "Go to Context:pane_focus:$PLEXI_PANE_ID" \
+    --scope context 
+
+
+if clean, `stint claim <task-id>` to claim on alpha, marking as in progress
+
+then create a worktree with 'wtp add -b <stint-is-number>-impl-<stint title/short desc>
+
+ALL WORK LIVES IN THIS WORKTREE
+
+if stint is 's' - small
+- immediatly look for the code change and implement swiftly, run e2e cargo test and finish
+
+if m
+Have a subagent generate a plan by reading the stint description, looking at the relevant code, and creating an execution pla
+then close that subagent and send the exicution plan to a new subagent. 
+
+if l
+have one subagent do a reasearch pass to create a multiphase plan
+then spawn subagents in this order. 
+impl-phase-1 - Only handling the implementation of the code for phase one.
+test-phase-2 - only responible for testing and reviewing the code quality, and running host tests
+impl-phase-1-b - If test phase 2 comes back with errors or suggestions on code quality changes as new commits on the worktree, 
+
+repeat impl and test loop untill all work in the plan lands
+
+Output on successful implementation:
+
+open a pr against alpha and wait for CI CD to pass
+then run just pr-install the pr number
+
+and send this to the user.
+
+```text
+[IMPLEMENTED]
+Stint <task-id>
+Branch: feature/stint-<task-id>-<slug>
+Files changed: <N>
+
+TESTING:
+<a short list of commands to run or things to spot check>
+<e.g. 'Run 'plexi-pr-1223 app list and make sure that... >
+
+
+"Pass, follow up, or fail?" 
+
+```
+
+if:
+PASS - Spawning sub-agent to merge pr into alpha, Addressing any merge conflicts, running just clean up commands. finally mark stint complete at the end, then say COMPLETE
+FOLLOW-UP - a list of improvments that need to be made, have a subagent go implemment those chages on the same worktree, commit to the same pr, and reinstall the new version with just pr-install. continue this till PASS
+FAIL - Add a section on the stint file that explains the fail, List some possible gotchas if there are any, as well as the user's feedback for the next attempt at implementation. mark stint as todo again. 
+
+During cleanup, move to alpha because issues arise if you try to remove a work tree you're currently working from. 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2639,25 +2639,67 @@ impl eframe::App for PlexiApp {
         // `ui` at all — still captures, and still answers (stints 0495, 0504).
         // It follows `update_preamble` so a request arriving on this pass is
         // issued on this pass, not one frame later.
-        self.service_pending_screenshots(ctx, frame.wgpu_render_state());
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::Screenshots,
+        );
+        crate::platform::logging::time_drain("service_pending_screenshots", || {
+            self.service_pending_screenshots(ctx, frame.wgpu_render_state())
+        });
 
         // Same reasoning for parked `pane slot wait` requests: an occluded
         // host must still expire them on schedule, so the caller sees the
         // host's typed timeout instead of its own (stint 0585).
-        self.service_pending_slot_waits(ctx);
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::SlotWaits,
+        );
+        crate::platform::logging::time_drain("service_pending_slot_waits", || {
+            self.service_pending_slot_waits(ctx)
+        });
 
         // And for `pane new --agent`, whose reply is owed either an idle
         // report, an expired deadline, or a pane that went away (stint 0584).
-        self.service_pending_agent_boots(ctx);
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::AgentBoots,
+        );
+        crate::platform::logging::time_drain("service_pending_agent_boots", || {
+            self.service_pending_agent_boots(ctx)
+        });
 
         // And for `pane send --submit`, which drives its settle → Enter →
         // confirm sequence from here: an occluded host must still press the
         // Enter it promised and still read the grid to confirm it (stint 0583).
-        self.service_pending_submits(ctx);
-        self.service_pane_heartbeats(ctx);
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::Submits,
+        );
+        crate::platform::logging::time_drain("service_pending_submits", || {
+            self.service_pending_submits(ctx)
+        });
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::PaneHeartbeats,
+        );
+        crate::platform::logging::time_drain("service_pane_heartbeats", || {
+            self.service_pane_heartbeats(ctx)
+        });
 
-        self.drain_app_subscription_replies();
-        self.deliver_app_event_subscriptions();
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::SubscriptionReplies,
+        );
+        crate::platform::logging::time_drain("drain_app_subscription_replies", || {
+            self.drain_app_subscription_replies()
+        });
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::EventDeliveries,
+        );
+        crate::platform::logging::time_drain("deliver_app_event_subscriptions", || {
+            self.deliver_app_event_subscriptions()
+        });
 
         // WASM Python panes are fed by external clients too — MCP server
         // processes, HTTP workers — and their guest runtimes run on their own
@@ -2665,13 +2707,23 @@ impl eframe::App for PlexiApp {
         // host still moves server data into the guest and guest replies out
         // (stint 0382 fix round; guard:
         // `mcp_reply_reaches_guest_while_window_hidden`).
-        self.service_python_pane_runtimes();
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::PythonRuntimes,
+        );
+        crate::platform::logging::time_drain("service_python_pane_runtimes", || {
+            self.service_python_pane_runtimes()
+        });
 
         // Host agent runtime (Phase C): consume queued event deliveries and
         // finished agent turns. Cheap no-op when nothing is pending. While a
         // turn runs on a worker thread, keep frames coming so its outcome is
         // collected promptly even when the UI is otherwise idle.
-        self.agent_host.tick();
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::AgentTick,
+        );
+        crate::platform::logging::time_drain("agent_host.tick", || self.agent_host.tick());
         if self.agent_host.turns_in_flight() {
             ctx.request_repaint_after(std::time::Duration::from_millis(100));
         }
@@ -2682,7 +2734,13 @@ impl eframe::App for PlexiApp {
         // occluded host executed no app command at all (see
         // `service_app_commands`). It runs last in `logic` because the services
         // above may queue work an app command then consumes on this same pass.
-        self.service_app_commands(ctx);
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::AppCommands,
+        );
+        crate::platform::logging::time_drain("service_app_commands", || {
+            self.service_app_commands(ctx)
+        });
         crate::platform::logging::mark_ui_phase(
             &self.ui_phase,
             crate::platform::logging::UiPhase::LogicComplete,

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -34,6 +34,10 @@ impl PlexiApp {
     /// pane command draining, update channel checks, PTY event draining, and
     /// focus-stack reconciliation.
     pub(super) fn update_preamble(&mut self, ctx: &egui::Context) {
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::PreambleAdoptedContext,
+        );
         if let Some(ctx_path) = crate::config::take_adopted_context_path() {
             log::info!("adopted context path: {}", ctx_path.display());
             self.new_context_at_path(ctx_path);
@@ -41,22 +45,52 @@ impl PlexiApp {
         }
         #[cfg(target_os = "macos")]
         {
-            let finder_paths = crate::platform::finder_service::drain();
-            if !finder_paths.is_empty() {
-                for path in finder_paths {
-                    log::info!("finder_service: opening context for {}", path.display());
-                    self.new_context_at_path(path);
+            crate::platform::logging::mark_ui_phase(
+                &self.ui_phase,
+                crate::platform::logging::UiPhase::PreambleFinderService,
+            );
+            crate::platform::logging::time_drain("finder_service::drain", || {
+                let finder_paths = crate::platform::finder_service::drain();
+                if !finder_paths.is_empty() {
+                    for path in finder_paths {
+                        log::info!("finder_service: opening context for {}", path.display());
+                        self.new_context_at_path(path);
+                    }
+                    self.save_workspace();
                 }
-                self.save_workspace();
-            }
+            });
         }
         if self.last_notify_poll.elapsed() >= std::time::Duration::from_secs(1) {
             let now = std::time::Instant::now();
             self.last_notify_poll = now;
-            self.drain_spawn_queue();
-            self.tick_terminal_activity();
-            self.tick_scheduler();
-            self.tick_notification_timeouts();
+            crate::platform::logging::mark_ui_phase(
+                &self.ui_phase,
+                crate::platform::logging::UiPhase::PreambleSpawnQueue,
+            );
+            crate::platform::logging::time_drain("drain_spawn_queue", || self.drain_spawn_queue());
+            crate::platform::logging::mark_ui_phase(
+                &self.ui_phase,
+                crate::platform::logging::UiPhase::PreambleTerminalActivity,
+            );
+            crate::platform::logging::time_drain("tick_terminal_activity", || {
+                self.tick_terminal_activity()
+            });
+            crate::platform::logging::mark_ui_phase(
+                &self.ui_phase,
+                crate::platform::logging::UiPhase::PreambleScheduler,
+            );
+            crate::platform::logging::time_drain("tick_scheduler", || self.tick_scheduler());
+            crate::platform::logging::mark_ui_phase(
+                &self.ui_phase,
+                crate::platform::logging::UiPhase::PreambleNotifyTimeouts,
+            );
+            crate::platform::logging::time_drain("tick_notification_timeouts", || {
+                self.tick_notification_timeouts()
+            });
+            crate::platform::logging::mark_ui_phase(
+                &self.ui_phase,
+                crate::platform::logging::UiPhase::PreambleUpdateCheck,
+            );
             if update_check_due(self.last_update_check, now) {
                 let config_dir = crate::config::config_dir();
                 if !crate::cli::updater::update_cache_fresh(&config_dir) {
@@ -71,8 +105,20 @@ impl PlexiApp {
                 }
             }
         }
-        self.poll_app_runtime_state();
-        self.drain_pane_cmd_channel();
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::PreambleRuntimePoll,
+        );
+        crate::platform::logging::time_drain("poll_app_runtime_state", || {
+            self.poll_app_runtime_state()
+        });
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::PreamblePaneCmds,
+        );
+        crate::platform::logging::time_drain("drain_pane_cmd_channel", || {
+            self.drain_pane_cmd_channel()
+        });
         if self.shutdown_requested {
             // `plexi host stop`'s clean-shutdown path (AppRequest::Shutdown).
             // eframe 0.34's macOS CloseRequested path may destroy the window
@@ -110,18 +156,31 @@ impl PlexiApp {
             }
             ctx.send_viewport_cmd(egui::ViewportCommand::Close);
         }
-        self.drain_pty_events();
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::PreamblePtyEvents,
+        );
+        crate::platform::logging::time_drain("drain_pty_events", || self.drain_pty_events());
 
         // Update the global pane context snapshot so that AiQuery dispatches
         // include all open panes in the workspace context (#396).
-        self.update_pane_context_snapshot();
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::PreambleSnapshot,
+        );
+        crate::platform::logging::time_drain("update_pane_context_snapshot", || {
+            self.update_pane_context_snapshot()
+        });
 
         // Auto-dismiss notifications from the focused pane before reconciling
         // the focus stack so modal state is already correct this frame.
-        self.auto_dismiss_sender_focused_notifications();
-
         // Focus stack: reconcile layer state BEFORE any input routing so
         // `input_captured_by_overlay()` answers correctly this frame.
+        crate::platform::logging::mark_ui_phase(
+            &self.ui_phase,
+            crate::platform::logging::UiPhase::PreambleFocusSync,
+        );
+        self.auto_dismiss_sender_focused_notifications();
         self.sync_notification_modal_focus();
         self.sync_confirm_close_focus();
         self.sync_context_close_focus();

--- a/src/platform/logging.rs
+++ b/src/platform/logging.rs
@@ -261,6 +261,30 @@ pub(crate) enum UiPhase {
     CloseRequest = 5,
     WorkspaceSave = 6,
     Exit = 7,
+    // Preamble-level phases (`update_preamble`), in call order.
+    PreambleAdoptedContext = 8,
+    PreambleFinderService = 9,
+    PreambleSpawnQueue = 10,
+    PreambleTerminalActivity = 11,
+    PreambleScheduler = 12,
+    PreambleNotifyTimeouts = 13,
+    PreambleUpdateCheck = 14,
+    PreambleRuntimePoll = 15,
+    PreamblePaneCmds = 16,
+    PreamblePtyEvents = 17,
+    PreambleSnapshot = 18,
+    PreambleFocusSync = 19,
+    // Logic-level phases (`PlexiApp::logic`), in call order.
+    Screenshots = 20,
+    SlotWaits = 21,
+    AgentBoots = 22,
+    Submits = 23,
+    PaneHeartbeats = 24,
+    SubscriptionReplies = 25,
+    EventDeliveries = 26,
+    PythonRuntimes = 27,
+    AgentTick = 28,
+    AppCommands = 29,
 }
 
 impl UiPhase {
@@ -274,6 +298,28 @@ impl UiPhase {
             Self::CloseRequest => "close_request",
             Self::WorkspaceSave => "workspace_save",
             Self::Exit => "exit",
+            Self::PreambleAdoptedContext => "preamble_adopted_context",
+            Self::PreambleFinderService => "preamble_finder_service",
+            Self::PreambleSpawnQueue => "preamble_spawn_queue",
+            Self::PreambleTerminalActivity => "preamble_terminal_activity",
+            Self::PreambleScheduler => "preamble_scheduler",
+            Self::PreambleNotifyTimeouts => "preamble_notify_timeouts",
+            Self::PreambleUpdateCheck => "preamble_update_check",
+            Self::PreambleRuntimePoll => "preamble_runtime_poll",
+            Self::PreamblePaneCmds => "preamble_pane_cmds",
+            Self::PreamblePtyEvents => "preamble_pty_events",
+            Self::PreambleSnapshot => "preamble_snapshot",
+            Self::PreambleFocusSync => "preamble_focus_sync",
+            Self::Screenshots => "screenshots",
+            Self::SlotWaits => "slot_waits",
+            Self::AgentBoots => "agent_boots",
+            Self::Submits => "submits",
+            Self::PaneHeartbeats => "pane_heartbeats",
+            Self::SubscriptionReplies => "subscription_replies",
+            Self::EventDeliveries => "event_deliveries",
+            Self::PythonRuntimes => "python_runtimes",
+            Self::AgentTick => "agent_tick",
+            Self::AppCommands => "app_commands",
         }
     }
 
@@ -286,6 +332,28 @@ impl UiPhase {
             5 => Self::CloseRequest,
             6 => Self::WorkspaceSave,
             7 => Self::Exit,
+            8 => Self::PreambleAdoptedContext,
+            9 => Self::PreambleFinderService,
+            10 => Self::PreambleSpawnQueue,
+            11 => Self::PreambleTerminalActivity,
+            12 => Self::PreambleScheduler,
+            13 => Self::PreambleNotifyTimeouts,
+            14 => Self::PreambleUpdateCheck,
+            15 => Self::PreambleRuntimePoll,
+            16 => Self::PreamblePaneCmds,
+            17 => Self::PreamblePtyEvents,
+            18 => Self::PreambleSnapshot,
+            19 => Self::PreambleFocusSync,
+            20 => Self::Screenshots,
+            21 => Self::SlotWaits,
+            22 => Self::AgentBoots,
+            23 => Self::Submits,
+            24 => Self::PaneHeartbeats,
+            25 => Self::SubscriptionReplies,
+            26 => Self::EventDeliveries,
+            27 => Self::PythonRuntimes,
+            28 => Self::AgentTick,
+            29 => Self::AppCommands,
             _ => Self::Startup,
         }
     }
@@ -334,6 +402,39 @@ fn unpack_ui_phase(packed: u64, now_ms: u64) -> UiPhaseSnapshot {
         name: phase.name(),
         age: Duration::from_millis(now_ms.saturating_sub(marked_at_ms)),
     }
+}
+
+/// Test-only accessor: the last phase name reached by the tracker, without
+/// locking. Lets integration tests (e.g. `HostHarness` smoke tests in other
+/// modules) assert on host progress without exposing `UiPhaseSnapshot`.
+#[cfg(test)]
+pub(crate) fn current_ui_phase_name(tracker: &UiPhaseTracker) -> &'static str {
+    ui_phase_snapshot(tracker).name
+}
+
+/// Pure threshold decision for the slow-drain log line: only worth a log line
+/// once a single drain call has eaten a meaningful slice of one frame budget.
+/// Kept separate from `time_drain` so it's directly unit-testable, matching
+/// this file's existing pattern (see `freeze_verdict`).
+pub(crate) fn should_log_slow_drain(elapsed: Duration) -> bool {
+    elapsed > Duration::from_millis(100)
+}
+
+/// Time a drain call and log at `info` when it crosses `should_log_slow_drain`'s
+/// threshold. No allocation on the happy path — the format! only runs when the
+/// drain was actually slow.
+pub(crate) fn time_drain<T>(name: &'static str, f: impl FnOnce() -> T) -> T {
+    let start = Instant::now();
+    let result = f();
+    let elapsed = start.elapsed();
+    if should_log_slow_drain(elapsed) {
+        log::info!(
+            target: "plexi::logging",
+            "logic_drain: {name} took {}ms",
+            elapsed.as_millis()
+        );
+    }
+    result
 }
 
 /// Create a new frame tick counter. Pass the clone to `spawn_heartbeat`, store the
@@ -463,6 +564,68 @@ mod tests {
         let snapshot = unpack_ui_phase(tracker.load(Ordering::Acquire), 100);
         assert_eq!(snapshot.name, "workspace_save");
         assert_eq!(snapshot.age, Duration::from_millis(58));
+    }
+
+    /// Every `UiPhase` variant must round-trip through `from_byte`, including
+    /// the preamble- and logic-level phases added in stint 0716. A gap here
+    /// means a variant silently decodes back to `Startup`.
+    #[test]
+    fn every_ui_phase_variant_round_trips_through_from_byte() {
+        let variants = [
+            UiPhase::Startup,
+            UiPhase::Logic,
+            UiPhase::LogicComplete,
+            UiPhase::UiRender,
+            UiPhase::RendererPresent,
+            UiPhase::CloseRequest,
+            UiPhase::WorkspaceSave,
+            UiPhase::Exit,
+            UiPhase::PreambleAdoptedContext,
+            UiPhase::PreambleFinderService,
+            UiPhase::PreambleSpawnQueue,
+            UiPhase::PreambleTerminalActivity,
+            UiPhase::PreambleScheduler,
+            UiPhase::PreambleNotifyTimeouts,
+            UiPhase::PreambleUpdateCheck,
+            UiPhase::PreambleRuntimePoll,
+            UiPhase::PreamblePaneCmds,
+            UiPhase::PreamblePtyEvents,
+            UiPhase::PreambleSnapshot,
+            UiPhase::PreambleFocusSync,
+            UiPhase::Screenshots,
+            UiPhase::SlotWaits,
+            UiPhase::AgentBoots,
+            UiPhase::Submits,
+            UiPhase::PaneHeartbeats,
+            UiPhase::SubscriptionReplies,
+            UiPhase::EventDeliveries,
+            UiPhase::PythonRuntimes,
+            UiPhase::AgentTick,
+            UiPhase::AppCommands,
+        ];
+        for variant in variants {
+            let round_tripped = UiPhase::from_byte(variant as u8);
+            assert_eq!(
+                round_tripped,
+                variant,
+                "variant {} (byte {}) did not round-trip; from_byte returned {}",
+                variant.name(),
+                variant as u8,
+                round_tripped.name()
+            );
+        }
+    }
+
+    #[test]
+    fn should_log_slow_drain_below_threshold_is_false() {
+        assert!(!should_log_slow_drain(Duration::from_millis(50)));
+        assert!(!should_log_slow_drain(Duration::from_millis(100)));
+    }
+
+    #[test]
+    fn should_log_slow_drain_above_threshold_is_true() {
+        assert!(should_log_slow_drain(Duration::from_millis(101)));
+        assert!(should_log_slow_drain(Duration::from_secs(1)));
     }
 
     /// Zero frames with no pending repaint is healthy idle — never a freeze.

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -6910,3 +6910,25 @@ fn scheduled_mode_app_never_suppresses_its_frame_wake() {
         "an input-driven app must never trade presentation latency for saved paints"
     );
 }
+
+/// Smoke test for stint 0716's `UiPhase` instrumentation: both visible and
+/// hidden-window frame passes must run every `logic` drain without panicking.
+/// A visible pass continues on into `ui`/present phases past `logic_complete`,
+/// but the hidden path is the one that matters here: `App::ui` never runs
+/// while the window is occluded (see the eframe-hidden-window trap in
+/// `CLAUDE.md`), so a hidden pass must still reach `logic_complete` — proof
+/// every external-client drain in `App::logic` ran to the end without a panic.
+#[test]
+fn logic_drains_run_without_panic_visible_and_hidden() {
+    let mut h = HostHarness::new();
+    let _term = h.add_focused_terminal();
+
+    h.run_frames(2);
+
+    h.run_hidden_frames(2);
+    assert_eq!(
+        crate::platform::logging::current_ui_phase_name(&h.app.ui_phase),
+        "logic_complete",
+        "hidden frame pass must still run every logic drain and end at logic_complete"
+    );
+}


### PR DESCRIPTION
## Summary
- Instrumentation-only pass to diagnose the residual UI-thread freeze reported after the #2562 lsof fix (stints 0705/0694 insufficient).
- Extends `UiPhase` with 22 new sub-phase variants covering every drain in `App::logic` and `update_preamble`, so the next `[FREEZE]` log line names the exact blocking call instead of just `logic`.
- Adds `time_drain`/`should_log_slow_drain` (>100ms threshold) to log slow-but-not-frozen precursors at `info`.
- Adds a `HostHarness` test proving all drains still execute (visible and hidden-window passes) without panicking.

## Deferred
- SIGPROF/backtrace stack capture (stint's step 3) was intentionally **not** implemented: malloc-in-signal-handler risk could turn a transient freeze into a permanent hang, and no signal-safe backtrace crate is in `Cargo.toml`. Left for a follow-up once a specific drain is narrowed down via this instrumentation.
- No behavior fix included — root cause (T1-T4 in stint 0716) is not yet identified; this PR only adds the diagnostic surface.

## Test plan
- [x] `cargo build` green
- [x] `cargo test --bin plexi` green (2306 passed)
- [ ] Live repro via drive-host session once merged, to capture a `[FREEZE]` line with the new phase granularity

Stint: 0716