### PR TITLE
fix(host/text-input): keep the draft while the guest echo is in flight; autofocus search fields

### DIFF
--- a/apps/github-issues/main.py
+++ b/apps/github-issues/main.py
@@ -262,6 +262,7 @@ def _list_view(data: dict):
                 value=data["filter"],
                 placeholder="filter labels or title",
                 on_change="issues-filter",
+                autofocus=True,
             ),
             body,
             Spacer(grow=True),

--- a/apps/logs/logs.py
+++ b/apps/logs/logs.py
@@ -173,6 +173,7 @@ def view():
             value=data["query"],
             placeholder="filter by target or message",
             on_change=SEARCH_INPUT,
+            autofocus=True,
         )
         if data["searching"]
         else TabBar(LEVEL_TAB, LEVELS, active=LEVELS.index(data["filter"]))

--- a/apps/wikipedia/wikipedia.py
+++ b/apps/wikipedia/wikipedia.py
@@ -373,6 +373,7 @@ def _search_view(data: dict):
                     placeholder="Try “Detroit”, “Tetris”, or “Ada Lovelace”",
                     on_change="wiki-query",
                     on_submit="wiki-submit",
+                    autofocus=True,
                 ),
                 Button(
                     "Search Wikipedia",

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -1702,6 +1702,11 @@ pub struct LiveWasmPane {
     /// Concatenated text of the last rendered view tree. Lets the headless
     /// scene runner assert on rendered content without re-entering the guest.
     last_text: String,
+    /// Monotonic generation of the tree handed to the renderer. This runtime
+    /// re-evaluates `view()` every frame, so every painted tree is genuinely
+    /// new; the counter is what host-owned edit buffers reconcile against
+    /// (stint 0720).
+    tree_seq: u64,
     /// Runtime-neutral semantics retained from the last committed guest tree.
     semantic_state: crate::host::pane::SemanticPaneState,
     /// egui texture id of the guest surface, registered once into the host's
@@ -1749,6 +1754,7 @@ impl LiveWasmPane {
             pending_init: Some(snapshot),
             error: None,
             last_text: String::new(),
+            tree_seq: 0,
             semantic_state: crate::host::pane::SemanticPaneState::empty("wasm"),
             surface_id: None,
             surface_dims: None,
@@ -2227,6 +2233,7 @@ impl LiveWasmPane {
             },
             None => None,
         };
+        self.tree_seq += 1;
         let result = super::wasm_render::render_ui_tree_with_canvas_fits(
             ui,
             &tree,
@@ -2235,6 +2242,7 @@ impl LiveWasmPane {
             None,
             pending_click,
             Some(crate::ui::focus::SurfaceKey::Pane(pane_key)),
+            self.tree_seq,
         );
         match self.inner.apply_render_result(result, now) {
             Ok(true) => {
@@ -3738,13 +3746,17 @@ mod tests {
         assert!(tree_text(&p.view()?).contains("Count: 0"));
 
         let colors = Colors::from_config(&crate::config::ThemeConfig::default());
+        let mut tree_seq: u64 = 0;
         let mut harness = egui_kittest::Harness::builder()
             .with_size(egui::Vec2::new(400.0, 300.0))
             .build_ui_state(
                 move |ui, pane| {
                     let tree = pane.view().expect("view");
+                    // This runtime re-evaluates `view()` every frame, so every
+                    // painted tree is a new generation — mirror the live pane.
+                    tree_seq += 1;
                     let result = crate::host::wasm_render::render_ui_tree_with_surface(
-                        ui, &tree, &colors, None, None,
+                        ui, &tree, &colors, None, None, tree_seq,
                     );
                     pane.apply_render_result(result, 0)
                         .expect("apply interactions");

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -888,6 +888,10 @@ pub struct LivePythonPane {
     app_id: String,
     title: Option<String>,
     tree: Option<Arc<PythonUiTree>>,
+    /// Monotonic generation of `tree`. Bumped on every swap (commit, reset) so
+    /// the renderer's host-owned edit buffers can tell a newly committed guest
+    /// tree from a repaint of the same stale one (stint 0720).
+    tree_seq: u64,
     pending_trees: HashMap<u64, Arc<PythonUiTree>>,
     initialized: bool,
     ready: bool,
@@ -2042,6 +2046,7 @@ impl LivePythonPane {
             app_id,
             title: None,
             tree: None,
+            tree_seq: 0,
             pending_trees: HashMap::new(),
             initialized: false,
             ready: false,
@@ -2260,6 +2265,7 @@ impl LivePythonPane {
                 Some(&tree.canvas_fits),
                 pending_click,
                 Some(crate::ui::focus::SurfaceKey::Pane(pane_key)),
+                self.tree_seq,
             );
             self.perf_ui_render += render_started.elapsed();
             self.perf_canvas_render += result.canvas_time;
@@ -2638,6 +2644,7 @@ impl LivePythonPane {
                         &mut self.frame_scheduler,
                         &mut self.pending_trees,
                         &mut self.tree,
+                        &mut self.tree_seq,
                         frame_id,
                     )
                 });
@@ -3673,6 +3680,7 @@ impl LivePythonPane {
         );
         self.runtime = runtime;
         self.tree = None;
+        self.tree_seq += 1;
         self.pending_trees.clear();
         self.initialized = false;
         self.ready = false;
@@ -4069,11 +4077,13 @@ fn commit_python_frame(
     scheduler: &mut PythonFrameScheduler,
     pending_trees: &mut HashMap<u64, Arc<PythonUiTree>>,
     visible_tree: &mut Option<Arc<PythonUiTree>>,
+    visible_tree_seq: &mut u64,
     frame_id: u64,
 ) -> Option<std::time::Instant> {
     let sent_at = scheduler.complete_frame(frame_id)?;
     if let Some(tree) = pending_trees.remove(&frame_id) {
         *visible_tree = Some(tree);
+        *visible_tree_seq += 1;
     }
     Some(sent_at)
 }
@@ -7309,13 +7319,23 @@ mod tests {
         .expect("pending tree");
         let mut pending = HashMap::from([(frame_id, Arc::new(pending_tree))]);
         let mut visible = None;
+        let mut visible_seq = 0;
 
         assert!(visible.is_none());
-        assert!(
-            commit_python_frame(&mut scheduler, &mut pending, &mut visible, frame_id,).is_some()
-        );
+        assert!(commit_python_frame(
+            &mut scheduler,
+            &mut pending,
+            &mut visible,
+            &mut visible_seq,
+            frame_id,
+        )
+        .is_some());
         assert!(pending.is_empty());
         assert!(visible.is_some());
+        assert_eq!(
+            visible_seq, 1,
+            "committing a tree bumps the generation the renderer reconciles against"
+        );
     }
 
     #[test]

--- a/src/host/wasm_render.rs
+++ b/src/host/wasm_render.rs
@@ -70,6 +70,7 @@ pub fn render_ui_tree_with_surface(
     render_ui_tree_with_canvas_fits(ui, tree, colors, surface, None, None, surface_key, tree_seq)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn render_ui_tree_with_canvas_fits(
     ui: &mut egui::Ui,
     tree: &UiTree,

--- a/src/host/wasm_render.rs
+++ b/src/host/wasm_render.rs
@@ -7,7 +7,7 @@
 // back to the guest. A depth cap guards against malformed/cyclic trees.
 
 use egui::{Color32, RichText};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use crate::ui::style;
 use crate::ui::theme::Colors;
@@ -53,14 +53,21 @@ pub struct RenderResult {
 
 /// Render a view tree, compositing `surface` into the first surface-node
 /// (the guest's GPU output). Pass `None` to draw a placeholder instead.
+///
+/// `tree_seq` identifies the *generation* of the tree being painted: callers
+/// bump it every time they swap in a newly committed guest tree, and repaint
+/// the same tree under the same value. Host-owned edit buffers use it to tell
+/// "the app pushed me a new value" apart from "I am painting the same stale
+/// tree again" — see `reconcile_text_input_buffer`.
 pub fn render_ui_tree_with_surface(
     ui: &mut egui::Ui,
     tree: &UiTree,
     colors: &Colors,
     surface: Option<egui::TextureId>,
     surface_key: Option<crate::ui::focus::SurfaceKey>,
+    tree_seq: u64,
 ) -> RenderResult {
-    render_ui_tree_with_canvas_fits(ui, tree, colors, surface, None, None, surface_key)
+    render_ui_tree_with_canvas_fits(ui, tree, colors, surface, None, None, surface_key, tree_seq)
 }
 
 pub fn render_ui_tree_with_canvas_fits(
@@ -71,6 +78,7 @@ pub fn render_ui_tree_with_canvas_fits(
     canvas_fits: Option<&HashMap<u32, CanvasFit>>,
     pending_click: Option<crate::host::pane::PendingPaneClick>,
     surface_key: Option<crate::ui::focus::SurfaceKey>,
+    tree_seq: u64,
 ) -> RenderResult {
     let mut out = RenderResult::default();
     let render_root = |ui: &mut egui::Ui, out: &mut RenderResult| {
@@ -85,6 +93,7 @@ pub fn render_ui_tree_with_canvas_fits(
             canvas_fits,
             pending_click,
             surface_key,
+            tree_seq,
         );
     };
     // Good-by-default spacing (stint 0445): a declarative app with no layout
@@ -116,6 +125,7 @@ pub fn render_ui_tree_with_canvas_fits(
             canvas_fits,
             pending_click,
             surface_key,
+            tree_seq,
         ) {
             egui::Frame::NONE
                 .inner_margin(root_content_inset())
@@ -142,6 +152,7 @@ fn render_root_with_chrome_bands(
     canvas_fits: Option<&HashMap<u32, CanvasFit>>,
     pending_click: Option<crate::host::pane::PendingPaneClick>,
     surface_key: Option<crate::ui::focus::SurfaceKey>,
+    tree_seq: u64,
 ) -> bool {
     let nodes = &tree.nodes;
     let Some(UiNodeData::Column(c)) = find_node(nodes, tree.root).map(|n| &n.data) else {
@@ -187,6 +198,7 @@ fn render_root_with_chrome_bands(
                         canvas_fits,
                         pending_click,
                         surface_key,
+                        tree_seq,
                     );
                 }
             });
@@ -230,6 +242,7 @@ fn render_root_with_chrome_bands(
                 canvas_fits,
                 pending_click,
                 surface_key,
+                tree_seq,
             );
         });
     }
@@ -252,6 +265,7 @@ fn render_root_with_chrome_bands(
                 canvas_fits,
                 pending_click,
                 surface_key,
+                tree_seq,
             );
         });
     }
@@ -321,7 +335,7 @@ pub fn render_ui_tree_to_png(
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show_inside(ui, |ui| {
-                    let _ = render_ui_tree_with_surface(ui, &tree, &colors, None, None);
+                    let _ = render_ui_tree_with_surface(ui, &tree, &colors, None, None, 0);
                 });
         });
     harness.run();
@@ -393,21 +407,105 @@ fn node_click_matches(pending_click: Option<crate::host::pane::PendingPaneClick>
     )
 }
 
-/// Resolve a `TextInput`'s edit buffer for this frame (stint 0456).
-/// `stored` is `(buffer, last_app_value)` from egui temp memory; returns the
-/// pair to edit this frame. The app's reported `value` wins only when it
-/// *changed* since we last saw it (a reset after submit, an external
-/// `SetState`) — an unchanged value (or the echo of our own `on_change`,
-/// which the caller records into `last_app_value`) never clobbers a local
-/// draft still round-tripping to the guest.
+/// Maximum un-echoed `on_change` values tracked per `TextInput`. A guest that
+/// stops answering must not grow this without bound; dropping the oldest entry
+/// only costs an adoption of a value the user typed many keystrokes ago.
+const TEXT_INPUT_PENDING_LIMIT: usize = 32;
+
+/// Host-owned edit state for one `TextInput`, held in egui temp memory
+/// (stints 0456, 0720).
+#[derive(Clone, Debug, Default, PartialEq)]
+struct TextInputEditState {
+    /// The draft the user is editing. Painted, not `ti.value`.
+    buf: String,
+    /// Generation of the committed guest tree this state last reconciled
+    /// against. Equal generations mean the same tree is being repainted.
+    seen_seq: u64,
+    /// Values already sent to the guest through `on_change` that have not yet
+    /// come back in a committed tree, oldest first.
+    pending: VecDeque<String>,
+    /// Set when `on_submit` fired: the guest is about to redefine the value
+    /// (clear it, keep it, transform it), so the next genuinely new tree is
+    /// authoritative — unless the user has typed since, in which case their
+    /// fresh draft wins.
+    awaiting_submit: bool,
+}
+
+/// Outcome of one reconcile, so the caller can log the lossy branch without
+/// re-deriving it.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum TextInputReconcile {
+    /// The local draft survived this frame.
+    KeptDraft,
+    /// The app's value replaced the local draft.
+    Adopted,
+}
+
+/// Resolve a `TextInput`'s edit buffer for this frame (stints 0456, 0720).
+///
+/// The app's `value` is a controlled input that round-trips asynchronously: a
+/// keystroke goes out as `on_change` and only comes back one or more guest
+/// frames later. Meanwhile the host repaints the *last committed* tree every
+/// frame, so the same stale `value` is presented over and over. Comparing
+/// values alone cannot separate that stale repaint from a genuine app-side
+/// reset, which is why typing faster than the guest's round trip used to drop
+/// characters. Two signals fix it:
+///
+/// - `seq` — the committed tree's generation. Unchanged generation means we are
+///   looking at a tree we already reconciled; it can never carry news, so the
+///   draft is kept verbatim.
+/// - `pending` — the values we sent out and are still waiting to see echoed. A
+///   new tree whose value is one of them is our own echo (possibly several
+///   keystrokes behind), so the draft is kept and the queue drained past it.
+///
+/// Anything else on a new tree is genuine app news (`SetState`, a post-submit
+/// reset) and is adopted.
+///
+/// Accepted residual: an app that *transforms* the value (uppercasing,
+/// filtering characters) emits a tree value that was never in `pending`, so it
+/// is adopted and the caret can jump to the end. Transforming controlled inputs
+/// are not supported by this contract; an app that needs one must own its own
+/// key handling.
 fn reconcile_text_input_buffer(
-    stored: Option<(String, String)>,
+    stored: Option<TextInputEditState>,
     app_value: &str,
-) -> (String, String) {
-    match stored {
-        Some((buf, last_app_value)) if app_value == last_app_value => (buf, last_app_value),
-        _ => (app_value.to_string(), app_value.to_string()),
+    seq: u64,
+) -> (TextInputEditState, TextInputReconcile) {
+    let adopt = |mut state: TextInputEditState| {
+        state.buf = app_value.to_string();
+        state.seen_seq = seq;
+        state.pending.clear();
+        state.awaiting_submit = false;
+        (state, TextInputReconcile::Adopted)
+    };
+
+    let Some(mut state) = stored else {
+        return adopt(TextInputEditState::default());
+    };
+
+    // Same committed tree as last frame: no news, never clobber the draft.
+    if state.seen_seq == seq {
+        return (state, TextInputReconcile::KeptDraft);
     }
+    state.seen_seq = seq;
+
+    // A submit hands the value back to the app — unless the user has already
+    // started a fresh draft in the gap, which outranks the app's answer.
+    if state.awaiting_submit {
+        state.awaiting_submit = false;
+        if state.buf.is_empty() {
+            return adopt(state);
+        }
+        return (state, TextInputReconcile::KeptDraft);
+    }
+
+    // Our own echo, possibly lagging several keystrokes behind.
+    if let Some(index) = state.pending.iter().position(|value| value == app_value) {
+        state.pending.drain(..=index);
+        return (state, TextInputReconcile::KeptDraft);
+    }
+
+    adopt(state)
 }
 
 fn find_node(nodes: &[IndexedNode], id: u32) -> Option<&IndexedNode> {
@@ -470,6 +568,7 @@ fn render_column_children(
     canvas_fits: Option<&HashMap<u32, CanvasFit>>,
     pending_click: Option<crate::host::pane::PendingPaneClick>,
     surface_key: Option<crate::ui::focus::SurfaceKey>,
+    tree_seq: u64,
 ) {
     let render_span = |ui: &mut egui::Ui, span: &[u32], out: &mut RenderResult| {
         ui.spacing_mut().item_spacing.y = gap;
@@ -485,6 +584,7 @@ fn render_column_children(
                 canvas_fits,
                 pending_click,
                 surface_key,
+                tree_seq,
             );
         }
     };
@@ -553,6 +653,7 @@ fn render_node(
     canvas_fits: Option<&HashMap<u32, CanvasFit>>,
     pending_click: Option<crate::host::pane::PendingPaneClick>,
     surface_key: Option<crate::ui::focus::SurfaceKey>,
+    tree_seq: u64,
 ) {
     if depth > MAX_DEPTH {
         return;
@@ -610,9 +711,19 @@ fn render_node(
             // external SetState) still wins over any local draft.
             let widget_id = ui.id().with(("l1_text_input", id));
             let state_id = widget_id.with("edit_state");
-            let stored: Option<(String, String)> =
+            let stored: Option<TextInputEditState> =
                 ui.ctx().memory_mut(|m| m.data.get_temp(state_id));
-            let (mut buf, mut last_app_value) = reconcile_text_input_buffer(stored, &ti.value);
+            let previous_draft = stored.as_ref().map(|s| s.buf.clone());
+            let (mut state, outcome) = reconcile_text_input_buffer(stored, &ti.value, tree_seq);
+            if outcome == TextInputReconcile::Adopted {
+                if let Some(draft) = previous_draft.filter(|d| !d.is_empty() && *d != ti.value) {
+                    log::info!(
+                        "l1_text_input: adopting app value node={id} app={:?} discarding draft={draft:?}",
+                        ti.value
+                    );
+                }
+            }
+            let mut buf = std::mem::take(&mut state.buf);
             let resp = crate::ui::text_field::TextField::singleline(widget_id, &ti.placeholder)
                 .password(ti.password)
                 .log_name("l1_text_input")
@@ -624,6 +735,21 @@ fn render_node(
                 // entry form gets a live cursor with no imperative focus
                 // command and no key-routing code of its own (stint 0674).
                 if ti.autofocus {
+                    // Edge-triggered: one line the first time this widget id
+                    // claims the pane default, so a duplicate registration for
+                    // one node in one frame is visible in the log.
+                    let logged_id = resp.id.with("plexi_autofocus_logged");
+                    let already: bool = ui.ctx().memory_mut(|m| {
+                        let seen = m.data.get_temp::<bool>(logged_id).unwrap_or(false);
+                        m.data.insert_temp(logged_id, true);
+                        seen
+                    });
+                    if !already {
+                        log::info!(
+                            "l1_text_input: autofocus claiming pane default surface pane={key:?} id={:?}",
+                            resp.id
+                        );
+                    }
                     crate::ui::focus::register_default_text_surface(ui.ctx(), key, resp.id);
                 } else {
                     crate::ui::focus::register_text_surface(ui.ctx(), key, resp.id);
@@ -639,12 +765,25 @@ fn render_node(
             }
             if resp.changed() {
                 out.value_changes.push((ti.on_change.clone(), buf.clone()));
-                // Treat our own change as already-seen so the app's echo
-                // doesn't reset the buffer mid-typing.
-                last_app_value = buf.clone();
+                // Remember what we sent so the guest's echo — however many
+                // keystrokes behind it arrives — is recognized as ours and
+                // never mistaken for an app-pushed reset.
+                if state.pending.len() >= TEXT_INPUT_PENDING_LIMIT {
+                    state.pending.pop_front();
+                }
+                state.pending.push_back(buf.clone());
             }
             if resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter)) {
                 out.actions.push(ti.on_submit.clone());
+                // Submitting hands the value back to the app, so the draft
+                // ends here: clearing it locally means a character typed
+                // before the guest's cleared tree arrives starts the next
+                // entry instead of re-extending the submitted one. If the app
+                // keeps its value instead of clearing it (a search field), the
+                // next committed tree is adopted and restores it.
+                buf.clear();
+                state.pending.clear();
+                state.awaiting_submit = true;
                 // Keep focus for consecutive entries — Enter submits, it
                 // doesn't dismiss the field. Escape leaves the field via
                 // egui's native focus surrender in `begin_pass`; the
@@ -654,8 +793,8 @@ fn render_node(
                     crate::ui::focus::claim_text_surface(ui.ctx(), key, resp.id);
                 }
             }
-            ui.ctx()
-                .memory_mut(|m| m.data.insert_temp(state_id, (buf, last_app_value)));
+            state.buf = buf;
+            ui.ctx().memory_mut(|m| m.data.insert_temp(state_id, state));
         }
 
         UiNodeData::Row(r) => {
@@ -673,6 +812,7 @@ fn render_node(
                         canvas_fits,
                         pending_click,
                         surface_key,
+                        tree_seq,
                     );
                 }
             });
@@ -712,6 +852,7 @@ fn render_node(
                         canvas_fits,
                         pending_click,
                         surface_key,
+                        tree_seq,
                     );
                 });
 
@@ -734,6 +875,7 @@ fn render_node(
                         canvas_fits,
                         pending_click,
                         surface_key,
+                        tree_seq,
                     );
                 });
             } else {
@@ -750,6 +892,7 @@ fn render_node(
                     canvas_fits,
                     pending_click,
                     surface_key,
+                    tree_seq,
                 );
             }
         }
