### PR TITLE
perf(host/terminal): coalesce terminal reflow to the trailing edge of a drag (stint 0719)

### DIFF
--- a/deps/egui_term/src/backend/mod.rs
+++ b/deps/egui_term/src/backend/mod.rs
@@ -41,7 +41,6 @@ pub enum BackendCommand {
     Scroll(i32),
     ScrollToTop,
     ScrollToBottom,
-    Resize(Size, Size),
     SelectStart(SelectionType, f32, f32, f32),
     SelectUpdate(f32, f32, f32),
     ClearSelection,
@@ -86,6 +85,74 @@ pub enum LinkAction {
     Clear,
     Hover,
     Open,
+}
+
+/// What [`TerminalBackend::request_resize`] did with a frame's layout geometry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResizeOutcome {
+    /// The cell grid is already what the shell has; nothing was sent.
+    Unchanged,
+    /// The geometry changed this frame and is being held for the trailing edge
+    /// of the drag. The caller must schedule another frame so the commit
+    /// cannot be stranded by a gesture that ends between frames.
+    Deferred,
+    /// `SIGWINCH` and the grid reflow ran for this geometry.
+    Committed,
+}
+
+/// Longest run of consecutive frames a pending resize may be held back. A drag
+/// that reports a new size on literally every frame never produces the stable
+/// frame the debounce waits for, so without a cap the grid would stay frozen
+/// at its pre-drag size for the entire gesture. The cap turns that into a
+/// bounded one-reflow-per-`MAX_DEFERRED_RESIZE_FRAMES` and keeps the visible
+/// grid tracking a long drag.
+const MAX_DEFERRED_RESIZE_FRAMES: u32 = 8;
+
+/// The cell grid a layout implies. Cell dimensions are part of it because a
+/// font-size change reflows the shell exactly like a pane-size change does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ResizeGeometry {
+    lines: u16,
+    cols: u16,
+    cell_height: u16,
+    cell_width: u16,
+}
+
+impl ResizeGeometry {
+    /// `None` for a layout that yields no rows or no columns — a zero-sized or
+    /// not-yet-laid-out pane, which the shell must never be told about.
+    fn derive(layout_size: Size, font_size: Size) -> Option<Self> {
+        let lines = (layout_size.height / font_size.height.floor()) as u16;
+        let cols = (layout_size.width / font_size.width.floor()) as u16;
+        if lines == 0 || cols == 0 {
+            return None;
+        }
+        Some(Self {
+            lines,
+            cols,
+            cell_height: font_size.height as u16,
+            cell_width: font_size.width as u16,
+        })
+    }
+
+    fn of(size: &TerminalSize) -> Self {
+        Self {
+            lines: size.num_lines,
+            cols: size.num_cols,
+            cell_height: size.cell_height,
+            cell_width: size.cell_width,
+        }
+    }
+}
+
+/// Geometry seen on a frame but not yet committed. See
+/// [`TerminalBackend::request_resize`].
+#[derive(Debug, Clone, Copy)]
+struct PendingResize {
+    geometry: ResizeGeometry,
+    /// Consecutive frames the reflow has been held back, including the frame
+    /// that produced this record.
+    deferred_frames: u32,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -169,6 +236,13 @@ pub struct TerminalBackend {
     /// terminal — without depending on a live child process echoing it back.
     /// Mirrors the cross-crate observation rationale of [`crate::diag`].
     input_tap: Mutex<Option<Vec<u8>>>,
+    /// Number of grid reflows actually committed to the PTY and the alacritty
+    /// grid. Observable so the resize-debounce regression test can assert a
+    /// multi-frame drag coalesces instead of reflowing once per frame.
+    resize_commits: u64,
+    /// Layout geometry seen but not yet committed, held by the frame-stability
+    /// debounce in [`Self::request_resize`].
+    pending_resize: Option<PendingResize>,
 }
 
 #[derive(Default)]
@@ -286,6 +360,8 @@ impl TerminalBackend {
             capture_state: Mutex::new(CaptureState::default()),
             max_scroll_limit: 10_000,
             input_tap: Mutex::new(None),
+            resize_commits: 0,
+            pending_resize: None,
         })
     }
 
