### PR TITLE
Auto-name new contexts without a rename modal (stint 0388)

### DIFF
--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -1122,7 +1122,7 @@ impl PlexiApp {
             .router
             .iter()
             .find(|c| c.context_id == context_id)
-            .map(|c| c.name.clone())
+            .map(|c| c.name.to_string())
             .unwrap_or_default();
 
         let mut items = Vec::new();
@@ -1156,7 +1156,7 @@ impl PlexiApp {
                             .router
                             .iter()
                             .find(|c| c.context_id == p.target_context_id)
-                            .map(|c| c.name.clone())
+                            .map(|c| c.name.to_string())
                             .unwrap_or_else(|| "Portal".to_string());
                         items.push(ContextCloseItem {
                             kind: "Context",

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -2650,7 +2650,7 @@ impl PlexiApp {
                             .filter(|context| {
                                 matches!(context.name, crate::host::context::ContextName::Auto(_))
                             })
-                            .and_then(|_| requested_auto_name.as_deref())
+                            .and(requested_auto_name.as_deref())
                             .filter(|base| created_name != *base);
                         let response = serde_json::json!({
                             "context_id": new_ctx_id,

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -238,7 +238,7 @@ impl PlexiApp {
                         .router
                         .iter()
                         .find(|ctx| ctx.context_id == win.context_id)
-                        .map(|ctx| ctx.name.clone())
+                        .map(|ctx| ctx.name.to_string())
                         .unwrap_or_default();
                     for (pane_id, pane) in &win.panes {
                         // Only emit panes that have a corresponding tile in the tree.
@@ -2519,6 +2519,15 @@ impl PlexiApp {
                     anchor_pane
                 );
                 let mut ctx_ok = true;
+                let requested_auto_name = name
+                    .is_none()
+                    .then(|| {
+                        root.as_ref().and_then(|path| {
+                            path.file_name()
+                                .map(|component| component.to_string_lossy().into_owned())
+                        })
+                    })
+                    .flatten();
                 // Track which context was active before and which context was just created.
                 // Windows must be placed in the new context regardless of focus state.
                 let orig_ctx_id = self.router.active().context_id;
@@ -2548,9 +2557,15 @@ impl PlexiApp {
                         log::warn!("pane_ipc: create_context with parent failed: {e}");
                         ctx_ok = false;
                     } else {
+                        let idx = self.router.len() - 1;
                         if let Some(n) = name {
-                            let idx = self.router.len() - 1;
-                            self.router.get_mut(idx).name = n.clone();
+                            self.router.get_mut(idx).name =
+                                crate::host::context::ContextName::custom(n);
+                        } else if let Some(path) = root {
+                            let context_id = self.router.get(idx).context_id;
+                            let auto_name = self.auto_context_name_for_path(context_id, path);
+                            self.router.get_mut(idx).name =
+                                crate::host::context::ContextName::auto(auto_name);
                         }
                         let new_ctx_idx = self.router.len() - 1;
                         new_ctx_id = self.router.get(new_ctx_idx).context_id;
@@ -2575,7 +2590,8 @@ impl PlexiApp {
                     }
                     if let Some(n) = name {
                         let idx = self.router.len() - 1;
-                        self.router.get_mut(idx).name = n.clone();
+                        self.router.get_mut(idx).name =
+                            crate::host::context::ContextName::custom(n);
                     }
                     new_ctx_id = self.router.get(self.router.len() - 1).context_id;
                 }
@@ -2623,9 +2639,24 @@ impl PlexiApp {
                                 })
                             })
                             .collect();
+                        let created_context = self
+                            .router
+                            .iter()
+                            .find(|context| context.context_id == new_ctx_id);
+                        let created_name = created_context
+                            .map(|context| context.name.displayed())
+                            .unwrap_or_default();
+                        let auto_name_collision_with = created_context
+                            .filter(|context| {
+                                matches!(context.name, crate::host::context::ContextName::Auto(_))
+                            })
+                            .and_then(|_| requested_auto_name.as_deref())
+                            .filter(|base| created_name != *base);
                         let response = serde_json::json!({
                             "context_id": new_ctx_id,
                             "windows": windows_info,
+                            "name": created_name,
+                            "auto_name_collision_with": auto_name_collision_with,
                         });
                         write_json_response(rf, response);
                     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1357,7 +1357,7 @@ impl PlexiApp {
             let ctx_name_map: std::collections::HashMap<u64, String> = ws
                 .contexts
                 .iter()
-                .map(|c| (c.context_id, c.name.clone()))
+                .map(|c| (c.context_id, c.name.to_string()))
                 .collect();
             let ctx_desc_map: std::collections::HashMap<u64, String> = ws
                 .contexts
@@ -1821,7 +1821,7 @@ impl PlexiApp {
             ctx: cc.egui_ctx.clone(),
             router: crate::workspace::router::WorkspaceRouter::new(
                 vec![crate::host::context::Context {
-                    name: default_name,
+                    name: crate::host::context::ContextName::custom(default_name),
                     root: default_root,
                     description: default_description,
                     context_id: 1,
@@ -2719,7 +2719,7 @@ impl PlexiApp {
     /// pane (the portal's target subcontext). Renders inline in the sidebar
     /// when visible, otherwise as the centered overlay.
     pub(crate) fn open_context_rename(&mut self, ctx_idx: usize) {
-        self.rename_buffer = self.router.get(ctx_idx).name.clone();
+        self.rename_buffer = self.router.get(ctx_idx).name.to_string();
         self.renaming_window = Some(ctx_idx);
         log::info!(
             "context_rename: opened for context {:?} (idx {ctx_idx})",
@@ -2731,7 +2731,7 @@ impl PlexiApp {
         self.router
             .iter()
             .find(|c| c.context_id == context_id)
-            .map(|c| c.name.clone())
+            .map(|c| c.name.to_string())
             .unwrap_or_default()
     }
 
@@ -2988,6 +2988,7 @@ impl eframe::App for PlexiApp {
         crate::platform::logging::time_drain("service_app_commands", || {
             self.service_app_commands(ctx)
         });
+        self.resolve_auto_context_names();
         crate::platform::logging::mark_ui_phase(
             &self.ui_phase,
             crate::platform::logging::UiPhase::LogicComplete,
@@ -3227,7 +3228,7 @@ impl eframe::App for PlexiApp {
             let context_label = if window_count > 1 {
                 format!("{} ({},{})", ws.name, context.grid_x, context.grid_y)
             } else {
-                ws.name.clone()
+                ws.name.to_string()
             };
             let title = match pane_name {
                 Some(name) => format!("{} — {}", context_label, name),

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -390,7 +390,7 @@ impl PlexiApp {
                     for &(pane_id, child_ctx_id) in &portal_panes {
                         let ctx_entry = self.router.iter().find(|c| c.context_id == child_ctx_id);
                         let ctx_name = ctx_entry
-                            .map(|c| c.name.clone())
+                            .map(|c| c.name.to_string())
                             .unwrap_or_else(|| "(deleted)".to_string());
                         let ctx_description = ctx_entry
                             .and_then(|c| c.description.clone())

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -3107,7 +3107,7 @@ fn perf_gate_delete_context_does_not_block_ui_thread() {
         let win_id = 9_200 + i;
         let pane_id = 9_300 + i;
         app.router.push(crate::host::context::Context {
-            name: format!("child-{i}"),
+            name: format!("child-{i}").into(),
             root: std::path::PathBuf::from(format!("/tmp/perf-gate-delete-context-{i}")),
             description: None,
             context_id: ctx_id,

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -154,7 +154,7 @@ fn new_child_context_does_not_adopt_focused_pane() {
 
     app.new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
         None,
-        parent_name.clone(),
+        parent_name.to_string(),
         std::path::PathBuf::from("/tmp/no_adopt"),
         true,
         false,
@@ -263,7 +263,7 @@ fn new_child_context_anchor_pane_overrides_focused() {
 
     app.new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
         None,
-        parent_name.clone(),
+        parent_name.to_string(),
         std::path::PathBuf::from("/tmp/anchor_pane"),
         true,
         false,
@@ -318,7 +318,7 @@ fn create_context_ipc_anchor_pane_places_portal() {
     let tile_b = h.app.windows[0].tree.tiles.find_pane(&pane_b).unwrap();
     h.app.windows[0].focused_pane = Some(tile_a);
     let parent_id = h.app.router.active().context_id;
-    let parent_name = h.app.router.active().name.clone();
+    let parent_name = h.app.router.active().name.to_string();
 
     let payload = serde_json::json!({
         "type": "create_context",
@@ -379,7 +379,7 @@ fn new_child_context_unknown_anchor_falls_back_to_focused() {
 
     app.new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
         None,
-        parent_name.clone(),
+        parent_name.to_string(),
         std::path::PathBuf::from("/tmp/anchor_missing"),
         true,
         false,
@@ -568,7 +568,7 @@ fn depth_four_chain_has_portal_tiles() {
 
     // Rename the initial context to "Root" for predictability.
     let root_idx = app.router.active_idx();
-    app.router.get_mut(root_idx).name = "Root".to_string();
+    app.router.get_mut(root_idx).name = "Root".to_string().into();
 
     let names = ["A", "B", "C", "D"];
     let mut parent_name = "Root".to_string();
@@ -589,7 +589,7 @@ fn depth_four_chain_has_portal_tiles() {
             break;
         }
         let new_idx = app.router.len() - 1;
-        app.router.get_mut(new_idx).name = child.to_string();
+        app.router.get_mut(new_idx).name = child.to_string().into();
         chain_ids.push(app.router.get(new_idx).context_id);
         parent_name = child.to_string();
     }
@@ -639,7 +639,7 @@ fn delete_context_portal_resets_stale_focused_pane() {
     let child_id = 9901u64;
     let child_win_id = 9902u64;
     app.router.push(crate::host::context::Context {
-        name: "Child".to_string(),
+        name: "Child".to_string().into(),
         root: std::path::PathBuf::from("/tmp/child_1854"),
         description: None,
         context_id: child_id,
@@ -717,7 +717,7 @@ fn delete_context_cascades_cleans_depth_stack_and_revokes_credentials() {
     let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
 
     let root_idx = app.router.active_idx();
-    app.router.get_mut(root_idx).name = "Root".to_string();
+    app.router.get_mut(root_idx).name = "Root".to_string().into();
     let root_id = app.router.active().context_id;
 
     // Manually insert child context A and grandchild B without PTY.
@@ -738,7 +738,7 @@ fn delete_context_cascades_cleans_depth_stack_and_revokes_credentials() {
     );
 
     app.router.push(crate::host::context::Context {
-        name: "A".to_string(),
+        name: "A".to_string().into(),
         root: std::path::PathBuf::from("/tmp/a"),
         description: None,
         context_id: a_id,
@@ -747,7 +747,7 @@ fn delete_context_cascades_cleans_depth_stack_and_revokes_credentials() {
         parked: false,
     });
     app.router.push(crate::host::context::Context {
-        name: "B".to_string(),
+        name: "B".to_string().into(),
         root: std::path::PathBuf::from("/tmp/b"),
         description: None,
         context_id: b_id,
@@ -901,14 +901,14 @@ fn delete_context_refuses_cascade_that_would_empty_router() {
     let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
 
     let root_idx = app.router.active_idx();
-    app.router.get_mut(root_idx).name = "Root".to_string();
+    app.router.get_mut(root_idx).name = "Root".to_string().into();
     let root_id = app.router.active().context_id;
 
     let child_id = 9101u64;
     let grandchild_id = 9102u64;
 
     app.router.push(crate::host::context::Context {
-        name: "Child".to_string(),
+        name: "Child".to_string().into(),
         root: std::path::PathBuf::from("/tmp/child"),
         description: None,
         context_id: child_id,
@@ -917,7 +917,7 @@ fn delete_context_refuses_cascade_that_would_empty_router() {
         parked: false,
     });
     app.router.push(crate::host::context::Context {
-        name: "Grandchild".to_string(),
+        name: "Grandchild".to_string().into(),
         root: std::path::PathBuf::from("/tmp/grandchild"),
         description: None,
         context_id: grandchild_id,
@@ -955,7 +955,7 @@ fn delete_context_cascade_allowed_when_unrelated_sibling_survives() {
     let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
 
     let root_idx = app.router.active_idx();
-    app.router.get_mut(root_idx).name = "Root".to_string();
+    app.router.get_mut(root_idx).name = "Root".to_string().into();
     let root_id = app.router.active().context_id;
 
     let a_id = 9201u64;
@@ -963,7 +963,7 @@ fn delete_context_cascade_allowed_when_unrelated_sibling_survives() {
     let sibling_id = 9203u64;
 
     app.router.push(crate::host::context::Context {
-        name: "A".to_string(),
+        name: "A".to_string().into(),
         root: std::path::PathBuf::from("/tmp/a"),
         description: None,
         context_id: a_id,
@@ -972,7 +972,7 @@ fn delete_context_cascade_allowed_when_unrelated_sibling_survives() {
         parked: false,
     });
     app.router.push(crate::host::context::Context {
-        name: "B".to_string(),
+        name: "B".to_string().into(),
         root: std::path::PathBuf::from("/tmp/b"),
         description: None,
         context_id: b_id,
@@ -981,7 +981,7 @@ fn delete_context_cascade_allowed_when_unrelated_sibling_survives() {
         parked: false,
     });
     app.router.push(crate::host::context::Context {
-        name: "Sibling".to_string(),
+        name: "Sibling".to_string().into(),
         root: std::path::PathBuf::from("/tmp/sibling"),
         description: None,
         context_id: sibling_id,
@@ -1204,12 +1204,96 @@ fn new_context_creates_top_level_empty_context() {
         "original pane still present"
     );
 
-    // Inline rename was opened for the new context.
+    // New contexts are immediately usable; the rename overlay is strictly
+    // user-initiated now.
     assert_eq!(
-        app.renaming_window,
-        Some(app.router.len() - 1),
-        "inline rename opened for new context"
+        app.renaming_window, None,
+        "new context must not open a rename overlay"
     );
+    assert!(matches!(
+        new_ctx.name,
+        crate::host::context::ContextName::Auto(_)
+    ));
+}
+
+#[test]
+fn context_rename_switches_between_custom_and_auto_name() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    app.rename_context(0, "Manual workspace");
+    assert!(matches!(
+        app.router.active().name,
+        crate::host::context::ContextName::Custom(ref name) if name == "Manual workspace"
+    ));
+
+    app.rename_context(0, "  ");
+    assert!(matches!(
+        app.router.active().name,
+        crate::host::context::ContextName::Auto(ref name) if !name.is_empty()
+    ));
+}
+
+#[test]
+fn unresolved_auto_name_uses_first_focused_pane_cwd_then_freezes() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+    let context_idx = app.router.active_idx();
+    let context_id = app.router.active().context_id;
+    app.router.get_mut(context_idx).name = crate::host::context::ContextName::auto("");
+    let pane_id = app.host.alloc_pane_id();
+
+    let window = app
+        .windows
+        .iter_mut()
+        .find(|window| window.context_id == context_id)
+        .expect("active context window");
+    let tile_id = window.tree.tiles.insert_pane(pane_id);
+    window.focused_pane = Some(tile_id);
+    let mut pane = test_app_pane(pane_id);
+    pane.as_app_mut().expect("app pane").workspace_root =
+        std::path::PathBuf::from("/projects/first-project");
+    window.panes.insert(pane_id, pane);
+
+    app.resolve_auto_context_names();
+    assert_eq!(app.router.active().name.displayed(), "first-project");
+
+    app.windows
+        .iter_mut()
+        .find(|window| window.context_id == context_id)
+        .and_then(|window| window.panes.get_mut(&pane_id))
+        .and_then(|pane| pane.as_app_mut())
+        .expect("focused app pane")
+        .workspace_root = std::path::PathBuf::from("/projects/later-project");
+    app.resolve_auto_context_names();
+
+    assert_eq!(app.router.active().name.displayed(), "first-project");
+}
+
+#[test]
+fn contexts_with_matching_auto_names_are_disambiguated() {
+    let mut h = crate::testing::HostHarness::new();
+    let left = tempfile::tempdir().expect("left root");
+    let right = tempfile::tempdir().expect("right root");
+    let first = left.path().join("project");
+    let second = right.path().join("project");
+    std::fs::create_dir(&first).expect("first project");
+    std::fs::create_dir(&second).expect("second project");
+
+    let before = h.app.router.len();
+    h.app.new_context_at_path(first);
+    if h.app.router.len() == before {
+        return; // PTY unavailable in this test environment.
+    }
+    h.app.new_context_at_path(second);
+    if h.app.router.len() == before + 1 {
+        return; // PTY became unavailable between the two requests.
+    }
+
+    assert_eq!(h.app.router.get(before).name.displayed(), "project");
+    assert_eq!(h.app.router.get(before + 1).name.displayed(), "project (2)");
 }
 
 /// Regression for stint 0607: a top-level context's root PTY must receive the
@@ -1221,6 +1305,7 @@ fn new_context_root_pty_env_uses_its_own_context_identity() {
     let previous_context_id = h.app.router.active().context_id;
 
     h.app.new_context();
+    h.app.resolve_auto_context_names();
 
     let new_context = h.app.router.active().clone();
     if new_context.context_id == previous_context_id {
@@ -1242,9 +1327,10 @@ fn new_context_root_pty_env_uses_its_own_context_identity() {
         terminal.spawn_env.get("PLEXI_CONTEXT_ID"),
         Some(&new_context.context_id.to_string())
     );
+    let new_context_name = new_context.name.to_string();
     assert_eq!(
         terminal.spawn_env.get("PLEXI_CONTEXT_NAME"),
-        Some(&new_context.name)
+        Some(&new_context_name)
     );
 }
 
@@ -1287,7 +1373,7 @@ fn delete_context_collapses_empty_portal_window() {
     let child_id = 77710u64;
     let child_win_id = 77711u64;
     app.router.push(crate::host::context::Context {
-        name: "Child2029".to_string(),
+        name: "Child2029".to_string().into(),
         root: std::path::PathBuf::from("/tmp/test_2029_child"),
         description: None,
         context_id: child_id,
@@ -1408,7 +1494,7 @@ fn delete_context_keeps_all_empty_windows_when_no_nonempty_sibling() {
     let child_id = 88810u64;
     let child_win_id = 88811u64;
     app.router.push(crate::host::context::Context {
-        name: "ChildEdge".to_string(),
+        name: "ChildEdge".to_string().into(),
         root: std::path::PathBuf::from("/tmp/test_2029_edge_child"),
         description: None,
         context_id: child_id,
@@ -1511,7 +1597,7 @@ fn test_app_pane(pane_id: u64) -> crate::host::pane::Pane {
 
 fn test_context(id: u64, parent_id: u64, name: &str) -> crate::host::context::Context {
     crate::host::context::Context {
-        name: name.to_string(),
+        name: name.to_string().into(),
         root: std::path::PathBuf::from(format!("/tmp/{name}")),
         description: None,
         context_id: id,
@@ -2003,7 +2089,7 @@ fn rename_on_focused_portal_falls_through_to_subcontext() {
     let root_id = app.router.active().context_id;
     let child_id = 7701u64;
     app.router.push(crate::host::context::Context {
-        name: "Child".to_string(),
+        name: "Child".to_string().into(),
         root: std::path::PathBuf::from("/tmp/child_rename"),
         description: None,
         context_id: child_id,
@@ -2681,7 +2767,7 @@ fn resolve_parent_context_prefers_id_over_duplicate_name() {
     let name = app.router.active().name.clone();
 
     let by_id = app
-        .resolve_parent_context(Some(duplicate_id), &name)
+        .resolve_parent_context(Some(duplicate_id), name.displayed())
         .expect("id must resolve");
     assert_eq!(
         app.router.get(by_id).context_id,
@@ -2691,7 +2777,7 @@ fn resolve_parent_context_prefers_id_over_duplicate_name() {
 
     // No id → first name match, the historical behaviour.
     let by_name = app
-        .resolve_parent_context(None, &name)
+        .resolve_parent_context(None, name.displayed())
         .expect("name must resolve");
     assert_eq!(app.router.get(by_name).context_id, first_id);
 
@@ -2699,7 +2785,7 @@ fn resolve_parent_context_prefers_id_over_duplicate_name() {
     // deleted; resolving its name would silently attach the child to whichever
     // unrelated context happens to share it.
     assert_eq!(
-        app.resolve_parent_context(Some(999_999), &name),
+        app.resolve_parent_context(Some(999_999), name.displayed()),
         None,
         "an id naming no live context must fail, not guess by name"
     );

--- a/src/cli/context_cli.rs
+++ b/src/cli/context_cli.rs
@@ -10,15 +10,12 @@ pub fn context_new_cli(
     direction: &str,
     from: Option<u64>,
 ) -> i32 {
-    let explicit_root = match path {
-        Some(_) => match resolve_path(path) {
-            Ok(p) => Some(p),
-            Err(e) => {
-                eprintln!("{e}");
-                return 1;
-            }
-        },
-        None => None,
+    let explicit_root = match resolve_path(path) {
+        Ok(p) => Some(p),
+        Err(e) => {
+            eprintln!("{e}");
+            return 1;
+        }
     };
     // "--parent" with no value resolves to the current context via env.
     // "--parent <name>" passes that name directly.
@@ -53,11 +50,10 @@ pub fn context_new_cli(
             }
         }
     };
-    // Only request a response file when creating a sub-context (--parent set).
-    // Top-level context new stays fire-and-forget to preserve existing behaviour.
-    let response_file = explicit_parent
-        .is_some()
-        .then(|| crate::rpc::response_file("context-new-response", "json"));
+    // Every creation waits for the host's authoritative name. Top-level calls
+    // stay quiet on success; the response only becomes user-visible when an
+    // automatic directory name had to be disambiguated.
+    let response_file = Some(crate::rpc::response_file("context-new-response", "json"));
     // Portal split anchor: explicit --from wins; otherwise the caller's own pane
     // (PLEXI_PANE_ID, set in every Plexi terminal). Only meaningful with --parent.
     let anchor_pane = from.or_else(|| {
@@ -108,10 +104,25 @@ pub fn context_new_cli(
     if rc != 0 {
         return rc;
     }
-    // Poll for response JSON (sub-context only).
+    // Sub-context callers retain their structured response. For top-level
+    // creation, print only the collision note rather than changing the
+    // established quiet success path.
     if let Some(rf) = response_file {
         match super::poll_rpc(&rf, "context-new") {
-            Ok(content) => println!("{content}"),
+            Ok(content) => {
+                let response: serde_json::Value =
+                    serde_json::from_str(&content).unwrap_or_default();
+                if explicit_parent.is_some() {
+                    println!("{content}");
+                } else if let (Some(name), Some(existing)) = (
+                    response["name"].as_str(),
+                    response["auto_name_collision_with"].as_str(),
+                ) {
+                    println!(
+                        "note: context name '{name}' disambiguated from existing context '{existing}'"
+                    );
+                }
+            }
             Err(code) => return code,
         }
     }

--- a/src/host/context.rs
+++ b/src/host/context.rs
@@ -7,6 +7,93 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+/// Whether a context label was derived by Plexi or explicitly chosen by the
+/// user (or a workspace anchor). Auto names are set exactly once from the
+/// first focused-pane cwd that becomes available.
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextName {
+    Auto(String),
+    Custom(String),
+}
+
+impl ContextName {
+    pub(crate) fn auto(name: impl Into<String>) -> Self {
+        Self::Auto(name.into())
+    }
+
+    pub(crate) fn custom(name: impl Into<String>) -> Self {
+        Self::Custom(name.into())
+    }
+
+    pub(crate) fn displayed(&self) -> &str {
+        match self {
+            Self::Auto(name) | Self::Custom(name) => name,
+        }
+    }
+
+    pub(crate) fn is_unresolved_auto(&self) -> bool {
+        matches!(self, Self::Auto(name) if name.is_empty())
+    }
+}
+
+impl Default for ContextName {
+    fn default() -> Self {
+        Self::Custom(String::new())
+    }
+}
+
+impl From<String> for ContextName {
+    fn from(name: String) -> Self {
+        Self::Custom(name)
+    }
+}
+
+impl From<&str> for ContextName {
+    fn from(name: &str) -> Self {
+        Self::Custom(name.to_owned())
+    }
+}
+
+impl PartialEq<str> for ContextName {
+    fn eq(&self, other: &str) -> bool {
+        self.displayed() == other
+    }
+}
+
+impl PartialEq<&str> for ContextName {
+    fn eq(&self, other: &&str) -> bool {
+        self.displayed() == *other
+    }
+}
+
+impl std::fmt::Display for ContextName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.displayed())
+    }
+}
+
+impl<'de> Deserialize<'de> for ContextName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Wire {
+            Legacy(String),
+            Auto { auto: String },
+            Custom { custom: String },
+        }
+
+        match Wire::deserialize(deserializer)? {
+            Wire::Legacy(name) => Ok(Self::Custom(name)),
+            Wire::Auto { auto } => Ok(Self::Auto(auto)),
+            Wire::Custom { custom } => Ok(Self::Custom(custom)),
+        }
+    }
+}
+
 pub(crate) enum WindowMenuAction {
     Rename,
     EditDescription,
@@ -30,7 +117,7 @@ pub(crate) enum WindowMenuAction {
 /// former `SavedContext` and unifies with `HostContext`.
 #[derive(Serialize, Clone, Debug)]
 pub struct Context {
-    pub name: String,
+    pub name: ContextName,
     /// The single directory this context is anchored to. Non-optional: every
     /// context is anchored somewhere (creation defaults to the creating
     /// pane's cwd, or home). New panes in this context open here, context
@@ -70,7 +157,7 @@ impl<'de> Deserialize<'de> for Context {
     {
         #[derive(Deserialize)]
         struct RawContext {
-            name: String,
+            name: ContextName,
             #[serde(default)]
             root: Option<PathBuf>,
             /// Legacy pre-0651 field; folded into `root` on read.
@@ -451,6 +538,21 @@ pub(crate) fn replace_child(container: &mut Container, old: TileId, new: TileId)
 mod tests {
     use super::*;
     use egui::{Pos2, Rect};
+
+    #[test]
+    fn context_name_persists_state_and_reads_legacy_strings_as_custom() {
+        let auto = ContextName::auto("project");
+        let encoded = serde_json::to_string(&auto).expect("serialize auto name");
+        assert_eq!(encoded, r#"{"auto":"project"}"#);
+        assert_eq!(
+            serde_json::from_str::<ContextName>(&encoded).expect("deserialize auto name"),
+            auto
+        );
+        assert_eq!(
+            serde_json::from_str::<ContextName>(r#""legacy""#).expect("deserialize legacy string"),
+            ContextName::custom("legacy")
+        );
+    }
 
     /// 6-pane 2-row × 3-col grid:
     ///     ┌───┬───┬───┐

--- a/src/host/context_state.rs
+++ b/src/host/context_state.rs
@@ -60,7 +60,7 @@ impl ContextState {
         let label = contexts
             .iter()
             .find(|c| c.context_id == context_id)
-            .map(|c| c.name.clone())
+            .map(|c| c.name.to_string())
             .unwrap_or_else(|| "(unknown)".to_string());
 
         let mut pane_summaries = Vec::new();
@@ -164,7 +164,7 @@ mod tests {
 
     fn make_context(id: u64, name: &str, parent: Option<u64>) -> Context {
         Context {
-            name: name.to_string(),
+            name: name.to_string().into(),
             root: PathBuf::from("/tmp"),
             description: None,
             context_id: id,

--- a/src/host/keys.rs
+++ b/src/host/keys.rs
@@ -106,7 +106,7 @@ pub enum Action {
     /// Create a new window to the right of the active one on the same
     /// grid row. Bound to Cmd+N.
     NewPageRight,
-    /// Create a new context (sidebar item) and immediately open the rename modal.
+    /// Create a new context (sidebar item) with an automatic cwd-derived name.
     /// Bound to Cmd+Shift+N.
     NewContext,
     /// Toggle the minimap overlay. Bound to Cmd+Shift+M.

--- a/src/notes.rs
+++ b/src/notes.rs
@@ -309,7 +309,7 @@ pub(crate) fn context_notes_scopes(
         }
         scopes.push(ContextNotesScope {
             dir: context_notes_dir(root),
-            label: Some(ctx.name.clone()),
+            label: Some(ctx.name.to_string()),
         });
     }
     scopes
@@ -816,7 +816,7 @@ mod tests {
 
     fn ctx(id: u64, name: &str, root: &str, depth: u32) -> Context {
         Context {
-            name: name.to_string(),
+            name: name.to_string().into(),
             root: PathBuf::from(root),
             description: None,
             context_id: id,

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -630,7 +630,7 @@ impl PlexiApp {
         let context_names: Vec<(u64, String)> = self
             .router
             .iter()
-            .map(|c| (c.context_id, c.name.clone()))
+            .map(|c| (c.context_id, c.name.to_string()))
             .collect();
 
         // ── Agent panes (every window, every context) ───────────────────────
@@ -689,7 +689,7 @@ impl PlexiApp {
                 };
                 contexts.push(CtxInfo {
                     ctx_id: ctx_meta.context_id,
-                    name: ctx_meta.name.clone(),
+                    name: ctx_meta.name.to_string(),
                     win_idx,
                     window_id: win.window_id,
                 });
@@ -2280,7 +2280,7 @@ mod tests {
         );
         h.app.windows.push(target);
         h.app.router.push(crate::host::context::Context {
-            name: "squad-alpha".to_string(),
+            name: "squad-alpha".to_string().into(),
             root: std::env::temp_dir(),
             description: None,
             context_id: 7,

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -641,17 +641,7 @@ impl PlexiApp {
         if cancel {
             self.renaming_window = None;
         } else if commit {
-            let new_name = self.rename_buffer.trim().to_string();
-            if !new_name.is_empty() {
-                self.router.get_mut(ctx_idx).name = new_name;
-                let context_id = self.router.get(ctx_idx).context_id;
-                let name = self.router.get(ctx_idx).name.clone();
-                crate::host::event_log::emit(crate::host::event_log::HostEvent::ContextRenamed {
-                    context_id,
-                    name,
-                    timestamp: crate::host::event_log::now_timestamp(),
-                });
-            }
+            self.rename_context(ctx_idx, &self.rename_buffer.clone());
             self.renaming_window = None;
         }
     }
@@ -675,7 +665,7 @@ impl PlexiApp {
         });
 
         let colors = self.colors;
-        let ctx_name = self.router.get(ctx_idx).name.clone();
+        let ctx_name = self.router.get(ctx_idx).name.to_string();
         let title = format!("Description for \"{ctx_name}\"");
         crate::ui::overlay::ModalShell::centered("edit_description_overlay")
             .title(&title)

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -581,7 +581,7 @@ mod tests {
 
         let mk_ctx = |id: u64, name: &str, root: &std::path::Path, depth: u32| {
             crate::host::context::Context {
-                name: name.to_string(),
+                name: name.to_string().into(),
                 root: root.to_path_buf(),
                 description: None,
                 context_id: id,

--- a/src/overlays/setup.rs
+++ b/src/overlays/setup.rs
@@ -12,7 +12,7 @@ impl PlexiApp {
         let active_context = self.active_window;
         let colors = self.colors;
         let ws_id = self.router.active().context_id;
-        let ws_name = self.router.active().name.clone();
+        let ws_name = self.router.active().name.to_string();
 
         // Anchor the Area at the actual panel position so its bounding rect
         // doesn't overlap the sidebar. Previously anchored at content_rect.min

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -2,7 +2,7 @@
 //! and on-disk workspace save.
 
 use crate::app::PlexiApp;
-use crate::host::context::Window;
+use crate::host::context::{ContextName, Window};
 use crate::host::shell;
 use crate::spatial::tiling::PaneId;
 use crate::workspace::WorkspaceFile;
@@ -297,7 +297,9 @@ impl PlexiApp {
     pub(crate) fn resolve_parent_context(&self, id: Option<u64>, name: &str) -> Option<usize> {
         match id {
             Some(want) => self.router.position(|c| c.context_id == want),
-            None => self.router.position(|c| c.name.eq_ignore_ascii_case(name)),
+            None => self
+                .router
+                .position(|c| c.name.displayed().eq_ignore_ascii_case(name)),
         }
     }
 
@@ -455,7 +457,7 @@ impl PlexiApp {
         // 3. Register the child context + window.
         ensure_context_state_ignore(&path);
         self.router.push(crate::host::context::Context {
-            name: ctx_name,
+            name: ContextName::custom(ctx_name),
             root: path.clone(),
             description: ctx_description,
             context_id: ctx_id,
@@ -491,7 +493,7 @@ impl PlexiApp {
     /// the child's working directory and names the child "Sub-context N".
     pub(crate) fn new_child_context_from_keyboard(&mut self) {
         let parent_ctx_id = self.router.active().context_id;
-        let parent_name = self.router.active().name.clone();
+        let parent_name = self.router.active().name.to_string();
         let parent_path = self.router.active().root.clone();
         let current_win_id = self.windows[self.active_window].window_id;
         let current_focused = self.windows[self.active_window].focused_pane;
@@ -645,7 +647,7 @@ impl PlexiApp {
         self.router.insert_after_subtree(
             parent_ctx_id,
             crate::host::context::Context {
-                name: ctx_name,
+                name: ContextName::custom(ctx_name),
                 root: parent_root.clone(),
                 description: None,
                 context_id: ctx_id,
@@ -685,6 +687,112 @@ impl PlexiApp {
         self.new_context_empty();
     }
 
+    pub(crate) fn auto_context_name_for_path(
+        &self,
+        context_id: u64,
+        path: &std::path::Path,
+    ) -> String {
+        let base = path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| format!("Context {}", self.router.len() + 1));
+        let existing = self
+            .router
+            .iter()
+            .find(|context| context.context_id != context_id && context.name.displayed() == base);
+        let Some(existing) = existing else {
+            return base;
+        };
+
+        let mut suffix = 2;
+        loop {
+            let candidate = format!("{base} ({suffix})");
+            if !self.router.iter().any(|context| {
+                context.context_id != context_id && context.name.displayed() == candidate
+            }) {
+                log::info!(
+                    "context_auto_name: '{}' collides with context {} — using '{}'",
+                    base,
+                    existing.context_id,
+                    candidate
+                );
+                return candidate;
+            }
+            suffix += 1;
+        }
+    }
+
+    /// Resolve an empty auto name from a focused terminal exactly once. A
+    /// terminal may not have reported its cwd on the creation frame, so this
+    /// runs from the host logic loop until that first report arrives.
+    pub(crate) fn resolve_auto_context_names(&mut self) {
+        let unresolved: Vec<(usize, u64)> = self
+            .router
+            .iter()
+            .enumerate()
+            .filter(|(_, context)| context.name.is_unresolved_auto())
+            .map(|(idx, context)| (idx, context.context_id))
+            .collect();
+        for (idx, context_id) in unresolved {
+            let cwd = self
+                .windows
+                .iter()
+                .find(|window| window.context_id == context_id)
+                .and_then(|window| {
+                    window
+                        .focused_pane
+                        .and_then(|tile_id| window.get_focused_pane_cwd(tile_id))
+                });
+            let Some(cwd) = cwd else {
+                continue;
+            };
+            let name = self.auto_context_name_for_path(context_id, &cwd);
+            self.router.get_mut(idx).name = ContextName::auto(name.clone());
+            log::info!(
+                "context_auto_name: context_id={context_id} cwd={} name={name}",
+                cwd.display()
+            );
+            self.save_workspace();
+        }
+    }
+
+    /// Apply a rename submission. Blank submissions intentionally return the
+    /// label to automatic mode, using the focused cwd (or the context root if
+    /// that terminal is between cwd reports).
+    pub(crate) fn rename_context(&mut self, ctx_idx: usize, submitted: &str) -> String {
+        let context_id = self.router.get(ctx_idx).context_id;
+        let trimmed = submitted.trim();
+        let name = if trimmed.is_empty() {
+            let cwd = self
+                .windows
+                .iter()
+                .find(|window| window.context_id == context_id)
+                .and_then(|window| {
+                    window
+                        .focused_pane
+                        .and_then(|tile_id| window.get_focused_pane_cwd(tile_id))
+                        .or_else(|| Some(window.path.clone()))
+                });
+            match cwd {
+                Some(cwd) => ContextName::auto(self.auto_context_name_for_path(context_id, &cwd)),
+                None => ContextName::auto(String::new()),
+            }
+        } else {
+            ContextName::custom(trimmed)
+        };
+        let displayed = name.displayed().to_owned();
+        self.router.get_mut(ctx_idx).name = name;
+        log::info!("context_rename: context_id={context_id} name={displayed}");
+        crate::host::event_log::emit(crate::host::event_log::HostEvent::ContextRenamed {
+            context_id,
+            name: displayed.clone(),
+            timestamp: crate::host::event_log::now_timestamp(),
+        });
+        self.save_workspace();
+        displayed
+    }
+
     /// Create a new standalone empty context at the home directory.
     fn new_context_empty(&mut self) {
         let cwd = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
@@ -695,7 +803,7 @@ impl PlexiApp {
         let win_id = self.next_window_id;
         self.next_window_id += 1;
 
-        let ctx_name = format!("Context {}", self.router.len() + 1);
+        let ctx_name = self.auto_context_name_for_path(ctx_id, &cwd);
         let context_env = super::create::PaneContextEnv {
             context_id: ctx_id,
             name: ctx_name.clone(),
@@ -730,7 +838,7 @@ impl PlexiApp {
 
         ensure_context_state_ignore(&cwd);
         self.router.push(crate::host::context::Context {
-            name: ctx_name,
+            name: ContextName::auto(String::new()),
             root: cwd,
             description: None,
             context_id: ctx_id,
@@ -744,16 +852,13 @@ impl PlexiApp {
         self.minimap.visible = false;
         self.apply_context_transition_effects();
 
-        let new_ctx_idx = self.router.len() - 1;
-        self.open_context_rename(new_ctx_idx);
         self.mark_workspace_dirty();
         log::info!(
-            "new_context_empty: emitting ContextCreated context_id={ctx_id} name={}",
-            self.rename_buffer
+            "new_context_empty: emitting ContextCreated context_id={ctx_id} name={ctx_name}"
         );
         crate::host::event_log::emit(crate::host::event_log::HostEvent::ContextCreated {
             context_id: ctx_id,
-            name: self.rename_buffer.clone(),
+            name: ctx_name,
             timestamp: crate::host::event_log::now_timestamp(),
         });
     }
@@ -773,7 +878,7 @@ impl PlexiApp {
         // Resolve the identity before spawning: the root pane starts before this
         // context is registered in the router.
         let anchor = crate::host::anchor::Anchor::detect(&path);
-        let (ctx_name, ctx_description) =
+        let (ctx_name, ctx_description, name_is_custom) =
             match anchor.as_ref().and_then(|a| a.context_defaults.as_ref()) {
                 Some(defaults) => {
                     let name = defaults.name.clone().unwrap_or_else(|| {
@@ -786,19 +891,24 @@ impl PlexiApp {
                         name,
                         defaults.description
                     );
-                    (name, defaults.description.clone())
+                    (name, defaults.description.clone(), defaults.name.is_some())
                 }
                 None => {
                     let name = path
                         .file_name()
                         .map(|n| n.to_string_lossy().into_owned())
                         .unwrap_or_else(|| format!("Context {}", self.router.len() + 1));
-                    (name, None)
+                    (name, None, false)
                 }
             };
+        let context_name = if name_is_custom {
+            ContextName::custom(ctx_name)
+        } else {
+            ContextName::auto(self.auto_context_name_for_path(ctx_id, &path))
+        };
         let context_env = super::create::PaneContextEnv {
             context_id: ctx_id,
-            name: ctx_name.clone(),
+            name: context_name.displayed().to_owned(),
             description: ctx_description.clone().unwrap_or_default(),
             root: Some(path.clone()),
             depth: 0,
@@ -833,7 +943,7 @@ impl PlexiApp {
 
         ensure_context_state_ignore(&path);
         self.router.push(crate::host::context::Context {
-            name: ctx_name,
+            name: context_name,
             root: path,
             description: ctx_description,
             context_id: ctx_id,

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -753,7 +753,7 @@ impl PlexiApp {
                 "context_auto_name: context_id={context_id} cwd={} name={name}",
                 cwd.display()
             );
-            self.save_workspace();
+            self.mark_workspace_dirty();
         }
     }
 
@@ -789,7 +789,7 @@ impl PlexiApp {
             name: displayed.clone(),
             timestamp: crate::host::event_log::now_timestamp(),
         });
-        self.save_workspace();
+        self.mark_workspace_dirty();
         displayed
     }
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -2138,7 +2138,7 @@ fn portal_context_state_refreshes_when_child_context_changes() {
     let child_ctx_id = 77001u64;
     let child_win_id = 77002u64;
     h.app.router.push(crate::host::context::Context {
-        name: "child".to_string(),
+        name: "child".to_string().into(),
         root: std::path::PathBuf::from("/tmp/harness_2023_child"),
         description: None,
         context_id: child_ctx_id,
@@ -5270,7 +5270,7 @@ mod routine_firing {
     fn root_default_context(h: &mut HostHarness, root: &std::path::Path) {
         let ctx = h.app.router.get_mut(0);
         ctx.root = root.to_path_buf();
-        ctx.name = "main".to_string();
+        ctx.name = "main".to_string().into();
     }
 
     /// Insert a builtin app pane (rooted at `root`, never a real machine dir)
@@ -5328,7 +5328,7 @@ mod routine_firing {
         let win_idx = h.app.windows.len() - 1;
         add_focused_app_pane(h, win_idx, root);
         h.app.router.push(Context {
-            name: name.to_string(),
+            name: name.to_string().into(),
             // Anchored beside (not at) the routines root: tick_scheduler
             // scans every context root, and this context must not load them.
             root: root.join("no-routines-anchor"),

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -258,17 +258,7 @@ impl PlexiApp {
                             if ui.input(|inp| inp.key_pressed(egui::Key::Escape)) {
                                 self.renaming_window = None;
                             } else {
-                                let new_name = self.rename_buffer.trim().to_string();
-                                if !new_name.is_empty() {
-                                    self.router.get_mut(i).name = new_name.clone();
-                                    crate::host::event_log::emit(
-                                        crate::host::event_log::HostEvent::ContextRenamed {
-                                            context_id: self.router.get(i).context_id,
-                                            name: new_name,
-                                            timestamp: crate::host::event_log::now_timestamp(),
-                                        },
-                                    );
-                                }
+                                self.rename_context(i, &self.rename_buffer.clone());
                                 self.renaming_window = None;
                             }
                             ui.input_mut(|inp| {
@@ -296,7 +286,7 @@ impl PlexiApp {
             }
 
             // --- Normal row via SidebarRow ---
-            let ctx_name = self.router.get(i).name.clone();
+            let ctx_name = self.router.get(i).name.to_string();
             let badge_count = if is_active {
                 self.visible_notification_count()
             } else {
@@ -436,7 +426,7 @@ impl PlexiApp {
             if self.parked_section_expanded {
                 for &i in &parked_order {
                     let ctx = self.router.get(i);
-                    let ctx_name = ctx.name.clone();
+                    let ctx_name = ctx.name.to_string();
                     let ctx_id = ctx.context_id;
                     let subtitle = Some(ctx.root.display().to_string());
 
@@ -718,7 +708,7 @@ mod tests {
 
         let context_id = 41;
         app.router.push(crate::host::context::Context {
-            name: "return target".to_string(),
+            name: "return target".to_string().into(),
             root: std::path::PathBuf::from("/tmp"),
             description: None,
             context_id,

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -787,7 +787,7 @@ mod tests {
             let child_ctx_id = active_ctx_id + 5000;
             // Register the child context so the portal header shows a real name.
             app.router.push(crate::host::context::Context {
-                name: "Notes".to_string(),
+                name: "Notes".to_string().into(),
                 root: editor_path.clone(),
                 description: Some("Editing notes".to_string()),
                 context_id: child_ctx_id,
@@ -1217,7 +1217,7 @@ mod tests {
             app.sidebar_visible = true;
             app.parked_section_expanded = false;
             let mk = |id: u64, name: &str| crate::host::context::Context {
-                name: name.to_string(),
+                name: name.to_string().into(),
                 root: std::env::temp_dir().join(name),
                 description: None,
                 context_id: id,
@@ -1290,7 +1290,7 @@ mod tests {
             app.parked_section_expanded = false;
             // Add a second active context so there is a drag source + a list.
             app.router.push(crate::host::context::Context {
-                name: "second".to_string(),
+                name: "second".to_string().into(),
                 root: std::env::temp_dir().join("second"),
                 description: None,
                 context_id: 71_001,
@@ -1326,7 +1326,7 @@ mod tests {
         let mut h = PlexiUiHarness::new_sized(900.0, 620.0);
         let child_ctx_id = h.with_app_mut(|app| {
             app.sidebar_visible = true;
-            app.router.get_mut(0).name = "master-one".to_string();
+            app.router.get_mut(0).name = "master-one".to_string().into();
             let parent_ctx_id = app.router.get(0).context_id;
             let child_ctx_id = parent_ctx_id + 9_000;
 
@@ -1334,7 +1334,7 @@ mod tests {
             // masters in router order — the position that used to shift the
             // second master's sidebar number from 2 to 3.
             app.router.push(crate::host::context::Context {
-                name: "child-of-one".to_string(),
+                name: "child-of-one".to_string().into(),
                 root: std::env::temp_dir().join("child-of-one"),
                 description: None,
                 context_id: child_ctx_id,
@@ -1343,7 +1343,7 @@ mod tests {
                 parked: false,
             });
             app.router.push(crate::host::context::Context {
-                name: "master-two".to_string(),
+                name: "master-two".to_string().into(),
                 root: std::env::temp_dir().join("master-two"),
                 description: None,
                 context_id: 72_002,
@@ -1393,7 +1393,7 @@ mod tests {
             let order = app.router.top_level_order();
             let names: Vec<&str> = order
                 .iter()
-                .map(|&i| app.router.get(i).name.as_str())
+                .map(|&i| app.router.get(i).name.displayed())
                 .collect();
             assert_eq!(
                 names,
@@ -1438,6 +1438,23 @@ mod tests {
             assert_eq!(app.router.len(), 1, "first-run is a single context");
         });
         h.save_screenshot("/tmp/plexi-0715-single-context-sidebar.png")
+            .expect("render failed");
+    }
+
+    /// Stint 0388: visual proof that creating a context lands directly in the
+    /// workspace with its auto-derived sidebar label and no rename overlay.
+    #[test]
+    fn screenshot_new_context_without_rename_modal() {
+        let mut h = PlexiUiHarness::new_sized_ppp(1280.0, 800.0, 2.0);
+        h.with_app_mut(|app| {
+            app.sidebar_visible = true;
+            let before = app.router.len();
+            app.new_context();
+            assert_eq!(app.router.len(), before + 1, "new context created");
+            assert_eq!(app.renaming_window, None, "rename overlay stays closed");
+        });
+        h.run_steps(6);
+        h.save_screenshot("/tmp/plexi-0388-new-context-auto-name.png")
             .expect("render failed");
     }
 
@@ -1514,7 +1531,7 @@ mod tests {
             let context_id = app.next_window_id;
             app.next_window_id += 1;
             app.router.push(crate::host::context::Context {
-                name: name.to_string(),
+                name: name.to_string().into(),
                 root: std::path::PathBuf::from(root),
                 description: None,
                 context_id,
@@ -1576,7 +1593,7 @@ mod tests {
         let (active_context_id, active_window_id) = h.with_app_mut(|app| {
             app.sidebar_visible = true;
             let idx = app.router.active_idx();
-            app.router.get_mut(idx).name = "PLEXI Workspace".to_string();
+            app.router.get_mut(idx).name = "PLEXI Workspace".to_string().into();
             app.router.get_mut(idx).root = std::path::PathBuf::from("/projects/PLEXI");
             (
                 app.router.get(idx).context_id,
@@ -1651,14 +1668,14 @@ mod tests {
     fn context_cycling_visits_master_contexts_only() {
         let mut h = PlexiUiHarness::new_sized(900.0, 620.0);
         let child_ctx_id = h.with_app_mut(|app| {
-            app.router.get_mut(0).name = "master-one".to_string();
+            app.router.get_mut(0).name = "master-one".to_string().into();
             let parent_ctx_id = app.router.get(0).context_id;
             let child_ctx_id = parent_ctx_id + 9_000;
 
             // Subcontext at router index 1, between the two masters — the
             // index the old raw-index walk would have landed on.
             app.router.push(crate::host::context::Context {
-                name: "child-of-one".to_string(),
+                name: "child-of-one".to_string().into(),
                 root: std::env::temp_dir().join("child-of-one"),
                 description: None,
                 context_id: child_ctx_id,
@@ -1667,7 +1684,7 @@ mod tests {
                 parked: false,
             });
             app.router.push(crate::host::context::Context {
-                name: "master-two".to_string(),
+                name: "master-two".to_string().into(),
                 root: std::env::temp_dir().join("master-two"),
                 description: None,
                 context_id: 72_002,
@@ -2690,7 +2707,7 @@ mod tests {
                 win.focused_pane = Some(first_tile);
             }
             let ctx_idx = app.router.active_idx();
-            app.router.get_mut(ctx_idx).name = "Command Palette Metadata".to_string();
+            app.router.get_mut(ctx_idx).name = "Command Palette Metadata".to_string().into();
             let ctx_id = app.router.get(ctx_idx).context_id;
             let extra_a = app.host.alloc_pane_id();
             let extra_b = app.host.alloc_pane_id();
@@ -2759,7 +2776,7 @@ mod tests {
 
         h.with_app_mut(|app| {
             let ctx_idx = app.router.active_idx();
-            app.router.get_mut(ctx_idx).name = "plexi".to_string();
+            app.router.get_mut(ctx_idx).name = "plexi".to_string().into();
 
             let agent_pane = |app: &mut crate::app::PlexiApp,
                               pane_name: &str,
@@ -2819,7 +2836,7 @@ mod tests {
             let squad_ctx_id = app.next_window_id;
             app.next_window_id += 1;
             app.router.push(crate::host::context::Context {
-                name: "squad-alpha".to_string(),
+                name: "squad-alpha".to_string().into(),
                 root: browser_root.clone(),
                 description: None,
                 context_id: squad_ctx_id,
@@ -3227,13 +3244,11 @@ mod tests {
         );
     }
 
-    /// Empty rename buffer must not overwrite the existing name.
+    /// Empty rename buffer returns the context to an auto-derived name.
     #[test]
-    fn context_rename_ignores_empty_buffer() {
+    fn context_rename_empty_buffer_reverts_to_auto() {
         let mut h = PlexiUiHarness::new();
         h.step();
-
-        let original_name = h.with_app(|app| app.router.active().name.clone());
 
         h.with_app_mut(|app| {
             let ctx_idx = app.router.active_idx();
@@ -3246,9 +3261,9 @@ mod tests {
         h.step();
 
         let name = h.with_app(|app| app.router.active().name.clone());
-        assert_eq!(
-            name, original_name,
-            "whitespace-only rename must be discarded"
+        assert!(
+            matches!(name, crate::host::context::ContextName::Auto(ref value) if !value.is_empty()),
+            "whitespace-only rename must restore a non-empty automatic name"
         );
     }
 
@@ -3482,7 +3497,7 @@ mod tests {
             app.next_window_id += 1;
             let plexi_root = std::env::temp_dir().join("GitHub/PLEXI");
             app.router.push(crate::host::context::Context {
-                name: "PLEXI".to_string(),
+                name: "PLEXI".to_string().into(),
                 root: plexi_root.clone(),
                 description: None,
                 context_id: plexi_ctx_id,
@@ -3511,7 +3526,7 @@ mod tests {
                 app.next_window_id += 1;
                 let root = std::env::temp_dir().join(dir);
                 app.router.push(crate::host::context::Context {
-                    name: name.to_string(),
+                    name: name.to_string().into(),
                     root: root,
                     description: None,
                     context_id: ctx_id,
@@ -3560,7 +3575,8 @@ mod tests {
             let active_context_idx = app.router.active_idx();
             let active_context_id = app.router.get(active_context_idx).context_id;
             let active_window_id = app.windows[app.active_window].window_id;
-            app.router.get_mut(active_context_idx).name = "PLEXI Workspace".to_string();
+            app.router.get_mut(active_context_idx).name =
+                "PLEXI Workspace".to_string().into();
             app.router.get_mut(active_context_idx).root =
                 std::path::PathBuf::from("/projects/PLEXI");
 
@@ -3571,7 +3587,7 @@ mod tests {
                 // Deliberately longer than a normal workspace title: the
                 // screenshot must exercise truncation without making the
                 // ordinary active title a false-positive fixture.
-                name: "Narrator Video Production Workspace".to_string(),
+                name: "Narrator Video Production Workspace".to_string().into(),
                 root: inactive_root.clone(),
                 description: None,
                 context_id: inactive_context_id,
@@ -3776,7 +3792,7 @@ mod tests {
                     app.next_window_id += 1;
                     let root = std::env::temp_dir().join(dir);
                     app.router.push(crate::host::context::Context {
-                        name: name.to_string(),
+                        name: name.to_string().into(),
                         root: root,
                         description: None,
                         context_id: ctx_id,

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -561,7 +561,7 @@ mod tests {
     #[test]
     fn context_serde_round_trip() {
         let ctx = Context {
-            name: "dev".to_string(),
+            name: "dev".to_string().into(),
             root: PathBuf::from("/projects/dev/src"),
             description: Some("main workspace".to_string()),
             context_id: 42,

--- a/src/workspace/router.rs
+++ b/src/workspace/router.rs
@@ -329,7 +329,7 @@ mod tests {
 
     fn make_ctx(id: u64, parent_id: Option<u64>, depth: u32) -> Context {
         Context {
-            name: format!("ctx{id}"),
+            name: format!("ctx{id}").into(),
             root: PathBuf::from("/tmp"),
             description: None,
             context_id: id,


### PR DESCRIPTION
## Summary

Implements stint 0388. No linked GitHub issue — stint is authoritative.

- Remove the forced rename overlay from context creation and persist explicit `Auto` versus `Custom` name state with legacy workspace compatibility.
- Resolve automatic names once from the focused pane cwd, revert blank manual renames to auto, and preserve anchor-provided names as custom.
- Route host and CLI directory creation through deterministic basename naming, including visible ` (2)` collision suffixes and a CLI collision note.

## Done When

- New contexts open directly into the workspace with no name-entry modal.
- Automatic names derive from the first focused-pane cwd and remain frozen across later directory changes.
- Cmd+Shift+R sets a custom name; submitting blank restores an automatic name from the current or last-known cwd.
- Directory and CLI creation share the same naming path; explicit anchor names remain custom.
- Duplicate automatic names are deterministically disambiguated and surfaced.

**Test evidence (attempt 1):**
- cargo test: 2320 passed, 0 failed, 5 ignored — filters: auto_name, focused context creation/rename regressions, full bin suite
- PlexiUiHarness render: /tmp/plexi-0388-new-context-auto-name.png — inspected new `ianburke` sidebar row with workspace focus and no rename overlay; artifact deleted after review
- cargo build: passed
- Conclusion: binary install required — visible host context-creation and rename behavior changed

**Test evidence (attempt 2):**
- cargo clippy --bin plexi -- -D warnings: passed
- cargo test: 3 passed, 0 failed — filter: auto_name
- Conclusion: binary install required — visible host context-creation and rename behavior changed