@@ -810,6 +953,7 @@ fn render_node(
                             canvas_fits,
                             pending_click,
                             surface_key,
+                            tree_seq,
                         );
                     })
                     .response
@@ -840,6 +984,7 @@ fn render_node(
                     canvas_fits,
                     pending_click,
                     surface_key,
+                    tree_seq,
                 );
             });
         }
@@ -864,6 +1009,7 @@ fn render_node(
                         canvas_fits,
                         pending_click,
                         surface_key,
+                        tree_seq,
                     );
                 });
         }
@@ -1080,6 +1226,7 @@ fn render_node(
                 canvas_fits,
                 pending_click,
                 surface_key,
+                tree_seq,
             );
         }
 
@@ -1255,39 +1402,80 @@ mod tests {
         }
     }
 
-    /// Stint 0456: the TextInput edit buffer only resets when the app
-    /// *pushes a different value* — our own echo and unchanged app frames
-    /// never clobber a local draft mid-round-trip.
+    /// Build an edit state as the render arm would leave it.
+    fn edit_state(buf: &str, seen_seq: u64, pending: &[&str]) -> TextInputEditState {
+        TextInputEditState {
+            buf: buf.to_string(),
+            seen_seq,
+            pending: pending.iter().map(|v| v.to_string()).collect(),
+            awaiting_submit: false,
+        }
+    }
+
+    /// Stints 0456/0720: the TextInput edit buffer only resets when the app
+    /// pushes news — a repaint of the same committed tree and the echo of our
+    /// own `on_change` never clobber a local draft mid-round-trip.
     #[test]
     fn text_input_buffer_reconciliation() {
         // Fresh widget: adopt the app's value.
-        assert_eq!(
-            reconcile_text_input_buffer(None, "seed"),
-            ("seed".to_string(), "seed".to_string())
-        );
+        let (state, outcome) = reconcile_text_input_buffer(None, "seed", 7);
+        assert_eq!(outcome, TextInputReconcile::Adopted);
+        assert_eq!(state, edit_state("seed", 7, &[]));
 
-        // Local draft survives frames where the app still reports the value
-        // we last saw (the typed change is still round-tripping).
+        // Stint 0720 regression: the SAME committed tree repainted, carrying a
+        // value that differs from the draft because the guest has not echoed
+        // yet. Value comparison alone called this an app reset and dropped the
+        // keystroke; the generation says there is no news.
+        let (state, outcome) =
+            reconcile_text_input_buffer(Some(edit_state("hi", 3, &["h", "hi"])), "", 3);
         assert_eq!(
-            reconcile_text_input_buffer(Some(("typed".to_string(), "".to_string())), ""),
-            ("typed".to_string(), "".to_string()),
-            "stale app value must not clobber the draft"
+            outcome,
+            TextInputReconcile::KeptDraft,
+            "a repaint of an already-reconciled tree must never clobber the draft"
         );
+        assert_eq!(state, edit_state("hi", 3, &["h", "hi"]));
 
-        // The caller records our own change into last_app_value, so the
-        // app's echo of it is a no-op.
-        assert_eq!(
-            reconcile_text_input_buffer(Some(("typed".to_string(), "typed".to_string())), "typed"),
-            ("typed".to_string(), "typed".to_string())
-        );
+        // A new tree carrying an echo we are still waiting on: keep the draft
+        // and drain the queue through that entry.
+        let (state, outcome) =
+            reconcile_text_input_buffer(Some(edit_state("hi", 3, &["h", "hi"])), "h", 4);
+        assert_eq!(outcome, TextInputReconcile::KeptDraft);
+        assert_eq!(state, edit_state("hi", 4, &["hi"]));
 
-        // An app-pushed change (reset after submit, external SetState) wins
-        // over any local draft.
-        assert_eq!(
-            reconcile_text_input_buffer(Some(("typed".to_string(), "typed".to_string())), ""),
-            ("".to_string(), "".to_string()),
-            "app reset must clear the draft"
-        );
+        // A new tree with a value we never sent is genuine app news (external
+        // SetState, post-submit reset) and wins over the draft.
+        let (state, outcome) =
+            reconcile_text_input_buffer(Some(edit_state("typed", 3, &["typed"])), "", 4);
+        assert_eq!(outcome, TextInputReconcile::Adopted);
+        assert_eq!(state, edit_state("", 4, &[]));
+    }
+
+    /// Stint 0720: after `on_submit` the app redefines the value, but a
+    /// character typed before its tree lands starts the next entry rather than
+    /// re-extending the submitted one.
+    #[test]
+    fn text_input_submit_hands_the_value_back_unless_the_user_typed_first() {
+        let submitted = TextInputEditState {
+            buf: String::new(),
+            seen_seq: 3,
+            pending: VecDeque::new(),
+            awaiting_submit: true,
+        };
+
+        // Untouched since submit: whatever the app decided is authoritative —
+        // cleared here, but a search field that keeps its query is restored the
+        // same way.
+        let (state, outcome) = reconcile_text_input_buffer(Some(submitted.clone()), "query", 4);
+        assert_eq!(outcome, TextInputReconcile::Adopted);
+        assert_eq!(state, edit_state("query", 4, &[]));
+
+        // Typed in the gap: the fresh draft outranks the app's answer.
+        let mut typed_after = submitted;
+        typed_after.buf = "z".to_string();
+        typed_after.pending.push_back("z".to_string());
+        let (state, outcome) = reconcile_text_input_buffer(Some(typed_after), "hi", 4);
+        assert_eq!(outcome, TextInputReconcile::KeptDraft);
+        assert_eq!(state, edit_state("z", 4, &["z"]));
     }
     use std::path::PathBuf;
 
