### PR TITLE
fix(host/context): auto sidebar name follows explicit root changes (stint 0726)

### DIFF
--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -2588,6 +2588,100 @@ fn set_context_root_ensures_app_state_gitignore() {
     );
 }
 
+/// Stint 0726: `set_context_root` is the shared invariant boundary for every
+/// explicit root-change caller (Cmd+Shift+I, sidebar Set Root, the
+/// context-root text overlay, `SetContextRoot` IPC) — an `Auto`-named
+/// context must reflect the new root's basename immediately, not only after
+/// a manual blank-rename round trip.
+#[test]
+fn set_context_root_updates_auto_name_immediately() {
+    let mut h = crate::testing::HostHarness::new();
+    let idx = h.app.router.active_idx();
+    h.app.router.get_mut(idx).name = crate::host::context::ContextName::auto("stale-name");
+
+    let parent = tempfile::tempdir().expect("tempdir");
+    let new_root = parent.path().join("new-project");
+    std::fs::create_dir(&new_root).expect("new-project dir");
+
+    h.app.set_context_root(new_root, None);
+
+    assert_eq!(
+        h.app.router.get(idx).name.displayed(),
+        "new-project",
+        "auto name must follow the new root's basename immediately"
+    );
+}
+
+/// A `Custom` name is user-owned and must never be overwritten by a root
+/// change — only a blank rename submission returns a context to `Auto`.
+#[test]
+fn set_context_root_preserves_custom_name() {
+    let mut h = crate::testing::HostHarness::new();
+    let idx = h.app.router.active_idx();
+    h.app.router.get_mut(idx).name = crate::host::context::ContextName::custom("My Workspace");
+
+    let new_root = tempfile::tempdir().expect("tempdir");
+    h.app.set_context_root(new_root.path().to_path_buf(), None);
+
+    assert!(
+        matches!(
+            h.app.router.get(idx).name,
+            crate::host::context::ContextName::Custom(ref name) if name == "My Workspace"
+        ),
+        "custom name must survive an explicit root change: {:?}",
+        h.app.router.get(idx).name
+    );
+}
+
+/// An auto name colliding with another context's displayed name after a
+/// root change must be disambiguated through the same deterministic suffix
+/// path as auto-naming a brand-new context, never silently duplicated.
+#[test]
+fn set_context_root_disambiguates_auto_name_collision() {
+    let mut h = crate::testing::HostHarness::new();
+    let active_id = h.app.router.active().context_id;
+    let other_id = active_id + 500;
+    h.app
+        .router
+        .push(test_context(other_id, active_id, "project"));
+    let other_idx = h.app.router.position(|c| c.context_id == other_id).unwrap();
+    h.app.router.get_mut(other_idx).name = crate::host::context::ContextName::auto("project");
+
+    let idx = h.app.router.active_idx();
+    h.app.router.get_mut(idx).name = crate::host::context::ContextName::auto("stale-name");
+
+    let parent = tempfile::tempdir().expect("tempdir");
+    let colliding_root = parent.path().join("project");
+    std::fs::create_dir(&colliding_root).expect("project dir");
+
+    h.app.set_context_root(colliding_root, None);
+
+    assert_eq!(
+        h.app.router.get(idx).name.displayed(),
+        "project (2)",
+        "colliding auto name must be disambiguated deterministically"
+    );
+}
+
+/// Cmd+Shift+I (`SetContextRootFromCwd`) must persist the updated root and
+/// automatic name exactly once, through `set_context_root`'s own dirty mark,
+/// so the sidebar state survives a restart rather than requiring a
+/// caller-specific `mark_workspace_dirty()` call.
+#[test]
+fn set_context_root_marks_workspace_dirty_for_persistence() {
+    let mut h = crate::testing::HostHarness::new();
+    h.app.workspace_dirty = false;
+
+    let new_root = tempfile::tempdir().expect("tempdir");
+    h.app.set_context_root(new_root.path().to_path_buf(), None);
+
+    assert!(
+        h.app.workspace_dirty,
+        "set_context_root must mark the workspace dirty so the new root and \
+         name survive a restart, regardless of caller"
+    );
+}
+
 /// Dissolve is only reachable for a context that hangs off a Portal tile.
 /// `dissolve_portal` early-returns without one, so the close-confirm modal
 /// must not offer the action for a top-level context (stint 0542).

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -1665,13 +1665,14 @@ impl PlexiApp {
 
     /// Set the `root` of a context. `context_id` targets a specific context
     /// (the caller's PLEXI_CONTEXT_ID over IPC); `None` means the active one.
+    ///
+    /// This is the single invariant boundary for explicit root changes: every
+    /// caller (Cmd+Shift+I, sidebar Set Root, the context-root text overlay,
+    /// the `SetContextRoot` IPC command) routes through here, so an `Auto`
+    /// name is reconciled to the new root's basename exactly once, in one
+    /// place, rather than in each caller.
     pub(crate) fn set_context_root(&mut self, root: PathBuf, context_id: Option<u64>) {
         let idx = self.resolve_context_idx(context_id, "set_context_root");
-        log::info!(
-            "set_context_root: ctx_id={} root={}",
-            self.router.get(idx).context_id,
-            root.display()
-        );
         auto_init_workspace(&root);
         let context_id = self.router.get(idx).context_id;
         for pane_id in self
@@ -1682,7 +1683,24 @@ impl PlexiApp {
         {
             crate::app::host_mcp::rebind_pane_credential(*pane_id, root.clone());
         }
-        self.router.get_mut(idx).root = root;
+        self.router.get_mut(idx).root = root.clone();
+
+        let is_auto = matches!(self.router.get(idx).name, ContextName::Auto(_));
+        let name_changed = if is_auto {
+            let new_name = self.auto_context_name_for_path(context_id, &root);
+            let changed = self.router.get(idx).name.displayed() != new_name;
+            self.router.get_mut(idx).name = ContextName::auto(new_name);
+            changed
+        } else {
+            false
+        };
+        log::info!(
+            "set_context_root: ctx_id={context_id} root={} name_mode={} name_changed={name_changed}",
+            root.display(),
+            if is_auto { "auto" } else { "custom" }
+        );
+        self.mark_workspace_dirty();
+
         // Transition effects (registry rescan, watcher restart, agent reload)
         // only apply when the *active* context's root changed.
         if idx == self.router.active_idx() {

--- a/src/ui_tests.rs
+++ b/src/ui_tests.rs
@@ -1458,6 +1458,32 @@ mod tests {
             .expect("render failed");
     }
 
+    /// Stint 0726: visual proof that the sidebar shows the new project's
+    /// basename immediately after an explicit root change, not the stale
+    /// automatic name from before the move.
+    #[test]
+    fn screenshot_sidebar_auto_name_follows_root_change() {
+        let mut h = PlexiUiHarness::new_sized_ppp(1280.0, 800.0, 2.0);
+        let parent = tempfile::tempdir().expect("tempdir");
+        let new_root = parent.path().join("plexi-target-project");
+        std::fs::create_dir(&new_root).expect("target project dir");
+
+        h.with_app_mut(|app| {
+            app.sidebar_visible = true;
+            let idx = app.router.active_idx();
+            app.router.get_mut(idx).name = crate::host::context::ContextName::auto("stale-name");
+            app.set_context_root(new_root.clone(), None);
+            assert_eq!(
+                app.router.get(idx).name.displayed(),
+                "plexi-target-project",
+                "sidebar label must resolve to the new root's basename"
+            );
+        });
+        h.run_steps(6);
+        h.save_screenshot("/tmp/plexi-0726-sidebar-auto-name-root-change.png")
+            .expect("render failed");
+    }
+
     /// Push a second spatial window onto `context_id` and return its index, so
     /// a sidebar row can be seeded with more than one pip capsule.
     fn push_window_for_context(


### PR DESCRIPTION
## Summary
- `set_context_root` is now the single invariant boundary for every root-change caller (Cmd+Shift+I, sidebar Set Root, the context-root text overlay, `SetContextRoot` IPC): an `Auto`-named context's displayed name is recomputed from the new root's basename immediately, reusing the existing `auto_context_name_for_path` collision-suffix path; `Custom` names are left untouched.
- Folded `mark_workspace_dirty()` into `set_context_root` itself, so `Cmd+Shift+I` (which previously called `set_context_root` without a follow-up dirty mark) now persists the updated root and name exactly once, same as every other caller.
- Added an info-level trace recording context id, new root, name mode, and whether the displayed name changed.

## Test plan
- [x] `set_context_root_updates_auto_name_immediately` — auto name follows an explicit root change without a rename round trip
- [x] `set_context_root_preserves_custom_name` — custom name survives a root change
- [x] `set_context_root_disambiguates_auto_name_collision` — colliding auto name gets the `(2)` suffix
- [x] `set_context_root_marks_workspace_dirty_for_persistence` — Cmd+Shift+I path persists via the shared function
- [x] `screenshot_sidebar_auto_name_follows_root_change` — visual regression, reviewed the rendered PNG and deleted it per TESTING.md
- [x] `cargo test --bin plexi` — 2355 passed, 0 failed, 7 ignored