### PR TITLE
docs(distribution): pin skills CLI for refs

### DIFF
--- a/skills/AGENTS.md
+++ b/skills/AGENTS.md
@@ -65,3 +65,11 @@ surface that binary does not have or the version stamp is off.
 - Frontmatter: `plexi_version` = the tree's `Cargo.toml` version (stamped by
   `just bump`); `skill_version` bumps when content changes; `last_verified` =
   date the prose was last re-read against the CLI.
+
+## Traps
+
+- **Always pin the installer CLI in published `skills` install commands.** Use
+  `npx -y skills@latest add …`, including release refs such as
+  `ianjamesburke/plexi-skills#v<version>`. Older cached or globally shadowing
+  `skills` CLIs predate ref support and embed `#v…` in the clone URL, ending
+  with `not valid`.

--- a/website/src/content/docs/getting-started.md
+++ b/website/src/content/docs/getting-started.md
@@ -31,10 +31,20 @@ only when a feature uses them.
 Plexi is built to be driven by coding agents. If you use Claude Code, Cursor, Codex, or any agent that supports [skills](https://skills.sh/), install the Plexi skill so your agent knows the CLI:
 
 ```sh
-npx skills add ianjamesburke/plexi-skills
+npx -y skills@latest add ianjamesburke/plexi-skills
 ```
 
 Run it in a project to install for that project, or add `-g` for a global install. The skill documents the `plexi` CLI surface — panes, apps, contexts, notifications — so your agent can drive Plexi without trial and error. To update it later, run `npx skills update`.
+
+To pin the skill to a Plexi release, use the same current CLI:
+
+```sh
+npx -y skills@latest add "ianjamesburke/plexi-skills#v0.2.0"
+```
+
+If a pinned install reports a clone URL with the `#v…` ref embedded in it and
+ends with `not valid`, a stale `skills` CLI is being used. Run the command above
+instead of bare `npx skills add`.
 
 ## Your First Session
 


### PR DESCRIPTION
## Summary
- install the Plexi skill through `npx -y skills@latest`
- document the stale-CLI ref failure signature
- retain the installer-version trap in the skills publish contract

## Validation
- `npm run build` (website)
- `LC_ALL=C LANG=C npm run test` (website)
- `RUSTC_WRAPPER= cargo build`
- `RUSTC_WRAPPER= env -u PLEXI_CHANNEL -u PLEXI_CONTEXT_ROOT -u PLEXI_CONTEXT_ID -u PLEXI_CONTEXT_NAME -u PLEXI_SOCKET -u PLEXI_RUNNING -u PLEXI_PANE_ID cargo test --bin plexi`

## Mirror
The public `ianjamesburke/plexi-skills` mirror was not pushed: its publish contract requires explicit per-push babysitter-head clearance.