### PR TITLE
perf: keep long host operations off the UI thread (stint 0548)

### DIFF
--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1431,7 +1431,7 @@ impl PlexiApp {
                 let result: Result<serde_json::Value, String> = (|| {
                     if *off {
                         self.pane_heartbeats.remove(pane_id);
-                        self.save_workspace();
+                        self.mark_workspace_dirty();
                         log::info!("pane_heartbeat: pane_id={pane_id} disabled");
                         Ok(serde_json::json!({"ok": true, "heartbeat": null}))
                     } else {
@@ -1462,7 +1462,7 @@ impl PlexiApp {
                                         + std::time::Duration::from_millis(every_ms),
                                 },
                             );
-                            self.save_workspace();
+                            self.mark_workspace_dirty();
                             log::info!(
                                 "pane_heartbeat: pane_id={pane_id} configured every_ms={every_ms} while_idle_only={while_idle_only}"
                             );
@@ -2629,7 +2629,7 @@ impl PlexiApp {
                         write_json_response(rf, response);
                     }
                 }
-                self.save_workspace();
+                self.mark_workspace_dirty();
             }
             crate::app_protocol::AppRequest::CreateSubContext {
                 name,
@@ -2756,7 +2756,7 @@ impl PlexiApp {
                         }),
                     );
                 }
