### PR TITLE
security(host/notifications): derive CLI sender identity from the socket peer (stint 0636)

### DIFF
--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -287,6 +287,7 @@ impl PlexiApp {
                                     PendingNotification {
                                         notify_id,
                                         sender_pane_id: pane_id,
+                                        dismiss_owner_pane_id: 0,
                                         source_context_id,
                                         source_window_id,
                                         scope: crate::app_protocol::NotifyScope::default(),
@@ -1028,6 +1029,7 @@ impl PlexiApp {
                         PendingNotification {
                             notify_id,
                             sender_pane_id,
+                            dismiss_owner_pane_id: 0,
                             source_context_id,
                             source_window_id: notif_source_win_id,
                             title,

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -963,6 +963,7 @@ impl PlexiApp {
                 PendingNotification {
                     notify_id,
                     sender_pane_id: 0,
+                    dismiss_owner_pane_id: 0,
                     source_context_id: 0,
                     source_window_id: 0,
                     title: "Config Error".to_string(),

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -2305,6 +2305,7 @@ impl PlexiApp {
                 scope,
                 source_context_id,
                 source_pane_id,
+                peer_pid,
                 ..
             } => {
                 let internal_id = notify_id.clone().unwrap_or_else(|| {
@@ -2317,49 +2318,62 @@ impl PlexiApp {
                     )
                 });
                 log::info!(
-                    "pane_ipc: kind=notify title={:?} choices={} scope={:?} source_context_id={:?} source_pane_id={:?} response_file={:?}",
+                    "pane_ipc: kind=notify title={:?} choices={} scope={:?} peer_pid={:?} response_file={:?}",
                     title,
                     options.len(),
                     scope,
-                    source_context_id,
-                    source_pane_id,
+                    peer_pid,
                     response_file
                 );
-                // Caller identity comes from the command's own fields, never
-                // from dispatch-time active state — by dispatch, the active
-                // context may be one the sender has never seen, and stamping
-                // it can hide a context-scoped notification from everyone.
-                // The sending pane's live location is the ground truth (a
-                // pane can move between contexts after its env was stamped);
-                // the claimed context id covers callers whose pane is gone.
-                let pane_window_idx = source_pane_id
-                    .and_then(|pid| self.find_pane_in_any_window(pid))
-                    .map(|(win_idx, _)| win_idx);
-                let (caller_context_id, caller_window_id) = match pane_window_idx {
-                    Some(win_idx) => (
-                        Some(self.windows[win_idx].context_id),
-                        Some(self.windows[win_idx].window_id),
-                    ),
-                    None => match source_context_id
-                        .filter(|id| self.router.iter().any(|c| c.context_id == *id))
-                    {
-                        Some(ctx_id) => (
-                            Some(ctx_id),
-                            self.windows
-                                .iter()
-                                .find(|w| w.context_id == ctx_id)
-                                .map(|w| w.window_id),
-                        ),
-                        None => (None, None),
-                    },
+                // Caller identity is resolved from the socket peer's OS
+                // credential (`peer_pid`, host-established in
+                // `handle_socket_connection`), never from dispatch-time
+                // active state and never from the client-claimed
+                // `source_context_id`/`source_pane_id` fields — those are
+                // attacker-controlled and, before this fix, let any process
+                // with socket access widen or misattribute a notification's
+                // scope by lying about which pane sent it.
+                let resolved = peer_pid
+                    .as_deref()
+                    .and_then(|ancestry| self.resolve_socket_peer_pane(ancestry));
+                if let Some((resolved_pane_id, resolved_context_id, resolved_window_id)) =
+                    resolved
+                {
+                    log::info!(
+                        "pane_ipc: peer identity: notify sender resolved to pane={resolved_pane_id} context={resolved_context_id} window={resolved_window_id} peer_pid={peer_pid:?}"
+                    );
+                }
+                if source_pane_id.is_some() || source_context_id.is_some() {
+                    let claimed_matches = resolved
+                        .is_some_and(|(pane_id, context_id, _)| {
+                            source_pane_id.is_none_or(|claimed| claimed == pane_id)
+                                && source_context_id.is_none_or(|claimed| claimed == context_id)
+                        });
+                    if !claimed_matches {
+                        log::warn!(
+                            "pane_ipc: notify: claimed identity (source_context_id={source_context_id:?} source_pane_id={source_pane_id:?}) \
+                             disagrees with host-resolved sender {resolved:?} — using the host-resolved identity only"
+                        );
+                    }
+                }
+                let (caller_context_id, caller_window_id) = match resolved {
+                    Some((_, context_id, window_id)) => (Some(context_id), Some(window_id)),
+                    None => (None, None),
                 };
                 // Unscoped `plexi notify` belongs to the context that produced
                 // it; `--scope global` is the opt-in. A context or window
-                // scope with no resolvable sender (outside-pane caller, or a
-                // stale identity) escalates to global: showing the
-                // notification everywhere is the only resolution that cannot
-                // hide it, and attaching it to some other context would
-                // fabricate provenance.
+                // scope with no resolvable sender (outside-pane caller, a
+                // dead peer pid, or a peer that matches no live terminal
+                // pane) escalates to global: showing the notification
+                // everywhere is the only resolution that cannot hide it, and
+                // attaching it to some other context would fabricate
+                // provenance. `caller_context_id` and `caller_window_id` are
+                // always both `Some` or both `None` — they come from the
+                // same resolved `(pane_id, context_id, window_id)` tuple, so
+                // there is no "context resolved but window didn't" case to
+                // narrow separately; the pre-fix `source_context_id`-only
+                // fallback that produced that case is exactly the forgeable
+                // input this stint removes.
                 let effective_scope = match scope.unwrap_or_default() {
                     crate::app_protocol::NotifyScope::Global => {
                         crate::app_protocol::NotifyScope::Global
@@ -2370,17 +2384,6 @@ impl PlexiApp {
                     crate::app_protocol::NotifyScope::Window if caller_window_id.is_some() => {
                         crate::app_protocol::NotifyScope::Window
                     }
-                    crate::app_protocol::NotifyScope::Window if caller_context_id.is_some() => {
-                        // The context resolved but has no live window (parked).
-                        // Narrow to the sender's own context — the least
-                        // widening that keeps the notification reachable;
-                        // global would expose it to every stranger's context.
-                        log::warn!(
-                            "pane_ipc: notify: window scope requested but context \
-                             {caller_context_id:?} has no live window — narrowing to context scope"
-                        );
-                        crate::app_protocol::NotifyScope::Context
-                    }
                     unresolvable => {
                         log::warn!(
                             "pane_ipc: notify: scope {unresolvable:?} needs a caller identity but none resolved \
@@ -2390,11 +2393,24 @@ impl PlexiApp {
                         crate::app_protocol::NotifyScope::Global
                     }
                 };
+                // The host-resolved sender pane, so `dismiss_notification_from_sender`
+                // can check ownership against a value the requester never
+                // controlled instead of re-parsing it out of `notify_id` (the
+                // pre-fix behavior — `notify_id` is itself client-generated,
+                // so that check was comparing two attacker-controlled values
+                // against each other). 0 = no resolvable sender — the
+                // notification can never be dismissed via `plexi notify
+                // dismiss`, same as before this fix for any non-CLI-format
+                // notify_id. Deliberately NOT `sender_pane_id`: that field
+                // drives auto-dismiss-on-focus (`notifications.rs`), which
+                // CLI notifications opt out of on purpose.
+                let dismiss_owner_pane_id = resolved.map(|(pane_id, ..)| pane_id).unwrap_or(0);
                 self.enqueue_notification(
                     crate::app::notifications::NotifySource::Cli,
                     PendingNotification {
                         notify_id: internal_id,
                         sender_pane_id: 0,
+                        dismiss_owner_pane_id,
                         // 0 = no context / no window, the same sentinel
                         // host-internal notifications use. Real ids start at 1.
                         source_context_id: caller_context_id.unwrap_or(0),
@@ -2422,12 +2438,41 @@ impl PlexiApp {
                 source_context_id,
                 source_pane_id,
                 response_file,
+                peer_pid,
             } => {
-                let result = match (source_context_id, source_pane_id) {
-                    (Some(_), Some(pane_id)) => self
-                        .dismiss_notification_from_sender(notify_id, *pane_id)
+                // Same trust boundary as `Notify`: ownership is decided from
+                // the socket peer's host-resolved pane, never from the
+                // client-claimed `source_context_id`/`source_pane_id` — those
+                // are attacker-controlled and, before this fix, were the
+                // entire ownership check (compared against a pane id
+                // re-parsed out of the equally client-generated `notify_id`).
+                let resolved = peer_pid
+                    .as_deref()
+                    .and_then(|ancestry| self.resolve_socket_peer_pane(ancestry));
+                if let Some((resolved_pane_id, resolved_context_id, resolved_window_id)) =
+                    resolved
+                {
+                    log::info!(
+                        "pane_ipc: peer identity: dismiss sender resolved to pane={resolved_pane_id} context={resolved_context_id} window={resolved_window_id} peer_pid={peer_pid:?}"
+                    );
+                }
+                if source_pane_id.is_some() || source_context_id.is_some() {
+                    let claimed_matches = resolved.is_some_and(|(pane_id, context_id, _)| {
+                        source_pane_id.is_none_or(|claimed| claimed == pane_id)
+                            && source_context_id.is_none_or(|claimed| claimed == context_id)
+                    });
+                    if !claimed_matches {
+                        log::warn!(
+                            "pane_ipc: notify dismiss: claimed identity (source_context_id={source_context_id:?} source_pane_id={source_pane_id:?}) \
+                             disagrees with host-resolved sender {resolved:?} — using the host-resolved identity only"
+                        );
+                    }
+                }
+                let result = match resolved {
+                    Some((pane_id, _, _)) => self
+                        .dismiss_notification_from_sender(notify_id, pane_id)
                         .map(|()| "dismissed"),
-                    _ => Err("notify dismiss requires caller pane and context"),
+                    None => Err("notify dismiss requires a resolvable caller pane"),
                 };
                 match result {
                     Ok(message) => {
@@ -3238,6 +3283,7 @@ impl PlexiApp {
             crate::app::notifications::PendingNotification {
                 notify_id: format!("routine-{millis}-{seq}"),
                 sender_pane_id: 0,
+                dismiss_owner_pane_id: 0,
                 source_context_id,
                 source_window_id: 0,
                 title: title.to_string(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -508,14 +508,67 @@ fn configure_egui_ctx(ctx: &egui::Context, colors: &Colors) {
     theme::setup_style(ctx, colors, true);
 }
 
+/// Single-byte sentinel written back to the socket peer once the host has
+/// captured its ancestry (`capture_peer_ancestry`) for a `Notify`/
+/// `DismissNotification` request. `notify_cli`/`dismiss_notify_cli` block
+/// reading this before the fire-and-forget path is allowed to exit — see
+/// the long comment at the ack-write call site below for why this exists.
+const PEER_IDENTITY_ACK: &[u8] = &[0x06]; // ASCII ACK
+
 /// Handle one newline-delimited JSON line from the notify socket: parse the
 /// `AppRequest` and queue it on the pane-IPC mailbox (which owns the UI wake).
+///
+/// `peer_ancestry` is the host-established ancestor-pid chain of the process
+/// on the other end of this connection, captured once per connection in
+/// `spawn_socket_listener`'s accept loop (`capture_peer_ancestry`, called at
+/// accept time — never from the request body, and never re-derived lazily
+/// here). It is stamped onto `Notify`/`DismissNotification` requests — the
+/// only variants that carry a `peer_pid` field — so `handle_pane_ipc_request`
+/// can resolve the sender pane from a value the client never controlled,
+/// instead of trusting the wire-supplied `source_context_id`/`source_pane_id`.
 fn handle_socket_line(
     line: &str,
     mailbox: &ui_mailbox::UiMailbox<crate::app_protocol::AppRequest>,
+    peer_ancestry: Option<&[u32]>,
+    ack_writer: &mut impl std::io::Write,
 ) {
     match serde_json::from_str::<crate::app_protocol::AppRequest>(line) {
-        Ok(cmd) => {
+        Ok(mut cmd) => {
+            let needs_identity_ack = matches!(
+                cmd,
+                crate::app_protocol::AppRequest::Notify { .. }
+                    | crate::app_protocol::AppRequest::DismissNotification { .. }
+            );
+            match &mut cmd {
+                crate::app_protocol::AppRequest::Notify { peer_pid: p, .. }
+                | crate::app_protocol::AppRequest::DismissNotification { peer_pid: p, .. } => {
+                    *p = peer_ancestry.map(<[u32]>::to_vec);
+                }
+                _ => {}
+            }
+            if needs_identity_ack {
+                // `capture_peer_ancestry` already ran, synchronously, in the
+                // accept loop — strictly before this connection was ever
+                // handed to a thread, let alone reached this line-parsing
+                // step. Sending this ack now, rather than never (as before
+                // this fix), lets a cooperating fire-and-forget caller
+                // (`plexi notify`/`plexi notify dismiss`, which otherwise
+                // exits the instant its write completes) block on reading
+                // it before exiting. Without this, a short-lived CLI process
+                // can race the host's own accept()-return latency under
+                // scheduler load: it exits before the host code that reads
+                // its ancestry has even run, `get_pid_ppid` then fails on an
+                // already-gone pid, and the notification silently
+                // misattributes to "outside pane" (global scope, no
+                // dismiss) even though the sender really was a live, known
+                // pane. A write failure here is logged, not fatal — the
+                // request is still queued below; an uncooperative or
+                // already-gone peer just proceeds without the guarantee,
+                // exactly like today's behavior.
+                if let Err(e) = ack_writer.write_all(PEER_IDENTITY_ACK) {
+                    log::warn!("pane_ipc: peer identity ack write failed: {e}");
+                }
+            }
             if mailbox.send(cmd).is_ok() {
                 log::debug!("pane_ipc: request queued — mailbox wakes idle UI thread");
             }
@@ -576,11 +629,28 @@ fn spawn_socket_listener(
                     continue;
                 }
             };
+            // Capture the peer's identity HERE, synchronously in the accept
+            // loop, before `std::thread::spawn` — not inside the spawned
+            // connection thread. A fire-and-forget CLI process (the default
+            // for `plexi notify`) can exit essentially immediately after
+            // writing its request; a thread-spawn is a real scheduling gap
+            // under load (backlog, CPU contention) that a short-lived peer
+            // can lose the race against. Resolving and walking the ancestry
+            // right here, on the accept thread, removes that gap entirely —
+            // this runs before the OS has even scheduled a new thread.
+            let peer_pid = resolve_socket_peer_pid(&stream);
+            let peer_ancestry = peer_pid.map(capture_peer_ancestry);
             let mailbox = mailbox.clone();
             let subscribe_mailbox = subscribe_mailbox.clone();
             let publish_mailbox = publish_mailbox.clone();
             std::thread::spawn(move || {
-                handle_socket_connection(stream, mailbox, subscribe_mailbox, publish_mailbox);
+                handle_socket_connection(
+                    stream,
+                    mailbox,
+                    subscribe_mailbox,
+                    publish_mailbox,
+                    peer_ancestry,
+                );
             });
         }
     });
@@ -598,11 +668,22 @@ fn handle_socket_connection(
         crate::host::event_subscriptions::HostSubscribeRequest,
     >,
     publish_mailbox: ui_mailbox::UiMailbox<crate::host::event_subscriptions::HostPublishRequest>,
+    // The peer's host-established ancestor-pid chain, captured by the
+    // caller (the accept loop in `spawn_socket_listener`) BEFORE this
+    // connection was handed to a spawned thread — not resolved in here.
+    // `None` means the peer credential lookup itself failed (platform
+    // unsupported, or the kernel call errored); a resolved-but-empty or
+    // no-match ancestry is logged separately in `resolve_socket_peer_pane`.
+    // This is the only trustworthy sender identity for
+    // `Notify`/`DismissNotification` — the request body's
+    // `source_context_id`/`source_pane_id` are attacker controlled (any
+    // process that can write to the socket can claim any pane).
+    peer_ancestry: Option<Vec<u32>>,
 ) {
     use std::io::{BufRead, BufReader};
     // A writable clone so a streaming handler can push NDJSON back while the
     // BufReader owns the read side.
-    let write_half = match stream.try_clone() {
+    let mut write_half = match stream.try_clone() {
         Ok(s) => s,
         Err(e) => {
             log::warn!("pane_ipc: try_clone failed: {e}");
@@ -643,7 +724,7 @@ fn handle_socket_connection(
         }
     }
     // Normal path: first line plus any remaining lines as AppRequests.
-    handle_socket_line(&first, &mailbox);
+    handle_socket_line(&first, &mailbox, peer_ancestry.as_deref(), &mut write_half);
     loop {
         let line = match read_socket_frame(&mut reader) {
             Ok(Some(line)) => line,
@@ -657,8 +738,74 @@ fn handle_socket_connection(
         if line.is_empty() {
             continue;
         }
-        handle_socket_line(&line, &mailbox);
+        handle_socket_line(&line, &mailbox, peer_ancestry.as_deref(), &mut write_half);
     }
+}
+
+/// Walk `peer_pid`'s ancestor chain and collect every visited pid
+/// (including `peer_pid` itself), using `get_pid_ppid`. Bounded to 32 hops
+/// so a lookup failure or a recycled pid mid-walk cannot spin forever;
+/// stops at pid 0/1 or a repeated pid (cycle guard). Called eagerly at
+/// socket-accept time — see the call site in `handle_socket_connection` for
+/// why this cannot be deferred to the UI thread.
+pub(crate) fn capture_peer_ancestry(peer_pid: u32) -> Vec<u32> {
+    const MAX_ANCESTOR_HOPS: u32 = 32;
+
+    let mut ancestry = Vec::new();
+    let mut candidate = peer_pid;
+    let mut seen = std::collections::HashSet::new();
+    for _ in 0..MAX_ANCESTOR_HOPS {
+        if candidate == 0 || candidate == 1 || !seen.insert(candidate) {
+            break;
+        }
+        ancestry.push(candidate);
+        match shell::get_pid_ppid(candidate) {
+            Some(ppid) => candidate = ppid,
+            None => break,
+        }
+    }
+    ancestry
+}
+
+/// Resolve the pid of the process on the other end of a connected
+/// `AF_UNIX` `SOCK_STREAM` socket. macOS has no stable-std API for this
+/// (`getsockopt(SOL_LOCAL, LOCAL_PEERPID)`, verified against `libc` 0.2's
+/// apple bindings); Linux exposes it directly via `UnixStream::peer_cred`.
+#[cfg(target_os = "macos")]
+fn resolve_socket_peer_pid(stream: &std::os::unix::net::UnixStream) -> Option<u32> {
+    use std::os::unix::io::AsRawFd;
+    let mut pid: libc::pid_t = 0;
+    let mut len = std::mem::size_of::<libc::pid_t>() as libc::socklen_t;
+    let rc = unsafe {
+        libc::getsockopt(
+            stream.as_raw_fd(),
+            libc::SOL_LOCAL,
+            libc::LOCAL_PEERPID,
+            &mut pid as *mut _ as *mut libc::c_void,
+            &mut len,
+        )
+    };
+    if rc != 0 || pid <= 0 {
+        log::warn!("pane_ipc: LOCAL_PEERPID getsockopt failed (rc={rc})");
+        return None;
+    }
+    Some(pid as u32)
+}
+
+#[cfg(target_os = "linux")]
+fn resolve_socket_peer_pid(stream: &std::os::unix::net::UnixStream) -> Option<u32> {
+    match stream.peer_cred() {
+        Ok(cred) => cred.pid.map(|p| p as u32),
+        Err(e) => {
+            log::warn!("pane_ipc: peer_cred failed: {e}");
+            None
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn resolve_socket_peer_pid(_stream: &std::os::unix::net::UnixStream) -> Option<u32> {
+    None
 }
 
 /// Stream one app's event deliveries to a CLI subscriber as NDJSON. Routes the
@@ -1815,6 +1962,54 @@ impl PlexiApp {
             .iter()
             .enumerate()
             .find_map(|(idx, win)| win.tree.tiles.find_pane(&pane_id).map(|tile| (idx, tile)))
+    }
+
+    /// Resolve a notify-socket peer's pre-captured ancestor chain
+    /// (`capture_peer_ancestry`) to the pane that owns it, by matching each
+    /// candidate pid against every live terminal pane's shell pid
+    /// (`TerminalBackend::child_pid()`). This is the trustworthy sender
+    /// identity for CLI commands whose provenance controls scope/ownership
+    /// (`Notify`, `DismissNotification`) — the ancestry is host-established
+    /// (captured from the socket's kernel credential at accept time, never
+    /// from the wire), so a match here cannot be forged by the request body.
+    ///
+    /// Deliberately does no OS lookups: the ancestry was already walked
+    /// eagerly, at accept time, while the peer process was still guaranteed
+    /// connected. A short-lived CLI process (the common case — `plexi
+    /// notify` does not wait around) can have already exited by the time
+    /// this runs on the UI thread after the mailbox drains; walking
+    /// `get_pid_ppid` lazily here would then fail on the very first hop and
+    /// misattribute every fire-and-forget notification to "unresolvable".
+    ///
+    /// Known limitation: this does not cross-check process start time, so a
+    /// pid reused between the CLI's fork and the ancestry capture could in
+    /// principle misattribute — `TerminalBackend` exposes no spawn
+    /// timestamp to guard against this, and adding one is out of scope for
+    /// this stint.
+    ///
+    /// Returns `(pane_id, context_id, window_id)` — the same identity shape
+    /// `Notify`/`DismissNotification` need, sourced from the owning window's
+    /// live `context_id`/`window_id` rather than the caller's claim.
+    pub(crate) fn resolve_socket_peer_pane(
+        &self,
+        peer_ancestry: &[u32],
+    ) -> Option<(crate::spatial::tiling::PaneId, u64, u64)> {
+        for &candidate in peer_ancestry {
+            for window in self.windows.iter() {
+                for (pane_id, pane) in window.panes.iter() {
+                    let Some(terminal) = pane.as_terminal() else {
+                        continue;
+                    };
+                    if terminal.backend.child_pid() == candidate {
+                        return Some((*pane_id, window.context_id, window.window_id));
+                    }
+                }
+            }
+        }
+        log::info!(
+            "pane_ipc: peer identity: ancestry {peer_ancestry:?} resolved to no live pane — treating as outside-pane caller"
+        );
+        None
     }
 
     fn complete_wasm_host_effect(

--- a/src/app/notifications.rs
+++ b/src/app/notifications.rs
@@ -6,6 +6,13 @@ use super::PlexiApp;
 pub(crate) struct PendingNotification {
     pub notify_id: String,
     pub sender_pane_id: u64,
+    /// Host-resolved pane id allowed to dismiss this notification via
+    /// `plexi notify dismiss` (`DismissNotification`'s `peer_pid` resolved
+    /// through `resolve_socket_peer_pane`). 0 = no verified sender —
+    /// unreachable by any dismiss request. Distinct from `sender_pane_id`,
+    /// which drives auto-dismiss-on-focus and is deliberately left 0 for CLI
+    /// notifications regardless of sender identity.
+    pub dismiss_owner_pane_id: u64,
     /// Stable context identity the notification originated from (stamped at drain time).
     pub source_context_id: u64,
     /// Stable window identity the notification originated from. Used by
@@ -54,6 +61,8 @@ pub(crate) struct PendingNotification {
 struct PersistedNotification {
     notify_id: String,
     sender_pane_id: u64,
+    #[serde(default)]
+    dismiss_owner_pane_id: u64,
     source_context_id: u64,
     #[serde(default)]
     source_window_id: u64,
@@ -98,6 +107,7 @@ pub(crate) fn save_pending_notifications_to(
             PersistedNotification {
                 notify_id: n.notify_id.clone(),
                 sender_pane_id: n.sender_pane_id,
+                dismiss_owner_pane_id: n.dismiss_owner_pane_id,
                 source_context_id: n.source_context_id,
                 source_window_id: n.source_window_id,
                 title: n.title.clone(),
@@ -158,6 +168,12 @@ pub(crate) fn load_pending_notifications_from(path: &std::path::Path) -> Vec<Pen
             Some(PendingNotification {
                 notify_id: p.notify_id,
                 sender_pane_id: p.sender_pane_id,
+                // Forced to 0 (unowned) on restore, same reasoning as
+                // `tombstoned: true` below: pane ids are re-issued fresh each
+                // session, so a persisted owner id could otherwise
+                // misattribute a restored notification to an unrelated pane
+                // that happens to reuse the same id post-restart.
+                dismiss_owner_pane_id: 0,
                 source_context_id: p.source_context_id,
                 source_window_id: p.source_window_id,
                 title: p.title,
@@ -239,18 +255,21 @@ impl PlexiApp {
     /// Remove a CLI notification only when the caller owns its stamped pane.
     /// This is deliberately a queue mutation rather than
     /// a UI-only close so sticky entries cannot survive a CLI dismissal.
+    ///
+    /// `resolved_pane_id` is the host-established sender pane — resolved by
+    /// `handle_pane_ipc_request` from the socket peer's OS credential via
+    /// `resolve_socket_peer_pane`, never from the request's own fields.
+    /// Ownership is checked against `PendingNotification::dismiss_owner_pane_id`
+    /// (stamped the same way at enqueue time), not by re-parsing `notify_id` —
+    /// `notify_id` is client-generated (`plexi notify`'s `"cli:{pane_id}:{uuid}"`),
+    /// so comparing it against a client-supplied pane id was comparing two
+    /// attacker-controlled values against each other and proved nothing.
+    /// `0` means either side has no verified owner and can never match.
     pub(crate) fn dismiss_notification_from_sender(
         &mut self,
         notify_id: &str,
-        source_pane_id: u64,
+        resolved_pane_id: u64,
     ) -> Result<(), &'static str> {
-        let expected_owner = notify_id
-            .strip_prefix("cli:")
-            .and_then(|rest| rest.split_once(':'))
-            .and_then(|(pane_id, _)| pane_id.parse::<u64>().ok());
-        if expected_owner != Some(source_pane_id) {
-            return Err("notification not found or not owned by caller");
-        }
         let Some(position) = self
             .pending_notifications
             .iter()
@@ -258,6 +277,11 @@ impl PlexiApp {
         else {
             return Err("notification not found or not owned by caller");
         };
+        if resolved_pane_id == 0
+            || self.pending_notifications[position].dismiss_owner_pane_id != resolved_pane_id
+        {
+            return Err("notification not found or not owned by caller");
+        }
         self.pending_notifications.remove(position);
         if self.current_notify_id.as_deref() == Some(notify_id) {
             self.current_notify_id = None;
@@ -267,9 +291,9 @@ impl PlexiApp {
         }
         self.save_notifications();
         log::info!(
-            "notify: dismissed id={} source_pane_id={}",
+            "notify: dismissed id={} resolved_pane_id={}",
             notify_id,
-            source_pane_id
+            resolved_pane_id
         );
         Ok(())
     }

--- a/src/app/tests/misc_tests.rs
+++ b/src/app/tests/misc_tests.rs
@@ -190,7 +190,7 @@ fn socket_line_queues_request_and_requests_repaint() {
         std::sync::Arc::new(crate::app::ui_mailbox::EguiWake::new(ctx.clone())),
         "pane_ipc",
     );
-    handle_socket_line(r#"{"type":"wake"}"#, &mailbox);
+    handle_socket_line(r#"{"type":"wake"}"#, &mailbox, None, &mut std::io::sink());
     assert!(
         matches!(rx.try_recv(), Ok(crate::app_protocol::AppRequest::Wake)),
         "request must be queued on the pane-IPC channel"
@@ -209,7 +209,7 @@ fn socket_line_parse_error_queues_nothing() {
         std::sync::Arc::new(crate::app::ui_mailbox::EguiWake::new(ctx.clone())),
         "pane_ipc",
     );
-    handle_socket_line("definitely not json", &mailbox);
+    handle_socket_line("definitely not json", &mailbox, None, &mut std::io::sink());
     assert!(
         rx.try_recv().is_err(),
         "parse failures must not queue anything"
@@ -239,7 +239,7 @@ fn run_socket_connection(
     client
         .shutdown(std::net::Shutdown::Write)
         .expect("close write half");
-    handle_socket_connection(server, mailbox, subscribe_mailbox, publish_mailbox);
+    handle_socket_connection(server, mailbox, subscribe_mailbox, publish_mailbox, None);
     rx
 }
 
@@ -816,7 +816,7 @@ fn socket_lines_after_idle_each_request_a_prompt_repaint() {
         "pane_ipc",
     );
     let line = r#"{"type":"log_marker","source":"test","message":"wake"}"#;
-    handle_socket_line(line, &mailbox);
+    handle_socket_line(line, &mailbox, None, &mut std::io::sink());
 
     match rx.try_recv() {
         Ok(crate::app_protocol::AppRequest::LogMarker { source, .. }) => {
@@ -838,6 +838,8 @@ fn socket_lines_after_idle_each_request_a_prompt_repaint() {
     handle_socket_line(
         r#"{"type":"list_panes","response_file":"/tmp/second-pane-list.json"}"#,
         &mailbox,
+        None,
+        &mut std::io::sink(),
     );
     assert!(
         matches!(
@@ -885,7 +887,7 @@ fn socket_line_parse_error_does_not_wake() {
         Arc::new(crate::app::ui_mailbox::EguiWake::new(ctx.clone())),
         "pane_ipc",
     );
-    handle_socket_line("not json", &mailbox);
+    handle_socket_line("not json", &mailbox, None, &mut std::io::sink());
 
     assert!(rx.try_recv().is_err(), "malformed line must not queue");
     assert_eq!(*woke.lock().unwrap(), 0, "malformed line must not wake");

--- a/src/app/tests/notification_tests.rs
+++ b/src/app/tests/notification_tests.rs
@@ -32,6 +32,7 @@ fn snoozed_notification_invisible_then_visible() {
     h.app.pending_notifications.push(PendingNotification {
         notify_id: "snoozed-woken".into(),
         sender_pane_id: 0,
+        dismiss_owner_pane_id: 0,
         source_context_id: h.app.router.active().context_id,
         source_window_id: h.app.windows[h.app.active_window].window_id,
         title: "Snoozed".into(),
@@ -78,6 +79,7 @@ fn snoozed_notification_exempt_from_timeout() {
     h.app.pending_notifications.push(PendingNotification {
         notify_id: "snoozed-no-timeout".into(),
         sender_pane_id: sender_id,
+        dismiss_owner_pane_id: 0,
         source_context_id: h.app.router.active().context_id,
         source_window_id: h.app.windows[h.app.active_window].window_id,
         title: "ShouldNotTimeout".into(),
@@ -115,6 +117,7 @@ fn persist_roundtrip() {
     let n = PendingNotification {
         notify_id: "test-id".into(),
         sender_pane_id: 0,
+        dismiss_owner_pane_id: 0,
         source_context_id: 1,
         source_window_id: 1,
         title: "Test".into(),
@@ -253,6 +256,7 @@ fn window_scoped_notification_visible_only_on_source_window() {
     h.app.pending_notifications.push(PendingNotification {
         notify_id: "win-scoped-1774".into(),
         sender_pane_id: 0,
+        dismiss_owner_pane_id: 0,
         source_context_id: h.app.router.active().context_id,
         source_window_id: win0_id,
         title: "Window Notification".into(),
@@ -315,6 +319,7 @@ fn auto_dismiss_removes_non_required_notification_when_sender_focused() {
     h.app.pending_notifications.push(PendingNotification {
         notify_id: "n-auto-dismiss".into(),
         sender_pane_id: pane_id,
+        dismiss_owner_pane_id: 0,
         source_context_id: ctx_id,
         source_window_id: win_id,
         title: "Should go away".into(),
@@ -368,6 +373,7 @@ fn auto_dismiss_spares_required_notifications() {
     h.app.pending_notifications.push(PendingNotification {
         notify_id: "n-required".into(),
         sender_pane_id: pane_id,
+        dismiss_owner_pane_id: 0,
         source_context_id: ctx_id,
         source_window_id: win_id,
         title: "Must stay".into(),
@@ -412,6 +418,7 @@ fn auto_dismiss_does_not_touch_other_pane_notifications() {
     h.app.pending_notifications.push(PendingNotification {
         notify_id: "n-other-pane".into(),
         sender_pane_id: sender_id, // different from focused_id
+        dismiss_owner_pane_id: 0,
         source_context_id: ctx_id,
         source_window_id: win_id,
         title: "From other pane".into(),
@@ -545,6 +552,7 @@ fn cue_test_notification(id: &str) -> PendingNotification {
     PendingNotification {
         notify_id: id.into(),
         sender_pane_id: 0,
+        dismiss_owner_pane_id: 0,
         source_context_id: 0,
         source_window_id: 0,
         title: "Title".into(),
@@ -746,7 +754,7 @@ fn plain_cli_notify_interrupts_and_focus_mode_mutes() {
     h.app.notifications_enabled = true;
     h.app.notifications_sound = Some("/tmp/cue.wav".to_string());
 
-    h.inject_ipc(cli_notify_request(None, None, None));
+    h.inject_ipc(cli_notify_request(None, None, None, None));
     h.run_frames(2);
 
     assert!(h.app.show_notification_modal, "plain CLI notify interrupts");
@@ -759,7 +767,7 @@ fn plain_cli_notify_interrupts_and_focus_mode_mutes() {
     focused.app.notifications_enabled = true;
     focused.app.notifications_sound = Some("/tmp/cue.wav".to_string());
     focused.app.notifications_focus_mode = true;
-    focused.inject_ipc(cli_notify_request(None, None, None));
+    focused.inject_ipc(cli_notify_request(None, None, None, None));
     focused.run_frames(2);
     assert!(!focused.app.show_notification_modal, "focus mode prevents interrupt");
     assert!(focused.app.notification_cue_playback.is_none(), "focus mode mutes cue");
@@ -804,10 +812,16 @@ fn disabled_notifications_never_play_a_cue() {
 }
 
 /// Build the `AppRequest::Notify` a `plexi notify` invocation produces.
+/// `peer_pid` stands in for the host-established socket-peer identity
+/// (`None` reproduces an unresolvable/outside-pane caller). Internally
+/// expanded to the single-hop ancestry `resolve_socket_peer_pane` expects —
+/// callers pass the pid they want matched directly (typically a live pane's
+/// own `child_pid`), same as the pre-0636-fix single-pid API.
 fn cli_notify_request(
     scope: Option<crate::app_protocol::NotifyScope>,
     source_context_id: Option<u64>,
     source_pane_id: Option<u64>,
+    peer_pid: Option<u32>,
 ) -> crate::app_protocol::AppRequest {
     crate::app_protocol::AppRequest::Notify {
         title: "CLI notify".into(),
@@ -826,7 +840,37 @@ fn cli_notify_request(
         scope,
         source_context_id,
         source_pane_id,
+        peer_pid: peer_pid.map(|pid| vec![pid]),
     }
+}
+
+/// Create a real PTY-backed terminal pane at a fresh grid slot so its
+/// shell's `child_pid` can stand in for a genuine `plexi notify` socket
+/// peer. Returns `None` when the environment has no PTY (headless CI) —
+/// every caller must treat that as "skip this test", matching the
+/// `pty_available` pattern used elsewhere in this test suite.
+fn spawn_real_terminal_pane(
+    h: &mut HostHarness,
+    grid_x: u32,
+    grid_y: u32,
+    context_id: u64,
+) -> Option<(crate::spatial::tiling::PaneId, u32, u64, u64)> {
+    let before = h.app.windows.len();
+    h.app.create_page_at(grid_x, grid_y, context_id, None, false, None);
+    if h.app.windows.len() == before {
+        return None; // no PTY in this environment
+    }
+    let win_idx = h.app.windows.len() - 1;
+    let pane_id = *h.app.windows[win_idx].panes.keys().next()?;
+    let child_pid = h.app.windows[win_idx]
+        .panes
+        .get(&pane_id)?
+        .as_terminal()?
+        .backend
+        .child_pid();
+    let ctx_id = h.app.windows[win_idx].context_id;
+    let window_id = h.app.windows[win_idx].window_id;
+    Some((pane_id, child_pid, ctx_id, window_id))
 }
 
 /// 0608: a parked app has no sender window. Window-scoped delivery must stay
@@ -845,6 +889,7 @@ fn parked_app_window_notification_narrows_without_active_window_provenance() {
         PendingNotification {
             notify_id: "parked-window-scope".into(),
             sender_pane_id: 0,
+            dismiss_owner_pane_id: 0,
             source_context_id: context_id,
             source_window_id,
             title: "Parked".into(),
@@ -874,15 +919,25 @@ fn parked_app_window_notification_narrows_without_active_window_provenance() {
     assert_eq!(notification.source_context_id, context_id);
 }
 
-/// 0610/0611: the CLI's display timeout reaches the host payload, while a
-/// sticky CLI notification can be removed only by its posting pane.
+/// 0610/0611, re-verified after 0636: the CLI's display timeout reaches the
+/// host payload, while a sticky CLI notification can be removed only by its
+/// posting pane — ownership now decided from the real socket-peer identity
+/// (`peer_pid`), not the client-claimed `source_pane_id` this test used to
+/// drive directly.
 #[test]
 fn cli_notification_timeout_and_sender_scoped_dismissal() {
     let mut h = HostHarness::new();
     h.app.notifications_enabled = true;
-    let owner_pane_id = h.add_test_pane();
-    let foreign_pane_id = h.add_test_pane();
-    let context_id = h.app.router.active().context_id;
+    let Some((owner_pane_id, owner_peer_pid, owner_ctx, _)) =
+        spawn_real_terminal_pane(&mut h, 92, 92, 503)
+    else {
+        return; // no PTY in this environment
+    };
+    let Some((foreign_pane_id, foreign_peer_pid, _, _)) =
+        spawn_real_terminal_pane(&mut h, 93, 93, 504)
+    else {
+        return; // no PTY in this environment
+    };
     let response_dir = tempfile::tempdir().expect("tempdir");
     let response_file = response_dir.path().join("dismiss-response");
 
@@ -901,8 +956,9 @@ fn cli_notification_timeout_and_sender_scoped_dismissal() {
         on_dismiss: None,
         response_file: None,
         scope: None,
-        source_context_id: Some(context_id),
+        source_context_id: Some(owner_ctx),
         source_pane_id: Some(owner_pane_id),
+        peer_pid: Some(vec![owner_peer_pid]),
     });
     h.run_frames(2);
 
@@ -913,43 +969,166 @@ fn cli_notification_timeout_and_sender_scoped_dismissal() {
         posted.sender_pane_id, 0,
         "CLI notifications must not auto-dismiss with their focused terminal"
     );
+    assert_eq!(
+        posted.dismiss_owner_pane_id, owner_pane_id,
+        "dismiss ownership must be stamped from the resolved socket peer"
+    );
 
+    // A different real pane (its own genuine socket peer) claims to be the
+    // owner via the wire fields — those claims must be ignored; only the
+    // resolved `peer_pid` decides ownership, and it names a stranger.
     h.inject_ipc(crate::app_protocol::AppRequest::DismissNotification {
         notify_id: format!("cli:{owner_pane_id}:sticky"),
-        source_context_id: Some(context_id),
-        source_pane_id: Some(foreign_pane_id),
+        source_context_id: Some(owner_ctx),
+        source_pane_id: Some(owner_pane_id), // forged claim
         response_file: response_file.to_string_lossy().into_owned(),
+        peer_pid: Some(vec![foreign_peer_pid]), // true peer disagrees
     });
     h.run_frames(2);
     assert_eq!(
         h.app.pending_notifications.len(),
         1,
-        "foreign pane must not dismiss"
+        "foreign pane must not dismiss, even while claiming to be the owner"
     );
 
     h.inject_ipc(crate::app_protocol::AppRequest::DismissNotification {
         notify_id: format!("cli:{owner_pane_id}:sticky"),
-        source_context_id: Some(context_id),
-        source_pane_id: Some(owner_pane_id),
+        source_context_id: Some(owner_ctx),
+        source_pane_id: Some(foreign_pane_id), // forged claim, must be ignored
         response_file: response_file.to_string_lossy().into_owned(),
+        peer_pid: Some(vec![owner_peer_pid]), // true peer is the real owner
     });
     h.run_frames(2);
     assert!(
         h.app.pending_notifications.is_empty(),
-        "owner dismissal removes sticky notification"
+        "owner dismissal removes sticky notification via the resolved peer"
     );
 }
 
+/// 0636: a socket peer that resolves to no live pane (outside-pane caller,
+/// or an already-closed pane) must not fall back to trusting the client's
+/// claimed identity — Notify escalates to Global and Dismiss is rejected,
+/// exactly like an absent identity.
+#[test]
+fn unresolvable_peer_escalates_notify_and_blocks_dismiss() {
+    let mut h = HostHarness::new();
+    h.app.notifications_enabled = true;
+    let real_context_id = h.app.router.active().context_id;
+
+    // No live terminal pane in this harness has this (or any) pid as an
+    // ancestor, so any peer_pid — including our own process — resolves to
+    // nothing.
+    let unresolvable_peer = std::process::id();
+
+    h.inject_ipc(crate::app_protocol::AppRequest::Notify {
+        title: "t".into(),
+        body: "b".into(),
+        kind: crate::app_protocol::NotifyKind::Message,
+        options: vec![],
+        input_prompt: None,
+        required: false,
+        actions: vec![],
+        notify_id: Some("unresolvable-peer".into()),
+        image_inline: None,
+        image_pipe_id: None,
+        timeout_secs: None,
+        on_dismiss: None,
+        response_file: None,
+        scope: Some(crate::app_protocol::NotifyScope::Context),
+        source_context_id: Some(real_context_id),
+        source_pane_id: None,
+        peer_pid: Some(vec![unresolvable_peer]),
+    });
+    h.run_frames(2);
+
+    let posted = &h.app.pending_notifications[0];
+    assert_eq!(
+        posted.scope,
+        crate::app_protocol::NotifyScope::Global,
+        "an unresolvable peer must escalate to Global rather than trust the claimed context"
+    );
+    assert_eq!(
+        posted.dismiss_owner_pane_id, 0,
+        "an unresolvable peer must not stamp any pane as the dismiss owner"
+    );
+
+    let response_dir = tempfile::tempdir().expect("tempdir");
+    let response_file = response_dir.path().join("dismiss-response");
+    h.inject_ipc(crate::app_protocol::AppRequest::DismissNotification {
+        notify_id: "unresolvable-peer".into(),
+        source_context_id: Some(real_context_id),
+        source_pane_id: Some(424_242), // forged, irrelevant
+        response_file: response_file.to_string_lossy().into_owned(),
+        peer_pid: Some(vec![unresolvable_peer]),
+    });
+    h.run_frames(2);
+    assert_eq!(
+        h.app.pending_notifications.len(),
+        1,
+        "dismiss with no resolvable sender must not remove the notification"
+    );
+}
+
+/// 0636: a forged `source_pane_id`/`source_context_id` naming a REAL pane
+/// must be ignored whenever it disagrees with the host-resolved socket peer
+/// — the notification is attributed to the true peer, never the claim.
+#[test]
+fn forged_source_pane_is_ignored_in_favor_of_resolved_peer() {
+    let mut h = HostHarness::new();
+    h.app.notifications_enabled = true;
+
+    let Some((_, real_peer_pid, real_ctx, _)) = spawn_real_terminal_pane(&mut h, 94, 94, 505)
+    else {
+        return; // no PTY in this environment
+    };
+    let Some((forged_pane_id, _, forged_ctx, _)) = spawn_real_terminal_pane(&mut h, 95, 95, 506)
+    else {
+        return; // no PTY in this environment
+    };
+    assert_ne!(real_ctx, forged_ctx);
+
+    h.inject_ipc(crate::app_protocol::AppRequest::Notify {
+        title: "t".into(),
+        body: "b".into(),
+        kind: crate::app_protocol::NotifyKind::Message,
+        options: vec![],
+        input_prompt: None,
+        required: false,
+        actions: vec![],
+        notify_id: Some("forged-claim".into()),
+        image_inline: None,
+        image_pipe_id: None,
+        timeout_secs: None,
+        on_dismiss: None,
+        response_file: None,
+        scope: Some(crate::app_protocol::NotifyScope::Context),
+        source_context_id: Some(forged_ctx),
+        source_pane_id: Some(forged_pane_id),
+        peer_pid: Some(vec![real_peer_pid]), // the true sender is the OTHER pane
+    });
+    h.run_frames(2);
+
+    let posted = &h.app.pending_notifications[0];
+    assert_eq!(
+        posted.source_context_id, real_ctx,
+        "must attribute to the host-resolved peer, not the claimed context"
+    );
+    assert_ne!(posted.source_context_id, forged_ctx);
+}
+
 /// 0569: an unscoped `plexi notify` from inside a pane is context-local, not
-/// global. Drives the real CLI surface end to end through pane_ipc, carrying
-/// the caller identity the CLI stamps from `PLEXI_CONTEXT_ID`.
+/// global. Drives the real CLI surface end to end through pane_ipc, with the
+/// caller identity coming from a real socket-peer resolution (0636) rather
+/// than a claimed `source_context_id`.
 #[test]
 fn cli_notify_without_scope_defaults_to_context() {
     let mut h = HostHarness::new();
     h.app.notifications_enabled = true;
-    let caller_ctx = h.app.router.active().context_id;
+    let Some((_, peer_pid, real_ctx, _)) = spawn_real_terminal_pane(&mut h, 90, 90, 501) else {
+        return; // no PTY in this environment
+    };
 
-    h.inject_ipc(cli_notify_request(None, Some(caller_ctx), None));
+    h.inject_ipc(cli_notify_request(None, None, None, Some(peer_pid)));
     h.run_frames(2);
 
     assert_eq!(h.app.pending_notifications.len(), 1, "notification queued");
@@ -959,8 +1138,8 @@ fn cli_notify_without_scope_defaults_to_context() {
         "unscoped CLI notify must stay in its own context, not leak globally"
     );
     assert_eq!(
-        h.app.pending_notifications[0].source_context_id, caller_ctx,
-        "provenance is the caller's claimed context"
+        h.app.pending_notifications[0].source_context_id, real_ctx,
+        "provenance is the host-resolved socket-peer context"
     );
 }
 
@@ -974,6 +1153,7 @@ fn cli_notify_explicit_global_scope_survives_the_new_default() {
         Some(crate::app_protocol::NotifyScope::Global),
         None,
         None,
+        None,
     ));
     h.run_frames(2);
 
@@ -985,68 +1165,55 @@ fn cli_notify_explicit_global_scope_survives_the_new_default() {
     );
 }
 
-/// Fix round 1 blocker 2: the notification attaches to the context the caller
-/// named, never to whichever context happens to be active at dispatch time.
-/// An agent notifying from a background context must not have its notification
-/// stamped with — and hidden inside — a stranger's context.
+/// Fix round 1 blocker 2, re-verified after 0636: the notification attaches
+/// to the socket peer's real context, never to whichever context happens to
+/// be active at dispatch time. An agent notifying from a background context
+/// must not have its notification stamped with — and hidden inside — a
+/// stranger's context.
 #[test]
 fn cli_notify_attaches_to_callers_context_not_active() {
     let mut h = HostHarness::new();
     h.app.notifications_enabled = true;
-    let parent_id = h.app.router.active().context_id;
-    let parent_name = h.app.router.active().name.clone();
+    let active_before = h.app.router.active().context_id;
 
-    h.app
-        .new_child_context(crate::pane_ops::ChildContextSpec::single_terminal(
-            Some(parent_id),
-            parent_name,
-            std::env::temp_dir(),
-            true,
-            false,
-            None,
-        ))
-        .expect("child context");
-    let child_id = h
-        .app
-        .router
-        .iter()
-        .map(|c| c.context_id)
-        .find(|id| *id != parent_id)
-        .expect("child context id");
-
-    // Whichever of the two contexts is NOT active plays the background caller.
-    let active_id = h.app.router.active().context_id;
-    let caller_id = if active_id == parent_id {
-        child_id
-    } else {
-        parent_id
+    // The real sender pane lives in a fresh window/context; the harness's
+    // originally-active context stays active throughout — the caller is
+    // never the active context, so any attribution to `active_before` would
+    // prove dispatch-time active state leaked in.
+    let Some((_, peer_pid, real_ctx, _)) = spawn_real_terminal_pane(&mut h, 91, 91, 502) else {
+        return; // no PTY in this environment
     };
-    assert_ne!(
-        caller_id, active_id,
-        "caller must not be the active context"
-    );
+    assert_ne!(real_ctx, active_before);
 
-    h.inject_ipc(cli_notify_request(None, Some(caller_id), None));
+    h.inject_ipc(cli_notify_request(None, None, None, Some(peer_pid)));
     h.run_frames(2);
 
     assert_eq!(h.app.pending_notifications.len(), 1);
     let n = &h.app.pending_notifications[0];
     assert_eq!(n.scope, crate::app_protocol::NotifyScope::Context);
     assert_eq!(
-        n.source_context_id, caller_id,
-        "provenance must be the caller's own context, not dispatch-time active state"
+        n.source_context_id, real_ctx,
+        "provenance must be the socket peer's own context, not dispatch-time active state"
     );
 }
 
-/// Fix round 1 blocker 2: an identity naming no live context is never
-/// reattributed to some other context — the notification escalates to global
-/// so it stays reachable everywhere instead of hiding in a fabricated home.
+/// Fix round 1 blocker 2, re-verified after 0636: an identity naming no
+/// resolvable socket peer is never reattributed to some other context — the
+/// notification escalates to global so it stays reachable everywhere instead
+/// of hiding in a fabricated home. `source_context_id`/`source_pane_id` are
+/// forged here to prove they are ignored entirely absent a host-resolved
+/// peer, not merely absent themselves.
 #[test]
 fn cli_notify_stale_identity_escalates_to_global() {
     let mut h = HostHarness::new();
     h.app.notifications_enabled = true;
 
-    h.inject_ipc(cli_notify_request(None, Some(999_999), Some(888_888)));
+    h.inject_ipc(cli_notify_request(
+        None,
+        Some(999_999),
+        Some(888_888),
+        None, // no resolvable socket peer
+    ));
     h.run_frames(2);
 
     assert_eq!(h.app.pending_notifications.len(), 1);
@@ -1059,42 +1226,6 @@ fn cli_notify_stale_identity_escalates_to_global() {
     assert_eq!(n.source_context_id, 0, "0 = no context, the host sentinel");
 }
 
-/// Fix round 1 blocker 2 (Codex finding): `--scope window` from a context
-/// that resolved but has no live window narrows to context scope — the least
-/// widening that keeps the notification reachable — never all the way to
-/// global.
-#[test]
-fn cli_notify_window_scope_without_live_window_narrows_to_context() {
-    let mut h = HostHarness::new();
-    h.app.notifications_enabled = true;
-    // A live context with no window (parked): in the router, not in windows.
-    h.app.router.push(crate::host::context::Context {
-        name: "Parked".into(),
-        root: std::env::temp_dir(),
-        description: None,
-        context_id: 777,
-        parent_id: None,
-        depth: 0,
-        parked: true,
-    });
-
-    h.inject_ipc(cli_notify_request(
-        Some(crate::app_protocol::NotifyScope::Window),
-        Some(777),
-        None,
-    ));
-    h.run_frames(2);
-
-    assert_eq!(h.app.pending_notifications.len(), 1);
-    let n = &h.app.pending_notifications[0];
-    assert_eq!(
-        n.scope,
-        crate::app_protocol::NotifyScope::Context,
-        "window scope with no live window must narrow to context, not widen to global"
-    );
-    assert_eq!(n.source_context_id, 777);
-}
-
 /// Fix round 1 blocker 2: a caller outside any pane (PLEXI_SOCKET exported by
 /// hand, no PLEXI_CONTEXT_ID) has no home context — its unscoped notification
 /// is global, matching what such callers always got.
@@ -1103,7 +1234,7 @@ fn cli_notify_outside_pane_unscoped_escalates_to_global() {
     let mut h = HostHarness::new();
     h.app.notifications_enabled = true;
 
-    h.inject_ipc(cli_notify_request(None, None, None));
+    h.inject_ipc(cli_notify_request(None, None, None, None));
     h.run_frames(2);
 
     assert_eq!(h.app.pending_notifications.len(), 1);
@@ -1148,4 +1279,131 @@ fn parse_notify_scope_maps_every_named_scope_explicitly() {
         Ok(Some(NotifyScope::Window))
     );
     assert!(crate::cli::parse_notify_scope(Some("nope")).is_err());
+}
+
+/// 0636 live regression: a genuine child process spawned as a real
+/// descendant of a HostHarness terminal pane's shell, connected to a real
+/// `UnixListener` (not `UnixStream::pair`, which only proves in-process
+/// wiring), sends a notify line with a DIFFERENT pane forged into
+/// `source_pane_id`/`source_context_id`. The host must attribute the
+/// notification to the true shell-descendant pane, never the forged claim.
+/// macOS-only: relies on `nc -U` (BSD netcat, always present on the
+/// project's dev/CI platform — see root `AGENTS.md`); the ancestor walk
+/// itself (`resolve_socket_peer_pane`) has an independent Linux path
+/// exercised indirectly by every other test in this module.
+#[cfg(target_os = "macos")]
+#[test]
+fn live_socket_peer_resolves_through_real_descendant_process() {
+    let mut h = HostHarness::new();
+    h.app.notifications_enabled = true;
+
+    let Some((real_pane_id, _real_shell_pid, real_ctx, _)) =
+        spawn_real_terminal_pane(&mut h, 96, 96, 507)
+    else {
+        return; // no PTY in this environment
+    };
+    let real_win_idx = h.app.windows.len() - 1;
+
+    let Some((forged_pane_id, _, forged_ctx, _)) = spawn_real_terminal_pane(&mut h, 97, 97, 508)
+    else {
+        return; // no PTY in this environment
+    };
+    assert_ne!(real_ctx, forged_ctx);
+
+    // A real kernel-backed AF_UNIX listener — not `UnixStream::pair`, which
+    // only proves the in-process handler wiring, never a genuine peer
+    // credential lookup across a real accept().
+    let dir = tempfile::tempdir().expect("tempdir");
+    let sock_path = dir.path().join("live-notify.sock");
+    let listener = std::os::unix::net::UnixListener::bind(&sock_path).expect("bind");
+
+    let mailbox = h.ipc_tx.clone();
+    let wake = std::sync::Arc::new(crate::app::ui_mailbox::EguiWake::new(
+        egui::Context::default(),
+    ));
+    let (subscribe_mailbox, _sub_rx) = crate::app::ui_mailbox::UiMailbox::<
+        crate::host::event_subscriptions::HostSubscribeRequest,
+    >::channel(wake.clone(), "event_subscribe");
+    let (publish_mailbox, _pub_rx) = crate::app::ui_mailbox::UiMailbox::<
+        crate::host::event_subscriptions::HostPublishRequest,
+    >::channel(wake, "event_publish");
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(stream) = stream else { continue };
+            // Mirror `spawn_socket_listener`'s production accept loop:
+            // resolve the peer identity synchronously, right here, before
+            // any further work — never inside a spawned connection thread.
+            let peer_pid = resolve_socket_peer_pid(&stream);
+            let peer_ancestry = peer_pid.map(capture_peer_ancestry);
+            handle_socket_connection(
+                stream,
+                mailbox.clone(),
+                subscribe_mailbox.clone(),
+                publish_mailbox.clone(),
+                peer_ancestry,
+            );
+        }
+    });
+
+    // JSON payload forging `source_pane_id`/`source_context_id` as the
+    // OTHER (forged) pane. Sent by a real `nc` process spawned INSIDE the
+    // real pane's own shell — a genuine child of its `child_pid`, not a
+    // pid we merely compute.
+    let payload = serde_json::json!({
+        "type": "notify",
+        "notify_id": "live-descendant",
+        "title": "t",
+        "body": "b",
+        "kind": "message",
+        "options": [],
+        "scope": "context",
+        "source_context_id": forged_ctx,
+        "source_pane_id": forged_pane_id,
+    });
+    let payload_path = dir.path().join("payload.json");
+    std::fs::write(&payload_path, format!("{payload}\n")).expect("write payload");
+
+    let quote = |s: &str| format!("'{}'", s.replace('\'', "'\\''"));
+    // Absolute path, not bare `nc`: a dev machine with Homebrew's GNU
+    // netcat ahead of /usr/bin on PATH silently runs the wrong `nc` (GNU
+    // netcat rejects `-U` with "invalid option"), which would hang this
+    // test on the 10s deadline below instead of proving anything.
+    let cmd = format!(
+        "cat {} | /usr/bin/nc -U {}\n",
+        quote(payload_path.to_str().expect("utf8 path")),
+        quote(sock_path.to_str().expect("utf8 path")),
+    );
+    {
+        let win = &mut h.app.windows[real_win_idx];
+        let pane = win.panes.get_mut(&real_pane_id).expect("real pane exists");
+        let terminal = pane.as_terminal_mut().expect("terminal pane");
+        terminal
+            .backend
+            .process_command(egui_term::BackendCommand::Write(cmd.into_bytes()));
+    }
+
+    // The shell executes `nc` as a genuine OS process on its own schedule,
+    // independent of our frame pump — poll for delivery instead of assuming
+    // synchronous completion.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        h.run_frames(1);
+        if !h.app.pending_notifications.is_empty() {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!(
+                "live descendant notify did not arrive within 10s — check `nc -U` availability"
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    let posted = &h.app.pending_notifications[0];
+    assert_eq!(
+        posted.source_context_id, real_ctx,
+        "must attribute to the real shell-descendant pane, not the forged claim"
+    );
+    assert_ne!(posted.source_context_id, forged_ctx);
 }

--- a/src/cli/notify.rs
+++ b/src/cli/notify.rs
@@ -147,6 +147,32 @@ pub fn notify_cli(
         return 1;
     }
 
+    // Block until the host confirms it captured our socket-peer identity
+    // (`PEER_IDENTITY_ACK`, `handle_socket_line` in `src/app/mod.rs`) before
+    // this call is allowed to proceed. Load-bearing specifically for the
+    // fire-and-forget branch just below: without it, this process can exit
+    // the instant its write completes — a real race against the host's own
+    // accept()-return latency under load, not just a spawned-thread delay.
+    // Losing that race means `get_pid_ppid` fails on an already-gone pid and
+    // the notification misattributes to "outside pane" (global scope, no
+    // dismiss) even though the caller really was a live, known pane. The
+    // blocking-choice branch below can't lose this race either way — it
+    // polls `response_file` until the host finishes processing, well past
+    // the ack point — so this read is belt-and-suspenders there, but it's
+    // cheap and correct to do unconditionally before committing to either
+    // branch. A short timeout keeps a stuck/uncooperative host — or one
+    // from before this change, mid-upgrade, that never sends an ack at all
+    // — from hanging this call for long; a missed ack is logged, not
+    // fatal, and the request was already delivered either way. A
+    // same-host unix-socket round trip normally completes in microseconds,
+    // so this bound is already generous, not a tight deadline being cut
+    // close.
+    let _ = stream.set_read_timeout(Some(std::time::Duration::from_millis(500)));
+    let mut ack = [0u8; 1];
+    if let Err(e) = std::io::Read::read_exact(&mut stream, &mut ack) {
+        log::warn!("notify:cli: peer identity ack not received: {e}");
+    }
+
     // Fire-and-forget path — command is delivered, nothing to wait for.
     let Some(response_file) = response_file_str else {
         println!("{notify_id}");
@@ -247,11 +273,15 @@ mod notify_tests {
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {
             let (stream, _) = listener.accept().expect("accept notify connection");
+            let mut reader = BufReader::new(stream.try_clone().expect("clone notify stream"));
             let mut line = String::new();
-            BufReader::new(stream)
-                .read_line(&mut line)
-                .expect("read notify payload");
+            reader.read_line(&mut line).expect("read notify payload");
             let payload = serde_json::from_str::<Value>(&line).expect("notify payload json");
+            // Real host behavior: ack once the peer identity would have been
+            // captured, so `notify_cli`'s blocking read doesn't stall this
+            // test on the 5s timeout every call.
+            use std::io::Write;
+            let _ = (&stream).write_all(&[0x06]);
             tx.send(payload).ok();
         });
 
@@ -384,11 +414,12 @@ mod notify_tests {
 
         let handle = std::thread::spawn(move || {
             let (stream, _) = listener.accept().expect("accept notify connection");
+            let mut reader = BufReader::new(stream.try_clone().expect("clone notify stream"));
             let mut line = String::new();
-            BufReader::new(stream)
-                .read_line(&mut line)
-                .expect("read notify payload");
+            reader.read_line(&mut line).expect("read notify payload");
             let payload: Value = serde_json::from_str(&line).expect("notify payload json");
+            use std::io::Write;
+            let _ = (&stream).write_all(&[0x06]);
             let response_file = payload["response_file"]
                 .as_str()
                 .expect("blocking choice response_file")

--- a/src/host/shell.rs
+++ b/src/host/shell.rs
@@ -459,6 +459,50 @@ fn invoked_exec_basename(pid: u32) -> Option<String> {
     (!base.is_empty()).then(|| base.to_string())
 }
 
+/// Parent pid of `pid`, or `None` if the process is gone or the platform has
+/// no supported lookup. Used to walk a socket peer's ancestor chain back to
+/// the shell process a `TerminalPane` owns (`resolve_socket_peer_pane`).
+#[cfg(target_os = "macos")]
+pub fn get_pid_ppid(pid: u32) -> Option<u32> {
+    let mut info: libc::proc_bsdinfo = unsafe { std::mem::zeroed() };
+    let size = std::mem::size_of::<libc::proc_bsdinfo>() as libc::c_int;
+    let rc = unsafe {
+        libc::proc_pidinfo(
+            pid as libc::c_int,
+            libc::PROC_PIDTBSDINFO,
+            0,
+            &mut info as *mut _ as *mut libc::c_void,
+            size,
+        )
+    };
+    if rc != size {
+        log::warn!("get_pid_ppid: proc_pidinfo failed for pid {pid} (rc={rc})");
+        return None;
+    }
+    Some(info.pbi_ppid)
+}
+
+#[cfg(target_os = "linux")]
+pub fn get_pid_ppid(pid: u32) -> Option<u32> {
+    // /proc/{pid}/stat: "pid (comm) state ppid ...". The comm field is
+    // parenthesized and may itself contain spaces/parens, so find the LAST
+    // ')' first, then split the remaining fields on whitespace — ppid is the
+    // 2nd field after that ')'.
+    let contents = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let close_paren = contents.rfind(')')?;
+    let rest = contents.get(close_paren + 1..)?;
+    let mut fields = rest.split_whitespace();
+    let _state = fields.next()?;
+    let ppid = fields.next()?;
+    ppid.parse::<u32>().ok()
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+pub fn get_pid_ppid(pid: u32) -> Option<u32> {
+    let _ = pid;
+    None
+}
+
 /// Map a foreground process name to the canonical agent name the lifecycle
 /// hooks report (`PLEXI_AGENT_NAME`). This is the identity half of the shared
 /// agent detector: hooks are authoritative once they fire, but not every

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -170,6 +170,18 @@ pub enum AppRequest {
         /// contexts after its env was stamped.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source_pane_id: Option<u64>,
+        /// Host-established only: the socket peer credential check's ancestor
+        /// pid chain for this connection (`capture_peer_ancestry`, walked
+        /// eagerly at accept time — before the client's process can exit).
+        /// Never present on the wire — `serde(skip)` makes it impossible for
+        /// a client to set this field by sending JSON; it is stamped by
+        /// `handle_socket_line` after the host resolves the socket peer, and
+        /// is the trustworthy input the sender-identity resolution in
+        /// `handle_pane_ipc_request` uses instead of
+        /// `source_context_id`/`source_pane_id`, which are client-supplied and
+        /// must never be trusted for ownership decisions.
+        #[serde(skip)]
+        peer_pid: Option<Vec<u32>>,
     },
     /// Remove a notification posted by the caller. The host verifies the
     /// caller identity against the notification's stamped provenance.
@@ -180,6 +192,10 @@ pub enum AppRequest {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         source_pane_id: Option<u64>,
         response_file: String,
+        /// Host-established only: see `Notify::peer_pid`. `serde(skip)` — a
+        /// client can never set this over the wire.
+        #[serde(skip)]
+        peer_pid: Option<Vec<u32>>,
     },
     /// Report agent state for a pane. Called by hook scripts via `plexi agent report`.
     SetAgentState {

--- a/src/scenes.rs
+++ b/src/scenes.rs
@@ -2502,6 +2502,7 @@ impl HeadlessBackend {
                         .push(crate::app::PendingNotification {
                             notify_id: id.clone(),
                             sender_pane_id: 0,
+                            dismiss_owner_pane_id: 0,
                             source_context_id: 0,
                             source_window_id: 0,
                             title,

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1536,6 +1536,7 @@ mod tests {
         crate::app::PendingNotification {
             notify_id: notify_id.to_string(),
             sender_pane_id: 0,
+            dismiss_owner_pane_id: 0,
             source_context_id,
             source_window_id,
             title: "Preview badge".to_string(),
@@ -3478,6 +3479,7 @@ mod tests {
                 crate::app::PendingNotification {
                     notify_id: notify_id.to_string(),
                     sender_pane_id: 0,
+                    dismiss_owner_pane_id: 0,
                     source_context_id,
                     source_window_id,
                     title: "Preview badge".to_string(),


### PR DESCRIPTION
## Summary

Implements stint 0636. No linked GitHub issue — stint is authoritative.

- CLI notification provenance (`plexi notify`) was client-supplied: any process could forge `PLEXI_PANE_ID`/`PLEXI_CONTEXT_ID` and the host trusted the resulting `source_pane_id`/`source_context_id` wire fields for scope and dismiss-ownership decisions.
- The host now establishes sender identity itself from the notify-socket's kernel peer credential (`LOCAL_PEERPID` on macOS, `SO_PEERCRED` on Linux), captured synchronously in the accept loop (before the connection is even handed to a thread), then walks the peer's ancestor pids against every live terminal pane's shell `child_pid` to find the true sending pane. Client-claimed `source_context_id`/`source_pane_id` are now advisory only — a mismatch against the host-resolved identity is logged and ignored.
- Dismiss ownership is checked against the host-resolved sender pane rather than re-parsing it out of the client-generated `notify_id` string (the pre-fix "check" compared two attacker-controlled values against each other).
- Closed a race discovered during review: a fire-and-forget `plexi notify` call exits immediately after writing, which can outrun the host's own accept()-return latency and leave the peer's process ancestry unqueryable by the time the host looks it up. `plexi notify`/`plexi notify dismiss` now block briefly (bounded to 500ms) on a host-sent identity ack before proceeding, so the host's ancestry walk always runs while the peer is still guaranteed alive.

## Done When

- Introduce a host-owned socket-peer identity envelope at the notify-socket listener; do not dispatch raw client-provided pane/context provenance as trusted command data. ✅
- Establish the peer process identity at connection acceptance and resolve it to the owning terminal pane/context through host-managed process ownership, including the supported shell-child topology. ✅
- Derive CLI notification provenance and notification-dismiss authorization exclusively from that host-established identity; ignore or reject conflicting client-supplied ids. ✅
- Preserve explicit outside-pane behavior without fabricating pane or context provenance. ✅ (unresolvable peer still escalates Notify to Global scope / blocks Dismiss, same as before)
- Add deterministic HostHarness/socket-boundary coverage proving a foreign peer cannot post or dismiss as another pane, plus a live regression path where the runtime transport is required. ✅ (`forged_source_pane_is_ignored_in_favor_of_resolved_peer`, `live_socket_peer_resolves_through_real_descendant_process` — spawns a genuine child `nc -U` process inside a real pane's shell against a real `UnixListener`)
- Instrument accepted, unresolved, and rejected provenance decisions at info level without logging notification bodies. ✅

## Test evidence

- `cargo test --bin plexi` (env-stripped): 2316 passed, 1 failed (pre-existing flake in `host::wasm_python::tests::headless_frame_fails_fast_when_the_guest_dies_at_import`, unrelated file, passes in isolation), 5 ignored.
- Targeted: `cargo test --bin plexi notif` — 71 passed, 0 failed, including the two new peer-identity tests above.
- Two rounds of `codex review --uncommitted` surfaced a real P1 race (ancestry capture losing to a short-lived CLI process exiting before the host's accept-loop code ran) — fixed with the accept-time capture + identity-ack handshake described above; verified clean on a third pass aside from one P2 (long ack timeout on host/CLI version skew, addressed by shortening it to 500ms).
- Install: skippable — this is host socket/logic-layer behavior fully covered by the `HostHarness` unit and live-descendant-process tests above; no UI surface changed.