@@ -1327,7 +1515,7 @@ mod tests {
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show_inside(ui, |ui| {
-                    let _ = render_ui_tree_with_surface(ui, tree, &colors, None, None);
+                    let _ = render_ui_tree_with_surface(ui, tree, &colors, None, None, 0);
                 });
         });
         output
@@ -1776,7 +1964,7 @@ mod tests {
                     .frame(egui::Frame::NONE)
                     .show_inside(ui, |ui| {
                         let _ =
-                            render_ui_tree_with_surface(ui, &tree, &colors, None, Some(key));
+                            render_ui_tree_with_surface(ui, &tree, &colors, None, Some(key), 0);
                     });
             });
             let registry = crate::ui::focus::drain_text_surfaces(&ctx);
@@ -1860,7 +2048,7 @@ mod tests {
             egui::CentralPanel::default()
                 .frame(egui::Frame::NONE)
                 .show_inside(ui, |ui| {
-                    let _ = render_ui_tree_with_surface(ui, &tree, &colors, None, None);
+                    let _ = render_ui_tree_with_surface(ui, &tree, &colors, None, None, 0);
                     allocated_height = ui.min_rect().height();
                 });
         });
@@ -1930,6 +2118,7 @@ mod tests {
                         Some(&fits),
                         None,
                         None,
+                        0,
                     );
                 });
         });