@@ -307,9 +383,6 @@ impl TerminalBackend {
             BackendCommand::ScrollToBottom => {
                 log::info!("terminal scroll: jump to bottom");
                 term.grid_mut().scroll_display(Scroll::Bottom);
-            },
-            BackendCommand::Resize(layout_size, font_size) => {
-                self.resize(&mut term, layout_size, font_size);
             },
             BackendCommand::SelectStart(selection_type, x, y, ppp) => {
                 self.start_selection(&mut term, selection_type, x, y, ppp);
@@ -892,41 +965,107 @@ impl TerminalBackend {
         }
     }
 
-    fn resize(
+    /// Ask the terminal to adopt this frame's layout geometry.
+    ///
+    /// The render pass calls this once per frame per visible terminal, so it is
+    /// the frequency gate for the whole reflow path: committing means a PTY
+    /// `SIGWINCH` plus an alacritty grid reflow whose cost scales with
+    /// scrollback, all synchronous inside the host's `ui` pass. During a
+    /// pane-divider or window-edge drag the geometry changes on every
+    /// intermediate frame, so committing each one stutters the drag for every
+    /// visible pane at once (stint 0719).
+    ///
+    /// Geometry is therefore held until it stops moving: a change is recorded
+    /// as pending and only committed once a later frame reports the *same*
+    /// geometry — the trailing edge of the drag. A `Deferred` outcome obliges
+    /// the caller to schedule another frame, otherwise a drag that ends between
+    /// frames would strand the last size.
+    pub fn request_resize(
+        &mut self,
+        layout_size: Size,
+        font_size: Size,
+    ) -> ResizeOutcome {
+        let Some(geometry) = ResizeGeometry::derive(layout_size, font_size)
+        else {
+            // Degenerate layout (zero rows or columns): there is no grid to
+            // give the shell, and a pending one would be equally meaningless.
+            self.pending_resize = None;
+            return ResizeOutcome::Unchanged;
+        };
+
+        if geometry == ResizeGeometry::of(&self.size) {
+            // Sub-pixel layout drift with an identical cell grid: record it,
+            // but the shell's view of the world has not changed.
+            self.pending_resize = None;
+            self.size.layout_size = layout_size;
+            return ResizeOutcome::Unchanged;
+        }
+
+        let held = self.pending_resize.take();
+        let settled = held.is_some_and(|pending| pending.geometry == geometry);
+        let deferred_frames =
+            held.map_or(0, |pending| pending.deferred_frames) + 1;
+
+        if !settled && deferred_frames < MAX_DEFERRED_RESIZE_FRAMES {
+            self.pending_resize = Some(PendingResize {
+                geometry,
+                deferred_frames,
+            });
+            return ResizeOutcome::Deferred;
+        }
+
+        log::info!(
+            "terminal {} resize commit: {}x{} cells, {} frame(s) coalesced ({})",
+            self.id,
+            geometry.cols,
+            geometry.lines,
+            deferred_frames - 1,
+            if settled {
+                "layout settled"
+            } else {
+                "defer cap reached"
+            },
+        );
+
+        let term = self.term.clone();
+        let mut term = term.lock();
+        self.commit_resize(&mut term, layout_size, geometry);
+        ResizeOutcome::Committed
+    }
+
+    fn commit_resize(
         &mut self,
         terminal: &mut Term<EventProxy>,
         layout_size: Size,
-        font_size: Size,
+        geometry: ResizeGeometry,
     ) {
-        let lines = (layout_size.height / font_size.height.floor()) as u16;
-        let cols = (layout_size.width / font_size.width.floor()) as u16;
-        if lines == 0 || cols == 0 {
-            return;
-        }
-
-        // Skip SIGWINCH if row/col count and cell dimensions are unchanged —
-        // sub-pixel layout changes don't affect the shell's grid.
-        if lines == self.size.num_lines
-            && cols == self.size.num_cols
-            && font_size.height as u16 == self.size.cell_height
-            && font_size.width as u16 == self.size.cell_width
-        {
-            self.size.layout_size = layout_size;
-            return;
-        }
-
         self.size = TerminalSize {
             layout_size,
-            cell_height: font_size.height as u16,
-            cell_width: font_size.width as u16,
-            num_lines: lines,
-            num_cols: cols,
+            cell_height: geometry.cell_height,
+            cell_width: geometry.cell_width,
+            num_lines: geometry.lines,
+            num_cols: geometry.cols,
         };
         *self.shared_size.lock().unwrap() = self.size;
+        self.resize_commits += 1;
 
         self.notifier.on_resize(self.size.into());
-        terminal.resize(TermSize::new(cols as usize, lines as usize));
+        terminal.resize(TermSize::new(
+            geometry.cols as usize,
+            geometry.lines as usize,
+        ));
         terminal.scroll_display(Scroll::Bottom);
+    }
+
+    /// How many grid reflows (PTY `SIGWINCH` + alacritty reflow) this terminal
+    /// has committed. Monotonic for the life of the backend.
+    pub fn resize_commits(&self) -> u64 {
+        self.resize_commits
+    }
+
+    /// The grid geometry the PTY was last told about, as `(cols, lines)`.
+    pub fn committed_grid(&self) -> (u16, u16) {
+        (self.size.num_cols, self.size.num_lines)
     }
 
     fn write<I: Into<Cow<'static, [u8]>>>(&self, input: I) {

--- a/deps/egui_term/src/lib.rs
+++ b/deps/egui_term/src/lib.rs
@@ -17,7 +17,9 @@ mod types;
 mod view;
 
 pub use backend::settings::BackendSettings;
-pub use backend::{BackendCommand, PtyEvent, TerminalBackend, TerminalMode};
+pub use backend::{
+    BackendCommand, PtyEvent, ResizeOutcome, TerminalBackend, TerminalMode,
+};
 pub use bindings::{Binding, BindingAction, InputKind, KeyboardBinding};
 pub use diag::{set_repaint_diag_hook, set_span_hook};
 pub use font::{FontSettings, TerminalFont};

--- a/deps/egui_term/src/view.rs
+++ b/deps/egui_term/src/view.rs
@@ -16,6 +16,7 @@ use egui::{Id, PointerButton};
 use std::time::{Duration, Instant};
 
 use crate::backend::BackendCommand;
+use crate::backend::ResizeOutcome;
 use crate::backend::TerminalBackend;
 use crate::backend::{LinkAction, MouseButton, SelectionType};
 use crate::bindings::Binding;
@@ -247,20 +248,29 @@ impl<'a> TerminalView<'a> {
     }
 
     fn resize(self, layout: &Response) -> Self {
-        // Timed as a whole (stint 0731 drag profiling): process_command
-        // takes self.term.lock() for every command, so this captures lock
-        // contention with the PTY reader thread, not just the reflow math.
+        // Timed as a whole (stint 0731 drag profiling): a committing frame
+        // takes self.term.lock(), so this captures lock contention with the
+        // PTY reader thread, not just the reflow math. A frame the debounce
+        // defers takes no lock at all, which is most of the win during a drag.
         let timed = crate::diag::span_hook_installed();
         let start = timed.then(std::time::Instant::now);
-        self.backend.process_command(BackendCommand::Resize(
+        let outcome = self.backend.request_resize(
             Size::from(grid_size(layout.rect.size(), self.padding)),
             self.font.font_measure(&layout.ctx),
-        ));
+        );
         if let Some(start) = start {
             crate::diag::span_note(
                 "terminal_resize",
                 start.elapsed().as_nanos() as u64,
             );
+        }
+
+        if outcome == ResizeOutcome::Deferred {
+            // The commit runs on the next frame that reports the same
+            // geometry, so a drag that ends between frames must still produce
+            // one more pass — otherwise the final size is stranded and the
+            // shell keeps wrapping to the pre-drag width (stint 0719).
+            layout.ctx.request_repaint();
         }
 
         self

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -7076,3 +7076,190 @@ mod sidebar_panel_width_tests {
         );
     }
 }
+
+/// Stint 0719: `TerminalView::ui` asks its backend to resize on every frame,
+/// so an in-flight pane-divider or window-edge drag used to run a full PTY
+/// `SIGWINCH` plus an alacritty grid reflow for *every* visible terminal on
+/// *every* intermediate frame — the reflow cost scales with scrollback, and it
+/// runs synchronously inside `App::ui`, which is where the reported drag
+/// stutter lives. These tests drive real terminal panes through real frames at
+/// changing widths and assert the reflow coalesces to the trailing edge of the
+/// drag instead of firing once per frame.
+#[cfg(test)]
+mod terminal_resize_debounce_tests {
+    use super::*;
+
+    /// Run one frame with the host window at `width`. A drag is simulated as a
+    /// sequence of these: each frame a slightly different window size, exactly
+    /// as winit reports a live resize.
+    fn frame_at_width(h: &mut HostHarness, width: f32) {
+        h.frame(RawInput {
+            screen_rect: Some(egui::Rect::from_min_size(
+                egui::Pos2::ZERO,
+                egui::vec2(width, 800.0),
+            )),
+            ..Default::default()
+        });
+    }
+
+    /// Three terminals side by side, so every window-width change changes every
+    /// terminal's column count — the freeze scales with pane count.
+    fn three_side_by_side_terminals(h: &mut HostHarness) -> [PaneId; 3] {
+        let first = h.add_focused_terminal();
+        let second = h
+            .app
+            .split_focused(false, None, false, false, None)
+            .expect("split must create a second terminal");
+        let third = h
+            .app
+            .split_focused(false, None, false, false, None)
+            .expect("split must create a third terminal");
+        [first, second, third]
+    }
+
+    fn commits(h: &mut HostHarness, terminals: &[PaneId]) -> Vec<u64> {
+        terminals
+            .iter()
+            .map(|id| h.terminal_backend(*id).resize_commits())
+            .collect()
+    }
+
+    fn grids(h: &mut HostHarness, terminals: &[PaneId]) -> Vec<(u16, u16)> {
+        terminals
+            .iter()
+            .map(|id| h.terminal_backend(*id).committed_grid())
+            .collect()
+    }
+
+    const START_WIDTH: f32 = 1280.0;
+    const DRAG_STEP: f32 = 40.0;
+
+    /// The core guard: a six-frame drag must produce one reflow per terminal
+    /// (at the trailing edge), not six. It also proves the trailing-edge commit
+    /// is never lost — the terminals end up narrower than they started and then
+    /// stay put.
+    #[test]
+    fn window_drag_coalesces_terminal_reflow_to_the_trailing_edge() {
+        let mut h = HostHarness::new();
+        let terminals = three_side_by_side_terminals(&mut h);
+
+        // Settle at the start width so the initial sizing is not counted.
+        for _ in 0..4 {
+            frame_at_width(&mut h, START_WIDTH);
+        }
+        let before = commits(&mut h, &terminals);
+        let start_grids = grids(&mut h, &terminals);
+
+        const DRAG_FRAMES: u32 = 6;
+        for step in 1..=DRAG_FRAMES {
+            frame_at_width(&mut h, START_WIDTH - step as f32 * DRAG_STEP);
+        }
+        // The drag has ended; the pointer is up and the size now holds.
+        let final_width = START_WIDTH - DRAG_FRAMES as f32 * DRAG_STEP;
+        for _ in 0..4 {
+            frame_at_width(&mut h, final_width);
+        }
+
+        let after = commits(&mut h, &terminals);
+        let end_grids = grids(&mut h, &terminals);
+        for (i, id) in terminals.iter().enumerate() {
+            let reflows = after[i] - before[i];
+            assert_eq!(
+                reflows, 1,
+                "terminal {id} must reflow once for the whole {DRAG_FRAMES}-frame drag, \
+                 not once per frame (got {reflows})"
+            );
+            assert!(
+                end_grids[i].0 < start_grids[i].0,
+                "terminal {id} must end the drag actually narrower — the trailing-edge \
+                 commit was lost (start {:?}, end {:?})",
+                start_grids[i],
+                end_grids[i]
+            );
+        }
+
+        // Converged: holding the size costs nothing more.
+        for _ in 0..6 {
+            frame_at_width(&mut h, final_width);
+        }
+        assert_eq!(
+            commits(&mut h, &terminals),
+            after,
+            "a terminal at a stable size must not reflow again"
+        );
+        assert_eq!(
+            grids(&mut h, &terminals),
+            end_grids,
+            "a settled terminal's committed grid must not drift"
+        );
+    }
+
+    /// A long drag must not starve: the deferral is capped, so the grid keeps
+    /// tracking a sustained drag at a bounded rate instead of freezing at the
+    /// pre-drag size for the whole gesture.
+    #[test]
+    fn sustained_drag_reflow_is_bounded_and_does_not_starve() {
+        let mut h = HostHarness::new();
+        let terminals = three_side_by_side_terminals(&mut h);
+
+        for _ in 0..4 {
+            frame_at_width(&mut h, START_WIDTH);
+        }
+        let before = commits(&mut h, &terminals);
+
+        const DRAG_FRAMES: u32 = 24;
+        for step in 1..=DRAG_FRAMES {
+            frame_at_width(&mut h, START_WIDTH - step as f32 * 20.0);
+        }
+        let during = commits(&mut h, &terminals);
+
+        for (i, id) in terminals.iter().enumerate() {
+            let reflows = during[i] - before[i];
+            assert!(
+                reflows >= 1,
+                "terminal {id} must keep tracking a {DRAG_FRAMES}-frame drag, \
+                 not freeze at the pre-drag size (got {reflows} reflows)"
+            );
+            assert!(
+                reflows <= DRAG_FRAMES as u64 / 4,
+                "terminal {id} reflowed {reflows} times across {DRAG_FRAMES} drag frames — \
+                 the per-frame reflow is back"
+            );
+        }
+    }
+
+    /// A single programmatic size change (no drag) must still land promptly. A
+    /// one-frame stability wait is the cost of the debounce; an indefinite
+    /// deferral would be a regression of its own.
+    #[test]
+    fn single_step_resize_commits_within_one_stable_frame() {
+        let mut h = HostHarness::new();
+        let terminals = three_side_by_side_terminals(&mut h);
+
+        for _ in 0..4 {
+            frame_at_width(&mut h, START_WIDTH);
+        }
+        let before = commits(&mut h, &terminals);
+        let start_grids = grids(&mut h, &terminals);
+
+        // One step, then hold: two frames is the whole budget.
+        frame_at_width(&mut h, START_WIDTH - 200.0);
+        frame_at_width(&mut h, START_WIDTH - 200.0);
+
+        let after = commits(&mut h, &terminals);
+        let end_grids = grids(&mut h, &terminals);
+        for (i, id) in terminals.iter().enumerate() {
+            assert_eq!(
+                after[i] - before[i],
+                1,
+                "terminal {id} must commit a single-step resize within two frames"
+            );
+            assert!(
+                end_grids[i].0 < start_grids[i].0,
+                "terminal {id} must be narrower after the step (start {:?}, end {:?})",
+                start_grids[i],
+                end_grids[i]
+            );
+        }
+    }
+}

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1759,6 +1759,124 @@ mod tests {
         println!("Screenshot saved to /tmp/plexi_with_pane.png");
     }
 
+    /// Visual review for the terminal reflow debounce (stint 0719). The
+    /// debounce holds a resize while the layout is still moving and commits
+    /// once the drag settles, so the pixel risk is a *stranded* commit: a
+    /// terminal left wrapping to its pre-drag width inside a narrower pane.
+    /// Three real terminals are dragged narrower one frame at a time, then
+    /// held — the assertion proves the grid followed, the PNG proves the
+    /// glyphs did too.
+    #[test]
+    fn screenshot_terminals_settle_after_window_drag() {
+        const START_W: f32 = 1200.0;
+        const HEIGHT: f32 = 700.0;
+        let mut h = PlexiUiHarness::new_sized(START_W, HEIGHT);
+        h.step();
+        add_focused_pane(&mut h);
+        h.step();
+        for _ in 0..3 {
+            h.with_app_mut(|app| app.split_focused(false, None, false, false, None));
+            h.run_steps(2);
+        }
+
+        let terminals: Vec<crate::spatial::tiling::PaneId> = h.with_app(|app| {
+            app.windows[app.active_window]
+                .panes
+                .iter()
+                .filter(|(_, pane)| matches!(pane, Pane::Terminal(_)))
+                .map(|(id, _)| *id)
+                .collect()
+        });
+        assert!(
+            terminals.len() >= 2,
+            "need several real terminals for the drag to be meaningful"
+        );
+        let widest_before = h.with_app_mut(|app| max_terminal_cols(app, &terminals));
+        seed_wrapping_text(&mut h, &terminals);
+
+        // Drag the window edge in: one frame per intermediate width, exactly
+        // as winit reports a live resize.
+        for step in 1..=6 {
+            h.harness()
+                .set_size(egui::vec2(START_W - step as f32 * 60.0, HEIGHT));
+            h.step();
+        }
+        h.run_steps(4);
+
+        let widest_after = h.with_app_mut(|app| max_terminal_cols(app, &terminals));
+        assert!(
+            widest_after < widest_before,
+            "the trailing-edge commit was stranded: terminals still {widest_before} cols \
+             wide after dragging the window narrower (now {widest_after})"
+        );
+
+        h.save_screenshot("/tmp/plexi_terminal_drag_settled.png")
+            .expect("render failed");
+        println!("Screenshot saved to /tmp/plexi_terminal_drag_settled.png");
+    }
+
+    /// Fill each terminal with a line long enough to wrap, so the screenshot
+    /// shows real reflowed content instead of an empty grid. Bounded: an
+    /// unresponsive shell degrades the visual evidence, never the assertions,
+    /// so this returns rather than failing the test.
+    fn seed_wrapping_text(h: &mut PlexiUiHarness, terminals: &[crate::spatial::tiling::PaneId]) {
+        let line = "the quick brown fox jumps over the lazy dog. ".repeat(6);
+        h.with_app_mut(|app| {
+            for id in terminals {
+                if let Some(terminal) = app.windows[app.active_window]
+                    .panes
+                    .get_mut(id)
+                    .and_then(|pane| pane.as_terminal_mut())
+                {
+                    terminal
+                        .backend
+                        .process_command(egui_term::BackendCommand::Write(
+                            line.as_bytes().to_vec(),
+                        ));
+                }
+            }
+        });
+        let deadline =
+            std::time::Instant::now() + crate::testing::load_aware_timeout(Duration::from_secs(5));
+        while std::time::Instant::now() < deadline {
+            h.run_steps(2);
+            let painted = h.with_app_mut(|app| {
+                terminals.iter().all(|id| {
+                    app.windows[app.active_window]
+                        .panes
+                        .get_mut(id)
+                        .and_then(|pane| pane.as_terminal_mut())
+                        .is_some_and(|terminal| {
+                            terminal
+                                .backend
+                                .capture_lines(4)
+                                .iter()
+                                .any(|row| row.contains("quick brown fox"))
+                        })
+                })
+            });
+            if painted {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Widest committed PTY grid among `terminals`, in columns.
+    fn max_terminal_cols(app: &mut PlexiApp, terminals: &[crate::spatial::tiling::PaneId]) -> u16 {
+        terminals
+            .iter()
+            .filter_map(|id| {
+                app.windows[app.active_window]
+                    .panes
+                    .get_mut(id)
+                    .and_then(|pane| pane.as_terminal_mut())
+                    .map(|terminal| terminal.backend.committed_grid().0)
+            })
+            .max()
+            .expect("terminals must still be open")
+    }
+
     /// Visual review for the diffed WASM tree path (stint 0438): a real
     /// CPython-in-WASM app (breakout) opened and stepped past its first frame,
     /// so frame 2+ arrive as `tree_delta`s the decoder thread reconstructs and


### PR DESCRIPTION
Stint 0719. Dragging a pane divider or the window edge stuttered because every visible terminal reflowed on every intermediate frame.

## Root cause

`TerminalView::ui` called `self.resize(&layout)` unconditionally each frame, and `TerminalBackend::resize` only early-returned when the cell grid was byte-identical to the previous frame's. During a drag the layout changes every frame, so the guard never fired: each frame ran `notifier.on_resize()` (PTY SIGWINCH) plus `terminal.resize()` (alacritty grid reflow, cost scales with scrollback) per visible pane, synchronously inside `App::ui`.

## Mechanism

`TerminalBackend::request_resize` replaces the per-frame commit with a frame-stability debounce: a changed grid is recorded as pending and committed only when a later frame reports the *same* geometry — the trailing edge of the drag. A deferred frame takes no `term.lock()` at all, so it also stops contending with the PTY reader thread.

Two properties the debounce must not break:

- **The trailing-edge commit is never lost.** A `Deferred` outcome obliges the view to `request_repaint()`, so a drag that ends between frames still produces the pass that commits the final size.
- **A long drag does not starve.** `MAX_DEFERRED_RESIZE_FRAMES` caps the hold, so a gesture reporting a new size on literally every frame reflows at a bounded rate rather than freezing at its pre-drag size for the whole gesture.

`BackendCommand::Resize` is removed rather than left as a second way in — the view was its only caller, and a single resize path keeps the debounce unbypassable.

Alacritty's reflow algorithm is untouched, per the stint's non-scope. Only how often it is invoked changed.

## Instrumentation

Each commit logs at info with the grid it adopted, how many frames it coalesced, and whether it fired because the layout settled or because the defer cap was reached:

```
terminal 3 resize commit: 71x43 cells, 5 frame(s) coalesced (layout settled)
```

The `terminal` and `terminal_resize` `PLEXI_UI_PROFILE` spans are unchanged, so before/after drag profiles stay comparable.

## Test evidence

Written failing-first. Against unfixed code the drag test reported `terminal 1 must reflow once for the whole 6-frame drag, not once per frame (got 6)` and the sustained-drag test reported 20 reflows across 24 frames.

New `HostHarness` tests (`src/testing/harness_tests.rs`, `terminal_resize_debounce_tests`) drive three real side-by-side terminal panes through real frames at changing widths:

- `window_drag_coalesces_terminal_reflow_to_the_trailing_edge` — a six-frame drag commits exactly **1** reflow per terminal (was 6), the terminals genuinely end narrower (no stranded commit), and holding the size costs nothing further.
- `sustained_drag_reflow_is_bounded_and_does_not_starve` — a 24-frame drag stays at or under 6 reflows per terminal while still committing at least once, so the grid keeps tracking a long gesture.
- `single_step_resize_commits_within_one_stable_frame` — a one-step programmatic resize still lands within two frames.

Visual review (`screenshot_terminals_settle_after_window_drag` in `src/ui_tests.rs`): three real terminals seeded with wrapping text, dragged narrower one frame at a time, then held and rendered through the real GPU path. Read the PNG — the text is reflowed to the *post*-drag width, wrapping exactly at each pane's new right edge with no clipping and no leftover pre-drag wrap column, which is precisely what a stranded trailing-edge commit would have shown. The test also asserts the committed grid shrank, so the invariant survives without the PNG. Screenshot deleted after review.

Gates, all from the feature worktree:

- `cargo build` — clean
- `cargo test --bin plexi` — **2339 passed, 0 failed, 7 ignored**
- `cargo clippy --bin plexi -- -D warnings` — clean
- `rustfmt --check` on every touched file — clean for the changed lines (alpha is not fmt-clean; pre-existing deviations left alone)