-                self.save_workspace();
+                self.mark_workspace_dirty();
             }
             crate::app_protocol::AppRequest::FocusContext { root } => {
                 log::warn!(
@@ -2783,7 +2783,7 @@ impl PlexiApp {
                     }
                 }
                 self.set_context_root(root.clone(), *context_id);
-                self.save_workspace();
+                self.mark_workspace_dirty();
             }
             crate::app_protocol::AppRequest::SetContextDescription {
                 description,
@@ -2797,7 +2797,7 @@ impl PlexiApp {
                 } else {
                     Some(trimmed)
                 };
-                self.save_workspace();
+                self.mark_workspace_dirty();
             }
             crate::app_protocol::AppRequest::ZoomIntoContext { context_id } => {
                 log::info!("pane_ipc: kind=zoom_into_context context_id={context_id}");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27,7 +27,7 @@ pub mod plexi_descriptor;
 pub(crate) mod python_env;
 pub mod registry;
 pub mod registry_watcher;
-mod render;
+pub(crate) mod render;
 pub(crate) mod screenshot;
 pub mod secrets_app;
 mod sync;
@@ -364,6 +364,23 @@ pub struct PlexiApp {
     /// is rescanned without a host restart.
     pub(crate) _registry_watcher: Option<crate::app::registry_watcher::AppRegistryWatcher>,
     pub(crate) registry_reload_rx: Option<ui_mailbox::MailboxReceiver<()>>,
+    /// Background `AppRegistry::load` result seam (stint 0548). A context
+    /// transition spawns the filesystem walk + manifest parse off the UI
+    /// thread and sends `(context_id, registry)` back here; drained in
+    /// `logic` each frame. The `context_id` guards staleness — if the user
+    /// has navigated away from the requesting context by the time the load
+    /// finishes, the result is discarded instead of applied.
+    pub(crate) registry_load_rx:
+        Option<ui_mailbox::MailboxReceiver<(u64, crate::app::registry::AppRegistry)>>,
+    /// True when workspace state changed since the last disk save. Set by
+    /// `mark_workspace_dirty()`, cleared by the debounce flush in
+    /// `update_preamble` (or by a forced `save_workspace_now()` on
+    /// shutdown/update-quit). Keeps a burst of workspace-changing calls from
+    /// each forcing a synchronous save on the UI thread (stint 0548).
+    pub(crate) workspace_dirty: bool,
+    /// Last time the workspace was flushed to disk, for the debounce tick in
+    /// `update_preamble`.
+    pub(crate) last_workspace_save: std::time::Instant,
     /// Watched panes scheduled for crash-restart. Value is the earliest `Instant` at
     /// which the restart fires — giving the developer ~2s to read the crash overlay.
     /// Spatial-grid minimap overlay state. Controls visibility, fade timer,
@@ -1617,6 +1634,9 @@ impl PlexiApp {
                     config_reload_rx: cfg_reload_rx.take(),
                     _registry_watcher: reg_watcher.take(),
                     registry_reload_rx: reg_reload_rx.take(),
+                    registry_load_rx: None,
+                    workspace_dirty: false,
+                    last_workspace_save: std::time::Instant::now(),
                     minimap: crate::render::minimap::MinimapState::with_visible(window_count >= 2),
                     last_page_x_per_row: HashMap::new(),
                     context_active_window: ws.context_active_window,
@@ -1895,6 +1915,9 @@ impl PlexiApp {
             config_reload_rx: cfg_reload_rx.take(),
             _registry_watcher: default_reg_watcher.take(),
             registry_reload_rx: default_reg_reload_rx.take(),
+            registry_load_rx: None,
+            workspace_dirty: false,
+            last_workspace_save: std::time::Instant::now(),
             minimap: crate::render::minimap::MinimapState::new(),
             last_page_x_per_row: HashMap::new(),
             context_active_window: HashMap::new(),
@@ -2413,6 +2436,9 @@ impl PlexiApp {
                 config_reload_rx: None,
                 _registry_watcher: None,
                 registry_reload_rx: None,
+                registry_load_rx: None,
+                workspace_dirty: false,
+                last_workspace_save: std::time::Instant::now(),
                 minimap: crate::render::minimap::MinimapState::new(),
                 last_page_x_per_row: HashMap::new(),
                 context_active_window: HashMap::new(),
@@ -3209,22 +3235,22 @@ impl eframe::App for PlexiApp {
                 Action::SplitHorizontal => {
                     self.windows[self.active_window].clear_zoom();
                     self.split_focused(false, None, false, false, None);
-                    self.save_workspace();
+                    self.mark_workspace_dirty();
                 }
                 Action::SplitVertical => {
                     self.windows[self.active_window].clear_zoom();
                     self.split_focused(true, None, false, false, None);
-                    self.save_workspace();
+                    self.mark_workspace_dirty();
                 }
                 Action::SplitRight => {
                     self.windows[self.active_window].clear_zoom();
                     self.split_focused_mirror(crate::host::command::Placement::Right);
-                    self.save_workspace();
+                    self.mark_workspace_dirty();
                 }
                 Action::SplitDown => {
                     self.windows[self.active_window].clear_zoom();
                     self.split_focused_mirror(crate::host::command::Placement::Below);
-                    self.save_workspace();
+                    self.mark_workspace_dirty();
                 }
                 Action::Navigate(dir) => {
                     let was_zoomed = self.windows[self.active_window].zoomed_pane.is_some();
@@ -3343,7 +3369,7 @@ impl eframe::App for PlexiApp {
                                 if let Some(i) = idx {
                                     log::info!("context_close: empty ctx={child_ctx_id} — closing immediately");
                                     self.delete_context(i);
-                                    self.save_workspace();
+                                    self.mark_workspace_dirty();
                                 }
                             } else {
                                 log::info!("context_close: ctx={child_ctx_id} has {} panes — showing dialog", state.items.len());
@@ -3354,7 +3380,7 @@ impl eframe::App for PlexiApp {
                         } else if self.execute_close_pane() {
                             ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                         } else {
-                            self.save_workspace();
+                            self.mark_workspace_dirty();
                         }
                     }
                 }
@@ -3369,7 +3395,7 @@ impl eframe::App for PlexiApp {
                 }
                 Action::NewTab => {
                     self.new_tab(self.active_window, None, false, None);
-                    self.save_workspace();
+                    self.mark_workspace_dirty();
                 }
                 Action::ToggleZoom => {
                     let (focused_tile, portal_target) = {
@@ -3423,7 +3449,13 @@ impl eframe::App for PlexiApp {
                 Action::Quit => {
                     if !self.confirm_quit() {
                         self.quitting = true;
-                        self.save_workspace();
+                        // Closing the viewport is the last frame this host
+                        // will run — a debounced `mark_workspace_dirty()`
+                        // never gets a later tick to flush, so quit paths
+                        // save synchronously (stint 0548).
+                        self.save_workspace_now();
+                        self.workspace_dirty = false;
+                        log::info!("workspace: synchronous save (quit)");
                         ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                     } else {
                         let now = std::time::Instant::now();
@@ -3440,7 +3472,9 @@ impl eframe::App for PlexiApp {
                             self.quit_press_count = 0;
                             self.quit_last_press = None;
                             self.quitting = true;
-                            self.save_workspace();
+                            self.save_workspace_now();
+                            self.workspace_dirty = false;
+                            log::info!("workspace: synchronous save (quit)");
                             ctx.send_viewport_cmd(egui::ViewportCommand::Close);
                         }
                     }
@@ -3505,7 +3539,7 @@ impl eframe::App for PlexiApp {
                                 log::info!(
                                     "pane_hide: pane={pane_id} name={name:?} hidden={new_val}"
                                 );
-                                self.save_workspace();
+                                self.mark_workspace_dirty();
                             }
                         }
                     }
@@ -3557,7 +3591,7 @@ impl eframe::App for PlexiApp {
                     let ctx_id = self.router.active().context_id;
                     if self.router.reorder_top_level(active, ContextMove::Up) {
                         log::info!("context: moved up — id={ctx_id}");
-                        self.save_workspace();
+                        self.mark_workspace_dirty();
                     }
                 }
                 Action::MoveContextDown => {
@@ -3565,7 +3599,7 @@ impl eframe::App for PlexiApp {
                     let ctx_id = self.router.active().context_id;
                     if self.router.reorder_top_level(active, ContextMove::Down) {
                         log::info!("context: moved down — id={ctx_id}");
-                        self.save_workspace();
+                        self.mark_workspace_dirty();
                     }
                 }
                 Action::IncreasePaneFontSize => {
@@ -3628,11 +3662,11 @@ impl eframe::App for PlexiApp {
                     } else {
                         self.new_page_right();
                     }
-                    self.save_workspace();
+                    self.mark_workspace_dirty();
                 }
                 Action::NewContext => {
                     self.new_context();
-                    self.save_workspace();
+                    self.mark_workspace_dirty();
                 }
                 Action::NewChildContext => {
                     self.new_child_context_from_keyboard();
@@ -3676,7 +3710,7 @@ impl eframe::App for PlexiApp {
                             let idx = self.router.active_idx();
                             log::info!("close_context: closing ctx={ctx_id} idx={idx} (empty={}, confirm={confirm})", state.items.is_empty());
                             self.delete_context(idx);
-                            self.save_workspace();
+                            self.mark_workspace_dirty();
                         } else {
                             log::info!(
                                 "close_context: ctx={ctx_id} has {} panes, showing confirm dialog",
@@ -3744,6 +3778,11 @@ impl eframe::App for PlexiApp {
             self.reload_app_registry_for_root(&root);
         }
 
+        // Context-transition registry rescan (stint 0548): drain the
+        // background `AppRegistry::load` result. Lives in `logic`, never
+        // `ui` — the load can finish while the window is hidden or occluded.
+        self.drain_registry_load();
+
         // Handle window close request (X button or macOS Cmd+Q OS event).
         //
         // On macOS, Cmd+Q fires BOTH a keyboard event (consumed by keys.rs →
@@ -3769,11 +3808,20 @@ impl eframe::App for PlexiApp {
                 self.quit_press_count
             );
             if self.quitting {
-                self.save_workspace();
+                // Triple-tap already completed and the window is closing this
+                // frame — no later tick will run the debounce flush, so save
+                // synchronously (stint 0548).
+                self.save_workspace_now();
+                self.workspace_dirty = false;
+                log::info!("workspace: synchronous save (quit)");
             } else if self.confirm_quit() && self.quit_press_count > 0 {
                 ctx.send_viewport_cmd(egui::ViewportCommand::CancelClose);
             } else {
-                self.save_workspace();
+                // X button / system close with no triple-tap in progress —
+                // the window closes immediately, same reasoning as above.
+                self.save_workspace_now();
+                self.workspace_dirty = false;
+                log::info!("workspace: synchronous save (quit)");
             }
         }
 

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -15,6 +15,16 @@ fn update_check_due(last_update_check: std::time::Instant, now: std::time::Insta
     now.saturating_duration_since(last_update_check) >= crate::cli::updater::CHECK_INTERVAL
 }
 
+/// Debounce window for `mark_workspace_dirty()` → disk flush. Keeps a burst of
+/// workspace-changing calls (drag, resize, rapid pane churn) from each forcing
+/// a synchronous save on the UI thread. `pub(crate)` so `mark_workspace_dirty`
+/// can schedule its delayed wake at the same interval the flush tick checks.
+pub(crate) const WORKSPACE_SAVE_DEBOUNCE_MS: u64 = 1_000;
+
+fn workspace_save_due(last: std::time::Instant, now: std::time::Instant) -> bool {
+    now.saturating_duration_since(last) >= std::time::Duration::from_millis(WORKSPACE_SAVE_DEBOUNCE_MS)
+}
+
 impl PlexiApp {
     /// Keep app runtime state truthful before serving pane IPC. This lives in
     /// the logic preamble because eframe can skip `ui()` while a host is
@@ -41,7 +51,7 @@ impl PlexiApp {
         if let Some(ctx_path) = crate::config::take_adopted_context_path() {
             log::info!("adopted context path: {}", ctx_path.display());
             self.new_context_at_path(ctx_path);
-            self.save_workspace();
+            self.mark_workspace_dirty();
         }
         #[cfg(target_os = "macos")]
         {
@@ -56,7 +66,7 @@ impl PlexiApp {
                         log::info!("finder_service: opening context for {}", path.display());
                         self.new_context_at_path(path);
                     }
-                    self.save_workspace();
+                    self.mark_workspace_dirty();
                 }
             });
         }
@@ -104,6 +114,12 @@ impl PlexiApp {
                     self.last_update_check = now;
                 }
             }
+            if self.workspace_dirty && workspace_save_due(self.last_workspace_save, now) {
+                self.save_workspace_now();
+                self.workspace_dirty = false;
+                self.last_workspace_save = now;
+                log::debug!("workspace: debounce flush after churn");
+            }
         }
         crate::platform::logging::mark_ui_phase(
             &self.ui_phase,
@@ -125,7 +141,9 @@ impl PlexiApp {
             // without terminating the process. Save synchronously, then exit
             // successfully so launchd also treats this as a clean stop.
             log::info!("host: shutdown requested — saving workspace and exiting");
-            self.save_workspace();
+            self.save_workspace_now();
+            self.workspace_dirty = false;
+            log::info!("workspace: synchronous save (shutdown/update-quit)");
             std::process::exit(0);
         }
         if let Some(rx) = &self.update_rx {
@@ -135,7 +153,9 @@ impl PlexiApp {
             }
         }
         if self.update_quit_pending {
-            self.save_workspace();
+            self.save_workspace_now();
+            self.workspace_dirty = false;
+            log::info!("workspace: synchronous save (shutdown/update-quit)");
             log::info!("ui: restarting for update");
             if let Some(bundle) = std::env::current_exe().ok().and_then(|p| {
                 p.ancestors()
@@ -297,7 +317,7 @@ impl PlexiApp {
                                 self.welcome_delete_press_count = 0;
                                 self.welcome_delete_last_press = None;
                                 self.delete_context(ctx_idx);
-                                self.save_workspace();
+                                self.mark_workspace_dirty();
                                 return;
                             }
                         }
@@ -1067,7 +1087,7 @@ impl PlexiApp {
                         }
                         crate::spatial::tiling::TabBarAction::Reorder { from_idx, to_idx } => {
                             if self.reorder_tab(container_tile, from_idx, to_idx) {
-                                self.save_workspace();
+                                self.mark_workspace_dirty();
                             }
                         }
                     }

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -99,6 +99,11 @@ fn switching_contexts_refreshes_workspace_app_registry() {
     });
 
     app.switch_workspace(1);
+    // Registry rescan is async (stint 0548) — spin-wait for the background
+    // load to land instead of asserting synchronously.
+    while !app.drain_registry_load() {
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
 
     assert!(
         app.registry.get("local-tool").is_some(),
@@ -1069,6 +1074,11 @@ fn context_transition_rescans_registry() {
     let idx0 = app.router.active_idx();
     app.router.get_mut(idx0).root = dir_a.clone();
     app.apply_context_transition_effects();
+    // Registry rescan is async (stint 0548) — spin-wait for the background
+    // load to land instead of asserting synchronously.
+    while !app.drain_registry_load() {
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
 
     let ids: Vec<String> = app
         .registry
@@ -1113,6 +1123,9 @@ fn context_transition_rescans_registry() {
     });
     let ctx_b_idx = app.router.len() - 1;
     app.switch_workspace(ctx_b_idx);
+    while !app.drain_registry_load() {
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
 
     let ids: Vec<String> = app
         .registry
@@ -2979,3 +2992,100 @@ fn audit_0678_two_contexts_accept_the_same_root() {
 // test existed to catch drifting apart can no longer diverge: there is only
 // one field. The test was deleted rather than adapted; nothing here survives
 // the fix to assert.
+
+// ── Perf gate: long host operations off the UI thread (stint 0548) ────────
+//
+// `delete_context`/`delete_window` used to drop removed `Window`s (and their
+// `WasmPythonRuntime` panes) synchronously on the UI thread, which blocks on
+// `WasmPythonRuntime::drop`'s `thread.join()` shutdown handshake. The fix
+// hands the doomed windows to a background thread and returns immediately.
+// These gates lock that: the synchronous portion of each call must return in
+// single-digit milliseconds regardless of how many windows/panes are queued
+// for disposal. Timing assertions are inherently machine-dependent, so both
+// are `#[ignore]`d — run explicitly on a quiet machine, not in CI.
+
+#[test]
+#[ignore = "perf-gate: run explicitly on a quiet machine"]
+fn perf_gate_delete_context_does_not_block_ui_thread() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let root_id = app.router.active().context_id;
+
+    // A handful of child contexts, each with its own window+pane, all
+    // parented under root so a single `delete_context(root_idx)` cascades
+    // and disposes every one of them.
+    for i in 0..8u64 {
+        let ctx_id = 9_100 + i;
+        let win_id = 9_200 + i;
+        let pane_id = 9_300 + i;
+        app.router.push(crate::host::context::Context {
+            name: format!("child-{i}"),
+            root: std::path::PathBuf::from(format!("/tmp/perf-gate-delete-context-{i}")),
+            description: None,
+            context_id: ctx_id,
+            parent_id: Some(root_id),
+            depth: 1,
+            parked: false,
+        });
+        let mut tiles = egui_tiles::Tiles::default();
+        let root_tile = tiles.insert_pane(pane_id);
+        let mut panes = std::collections::HashMap::new();
+        panes.insert(pane_id, test_app_pane(pane_id));
+        app.windows.push(crate::host::context::Window {
+            name: String::new(),
+            path: std::path::PathBuf::from(format!("/tmp/perf-gate-delete-context-{i}")),
+            tree: egui_tiles::Tree::new(format!("plexi_perf_gate_{i}"), root_tile, tiles),
+            panes,
+            focused_pane: None,
+            zoomed_pane: None,
+            grid_x: 0,
+            grid_y: 0,
+            window_id: win_id,
+            context_id: ctx_id,
+        });
+    }
+
+    let root_idx = app.router.position(|c| c.context_id == root_id).unwrap();
+    let start = std::time::Instant::now();
+    app.delete_context(root_idx);
+    let elapsed = start.elapsed();
+    eprintln!("perf_gate_delete_context_does_not_block_ui_thread: elapsed={elapsed:?}");
+
+    assert!(
+        elapsed < std::time::Duration::from_millis(20),
+        "delete_context must not block the UI thread on window disposal; took {elapsed:?}"
+    );
+}
+
+#[test]
+#[ignore = "perf-gate: run explicitly on a quiet machine"]
+fn perf_gate_context_transition_does_not_block_ui_thread() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+
+    let root = tempfile::tempdir().expect("root");
+    app.router.get_mut(0).root = root.path().to_path_buf();
+
+    // The registry rescan itself now runs on a background thread (stint
+    // 0548), so this gate covers only the synchronous remainder: agent-host
+    // reload, watcher restart, and config reload.
+    let start = std::time::Instant::now();
+    app.apply_context_transition_effects();
+    let elapsed = start.elapsed();
+    eprintln!("perf_gate_context_transition_does_not_block_ui_thread: elapsed={elapsed:?}");
+
+    assert!(
+        elapsed < std::time::Duration::from_millis(25),
+        "apply_context_transition_effects' synchronous remainder must not block \
+         the UI thread waiting on the registry rescan; took {elapsed:?}"
+    );
+
+    // Drain the background load so the test doesn't leak a dangling thread
+    // assertion for the next test in the binary.
+    while !app.drain_registry_load() {
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -5916,7 +5916,7 @@ mod tests {
             let live_address = live_state_address(&harness, pane_id);
             seed_items(&live_address, &serde_json::json!(["buy milk"]));
 
-            harness.app.save_workspace();
+            harness.app.save_workspace_now();
             let saved = crate::workspace::WorkspaceFile::load().expect("saved workspace");
             let record = saved
                 .windows

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -1534,12 +1534,12 @@ impl PlexiApp {
             PaletteCommand::SplitRight => {
                 self.windows[self.active_window].clear_zoom();
                 self.split_focused(false, None, false, false, None);
-                self.save_workspace();
+                self.mark_workspace_dirty();
             }
             PaletteCommand::SplitDown => {
                 self.windows[self.active_window].clear_zoom();
                 self.split_focused(true, None, false, false, None);
-                self.save_workspace();
+                self.mark_workspace_dirty();
             }
             PaletteCommand::OpenConfig => {
                 crate::config::open_config_file();
@@ -1563,7 +1563,7 @@ impl PlexiApp {
         self.windows[self.active_window].clear_zoom();
         let initial_cmd = format!("plexi run {}", shell_single_quote(name));
         self.split_focused(false, Some(&initial_cmd), false, false, cwd);
-        self.save_workspace();
+        self.mark_workspace_dirty();
     }
 
     /// Focus an agent pane selected in the palette. Routes through the same

--- a/src/overlays/confirmations.rs
+++ b/src/overlays/confirmations.rs
@@ -70,7 +70,7 @@ impl PlexiApp {
             if self.execute_close_pane() {
                 ctx.send_viewport_cmd(egui::ViewportCommand::Close);
             } else {
-                self.save_workspace();
+                self.mark_workspace_dirty();
             }
         } else if cancelled {
             self.pending_close = false;
@@ -177,7 +177,7 @@ impl PlexiApp {
                     state.context_name
                 );
                 self.delete_context(i);
-                self.save_workspace();
+                self.mark_workspace_dirty();
             } else {
                 log::warn!(
                     "context_close: close_all ctx={} not found in router",
@@ -191,7 +191,7 @@ impl PlexiApp {
                 state.context_name
             );
             self.dissolve_portal(state.context_id);
-            self.save_workspace();
+            self.mark_workspace_dirty();
         } else if cancelled {
             log::info!("context_close: cancelled ctx={}", state.context_id);
         } else {

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -528,7 +528,7 @@ impl PlexiApp {
                         let ctx_id = self.router.get(idx).context_id;
                         self.set_context_root(resolved, Some(ctx_id));
                     }
-                    self.save_workspace();
+                    self.mark_workspace_dirty();
                 }
             }
         }
@@ -720,7 +720,7 @@ impl PlexiApp {
             };
             self.editing_description = None;
             self.pop_focus_layer(&crate::app::FocusKind::ContextDescription);
-            self.save_workspace();
+            self.mark_workspace_dirty();
             log::info!("context_description: updated ctx_idx={ctx_idx}");
         }
     }

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -477,7 +477,7 @@ impl PlexiApp {
         });
         self.context_active_window.insert(ctx_id, win_id);
 
-        self.save_workspace();
+        self.mark_workspace_dirty();
         Ok(ChildContext {
             context_id: ctx_id,
             pane_ids: child_pane_ids,
@@ -677,7 +677,7 @@ impl PlexiApp {
             .expect("just-inserted subcontext must be in router");
         self.switch_workspace(new_ctx_idx);
 
-        self.save_workspace();
+        self.mark_workspace_dirty();
     }
 
     pub(crate) fn new_context(&mut self) {
@@ -746,7 +746,7 @@ impl PlexiApp {
 
         let new_ctx_idx = self.router.len() - 1;
         self.open_context_rename(new_ctx_idx);
-        self.save_workspace();
+        self.mark_workspace_dirty();
         log::info!(
             "new_context_empty: emitting ContextCreated context_id={ctx_id} name={}",
             self.rename_buffer
@@ -761,7 +761,7 @@ impl PlexiApp {
     /// Create a new context at a specific directory path. The terminal pane
     /// opens at `path` and the context root is set to it. Named after the
     /// directory basename, unless the path has a `.plexi/workspace.toml` with
-    /// `[context]` defaults. Callers must call `save_workspace()` afterward.
+    /// `[context]` defaults. Callers must call `mark_workspace_dirty()` afterward.
     pub(crate) fn new_context_at_path(&mut self, path: PathBuf) {
         log::info!("new_context_at_path: path={}", path.display());
 
@@ -1068,7 +1068,31 @@ impl PlexiApp {
         {
             revoke_window_pane_credentials(window);
         }
-        self.windows.retain(|c| !deleted.contains(&c.context_id));
+        let doomed: Vec<Window> = {
+            let mut kept = Vec::new();
+            let mut doomed = Vec::new();
+            for w in std::mem::take(&mut self.windows) {
+                if deleted.contains(&w.context_id) {
+                    doomed.push(w);
+                } else {
+                    kept.push(w);
+                }
+            }
+            self.windows = kept;
+            doomed
+        };
+        log::info!(
+            "delete_context: disposing {} window(s) off UI thread (ctx_id={target_ctx_id})",
+            doomed.len()
+        );
+        std::thread::spawn(move || {
+            let start = std::time::Instant::now();
+            drop(doomed);
+            log::debug!(
+                "delete_context: window disposal thread finished in {:?}",
+                start.elapsed()
+            );
+        });
 
         // 4. Remove Portal tiles in surviving windows that point to any deleted ctx.
         for win in &mut self.windows {
@@ -1257,7 +1281,18 @@ impl PlexiApp {
             .insert(removed_ws_id, self.minimap.visible);
 
         revoke_window_pane_credentials(&self.windows[index]);
-        self.windows.remove(index);
+        let removed_window = self.windows.remove(index);
+        log::info!(
+            "delete_window: disposing window off UI thread (window_id={removed_win_id}, ctx_id={removed_ws_id})"
+        );
+        std::thread::spawn(move || {
+            let start = std::time::Instant::now();
+            drop(removed_window);
+            log::debug!(
+                "delete_window: window disposal thread finished in {:?}",
+                start.elapsed()
+            );
+        });
 
         // If the deleted window was the stored last-visited for its context,
         // point to another window in the same context so the palette doesn't
@@ -1447,7 +1482,7 @@ impl PlexiApp {
                 "context: unparked '{}' (idx={idx})",
                 self.router.get(idx).name
             );
-            self.save_workspace();
+            self.mark_workspace_dirty();
             return;
         }
 
@@ -1468,7 +1503,7 @@ impl PlexiApp {
         }
         // If all contexts are parked, stay on the current one (degenerate case).
 
-        self.save_workspace();
+        self.mark_workspace_dirty();
     }
 
     /// Park a specific context by index, moving focus to the nearest unparked neighbor.
@@ -1489,7 +1524,7 @@ impl PlexiApp {
                 self.switch_workspace(new_idx);
             }
         }
-        self.save_workspace();
+        self.mark_workspace_dirty();
     }
 
     /// Unpark a specific context by index and switch focus to it.
@@ -1500,7 +1535,7 @@ impl PlexiApp {
             self.router.get(idx).name
         );
         self.switch_workspace(idx);
-        self.save_workspace();
+        self.mark_workspace_dirty();
     }
 
     /// Resolve an optional context id to a router index. Falls back to the
@@ -1557,16 +1592,38 @@ impl PlexiApp {
     ///      must still get its agents attached.
     pub(crate) fn apply_context_transition_effects(&mut self) {
         let root = self.router.active().root.clone();
+        let context_id = self.router.active().context_id;
         log::info!(
-            "transition_context: ctx_id={} root={} — rescanning registry + reloading config + restarting watcher",
-            self.router.active().context_id,
+            "transition_context: ctx_id={context_id} root={} — rescanning registry off-thread + reloading config + restarting watcher",
             root.display()
         );
-        self.registry = crate::app::registry::AppRegistry::load(&root);
-        // Same workspace resolution the registry just performed (cwd-walk to
-        // the channel dir) — agents live in that workspace's `agents/` dir.
+        // The full registry rescan (apps/agents dir walk + every manifest.toml
+        // parse) is a filesystem-bound operation that can stall the UI thread
+        // on a workspace with many apps. Spawn it off-thread and apply the
+        // result later via `registry_load_rx`, guarded by `context_id` so a
+        // stale result (user already navigated elsewhere) is dropped instead
+        // of applied (stint 0548).
+        let (tx, rx) = crate::app::ui_mailbox::UiMailbox::channel(
+            std::sync::Arc::clone(&self.ui_wake),
+            "registry_load",
+        );
+        self.registry_load_rx = Some(rx);
+        let load_root = root.clone();
+        std::thread::spawn(move || {
+            let start = std::time::Instant::now();
+            let registry = crate::app::registry::AppRegistry::load(&load_root);
+            log::debug!(
+                "transition_context: registry load thread finished in {:?} (ctx_id={context_id})",
+                start.elapsed()
+            );
+            let _ = tx.send((context_id, registry));
+        });
+        // Same workspace resolution `AppRegistry::load` performs internally
+        // (cwd-walk to the channel dir) — cheap enough to run synchronously,
+        // and agents live in that workspace's `agents/` dir, so the agent host
+        // reload doesn't need to wait on the background registry scan.
         self.agent_host
-            .reload_workspace(self.registry.loaded_workspace.clone());
+            .reload_workspace(crate::app::registry::resolve_workspace_root(&root));
         let watch_dirs = crate::app::registry::registry_watch_dirs(&root);
         match crate::app::registry_watcher::start(watch_dirs, std::sync::Arc::clone(&self.ui_wake))
         {
@@ -1582,6 +1639,37 @@ impl PlexiApp {
         // Reload config so workspace-scoped config.toml applies immediately —
         // both on initial launch and on context switches.
         self.reload_config_for_active_context();
+    }
+
+    /// Drain the background `AppRegistry::load` result queued by
+    /// [`Self::apply_context_transition_effects`]. Only the newest queued
+    /// result is applied — anything older is superseded. Returns `true` when
+    /// a result was applied or discarded (i.e. a message was drained at
+    /// all), so tests can spin-wait on this instead of guessing a sleep.
+    pub(crate) fn drain_registry_load(&mut self) -> bool {
+        let Some(rx) = &self.registry_load_rx else {
+            return false;
+        };
+        let mut latest = None;
+        while let Ok((loaded_ctx_id, registry)) = rx.try_recv() {
+            latest = Some((loaded_ctx_id, registry));
+        }
+        let Some((loaded_ctx_id, registry)) = latest else {
+            return false;
+        };
+        if self.router.active().context_id == loaded_ctx_id {
+            let app_count = registry.list().len();
+            self.registry = registry;
+            log::info!(
+                "transition_context: registry reload applied for ctx_id={loaded_ctx_id} ({app_count} apps)"
+            );
+        } else {
+            log::debug!(
+                "transition_context: discarding stale registry load for ctx_id={loaded_ctx_id} — active context is now {}",
+                self.router.active().context_id
+            );
+        }
+        true
     }
 
     /// True when the active window holds a Portal tile targeting `child_ctx_id`,
@@ -1862,7 +1950,35 @@ impl PlexiApp {
         }
     }
 
-    pub(crate) fn save_workspace(&self) {
+    /// Mark the workspace dirty so the debounce flush in `update_preamble`
+    /// picks it up on its next tick, instead of writing to disk synchronously
+    /// on the UI thread for every call site that used to call
+    /// `save_workspace_now` directly. No I/O here — just a flag.
+    ///
+    /// The debounce flush only runs inside a frame, and Plexi legitimately
+    /// produces zero frames while fully idle (App Nap trap). Without a
+    /// scheduled wake, a mutation that happens to be the host's last activity
+    /// before it goes idle would never reach a frame where the debounce
+    /// deadline is checked, and the workspace would stay unsaved
+    /// indefinitely. On the 0→1 transition, arm a one-shot background wake
+    /// through the sanctioned `ui_wake` seam (never a raw `request_repaint()`)
+    /// timed to land after the debounce window, guaranteeing at least one
+    /// later frame observes `workspace_dirty` and flushes it.
+    pub(crate) fn mark_workspace_dirty(&mut self) {
+        let was_clean = !self.workspace_dirty;
+        self.workspace_dirty = true;
+        if was_clean {
+            let wake = std::sync::Arc::clone(&self.ui_wake);
+            std::thread::spawn(move || {
+                std::thread::sleep(std::time::Duration::from_millis(
+                    crate::app::render::WORKSPACE_SAVE_DEBOUNCE_MS,
+                ));
+                wake.wake("workspace_dirty_flush");
+            });
+        }
+    }
+
+    pub(crate) fn save_workspace_now(&self) {
         crate::platform::logging::mark_ui_phase(
             &self.ui_phase,
             crate::platform::logging::UiPhase::WorkspaceSave,

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -216,6 +216,12 @@ fn pane_heartbeat_persists_with_pane_state() {
     });
     h.run_frames(1);
 
+    // Workspace saves are debounced off the UI thread (stint 0548); the
+    // heartbeat handler only marks the workspace dirty. Force the flush here
+    // so the test observes deterministic persistence instead of racing the
+    // 1s debounce tick.
+    h.app.save_workspace_now();
+
     let saved = crate::workspace::WorkspaceFile::load().expect("saved workspace");
     let heartbeat = saved
         .windows

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -607,7 +607,7 @@ impl PlexiApp {
                         drop.slot
                     );
                 }
-                self.save_workspace();
+                self.mark_workspace_dirty();
             }
             self.drag_context = None;
         }
@@ -649,7 +649,7 @@ impl PlexiApp {
                     );
                     let ctx_id = self.router.get(i).context_id;
                     self.set_context_root(path, Some(ctx_id));
-                    self.save_workspace();
+                    self.mark_workspace_dirty();
                 }
                 WindowMenuAction::OpenRootOverlay => {
                     let existing = self.router.get(i).root.display().to_string();


### PR DESCRIPTION
## Summary

Implements stint 0548. No linked GitHub issue — stint is authoritative.

- `delete_context`/`delete_window` no longer drop removed `Window`s (and their `WasmPythonRuntime` panes) synchronously on the UI thread — the guest-shutdown handshake in `WasmPythonRuntime::drop` was blocking `thread.join()` for 277ms–6.5s per the 0541 audit. Doomed windows are now handed to a background thread for disposal, guarded by the existing `revoke_window_pane_credentials` synchronous cleanup.
- Context transitions now rescan the app registry (`AppRegistry::load`, a filesystem walk + manifest parse) off the UI thread via a new `ui_mailbox` seam, guarded by `context_id` so a stale result is discarded if the user navigated away before the load finished. Drained in `App::logic`, never `ui`, per the hidden-window trap.
- `workspace_save` is now debounced (1s window) behind a `workspace_dirty` flag instead of writing to disk synchronously on every one of ~40 call sites; quit/shutdown/update-quit paths still force a synchronous `save_workspace_now()` so no state is lost on exit. A one-shot background wake (via the sanctioned `ui_wake` seam, not a raw `request_repaint()`) guarantees the debounce flush still runs even if the host goes idle right after the last mutation.
- Adds two `#[ignore]`d `perf_gate_*` regression tests asserting the synchronous portion of `delete_context` and the context-transition path stay under a tight wall-clock budget (verified locally: ~3ms and ~6ms respectively, well under the 20ms/25ms budgets).

## Done When

- Reproduce the correlated round-trip stall via the `CPython-WASM perf` telemetry (audit already documented the correlation in stint 0541; this PR did not re-drive a live host reproduction — see stint 0548 body).
- Every long synchronous UI-thread operation identified by the audit (context dissolve/`delete_context`, `workspace_save`, `transition_context`'s registry rescan) is made incremental or asynchronous per the ordering-dependency rule in the task.
- New background completions wake the host via `ui_mailbox`, never a raw `request_repaint()`.
- New drains for external/background state run in `App::logic`, never `ui`.
- A regression guard fails if one of these operations blocks the UI thread beyond a set budget.

## Test evidence

- `cargo build`: clean.
- `cargo test --bin plexi` (full suite, PLEXI_* env stripped): 2312 passed, 3 failed — all 3 confirmed pre-existing/unrelated: 2 are `testing::cargo_lease::*` flakes in files untouched by this diff, 1 (`host::wasm_python::tests::headless_frame_fails_fast_when_the_guest_dies_at_import`) is a documented CPU-contention flake (its own comment says so) that passes cleanly in isolation (10s, well under its 15s budget).
- `cargo test --bin plexi perf_gate_ -- --ignored`: both new gates pass — `perf_gate_delete_context_does_not_block_ui_thread` and `perf_gate_context_transition_does_not_block_ui_thread`.
- Codex review (max 2 rounds) run pre-push: 2 real P1s found and fixed (quit-path save ordering, idle-forever debounce wake); 1 finding accepted as out-of-scope follow-up (backgrounding the `workspace_save_now` disk write itself — this stint's spec only calls for debouncing it, not making the write async).

**Validate attempt 1:** PASS
**Test date:** 2026-08-03