@@ -1969,6 +2158,7 @@ mod tests {
                         Some(&fits),
                         None,
                         None,
+                        0,
                     );
                 });
         });
@@ -2023,7 +2213,7 @@ mod tests {
         let mut captured = RenderResult::default();
         let _ = ctx.run_ui(egui::RawInput::default(), |ui| {
             egui::CentralPanel::default().show_inside(ui, |ui| {
-                captured = render_ui_tree_with_surface(ui, &tree, &colors, None, None);
+                captured = render_ui_tree_with_surface(ui, &tree, &colors, None, None, 0);
             });
         });
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -3744,6 +3744,103 @@ fn focused_text_input_receives_typing_and_enter_submits() {
     wait_for_text_label(&mut h, pane_id, "keys:", "keys:2");
 }
 
+/// Stint 0720: typing faster than the guest's render round trip must not lose
+/// characters. The app path re-renders the last *committed* guest tree every
+/// host frame, and a real subprocess can never echo a keystroke in the same
+/// frame it was typed — so between the keystroke and the echo there are frames
+/// whose tree still carries the stale value. Those frames must leave the local
+/// draft alone. `focused_text_input_receives_typing_and_enter_submits` types one
+/// character and then waits, so it never enters that window; this drives two
+/// keystrokes on consecutive frames, then a keystroke on the frame right after
+/// Enter, where the guest has cleared the draft but its committed tree has not
+/// caught up.
+#[test]
+fn text_input_keeps_the_draft_while_the_guest_echo_is_in_flight() {
+    let mut h = HostHarness::new();
+
+    let app_dir =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("apps/dev/text-input-probe");
+    h.app
+        .launch_app_by_path_with_layout(&app_dir.to_string_lossy(), None, None, &[])
+        .expect("launch text-input-probe");
+    let pane_id = *h
+        .state()
+        .open_panes
+        .last()
+        .expect("a pane appears after launching text-input-probe");
+
+    let start = std::time::Instant::now();
+    loop {
+        h.run_frames(1);
+        let rendered = h.app.windows[h.app.active_window]
+            .panes
+            .get(&pane_id)
+            .and_then(Pane::as_app)
+            .is_some_and(
+                |pane| matches!(&pane.runtime, AppRuntime::Python(p) if p.has_rendered_tree()),
+            );
+        if rendered {
+            break;
+        }
+        assert!(
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            "text-input-probe did not render its first frame in time"
+        );
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+    h.focus_pane(pane_id);
+    h.run_frames(2);
+
+    let input_node_id = h.app.windows[h.app.active_window]
+        .panes
+        .get(&pane_id)
+        .and_then(Pane::as_app)
+        .map(|pane| pane.semantic_state())
+        .and_then(|state| {
+            state
+                .nodes
+                .iter()
+                .find(|n| n.role == "text_input")
+                .map(|n| n.id.clone())
+        })
+        .expect("semantic tree exposes the TextInput node");
+    h.inject_node_click(pane_id, &input_node_id, "left", None);
+    h.run_frames(2);
+
+    // Two keystrokes on two consecutive host frames, with no wait between —
+    // the second lands while the first is still round-tripping to the guest.
+    frame_with_events(
+        &mut h,
+        vec![
+            pressed_key(egui::Key::H),
+            egui::Event::Text("h".to_string()),
+        ],
+    );
+    frame_with_events(
+        &mut h,
+        vec![
+            pressed_key(egui::Key::I),
+            egui::Event::Text("i".to_string()),
+        ],
+    );
+    wait_for_text_label(&mut h, pane_id, "draft:", "draft:hi");
+
+    // Enter submits, then a keystroke on the very next frame — before the
+    // guest's cleared-draft tree arrives. The new character must start a fresh
+    // draft, never re-extend the submitted text.
+    frame_with_events(&mut h, vec![pressed_key(egui::Key::Enter)]);
+    frame_with_events(
+        &mut h,
+        vec![
+            pressed_key(egui::Key::Z),
+            egui::Event::Text("z".to_string()),
+        ],
+    );
+    wait_for_text_label(&mut h, pane_id, "submitted:", "submitted:hi");
+    wait_for_text_label(&mut h, pane_id, "draft:", "draft:z");
+}
+
 // ─── Editor release gate: host-driven layer (stint 0479) ─────────────────────
 
 /// One host-level input step for the notes pane: either raw text through

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -3974,4 +3974,88 @@ mod tests {
             }
         }
     }
+
+    /// Stint 0720 visual review: the todo app's add form, autofocused and
+    /// mid-draft. Drives the real app process through the production paths —
+    /// `a` opens the form on the guest's raw KeyEvent path, `autofocus` hands
+    /// the cursor to the host TextEdit with no click, and the typed draft is
+    /// painted from the host-owned buffer while it round-trips to the guest.
+    /// The assertion is the gate; the PNG is for a human/agent to look at.
+    #[test]
+    fn screenshot_todo_add_form_autofocused_draft() {
+        let app_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("apps/todo");
+        let mut h = PlexiUiHarness::new_sized(900.0, 620.0);
+        let pane_id = h.open_app_at(&app_dir, &[]).expect("launch todo");
+        h.wait_for_app_frame(pane_id, Duration::from_secs(30))
+            .expect("todo renders its first frame");
+        h.focus_pane(pane_id).expect("focus todo pane");
+        h.run_steps(2);
+
+        // `a` opens the add form (the guest's raw KeyEvent path — no text
+        // surface is focused yet).
+        h.harness().input_mut().events.push(egui::Event::Key {
+            key: egui::Key::A,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: egui::Modifiers::NONE,
+        });
+        h.step();
+
+        let pane_text = |h: &PlexiUiHarness| -> String {
+            h.with_app(|app| {
+                app.windows[app.active_window]
+                    .panes
+                    .get(&pane_id)
+                    .and_then(Pane::as_app)
+                    .map(|pane| {
+                        pane.semantic_state()
+                            .nodes
+                            .iter()
+                            .flat_map(|n| {
+                                n.label
+                                    .clone()
+                                    .into_iter()
+                                    .chain(n.value.clone().map(|v| format!("value:{v}")))
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n")
+                    })
+                    .unwrap_or_default()
+            })
+        };
+        let start = Instant::now();
+        while !pane_text(&h).contains("What needs doing?") {
+            assert!(
+                start.elapsed() < Duration::from_secs(30),
+                "todo add form never appeared:\n{}",
+                pane_text(&h)
+            );
+            h.step();
+            std::thread::sleep(Duration::from_millis(25));
+        }
+
+        // Type without clicking: `autofocus` must already own the cursor. One
+        // character per frame, faster than the guest can echo any of them.
+        for ch in "Buy oat milk".chars() {
+            h.harness()
+                .input_mut()
+                .events
+                .push(egui::Event::Text(ch.to_string()));
+            h.step();
+        }
+        let start = Instant::now();
+        while !pane_text(&h).contains("value:Buy oat milk") {
+            assert!(
+                start.elapsed() < Duration::from_secs(30),
+                "autofocused draft never round-tripped to the guest:\n{}",
+                pane_text(&h)
+            );
+            h.step();
+            std::thread::sleep(Duration::from_millis(25));
+        }
+
+        h.save_screenshot("/tmp/plexi-render-0720-todo-add-form.png")
+            .expect("render todo add form");
+    }
 }


### PR DESCRIPTION
Stint 0720 — text input autofocus gaps and todo input glitch.

## Root cause (todo input glitch)

`reconcile_text_input_buffer` in `src/host/wasm_render.rs` could only compare values, and "the guest hasn't caught up yet" is value-identical to "the guest pushed a new value". The app path re-renders the last *committed* guest tree every host frame, and the Python guest is a subprocess, so the echo is never same-frame:

- Frame N: user types `h` → buf `"h"`, `on_change` emitted, memory `("h","h")`.
- Frame N+1: same committed tree re-rendered, value still `""` → reconciler falls through and **resets buf to `""`**. `resp.changed()` doesn't fire, so nothing is sent. Caret clamps to 0.
- Frame N+2: echo arrives, `"h"` reappears.

Per-keystroke flicker, and outright data loss when typing faster than one committed guest frame per character. Submit was the same defect: the stale tree still carried the submitted text, so a character typed in the gap emitted `on_change "hiz"` and resurrected it.

`src/ui/text_field.rs` is untouched — the rename overlays own their buffer outright and never enter this path, exactly as the stint predicted.

## Fix

- `tree_seq: u64` on `LivePythonPane` / `LiveWasmPane`, threaded into `render_node`.
- `TextInputEditState { buf, seen_seq, pending, awaiting_submit }` replacing the `(String, String)` tuple. Same seq → keep the draft verbatim; new tree matching a `pending` echo → keep the draft; new tree not in `pending` → adopt (genuine `SetState`/reset). Submit clears locally and marks the next tree authoritative, unless the user typed in the gap.
- Two `info!` traces at the reconcile/focus-claim sites (edge-triggered, not per-frame).

## Autofocus

`autofocus=True` added to `apps/wikipedia`, `apps/github-issues`, `apps/logs` primary inputs.

## Tests

New `text_input_keeps_the_draft_while_the_guest_echo_is_in_flight` (real subprocess app, two keystrokes on consecutive frames with no wait). RED before the fix:

```
timed out waiting for label 'draft:hi' (last seen: Some("draft:i"))
```

Green after. Also: `wasm_render` 17, `focus::` 3, `rename` 21, reconciler unit suite rewritten with the stale-tree case whose absence let this ship. Visual review via new `screenshot_todo_add_form_autofocused_draft` in `src/ui_tests.rs` — 12 characters typed one per host frame, all survived.

Full suite: 2317 passed, 1 pre-existing PTY load flake (`pane_send_submit_unconfirmed_reports_observed_input_line`, passes in isolation, untouched by this diff).

## Caveats

- **Autofocus vs single-letter keys.** `github-issues` and `logs` bind single-letter shortcuts on their raw `KeyEvent` path; with autofocus the pane's default text surface takes those keystrokes until Escape. Same trade `todo` already accepts. Key maps intentionally not redesigned.
- **Accepted residual.** An app that *transforms* the value (uppercase/filter) emits a tree value never in `pending`, so it is adopted and the caret can jump to the end. Documented in the doc comment.
- **Latent, out of scope.** `render_column_children` renders the post-`Spacer(grow=True)` tail twice per frame, producing two `register_*_text_surface` entries; `SurfaceRegistry::default_for` returns the phantom sizing-pass id. No current app trips it (inputs precede the spacer). The new autofocus trace makes it self-diagnosing.
- `apps/todo/todo.py` deliberately untouched — stint 0714 rewrites it and rebases on top.