### PR TITLE
host/scope: one host-stamped origin and resolved-source policy across contexts (stint 0724)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -676,6 +676,11 @@ impl AgentHost {
                     trigger_mode: sub.trigger,
                     resource_id: None,
                     duration: GrantDuration::Session,
+                    // Viewer context for `evaluate_reach` (stint 0724 Phase
+                    // D) — `AgentHost` itself remains a single
+                    // active-context singleton (flagged in Phase C), so this
+                    // is simply the context that reload last observed.
+                    subscriber_context_id: self.context_id,
                     created_at: crate::host::event_log::now_timestamp(),
                 },
             );

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -543,6 +543,20 @@ pub struct AgentHost {
     timeline: Arc<Mutex<AppTimeline>>,
     ai_broker: Arc<dyn AiBroker>,
     workspace_root: PathBuf,
+    /// The active host context this `AgentHost` last reloaded for — stint
+    /// 0724 Phase C. `gated_dispatcher` resolves connector-tool reachability
+    /// from this, never from `workspace_root` path-equality. `0` before the
+    /// first `reload_workspace` call (matches no real context; `AgentHost`
+    /// has no agents yet at that point, so `gated_dispatcher` is never
+    /// exercised against it).
+    ///
+    /// NOTE: `AgentHost` itself remains a single active-context singleton
+    /// (like `workspace_root`) — reloaded wholesale on every context
+    /// transition rather than keyed per-context the way `RegistryViews`
+    /// (Phase B) is. This mirrors the pre-Phase-B `AppRegistry` bug class for
+    /// agents specifically; fixing it is out of scope for Phase C and is
+    /// flagged for a future stint.
+    context_id: u64,
     /// Where to re-read `grants.toml` from on workspace reload (`Some` in
     /// production). Until the Phase D grant sheet lands, grants are edited on
     /// disk, so a reload must pick them up. `None` (tests) keeps the
@@ -568,6 +582,7 @@ impl AgentHost {
             timeline,
             ai_broker,
             workspace_root,
+            context_id: 0,
             grants_dir: None,
             outcome_tx,
             outcome_rx,
@@ -580,8 +595,13 @@ impl AgentHost {
     /// becomes active after boot are picked up. Detaches every current agent
     /// (removing its timeline subscriptions), re-reads grants from disk when
     /// `grants_dir` is set, and attaches the new root's agents. `None` =
-    /// no active workspace = no agents.
-    pub fn reload_workspace(&mut self, workspace_root: Option<PathBuf>) {
+    /// no active workspace = no agents. `context_id` is the host-observed
+    /// active context (`WorkspaceRouter::active().context_id` at the call
+    /// site) — stored unconditionally so `gated_dispatcher`'s connector-tool
+    /// reachability always reflects the context this reload is for, even
+    /// when `workspace_root` resolves to `None`.
+    pub fn reload_workspace(&mut self, workspace_root: Option<PathBuf>, context_id: u64) {
+        self.context_id = context_id;
         if !self.agents.is_empty() {
             let mut timeline = self.timeline.lock().unwrap();
             for agent in &self.agents {
@@ -782,11 +802,8 @@ impl AgentHost {
     /// this workspace whose `app_connector:app.<tool_name>` target evaluates
     /// to `Allow` for the agent (user grants + the agent's posture tiers).
     fn gated_dispatcher(&self, agent: &AgentRuntime) -> ToolDispatcher {
-        let mut dispatcher = ToolDispatcher::from_registry(
-            0,
-            format!("agent:{}", agent.def.id),
-            self.workspace_root.clone(),
-        );
+        let mut dispatcher =
+            ToolDispatcher::from_registry(0, format!("agent:{}", agent.def.id), self.context_id);
         let allowed: HashSet<String> = dispatcher
             .all_tools()
             .into_iter()
@@ -1125,18 +1142,18 @@ default_tier = "low"
         assert!(host.agents.is_empty());
 
         // Workspace becomes active → agent attaches with its subscription.
-        host.reload_workspace(Some(ws.path().to_path_buf()));
+        host.reload_workspace(Some(ws.path().to_path_buf()), 1);
         assert_eq!(host.agents.len(), 1);
         assert_eq!(host.agents[0].subscription_ids.len(), 1);
         assert_eq!(timeline.lock().unwrap().subscriptions().len(), 1);
 
         // Reload onto the same workspace must not duplicate.
-        host.reload_workspace(Some(ws.path().to_path_buf()));
+        host.reload_workspace(Some(ws.path().to_path_buf()), 1);
         assert_eq!(host.agents.len(), 1);
         assert_eq!(timeline.lock().unwrap().subscriptions().len(), 1);
 
         // Switching to no workspace detaches and removes subscriptions.
-        host.reload_workspace(None);
+        host.reload_workspace(None, 1);
         assert!(host.agents.is_empty());
         assert!(timeline.lock().unwrap().subscriptions().is_empty());
     }

--- a/src/app/canvas_bindings.rs
+++ b/src/app/canvas_bindings.rs
@@ -398,6 +398,15 @@ impl PlexiApp {
     /// a split to its right.
     fn open_file_in_app(&mut self, sender_pane_id: PaneId, path: &str) {
         use crate::app::file_handlers::FileHandler;
+        // Resolve the registry view against the REQUESTING pane's own
+        // context, not whichever context is currently active (stint 0724
+        // Phase B) — `find_pane_in_any_window` finds it via the pane table,
+        // never `active_window`/`router.active()`, so a background pane
+        // asking to open a file still resolves its own workspace's handlers.
+        let context_id = self
+            .find_pane_in_any_window(sender_pane_id)
+            .map(|(window_index, _)| self.windows[window_index].context_id)
+            .unwrap_or_else(|| self.windows[self.active_window].context_id);
         let ext = std::path::Path::new(path)
             .extension()
             .and_then(|e| e.to_str())
@@ -443,7 +452,12 @@ impl PlexiApp {
         }
 
         // (b) app manifest `file_types` association.
-        if let Some(id) = self.registry.handler_for_ext(&ext).map(|s| s.to_string()) {
+        if let Some(id) = self
+            .registries
+            .view_for_context(context_id, &self.router)
+            .handler_for_ext(&ext)
+            .map(|s| s.to_string())
+        {
             if self.launch_app_with_path(&id, path) {
                 log::info!("open: '{path}' → app '{id}' (manifest file_types)");
                 return;

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1159,7 +1159,6 @@ impl PlexiApp {
                     pipe_id,
                     payload,
                 } => {
-                    let active = self.active_window;
                     // JSON pipe messages route only through directed pipes
                     // (#286): the host scopes delivery to the non-sender member
                     // of the recorded `(sender, target)` pair. The legacy
@@ -1167,9 +1166,23 @@ impl PlexiApp {
                     // event streams (subscription-scoped, cross-window) replace
                     // it. A send on a pipe that was never opened directed is
                     // dropped with a warning.
-                    let Some(&(a, b)) = self.directed_pipes.get(&pipe_id) else {
+                    //
+                    // The lookup key is the CALLER's own host-established
+                    // context (stint 0724 Phase D 2/2) — never the client's
+                    // claim, never `active_window` — so a caller can never
+                    // blindly hit a `pipe_id` string that happens to belong to
+                    // a different context's directed pipe.
+                    let Some(sender_origin) = self.origin_for_pane(sender_pane_id) else {
                         log::warn!(
-                            "DeliverPipeMessage: '{pipe_id}' from pane {sender_pane_id} is not a directed pipe; dropping (non-directed JSON pipes were removed in 0327)"
+                            "DeliverPipeMessage: sender pane {sender_pane_id} not found; '{pipe_id}' dropped"
+                        );
+                        continue;
+                    };
+                    let key = (sender_origin.context_id, pipe_id.clone());
+                    let Some(&(a, b)) = self.directed_pipes.get(&key) else {
+                        log::warn!(
+                            "DeliverPipeMessage: '{pipe_id}' from pane {sender_pane_id} (context {}) is not a directed pipe; dropping (non-directed JSON pipes were removed in 0327)",
+                            sender_origin.context_id
                         );
                         continue;
                     };
@@ -1186,13 +1199,18 @@ impl PlexiApp {
                         None
                     };
                     if let Some(tid) = target_pid {
-                        if let Some(pane) = self.windows[active].panes.get_mut(&tid) {
-                            let event = crate::app_protocol::PlexiEvent::PipeMessage {
-                                pipe_id: pipe_id.clone(),
-                                payload: payload.clone(),
-                            };
-                            if let Some(app) = pane.as_app_mut() {
-                                app.runtime.queue_outbound_event(event);
+                        // Never assume the target lives in the active window —
+                        // a directed pipe's two ends share a context, not
+                        // necessarily a window.
+                        if let Some((window_index, _)) = self.find_pane_in_any_window(tid) {
+                            if let Some(pane) = self.windows[window_index].panes.get_mut(&tid) {
+                                let event = crate::app_protocol::PlexiEvent::PipeMessage {
+                                    pipe_id: pipe_id.clone(),
+                                    payload: payload.clone(),
+                                };
+                                if let Some(app) = pane.as_app_mut() {
+                                    app.runtime.queue_outbound_event(event);
+                                }
                             }
                         }
                     }
@@ -1202,43 +1220,96 @@ impl PlexiApp {
                     pipe_id,
                     target_pane_id,
                 } => {
+                    // Resolve host-established origins for BOTH ends — never
+                    // `router.active()`/`active_window` — so reachability is
+                    // decided from facts the host itself observed, not a
+                    // claim or ambient focus state (stint 0724 Phase D 2/2).
+                    let Some(sender_origin) = self.origin_for_pane(sender_pane_id) else {
+                        log::warn!(
+                            "OpenDirectedPipe: sender pane {sender_pane_id} not found; pipe '{pipe_id}' dropped"
+                        );
+                        continue;
+                    };
+                    let Some(target_origin) = self.origin_for_pane(target_pane_id) else {
+                        log::warn!(
+                            "OpenDirectedPipe: target pane {target_pane_id} not found; pipe '{pipe_id}' dropped"
+                        );
+                        continue;
+                    };
+                    // A directed pipe is an exclusive channel to ONE named
+                    // pane — the tightest scope available — so a caller in
+                    // another context is rejected outright. No
+                    // `CrossContextGrant` consumer exists for directed pipes
+                    // yet; `evaluate_reach` already logs the rejection.
+                    let owner = crate::host::scope::Scope::Pane {
+                        pane_id: target_pane_id,
+                        context_id: target_origin.context_id,
+                    };
+                    if crate::host::scope::evaluate_reach(&owner, sender_origin.context_id, None)
+                        == crate::host::scope::Reach::Rejected
+                    {
+                        log::warn!(
+                            "OpenDirectedPipe: target {target_pane_id} is in context {} but caller {sender_pane_id} is in context {} — rejected",
+                            target_origin.context_id, sender_origin.context_id
+                        );
+                        continue;
+                    }
+
                     // Subscribe both sides + record the pair so subsequent
                     // `DeliverPipeMessage` for this pipe routes ONLY between
                     // them (#286). The sender already registered the pipe
                     // locally inside its own app runtime; we need to register
                     // it on the target so its `has_reader` returns true and
                     // its SDK has a Pipe handle if it sends in reverse.
-                    let active = self.active_window;
-                    let target_kind =
-                        self.windows[active]
-                            .panes
-                            .get(&target_pane_id)
-                            .map(|p| match p {
-                                crate::host::pane::Pane::App(_) => "app",
-                                crate::host::pane::Pane::Terminal(_) => "terminal",
-                                crate::host::pane::Pane::Portal(_) => "portal",
-                            });
+                    // Never assume the target lives in the active window.
+                    let Some((target_window_index, _)) =
+                        self.find_pane_in_any_window(target_pane_id)
+                    else {
+                        // Origin resolved above but the pane vanished between
+                        // the two lookups (closed this same frame) — drop.
+                        log::warn!(
+                            "OpenDirectedPipe: target pane {target_pane_id} closed before registration; pipe '{pipe_id}' dropped"
+                        );
+                        continue;
+                    };
+                    let target_kind = self.windows[target_window_index]
+                        .panes
+                        .get(&target_pane_id)
+                        .map(|p| match p {
+                            crate::host::pane::Pane::App(_) => "app",
+                            crate::host::pane::Pane::Terminal(_) => "terminal",
+                            crate::host::pane::Pane::Portal(_) => "portal",
+                        });
                     match target_kind {
                         Some("app") => {
                             // Register pipe on target's registry so it can
-                            // PipeSend back through the same id.
-                            let registered = if let Some(pane) =
-                                self.windows[active].panes.get_mut(&target_pane_id)
+                            // PipeSend back through the same id. Best-effort
+                            // only: no runtime has a reachable registry hookup
+                            // today (see `register_directed_pipe_on_target`),
+                            // so failure here is informational, never fatal —
+                            // the actual duplex data plane is host-mediated
+                            // via `directed_pipes` + `queue_outbound_event`,
+                            // not this local bookkeeping.
+                            let registered = if let Some(pane) = self.windows[target_window_index]
+                                .panes
+                                .get_mut(&target_pane_id)
                             {
                                 register_directed_pipe_on_target(pane, &pipe_id)
                             } else {
                                 false
                             };
                             if !registered {
-                                log::warn!(
-                                    "OpenDirectedPipe: failed to register '{pipe_id}' on target {target_pane_id}"
+                                log::info!(
+                                    "OpenDirectedPipe: '{pipe_id}' target {target_pane_id} has no local pipe registry hookup for its runtime yet — host-side routing still proceeds"
                                 );
-                                continue;
                             }
-                            self.directed_pipes
-                                .insert(pipe_id.clone(), (sender_pane_id, target_pane_id));
+                            self.directed_pipes.insert(
+                                (sender_origin.context_id, pipe_id.clone()),
+                                (sender_pane_id, target_pane_id),
+                            );
                             log::info!(
-                                "OpenDirectedPipe: '{pipe_id}' subscribed pane {sender_pane_id} ↔ pane {target_pane_id}"
+                                "OpenDirectedPipe: '{pipe_id}' subscribed pane {sender_pane_id} ↔ pane {target_pane_id} (context {})",
+                                sender_origin.context_id
                             );
                         }
                         Some(other) => log::warn!(
@@ -1559,13 +1630,39 @@ impl PlexiApp {
                     AppCommand::SpawnApp { .. }
                     | AppCommand::SpawnPane { .. }
                     | AppCommand::ForwardPaneRequest { .. }
-                    | AppCommand::DeliverPipeMessage { .. }
-                    | AppCommand::OpenDirectedPipe { .. }
                     | AppCommand::DeliverRunUpdate { .. }
                     | AppCommand::InsertPathToken { .. }
                     | AppCommand::RequestCommandPreview { .. }
                     | AppCommand::OpenArtifact { .. }
                     | AppCommand::QueryContextState { .. } => deferred.push(cmd),
+                    // Every SDK bridge that constructs these emits a
+                    // placeholder sender_pane_id=0 (it doesn't know its own
+                    // pane id); rewrite to the real pane_id here, where it's
+                    // known, so `origin_for_pane(sender_pane_id)` downstream
+                    // resolves the ACTUAL caller instead of failing to find
+                    // pane 0 (stint 0724 Phase D 2/2 — required for the
+                    // directed-pipe reachability check to see a real caller
+                    // at all, not just cosmetic).
+                    AppCommand::DeliverPipeMessage {
+                        pipe_id, payload, ..
+                    } => {
+                        deferred.push(AppCommand::DeliverPipeMessage {
+                            sender_pane_id: pane_id,
+                            pipe_id,
+                            payload,
+                        });
+                    }
+                    AppCommand::OpenDirectedPipe {
+                        pipe_id,
+                        target_pane_id,
+                        ..
+                    } => {
+                        deferred.push(AppCommand::OpenDirectedPipe {
+                            sender_pane_id: pane_id,
+                            pipe_id,
+                            target_pane_id,
+                        });
+                    }
                     // Builtin apps emit sender_pane_id=0; rewrite to
                     // the real pane_id so the host can route the response.
                     AppCommand::RequestLinkedTerminal {

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1105,12 +1105,16 @@ impl PlexiApp {
                     log::info!(
                         "notify:action: pane_id={pane_id} notify_id={notify_id:?} value={value:?} host_action={host_action:?}"
                     );
-                    crate::host::event_log::emit(
+                    let context_root = self
+                        .origin_for_pane(pane_id)
+                        .map(|origin| origin.context_root);
+                    crate::host::event_log::emit_scoped(
                         crate::host::event_log::HostEvent::NotificationActionInvoked {
                             id: notify_id.clone(),
                             action: action_label.clone(),
                             timestamp: crate::host::event_log::now_timestamp(),
                         },
+                        context_root.as_deref(),
                     );
                     // Execute host-side action synchronously before writing the response
                     // file so the navigation is complete before the shell unblocks.

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -417,23 +417,17 @@ impl PlexiApp {
                             let provider = self.windows.iter().find_map(|window| {
                                 window.panes.get(&pane_id).and_then(|pane| {
                                     pane.as_app().and_then(|app| {
-                                        app.runtime.tool_event_sender(ctx.clone()).map(|sender| {
-                                            (
-                                                app.manifest_id.clone(),
-                                                app.workspace_root.clone(),
-                                                sender,
-                                            )
-                                        })
+                                        app.runtime
+                                            .tool_event_sender(ctx.clone())
+                                            .map(|sender| (app.manifest_id.clone(), sender))
                                     })
                                 })
                             });
-                            if let Some((app_id, workspace_root, sender)) = provider {
+                            if let (Some((app_id, sender)), Some(origin)) =
+                                (provider, self.origin_for_pane(pane_id))
+                            {
                                 crate::plexi_ai::tool_dispatch::register(
-                                    pane_id,
-                                    app_id,
-                                    tools,
-                                    sender,
-                                    workspace_root,
+                                    pane_id, app_id, tools, sender, origin,
                                 );
                                 Some(InputEvent::DeclareToolsResult(Ok(names)))
                             } else {
@@ -468,19 +462,17 @@ impl PlexiApp {
                     let provider = self.windows.iter().find_map(|window| {
                         window.panes.get(&pane_id).and_then(|pane| {
                             pane.as_app().and_then(|app| {
-                                app.runtime.tool_event_sender(ctx.clone()).map(|sender| {
-                                    (app.manifest_id.clone(), app.workspace_root.clone(), sender)
-                                })
+                                app.runtime
+                                    .tool_event_sender(ctx.clone())
+                                    .map(|sender| (app.manifest_id.clone(), sender))
                             })
                         })
                     });
-                    if let Some((app_id, workspace_root, sender)) = provider {
+                    if let (Some((app_id, sender)), Some(origin)) =
+                        (provider, self.origin_for_pane(pane_id))
+                    {
                         crate::plexi_ai::tool_dispatch::register(
-                            pane_id,
-                            app_id,
-                            tools,
-                            sender,
-                            workspace_root,
+                            pane_id, app_id, tools, sender, origin,
                         );
                     } else {
                         log::warn!(

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -506,12 +506,24 @@ impl PlexiApp {
                         log::warn!("app events: source pane {pane_id} is closed");
                         continue;
                     };
+                    // Host-established context this app instance lives in
+                    // (stint 0724 Phase D) — the owning scope every stream
+                    // this pane declares/emits on is stamped with. Resolved
+                    // fresh here, never cached: the pane just resolved above
+                    // is live, so its owning window's `context_id` is too.
+                    let Some(context_id) = self
+                        .origin_for_pane(pane_id)
+                        .map(|origin| origin.context_id)
+                    else {
+                        log::warn!("app events: source pane {pane_id} has no resolvable origin");
+                        continue;
+                    };
                     let response = match request {
                         crate::app_protocol::AppRequest::DeclareEventStreams { streams } => {
                             match crate::host::app_timeline::global()
                                 .lock()
                                 .unwrap()
-                                .declare_streams(&app_id, streams)
+                                .declare_streams(context_id, &app_id, streams)
                             {
                                 Ok(streams) => {
                                     crate::app_protocol::PlexiEvent::DeclareEventStreamsResult {
@@ -562,7 +574,7 @@ impl PlexiApp {
                             match crate::host::app_timeline::global()
                                 .lock()
                                 .unwrap()
-                                .record_event(&app_id, pane_id, emitted)
+                                .record_event(context_id, &app_id, pane_id, emitted)
                             {
                                 Ok(outcome) => crate::app_protocol::PlexiEvent::EmitEventResult {
                                     sequence: Some(outcome.event_id),

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -1457,7 +1457,10 @@ impl PlexiApp {
         let mut deferred = Vec::new();
 
         for (type_id, park_context_id, cmds) in &parked {
-            let resolved_scope = self.registry.default_notification_scope_for(type_id);
+            let resolved_scope = self
+                .registries
+                .view_for_context(*park_context_id, &self.router)
+                .default_notification_scope_for(type_id);
             for cmd in cmds.iter() {
                 match cmd {
                     AppCommand::ShowNotification {
@@ -1513,7 +1516,10 @@ impl PlexiApp {
             // `DefaultNotifyScope`'s own default (`Window`, the most
             // restrictive), which is a declared per-app policy and so does not
             // go through `NotifyScope::default()`.
-            let resolved_scope = self.registry.default_notification_scope_for(&type_id);
+            let resolved_scope = self
+                .registries
+                .view_for_context(context_id, &self.router)
+                .default_notification_scope_for(&type_id);
             for cmd in cmds {
                 match cmd {
                     AppCommand::WasmHostEffect { effect, .. } => {

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -879,47 +879,20 @@ impl PlexiApp {
         self.reload_config_for_active_context();
     }
 
+    /// Ensures the active context's `AppRegistry` view exists (a cache hit
+    /// after the first call — `RegistryViews` no longer needs a staleness
+    /// comparison the way the old single shared `AppRegistry` did, stint 0724
+    /// Phase B) and reloads config for the active workspace. Registry views
+    /// for OTHER contexts are resolved independently at their own point of
+    /// use (`RegistryViews::view_for_context`); this only guarantees the
+    /// active one is warm before config reload reads workspace-scoped keys.
     pub(crate) fn reload_config_for_active_context(&mut self) {
         let active_workspace = Some(self.router.active().root.clone());
-        self.sync_app_registry_for_active_context(active_workspace.as_deref());
+        let active_context_id = self.router.active().context_id;
+        let _ = self
+            .registries
+            .view_for_context(active_context_id, &self.router);
         self.reload_config_for_workspace(active_workspace.as_deref());
-    }
-
-    pub(crate) fn reload_app_registry_for_root(&mut self, root: &Path) {
-        log::info!(
-            "app_registry: rescanning registry for root={}",
-            root.display()
-        );
-        self.registry = crate::app::registry::AppRegistry::load(root);
-        match crate::app::registry_watcher::start(
-            crate::app::registry::registry_watch_dirs(root),
-            std::sync::Arc::clone(&self.ui_wake),
-        ) {
-            Some((watcher, rx)) => {
-                self._registry_watcher = Some(watcher);
-                self.registry_reload_rx = Some(rx);
-            }
-            None => {
-                self._registry_watcher = None;
-                self.registry_reload_rx = None;
-            }
-        }
-    }
-
-    fn sync_app_registry_for_active_context(&mut self, active_workspace: Option<&Path>) {
-        let fallback;
-        let root = match active_workspace {
-            Some(root) => root,
-            None => {
-                fallback = std::env::current_dir()
-                    .unwrap_or_else(|_| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
-                fallback.as_path()
-            }
-        };
-        let expected_workspace = crate::app::registry::resolve_workspace_root(root);
-        if self.registry.loaded_workspace.as_ref() != expected_workspace.as_ref() {
-            self.reload_app_registry_for_root(root);
-        }
     }
 
     pub(crate) fn reload_config_for_workspace(&mut self, active_workspace: Option<&Path>) {

--- a/src/app/focus.rs
+++ b/src/app/focus.rs
@@ -425,19 +425,26 @@ impl PlexiApp {
         // don't emit a spurious crash_recovery on the next startup.
         crate::app::focus_journal::clear_journal(&self.focus_journal_path);
 
-        crate::host::event_log::emit(crate::host::event_log::HostEvent::FocusChanged {
-            pane_id: meta.pane_id,
-            context_name: meta.context_name,
-            context_description: meta.context_description,
-            context_root: meta.context_root,
-            cwd: meta.cwd,
-            pty_title: meta.pty_title,
-            pane_name: meta.pane_name,
-            app_type_id: meta.app_type_id,
-            reason: Some(reason.as_str().to_string()),
-            duration_secs,
-            timestamp: crate::host::event_log::now_timestamp(),
-        });
+        // `meta.context_root` is already resolved for the event body/Stats
+        // (`collect_pane_metadata`); reuse it for routing instead of resolving
+        // the origin a second time.
+        let context_root = meta.context_root.clone().map(std::path::PathBuf::from);
+        crate::host::event_log::emit_scoped(
+            crate::host::event_log::HostEvent::FocusChanged {
+                pane_id: meta.pane_id,
+                context_name: meta.context_name,
+                context_description: meta.context_description,
+                context_root: meta.context_root,
+                cwd: meta.cwd,
+                pty_title: meta.pty_title,
+                pane_name: meta.pane_name,
+                app_type_id: meta.app_type_id,
+                reason: Some(reason.as_str().to_string()),
+                duration_secs,
+                timestamp: crate::host::event_log::now_timestamp(),
+            },
+            context_root.as_deref(),
+        );
     }
 
     /// Write (or overwrite) the focus journal checkpoint for the pane currently
@@ -1371,12 +1378,16 @@ impl PlexiApp {
                 log::info!(
                     "notify:action: pane_id={pane_id} notify_id={notify_id:?} value={value:?} host_action={host_action:?}"
                 );
-                crate::host::event_log::emit(
+                let context_root = self
+                    .origin_for_pane(pane_id)
+                    .map(|origin| origin.context_root);
+                crate::host::event_log::emit_scoped(
                     crate::host::event_log::HostEvent::NotificationActionInvoked {
                         id: notify_id.clone(),
                         action: action_label.clone(),
                         timestamp: crate::host::event_log::now_timestamp(),
                     },
+                    context_root.as_deref(),
                 );
                 // Execute host-side action synchronously before writing the response
                 // file so the navigation is complete before the shell unblocks.

--- a/src/app/focus_journal.rs
+++ b/src/app/focus_journal.rs
@@ -105,19 +105,26 @@ pub(crate) fn recover_from_focus_journal(path: &Path) {
         entry.context_name
     );
 
-    crate::host::event_log::emit(crate::host::event_log::HostEvent::FocusChanged {
-        pane_id: entry.pane_id,
-        context_name: entry.context_name,
-        context_description: entry.context_description,
-        context_root: entry.context_root,
-        cwd: entry.cwd,
-        pty_title: entry.pty_title,
-        pane_name: entry.pane_name,
-        app_type_id: entry.app_type_id,
-        reason: Some("crash_recovery".to_string()),
-        duration_secs,
-        timestamp: crate::host::event_log::now_timestamp(),
-    });
+    // The journal already carries the pane's context root as a string (for
+    // the event body/Stats); reuse it as this event's routing root too,
+    // rather than resolving it again.
+    let context_root = entry.context_root.clone().map(std::path::PathBuf::from);
+    crate::host::event_log::emit_scoped(
+        crate::host::event_log::HostEvent::FocusChanged {
+            pane_id: entry.pane_id,
+            context_name: entry.context_name,
+            context_description: entry.context_description,
+            context_root: entry.context_root,
+            cwd: entry.cwd,
+            pty_title: entry.pty_title,
+            pane_name: entry.pane_name,
+            app_type_id: entry.app_type_id,
+            reason: Some("crash_recovery".to_string()),
+            duration_secs,
+            timestamp: crate::host::event_log::now_timestamp(),
+        },
+        context_root.as_deref(),
+    );
 
     clear_journal(path);
 }

--- a/src/app/host_mcp.rs
+++ b/src/app/host_mcp.rs
@@ -392,7 +392,7 @@ fn handle_connection(
                 caller.workspace_root.display()
             );
             let result = match tool_name {
-                "list_event_streams" => tool_list_event_streams(),
+                "list_event_streams" => tool_list_event_streams(&caller),
                 "subscribe_and_wait" => tool_subscribe_and_wait(&arguments, subscribe_tx, &caller),
                 other => {
                     let input_json = serde_json::to_string(&arguments)
@@ -432,15 +432,20 @@ fn handle_connection(
     write_http_response(&mut write_stream, 200, &body_bytes)
 }
 
-/// `list_event_streams` — read declared streams from the global timeline.
-fn tool_list_event_streams() -> Result<String, String> {
+/// `list_event_streams` — read declared streams from the global timeline,
+/// filtered to the caller's own context (stint 0724 Phase D): a stream
+/// declared only in another context can never be subscribed to from here
+/// anyway (no cross-context grant exists), so listing it would be
+/// misleading.
+fn tool_list_event_streams(caller: &McpCaller) -> Result<String, String> {
     let streams = crate::host::app_timeline::global()
         .lock()
         .unwrap()
         .all_declared_streams();
     let arr: Vec<serde_json::Value> = streams
         .iter()
-        .map(|(a, s)| serde_json::json!({ "app_id": a, "stream": s }))
+        .filter(|(context_id, _, _)| *context_id == caller.context_id)
+        .map(|(_, a, s)| serde_json::json!({ "app_id": a, "stream": s }))
         .collect();
     serde_json::to_string(&serde_json::json!({ "streams": arr }))
         .map_err(|e| format!("serialize failed: {e}"))
@@ -498,6 +503,12 @@ fn tool_subscribe_and_wait(
         subscriber_type_override: None,
         broker_actor_override: Some(actor_id),
         workspace_root_override: Some(caller.workspace_root.clone()),
+        context_id_override: Some(caller.context_id),
+        // The authenticated bearer credential already establishes this
+        // caller's identity (bound to `caller.pane_id`/`context_id` at
+        // registration — see `register_pane_credential`); there is no raw
+        // socket peer to independently verify here.
+        peer_ancestry: None,
         reply: reply_tx,
     };
     subscribe_tx
@@ -875,10 +886,15 @@ mod tests {
         use crate::host::app_timeline::EmittedEvent;
         let app = "mcp-it-app";
         let stream = "it.tick";
+        // `start_test_server` registers its pane credential with `context_id
+        // = 1` (see `register_pane_credential(pane_id, 1, ...)` below), so
+        // the stream must be declared under that same context for the
+        // subscribe to see it as declared (stint 0724 Phase D).
         crate::host::app_timeline::global()
             .lock()
             .unwrap()
             .declare_streams(
+                1,
                 app,
                 vec![EventStreamDecl {
                     name: stream.to_string(),
@@ -896,6 +912,7 @@ mod tests {
                 .lock()
                 .unwrap()
                 .record_event(
+                    1,
                     app,
                     1,
                     EmittedEvent {

--- a/src/app/host_mcp.rs
+++ b/src/app/host_mcp.rs
@@ -48,6 +48,10 @@ fn discovery() -> Option<u16> {
 #[derive(Clone)]
 struct McpCaller {
     pane_id: u64,
+    /// Host-established context this pane lives in — stint 0724 Phase C.
+    /// `from_namespaced_registry` resolves connector-tool reachability from
+    /// this, never from `workspace_root` path-equality.
+    context_id: u64,
     workspace_root: PathBuf,
 }
 
@@ -64,14 +68,16 @@ fn credentials() -> &'static Mutex<CredentialRegistry> {
 }
 
 /// Register or refresh the credential injected into one pane. The caller's
-/// workspace comes from host-owned pane construction, never the MCP request.
-fn register_pane_credential(pane_id: u64, workspace_root: PathBuf) -> String {
+/// context and workspace come from host-owned pane construction, never the
+/// MCP request.
+fn register_pane_credential(pane_id: u64, context_id: u64, workspace_root: PathBuf) -> String {
     let mut registry = credentials().lock().unwrap();
     if let Some(token) = registry.by_pane.get(&pane_id).cloned() {
         registry.by_token.insert(
             token.clone(),
             McpCaller {
                 pane_id,
+                context_id,
                 workspace_root,
             },
         );
@@ -83,11 +89,12 @@ fn register_pane_credential(pane_id: u64, workspace_root: PathBuf) -> String {
         token.clone(),
         McpCaller {
             pane_id,
+            context_id,
             workspace_root: workspace_root.clone(),
         },
     );
     log::info!(
-        "host_mcp: registered scoped credential pane={pane_id} workspace={}",
+        "host_mcp: registered scoped credential pane={pane_id} context={context_id} workspace={}",
         workspace_root.display()
     );
     token
@@ -95,9 +102,13 @@ fn register_pane_credential(pane_id: u64, workspace_root: PathBuf) -> String {
 
 /// Return the singleton endpoint plus a credential bound to this host-owned
 /// pane identity. This is the only discovery surface pane environments use.
-pub(crate) fn discovery_for_pane(pane_id: u64, workspace_root: PathBuf) -> Option<(u16, String)> {
+pub(crate) fn discovery_for_pane(
+    pane_id: u64,
+    context_id: u64,
+    workspace_root: PathBuf,
+) -> Option<(u16, String)> {
     discovery().map(|port| {
-        let token = register_pane_credential(pane_id, workspace_root);
+        let token = register_pane_credential(pane_id, context_id, workspace_root);
         (port, token)
     })
 }
@@ -138,21 +149,31 @@ impl Drop for PendingPaneCredential {
 }
 
 /// Update the trusted workspace attached to a live pane without rotating its
-/// credential. Context roots can change while their panes remain alive.
+/// credential. Context roots can change while their panes remain alive — the
+/// pane's `context_id` never changes on a root move, so it is carried forward
+/// from the existing credential rather than taken as a parameter here.
 pub(crate) fn rebind_pane_credential(pane_id: u64, workspace_root: PathBuf) {
     let mut registry = credentials().lock().unwrap();
     let Some(token) = registry.by_pane.get(&pane_id).cloned() else {
+        return;
+    };
+    let Some(context_id) = registry
+        .by_token
+        .get(&token)
+        .map(|caller| caller.context_id)
+    else {
         return;
     };
     registry.by_token.insert(
         token,
         McpCaller {
             pane_id,
+            context_id,
             workspace_root: workspace_root.clone(),
         },
     );
     log::info!(
-        "host_mcp: rebound scoped credential pane={pane_id} workspace={}",
+        "host_mcp: rebound scoped credential pane={pane_id} context={context_id} workspace={}",
         workspace_root.display()
     );
 }
@@ -162,8 +183,12 @@ fn authenticate(token: &str) -> Option<McpCaller> {
 }
 
 #[cfg(test)]
-pub(crate) fn register_pane_credential_for_test(pane_id: u64, workspace_root: PathBuf) -> String {
-    register_pane_credential(pane_id, workspace_root)
+pub(crate) fn register_pane_credential_for_test(
+    pane_id: u64,
+    context_id: u64,
+    workspace_root: PathBuf,
+) -> String {
+    register_pane_credential(pane_id, context_id, workspace_root)
 }
 
 #[cfg(test)]
@@ -333,7 +358,7 @@ fn handle_connection(
     };
     let dispatcher = crate::plexi_ai::tool_dispatch::ToolDispatcher::from_namespaced_registry(
         caller.pane_id,
-        caller.workspace_root.clone(),
+        caller.context_id,
     );
 
     let id = json.get("id").cloned().unwrap_or(serde_json::Value::Null);
@@ -621,7 +646,7 @@ mod tests {
         // endpoint never collides with a sibling test's port.
         let dir = tempfile::tempdir().unwrap();
         let port = start_host_mcp_server(tx, dir.path()).unwrap();
-        let token = register_pane_credential(pane_id, workspace_root);
+        let token = register_pane_credential(pane_id, 1, workspace_root);
         (port, token)
     }
 
@@ -641,6 +666,7 @@ mod tests {
             .map(|pane_id| {
                 register_pane_credential(
                     *pane_id,
+                    1,
                     PathBuf::from(format!("/workspace/aborted-{pane_id}")),
                 )
             })
@@ -658,7 +684,7 @@ mod tests {
 
         let live_id = 65_300_303u64;
         let live_root = PathBuf::from("/workspace/live");
-        let live_token = register_pane_credential(live_id, live_root.clone());
+        let live_token = register_pane_credential(live_id, 1, live_root.clone());
         PendingPaneCredential::new(live_id).mark_live();
 
         assert_eq!(
@@ -709,15 +735,30 @@ mod tests {
         assert!(names.contains(&"subscribe_and_wait"));
     }
 
+    /// A `ScopeOrigin` for a tool provider pane — mirrors
+    /// `tool_dispatch::tests::origin` (private to that module), duplicated
+    /// here since this test lives in a different module. Only `context_id`
+    /// and `pane_id` matter to `evaluate_reach`.
+    fn test_provider_origin(context_id: u64, pane_id: u64) -> crate::host::scope::ScopeOrigin {
+        crate::host::scope::ScopeOrigin {
+            context_id,
+            context_root: PathBuf::from(format!("/ctx-root-{context_id}")),
+            window_id: context_id,
+            pane_id,
+            app_id: None,
+        }
+    }
+
     #[test]
-    fn pane_credential_lists_and_calls_only_workspace_app_tools() {
+    fn pane_credential_lists_and_calls_only_context_app_tools() {
         use crate::app_protocol::{AiTool, PlexiEvent};
         use crate::plexi_ai::tool_dispatch::{self, AppEventSender, ToolCallResult};
 
         let (port, _test_token) = start_test_server(None);
+        let context_a = 100u64;
+        let context_b = 200u64; // a different context — must stay unreachable
         let workspace_a = PathBuf::from("/workspace/host-mcp-a");
-        let workspace_b = PathBuf::from("/workspace/host-mcp-b");
-        let caller_token = register_pane_credential(7_001, workspace_a.clone());
+        let caller_token = register_pane_credential(7_001, context_a, workspace_a);
         let (provider_tx, provider_rx) = std::sync::mpsc::channel();
         let (other_tx, _other_rx) = std::sync::mpsc::channel();
         let tool = |name: &str| AiTool {
@@ -733,14 +774,14 @@ mod tests {
             "workspace-a-app".to_string(),
             vec![tool("echo")],
             AppEventSender::Channel(provider_tx),
-            workspace_a,
+            test_provider_origin(context_a, 7_002),
         );
         tool_dispatch::register(
             7_003,
             "workspace-b-app".to_string(),
             vec![tool("secret")],
             AppEventSender::Channel(other_tx),
-            workspace_b,
+            test_provider_origin(context_b, 7_003),
         );
 
         let (status, body) = post(

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -132,14 +132,35 @@ impl PlexiApp {
             return;
         }
         self.host_subscriptions.reload(&crate::config::config_dir());
-        for req in subscribe_reqs {
+        // Resolve the caller's host-established origin here, at the point of
+        // dispatch — never cached, never trusted verbatim from the wire
+        // (stint 0724 Phase D). A request whose sender already resolved its
+        // own origin (host MCP, a WASM/Python app's own subscribe path) is
+        // left untouched; only the raw CLI-socket shape (`context_id_override
+        // == None`) is resolved here, preferring kernel-verified
+        // `peer_ancestry` over the client-forwarded `from_pane_id` claim.
+        for mut req in subscribe_reqs {
+            if req.context_id_override.is_none() {
+                let (verified_pane_id, context_id, workspace_root) =
+                    self.resolve_event_bus_caller(req.from_pane_id, req.peer_ancestry.as_deref());
+                req.from_pane_id = verified_pane_id;
+                req.context_id_override = context_id;
+                req.workspace_root_override = workspace_root;
+            }
             // `Allow`/`Deny`/undeclared answer the transport inline; `Ask`
             // returns a parked consent we surface as a host modal next frame.
             if let Some(consent) = self.host_subscriptions.classify_subscribe_request(req) {
                 self.pending_event_consents.push_back(consent);
             }
         }
-        for req in publish_reqs {
+        for mut req in publish_reqs {
+            if req.context_id_override.is_none() {
+                let (verified_pane_id, context_id, workspace_root) =
+                    self.resolve_event_bus_caller(req.from_pane_id, req.peer_ancestry.as_deref());
+                req.from_pane_id = verified_pane_id;
+                req.context_id_override = context_id;
+                req.workspace_root_override = workspace_root;
+            }
             if let Some(consent) = self.host_subscriptions.classify_publish_request(req) {
                 self.pending_event_consents.push_back(consent);
             }
@@ -1561,31 +1582,30 @@ impl PlexiApp {
                         } else if let Some(app_pane) = pane.as_app_mut() {
                             let runtime = &mut app_pane.runtime;
                             match super::drive_native_pane_key(runtime, key) {
-                                    Ok(disposition) => {
-                                        let disposition_label = match disposition {
-                                            crate::app::app_trait::KeyDisposition::Consumed => {
-                                                "consumed"
-                                            }
-                                            crate::app::app_trait::KeyDisposition::Passthrough => {
-                                                passthrough_raw =
-                                                    super::key_str_to_egui_raw_input(key);
-                                                "passthrough"
-                                            }
-                                        };
-                                        log::info!(
-                                            "pane_ipc: key_pane: native app pane_id={pane_id} \
+                                Ok(disposition) => {
+                                    let disposition_label = match disposition {
+                                        crate::app::app_trait::KeyDisposition::Consumed => {
+                                            "consumed"
+                                        }
+                                        crate::app::app_trait::KeyDisposition::Passthrough => {
+                                            passthrough_raw = super::key_str_to_egui_raw_input(key);
+                                            "passthrough"
+                                        }
+                                    };
+                                    log::info!(
+                                        "pane_ipc: key_pane: native app pane_id={pane_id} \
                                              key_chars={} disposition={disposition_label}",
-                                            key.chars().count()
-                                        );
-                                        Ok(serde_json::json!({
-                                            "ok": true,
-                                            "disposition": disposition_label,
-                                        }))
-                                    }
-                                    Err(e) => {
-                                        log::warn!("pane_ipc: key_pane: {e}");
-                                        Err(e)
-                                    }
+                                        key.chars().count()
+                                    );
+                                    Ok(serde_json::json!({
+                                        "ok": true,
+                                        "disposition": disposition_label,
+                                    }))
+                                }
+                                Err(e) => {
+                                    log::warn!("pane_ipc: key_pane: {e}");
+                                    Err(e)
+                                }
                             }
                         } else {
                             Err(format!("pane {pane_id}: unknown pane type"))
@@ -2345,19 +2365,17 @@ impl PlexiApp {
                 let resolved = peer_pid
                     .as_deref()
                     .and_then(|ancestry| self.resolve_socket_peer_pane(ancestry));
-                if let Some((resolved_pane_id, resolved_context_id, resolved_window_id)) =
-                    resolved
+                if let Some((resolved_pane_id, resolved_context_id, resolved_window_id)) = resolved
                 {
                     log::info!(
                         "pane_ipc: peer identity: notify sender resolved to pane={resolved_pane_id} context={resolved_context_id} window={resolved_window_id} peer_pid={peer_pid:?}"
                     );
                 }
                 if source_pane_id.is_some() || source_context_id.is_some() {
-                    let claimed_matches = resolved
-                        .is_some_and(|(pane_id, context_id, _)| {
-                            source_pane_id.is_none_or(|claimed| claimed == pane_id)
-                                && source_context_id.is_none_or(|claimed| claimed == context_id)
-                        });
+                    let claimed_matches = resolved.is_some_and(|(pane_id, context_id, _)| {
+                        source_pane_id.is_none_or(|claimed| claimed == pane_id)
+                            && source_context_id.is_none_or(|claimed| claimed == context_id)
+                    });
                     if !claimed_matches {
                         log::warn!(
                             "pane_ipc: notify: claimed identity (source_context_id={source_context_id:?} source_pane_id={source_pane_id:?}) \
@@ -2459,8 +2477,7 @@ impl PlexiApp {
                 let resolved = peer_pid
                     .as_deref()
                     .and_then(|ancestry| self.resolve_socket_peer_pane(ancestry));
-                if let Some((resolved_pane_id, resolved_context_id, resolved_window_id)) =
-                    resolved
+                if let Some((resolved_pane_id, resolved_context_id, resolved_window_id)) = resolved
                 {
                     log::info!(
                         "pane_ipc: peer identity: dismiss sender resolved to pane={resolved_pane_id} context={resolved_context_id} window={resolved_window_id} peer_pid={peer_pid:?}"
@@ -3209,11 +3226,8 @@ impl PlexiApp {
 
     pub(crate) fn tick_scheduler(&mut self) {
         // Load routines from every context root
-        let roots: Vec<std::path::PathBuf> = self
-            .router
-            .iter()
-            .map(|ctx| ctx.root.clone())
-            .collect();
+        let roots: Vec<std::path::PathBuf> =
+            self.router.iter().map(|ctx| ctx.root.clone()).collect();
         for root in &roots {
             let failures = self.scheduler.load_from_root(root);
             for f in failures {

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -1271,9 +1271,18 @@ impl PlexiApp {
                     // CLI/spawn-request app opens default to a sibling split, never
                     // an overlay takeover of the caller's pane. Manifest `[launch]
                     // placement` still overrides the default (stint 0330).
+                    //
+                    // `self.active_window` has already been redirected to the
+                    // target window above (when `from_pane_id` named one), so
+                    // its context_id is the launch's actual target context —
+                    // matching what `launch_app_by_id_with_layout` itself
+                    // resolves against (stint 0724 Phase B).
+                    let target_context_id = self.windows[self.active_window].context_id;
                     let placement = crate::pane_ops::cli_open_placement(
                         spec.layout.clone(),
-                        self.registry.placement_for(type_id),
+                        self.registries
+                            .view_for_context(target_context_id, &self.router)
+                            .placement_for(type_id),
                     );
                     launch_result = self
                         .launch_app_by_id_with_layout(

--- a/src/app/lifecycle.rs
+++ b/src/app/lifecycle.rs
@@ -204,11 +204,17 @@ impl PlexiApp {
                     }
                 }
                 if found {
-                    crate::host::event_log::emit(crate::host::event_log::HostEvent::PaneRenamed {
-                        pane_id: *pane_id,
-                        name: name.clone(),
-                        timestamp: crate::host::event_log::now_timestamp(),
-                    });
+                    let context_root = self
+                        .origin_for_pane(*pane_id)
+                        .map(|origin| origin.context_root);
+                    crate::host::event_log::emit_scoped(
+                        crate::host::event_log::HostEvent::PaneRenamed {
+                            pane_id: *pane_id,
+                            name: name.clone(),
+                            timestamp: crate::host::event_log::now_timestamp(),
+                        },
+                        context_root.as_deref(),
+                    );
                 }
                 if !found {
                     log::warn!("pane_ipc: set_pane_title: pane_id={pane_id} not found");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -344,15 +344,29 @@ pub struct PlexiApp {
     /// `park_context_id` is the context_id the app was running in when its
     /// pane was closed. Used to route notifications to the correct context.
     pub(crate) background_apps: HashMap<String, (u64, Box<dyn crate::app::app_trait::App>)>,
-    /// Directed inter-agent / inter-app pipes (#286). Keyed by `pipe_id`,
-    /// value is the `(sender_pane_id, target_pane_id)` pair the host scopes
-    /// `PipeMessage` deliveries to. This is the sole JSON-pipe delivery path:
-    /// `DeliverPipeMessage` routes ONLY to the non-sender member of the pair;
-    /// a send on a pipe absent from this map is dropped. The legacy non-directed
-    /// peer-broadcast fan-out was removed in 0327 in favour of event streams.
-    /// `PipeOpenDirected` is a thin alias over this map — an exclusive duplex
-    /// channel primitive; resource-scoped fan-out belongs on the event bus.
-    pub(crate) directed_pipes: HashMap<String, (u64, u64)>,
+    /// Directed inter-agent / inter-app pipes (#286). Keyed by
+    /// `(context_id, pipe_id)` (stint 0724 Phase D 2/2) — `context_id` is the
+    /// opening caller's own context, resolved via `origin_for_pane`, never a
+    /// client-supplied value. Composite-keying (rather than `pipe_id` alone)
+    /// is required, not cosmetic: two different contexts choosing the same
+    /// caller-selected `pipe_id` string (e.g. both pick `"agent-chat"`) must
+    /// never collide or cross-deliver, and before this phase they shared one
+    /// flat namespace. Value is the `(sender_pane_id, target_pane_id)` pair
+    /// the host scopes `PipeMessage` deliveries to. This is the sole
+    /// JSON-pipe delivery path: `DeliverPipeMessage` routes ONLY to the
+    /// non-sender member of the pair; a send on a pipe absent from this map
+    /// is dropped. The legacy non-directed peer-broadcast fan-out was removed
+    /// in 0327 in favour of event streams. `PipeOpenDirected` is a thin alias
+    /// over this map — an exclusive duplex channel primitive; resource-scoped
+    /// fan-out belongs on the event bus.
+    ///
+    /// `OpenDirectedPipe` rejects (never inserts) a request whose target pane
+    /// lives in a different context than the caller — see `evaluate_reach` in
+    /// `dispatch.rs`'s handler — so every entry here is guaranteed to have
+    /// both pane ids live in the SAME context, making `context_id` safe to
+    /// key on regardless of which side (sender or target) later calls
+    /// `pipe_send`.
+    pub(crate) directed_pipes: HashMap<(u64, String), (u64, u64)>,
     /// Hot-reload watcher set (#83). Owns one notify watcher per pane that
     /// opted-in via manifest `[app] watch = true` (workspace-local only).
     /// `hot_reload_rx` is drained each frame; pending requests trigger a
@@ -4525,8 +4539,24 @@ fn drive_native_pane_key(
     Ok(disposition)
 }
 
-/// process-app registry to register against (terminals — should never reach
-/// this path; logged at the call site).
+/// Best-effort: register the directed pipe on the target's OWN local pipe
+/// registry, so a runtime that supports one can report `has_reader`/
+/// `is_connected` true for it (SDK ergonomics on the target's reverse-send
+/// path). Returns `false` unconditionally today — the old `AppRuntime::Process`
+/// arm this backed was removed by the CPython-in-WASM migration (#2386,
+/// 2026-07-12) and neither `AppRuntime::Wasm` nor `AppRuntime::Python` has a
+/// reachable hookup into their pipe registry from outside the runtime yet.
+/// This is a known, pre-existing gap (flagged in stint 0724 Phase D 2/2, not
+/// introduced by it) — restoring it is separate follow-up work.
+///
+/// Its result is deliberately NOT fatal to `OpenDirectedPipe` at the call
+/// site: the actual duplex data plane is host-mediated (the caller inserts
+/// the pair into `directed_pipes` and `DeliverPipeMessage` routes by
+/// consulting that map directly — see `dispatch.rs`), so it never depends on
+/// this registration succeeding. Before this phase, a `false` return here
+/// silently aborted the ENTIRE `OpenDirectedPipe` request (the map insert was
+/// unreachable), so no directed pipe has ever actually routed a message —
+/// this call is now purely advisory.
 fn register_directed_pipe_on_target(pane: &mut crate::host::pane::Pane, pipe_id: &str) -> bool {
     let _ = (pane, pipe_id);
     false

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -26,6 +26,7 @@ pub mod permissions;
 pub mod plexi_descriptor;
 pub(crate) mod python_env;
 pub mod registry;
+pub(crate) mod registry_views;
 pub mod registry_watcher;
 pub(crate) mod render;
 pub(crate) mod screenshot;
@@ -103,7 +104,6 @@ pub(crate) struct TextInputOverlay {
     pub buffer: String,
 }
 
-use crate::app::registry::AppRegistry;
 use crate::config;
 use crate::host::context::Window;
 use crate::host::keys::{self, Action};
@@ -229,7 +229,11 @@ pub struct PlexiApp {
     pub(crate) drag_context: Option<usize>,
     /// Whether the "Parked (N)" section in the sidebar is expanded.
     pub(crate) parked_section_expanded: bool,
-    pub(crate) registry: AppRegistry,
+    /// Per-canonical-root `AppRegistry` cache (stint 0724 Phase B). Replaces
+    /// the old single active-context-following `AppRegistry` — every context
+    /// resolves against its OWN root's view, never whichever context was last
+    /// active. See `crate::app::registry_views` for the invalidation rules.
+    pub(crate) registries: crate::app::registry_views::RegistryViews,
     pub(crate) show_command_palette: bool,
     pub(crate) palette_query: String,
     pub(crate) palette_selected: usize,
@@ -367,19 +371,20 @@ pub struct PlexiApp {
     /// a signal so `reload_config()` runs automatically.
     pub(crate) _config_watcher: Option<crate::config::watcher::ConfigWatcher>,
     pub(crate) config_reload_rx: Option<ui_mailbox::MailboxReceiver<()>>,
-    /// App registry filesystem watcher (#1712). Watches the global and workspace-local
-    /// apps dirs; signals `registry_reload_rx` on any directory change so the registry
-    /// is rescanned without a host restart.
-    pub(crate) _registry_watcher: Option<crate::app::registry_watcher::AppRegistryWatcher>,
-    pub(crate) registry_reload_rx: Option<ui_mailbox::MailboxReceiver<()>>,
-    /// Background `AppRegistry::load` result seam (stint 0548). A context
-    /// transition spawns the filesystem walk + manifest parse off the UI
-    /// thread and sends `(context_id, registry)` back here; drained in
-    /// `logic` each frame. The `context_id` guards staleness — if the user
-    /// has navigated away from the requesting context by the time the load
-    /// finishes, the result is discarded instead of applied.
-    pub(crate) registry_load_rx:
-        Option<ui_mailbox::MailboxReceiver<(u64, crate::app::registry::AppRegistry)>>,
+    /// App registry filesystem watchers (#1712, re-keyed per-root in stint
+    /// 0724 Phase B). One watcher per canonical root currently held by
+    /// `registries` — an inactive context's root is watched exactly like the
+    /// active one's, so a change lands in `registries` regardless of focus.
+    /// Reconciled every `logic` pass by `reconcile_registry_watchers` (starts
+    /// watchers for newly-cached roots, drops watchers for roots `registries`
+    /// no longer holds).
+    pub(crate) registry_watchers: HashMap<
+        std::path::PathBuf,
+        (
+            crate::app::registry_watcher::AppRegistryWatcher,
+            ui_mailbox::MailboxReceiver<()>,
+        ),
+    >,
     /// True when workspace state changed since the last disk save. Set by
     /// `mark_workspace_dirty()`, cleared by the debounce flush in
     /// `update_preamble` (or by a forced `save_workspace_now()` on
@@ -1144,6 +1149,34 @@ fn handle_events_publish(
     let _ = write_half.flush();
 }
 
+/// Start a registry watcher for every root `registries` currently holds a
+/// view for. Used at construction (eagerly watch whatever root(s) were
+/// loaded up front) and kept in sync every `logic` pass by
+/// `PlexiApp::reconcile_registry_watchers` — a root gains a watcher the
+/// first time something resolves a view for it, regardless of which context
+/// is active (stint 0724 Phase B).
+fn start_registry_watchers_for(
+    registries: &crate::app::registry_views::RegistryViews,
+    ui_wake: &std::sync::Arc<dyn ui_mailbox::UiWake>,
+) -> HashMap<
+    std::path::PathBuf,
+    (
+        crate::app::registry_watcher::AppRegistryWatcher,
+        ui_mailbox::MailboxReceiver<()>,
+    ),
+> {
+    let mut watchers = HashMap::new();
+    for root in registries.roots() {
+        if let Some((watcher, rx)) = crate::app::registry_watcher::start(
+            crate::app::registry::registry_watch_dirs(&root),
+            std::sync::Arc::clone(ui_wake),
+        ) {
+            watchers.insert(root, (watcher, rx));
+        }
+    }
+    watchers
+}
+
 /// Test-only observability for `PlexiApp::emit_scope_invalidation`. Phase A
 /// (stint 0724) has no real consumer of `ScopeInvalidation` — later phases
 /// add handling inside that method as they migrate onto the scope model — so
@@ -1295,15 +1328,9 @@ impl PlexiApp {
         let (tx, rx) = mpsc::channel();
 
         let cwd = std::env::current_dir().unwrap_or_default();
-        let registry = AppRegistry::load(&cwd);
-
-        let (mut reg_watcher, mut reg_reload_rx) = match crate::app::registry_watcher::start(
-            crate::app::registry::registry_watch_dirs(&cwd),
-            std::sync::Arc::clone(&ui_wake),
-        ) {
-            Some((w, rx)) => (Some(w), Some(rx)),
-            None => (None, None),
-        };
+        let mut registries = crate::app::registry_views::RegistryViews::new();
+        registries.view_for_root(&cwd);
+        let registry_watchers = start_registry_watchers_for(&registries, &ui_wake);
 
         // Initialize the event log. Global log goes to ~/.plexi-*/events.jsonl;
         // workspace log goes to .plexi/events.jsonl if we're inside a workspace.
@@ -1623,7 +1650,7 @@ impl PlexiApp {
                     renaming_pane: None,
                     text_overlay: None,
                     text_overlay_browse_rx: None,
-                    registry,
+                    registries,
                     features,
                     pending_notifications: load_pending_notifications_from(
                         &crate::config::config_dir().join("notifications.json"),
@@ -1664,9 +1691,7 @@ impl PlexiApp {
                     state_watch_rx: sw_rx,
                     _config_watcher: cfg_watcher.take(),
                     config_reload_rx: cfg_reload_rx.take(),
-                    _registry_watcher: reg_watcher.take(),
-                    registry_reload_rx: reg_reload_rx.take(),
-                    registry_load_rx: None,
+                    registry_watchers,
                     workspace_dirty: false,
                     last_workspace_save: std::time::Instant::now(),
                     minimap: crate::render::minimap::MinimapState::with_visible(window_count >= 2),
@@ -1798,15 +1823,10 @@ impl PlexiApp {
         };
 
         let default_cwd = std::env::current_dir().unwrap_or_default();
-        let default_registry = AppRegistry::load(&default_cwd);
-        let (mut default_reg_watcher, mut default_reg_reload_rx) =
-            match crate::app::registry_watcher::start(
-                crate::app::registry::registry_watch_dirs(&default_cwd),
-                std::sync::Arc::clone(&ui_wake),
-            ) {
-                Some((w, rx)) => (Some(w), Some(rx)),
-                None => (None, None),
-            };
+        let mut default_registries = crate::app::registry_views::RegistryViews::new();
+        default_registries.view_for_root(&default_cwd);
+        let default_registry_watchers =
+            start_registry_watchers_for(&default_registries, &ui_wake);
 
         let agent_host = crate::agent::AgentHost::production(config.ai.clone());
         // Standing ruling: a context root must gitignore its app_states dir
@@ -1906,7 +1926,7 @@ impl PlexiApp {
             renaming_pane: None,
             text_overlay: None,
             text_overlay_browse_rx: None,
-            registry: default_registry,
+            registries: default_registries,
             features,
             pending_notifications: load_pending_notifications_from(
                 &crate::config::config_dir().join("notifications.json"),
@@ -1947,9 +1967,7 @@ impl PlexiApp {
             state_watch_rx: sw_rx2,
             _config_watcher: cfg_watcher.take(),
             config_reload_rx: cfg_reload_rx.take(),
-            _registry_watcher: default_reg_watcher.take(),
-            registry_reload_rx: default_reg_reload_rx.take(),
-            registry_load_rx: None,
+            registry_watchers: default_registry_watchers,
             workspace_dirty: false,
             last_workspace_save: std::time::Instant::now(),
             minimap: crate::render::minimap::MinimapState::new(),
@@ -2118,17 +2136,73 @@ impl PlexiApp {
     /// Single choke point for every scope-affecting lifecycle event: a
     /// context's root moving, a context or pane being removed, a package
     /// being installed/replaced, or a watched source reporting a new
-    /// generation. Phase A (stint 0724) only logs — no consumers subscribe
-    /// yet. Later phases add real invalidation handling here as state
-    /// routing, connector tools, the event bus, and notifications migrate
-    /// onto the scope model, so every future consumer reacts to one shared
-    /// vocabulary of "what changed" instead of re-deriving it from ad hoc
-    /// call sites. Never logs secrets, notification bodies, or event
-    /// payloads — `ScopeInvalidation` carries only ids and paths.
+    /// generation. Phase A (stint 0724) wired the plumbing; Phase B gives it
+    /// its first two real consumers — `registries` (the per-root `AppRegistry`
+    /// cache) and, for `ContextRootChanged`, every live app pane in the
+    /// affected context, not just the ones in the currently-rendered window.
+    /// Later phases (connector tools, the event bus, notifications) add
+    /// handling here too, so every future consumer reacts to one shared
+    /// vocabulary of "what changed" instead of re-deriving it from ad hoc call
+    /// sites. Never logs secrets, notification bodies, or event payloads —
+    /// `ScopeInvalidation` carries only ids and paths.
     pub(crate) fn emit_scope_invalidation(&mut self, ev: crate::host::scope::ScopeInvalidation) {
         log::info!(target: "plexi::scope", "invalidation: {ev:?}");
         #[cfg(test)]
         SCOPE_INVALIDATION_COUNT_FOR_TEST.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        self.registries.invalidate(&ev, &self.router);
+
+        // A context's root moved: every live app pane in that context must
+        // see the new root immediately, not just whichever pane happens to
+        // be in the currently-rendered (active) window. `render::app_pane`
+        // already refreshes the active window's app panes every frame
+        // (stint 0652), which covers the common case with zero staleness —
+        // but a pane in a background/inactive context never gets a render
+        // pass at all (see the "not rendering has two independent axes" trap
+        // in the repo root AGENTS.md), so without this it would keep
+        // persisting state against the OLD root until the user happened to
+        // navigate back to it.
+        if let crate::host::scope::ScopeInvalidation::ContextRootChanged {
+            context_id,
+            new_root,
+            ..
+        } = &ev
+        {
+            for window in self
+                .windows
+                .iter_mut()
+                .filter(|w| w.context_id == *context_id)
+            {
+                for pane in window.panes.values_mut() {
+                    if let Some(app_pane) = pane.as_app_mut() {
+                        app_pane.runtime.refresh_context_root(new_root);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Keep `registry_watchers` in sync with whatever roots `registries`
+    /// currently holds a view for: start a watcher for any newly-cached root
+    /// (regardless of which context is active) and drop watchers for roots
+    /// `registries` no longer holds (dropped as orphaned by an invalidation).
+    /// Called once per `logic` pass — cheap when nothing changed, since an
+    /// already-watched root is just a `HashMap` membership check.
+    pub(crate) fn reconcile_registry_watchers(&mut self) {
+        let live_roots: std::collections::HashSet<std::path::PathBuf> =
+            self.registries.roots().into_iter().collect();
+        for root in &live_roots {
+            if !self.registry_watchers.contains_key(root) {
+                if let Some((watcher, rx)) = crate::app::registry_watcher::start(
+                    crate::app::registry::registry_watch_dirs(root),
+                    std::sync::Arc::clone(&self.ui_wake),
+                ) {
+                    self.registry_watchers.insert(root.clone(), (watcher, rx));
+                }
+            }
+        }
+        self.registry_watchers
+            .retain(|root, _| live_roots.contains(root));
     }
 
     fn complete_wasm_host_effect(
@@ -2495,7 +2569,13 @@ impl PlexiApp {
                 renaming_pane: None,
                 text_overlay: None,
                 text_overlay_browse_rx: None,
-                registry: AppRegistry::load_with_global(&path, &path.join("nonexistent-apps-dir")),
+                registries: {
+                    let mut views = crate::app::registry_views::RegistryViews::new_with_global(
+                        &path.join("nonexistent-apps-dir"),
+                    );
+                    views.view_for_root(&path);
+                    views
+                },
                 features,
                 pending_notifications: Vec::new(),
                 show_notification_modal: false,
@@ -2532,9 +2612,7 @@ impl PlexiApp {
                 state_watch_rx: sw_rx,
                 _config_watcher: None,
                 config_reload_rx: None,
-                _registry_watcher: None,
-                registry_reload_rx: None,
-                registry_load_rx: None,
+                registry_watchers: HashMap::new(),
                 workspace_dirty: false,
                 last_workspace_save: std::time::Instant::now(),
                 minimap: crate::render::minimap::MinimapState::new(),
@@ -3869,28 +3947,34 @@ impl eframe::App for PlexiApp {
             self.reload_config();
         }
 
-        // App registry hot-reload (#1712): drain filesystem watcher signals.
-        let registry_changed = self.registry_reload_rx.as_ref().is_some_and(|rx| {
-            let hit = rx.try_recv().is_ok();
-            if hit {
-                while rx.try_recv().is_ok() {}
-            }
-            hit
-        });
-        if registry_changed {
-            let root = self.router.active().root.clone();
+        // App registry hot-reload (#1712, re-keyed per-root in stint 0724
+        // Phase B): drain filesystem watcher signals for EVERY live root, not
+        // just the active context's — an inactive context's registry must
+        // react to on-disk changes exactly like the active one's.
+        let changed_roots: Vec<std::path::PathBuf> = self
+            .registry_watchers
+            .iter()
+            .filter_map(|(root, (_watcher, rx))| {
+                let hit = rx.try_recv().is_ok();
+                if hit {
+                    while rx.try_recv().is_ok() {}
+                }
+                hit.then(|| root.clone())
+            })
+            .collect();
+        for root in changed_roots {
             self.emit_scope_invalidation(
                 crate::host::scope::ScopeInvalidation::SourceGenerationChanged {
-                    source_path: root.clone(),
+                    source_path: root,
                 },
             );
-            self.reload_app_registry_for_root(&root);
         }
 
-        // Context-transition registry rescan (stint 0548): drain the
-        // background `AppRegistry::load` result. Lives in `logic`, never
-        // `ui` — the load can finish while the window is hidden or occluded.
-        self.drain_registry_load();
+        // Registries are a synchronous per-root cache (stint 0724 Phase B) —
+        // resolving or rescanning a view happens at the point of use, so
+        // there is no background-load result to drain here anymore. Keep the
+        // watcher set in sync with whatever roots are now cached.
+        self.reconcile_registry_watchers();
 
         // Handle window close request (X button or macOS Cmd+Q OS event).
         //

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -739,7 +739,13 @@ fn handle_socket_connection(
     if let Ok(val) = serde_json::from_str::<serde_json::Value>(&first) {
         match val.get("type").and_then(|t| t.as_str()) {
             Some("events_subscribe") => {
-                handle_events_subscribe(write_half, reader.lines(), val, &subscribe_mailbox);
+                handle_events_subscribe(
+                    write_half,
+                    reader.lines(),
+                    val,
+                    &subscribe_mailbox,
+                    peer_ancestry.as_deref(),
+                );
                 return;
             }
             Some("events_list") => {
@@ -747,7 +753,7 @@ fn handle_socket_connection(
                 return;
             }
             Some("events_declare") | Some("events_emit") => {
-                handle_events_publish(write_half, val, &publish_mailbox);
+                handle_events_publish(write_half, val, &publish_mailbox, peer_ancestry.as_deref());
                 return;
             }
             _ => {}
@@ -849,6 +855,11 @@ fn handle_events_subscribe(
     subscribe_mailbox: &ui_mailbox::UiMailbox<
         crate::host::event_subscriptions::HostSubscribeRequest,
     >,
+    // Host-captured kernel ancestry of the socket peer (see
+    // `handle_socket_connection`'s doc comment) — forwarded so the UI thread
+    // can independently verify `from_pane_id` instead of trusting the
+    // client-forwarded `PLEXI_PANE_ID` value alone (stint 0724 Phase D).
+    peer_ancestry: Option<&[u32]>,
 ) {
     use crate::host::event_subscriptions::{HostSubscribeReply, HostSubscribeRequest};
     use std::io::Write;
@@ -885,7 +896,11 @@ fn handle_events_subscribe(
         // CLI identity (`pane:N`) is already stable and unique per pane, so the
         // broker actor is the routing id itself — no decoupling needed.
         broker_actor_override: None,
+        // Resolved on the UI thread from `from_pane_id` (verified against
+        // `peer_ancestry` first) — see `drain_event_subscribe_channel`.
         workspace_root_override: None,
+        context_id_override: None,
+        peer_ancestry: peer_ancestry.map(<[u32]>::to_vec),
         reply: reply_tx,
     };
     if subscribe_mailbox.send(req).is_err() {
@@ -995,8 +1010,10 @@ fn handle_events_subscribe(
     );
 }
 
-/// Answer `events_list`: write the declared `(app_id, stream)` pairs and close.
-/// Pure discovery — no grant check, no identity, no streaming.
+/// Answer `events_list`: write the declared `(context_id, app_id, stream)`
+/// triples and close. Pure discovery — no grant check, no identity, no
+/// streaming. Context-qualified since stint 0724 Phase D: the same `app_id`
+/// may declare different streams/schemas in different contexts.
 fn handle_events_list(mut write_half: std::os::unix::net::UnixStream, val: &serde_json::Value) {
     use std::io::Write;
     let json_mode = val["json"].as_bool().unwrap_or(false);
@@ -1011,7 +1028,9 @@ fn handle_events_list(mut write_half: std::os::unix::net::UnixStream, val: &serd
     if json_mode {
         let arr: Vec<serde_json::Value> = streams
             .iter()
-            .map(|(a, s)| serde_json::json!({"app_id": a, "stream": s}))
+            .map(|(context_id, a, s)| {
+                serde_json::json!({"context_id": context_id, "app_id": a, "stream": s})
+            })
             .collect();
         let _ = writeln!(
             write_half,
@@ -1021,8 +1040,8 @@ fn handle_events_list(mut write_half: std::os::unix::net::UnixStream, val: &serd
     } else if streams.is_empty() {
         let _ = writeln!(write_half, "No event streams declared by running apps.");
     } else {
-        for (app_id, stream) in &streams {
-            let _ = writeln!(write_half, "{app_id}  {stream}");
+        for (context_id, app_id, stream) in &streams {
+            let _ = writeln!(write_half, "{context_id}  {app_id}  {stream}");
         }
     }
     let _ = write_half.flush();
@@ -1037,6 +1056,8 @@ fn handle_events_publish(
     mut write_half: std::os::unix::net::UnixStream,
     val: serde_json::Value,
     publish_mailbox: &ui_mailbox::UiMailbox<crate::host::event_subscriptions::HostPublishRequest>,
+    // See `handle_events_subscribe`'s matching parameter.
+    peer_ancestry: Option<&[u32]>,
 ) {
     use crate::host::event_subscriptions::{HostPublishReply, HostPublishRequest, PublishAction};
     use std::io::Write;
@@ -1115,6 +1136,10 @@ fn handle_events_publish(
         action,
         from_pane_id,
         subscriber_override: None,
+        // Resolved on the UI thread — see `drain_event_subscribe_channel`.
+        workspace_root_override: None,
+        context_id_override: None,
+        peer_ancestry: peer_ancestry.map(<[u32]>::to_vec),
         reply: reply_tx,
     };
     if publish_mailbox.send(req).is_err() {
@@ -1371,8 +1396,6 @@ impl PlexiApp {
         );
         let host_subscriptions = crate::host::event_subscriptions::HostSubscriptionService::new(
             &crate::config::config_dir(),
-            crate::config::active_workspace_root()
-                .unwrap_or_else(|| std::env::current_dir().unwrap_or_default()),
             crate::host::app_timeline::global(),
         );
         if let Err(e) = host_mcp::start_host_mcp_server(
@@ -2133,6 +2156,43 @@ impl PlexiApp {
         self.origin_for_pane(pane_id)
     }
 
+    /// Resolve the host-established origin for a raw event-bus socket request
+    /// (`events_subscribe`/`events_declare`/`events_emit`) — stint 0724 Phase
+    /// D. Returns `(verified_pane_id, context_id, workspace_root)`, all
+    /// `None` together when neither ancestry nor the claimed pane id resolve
+    /// to a live pane (an outside-pane connection).
+    ///
+    /// `peer_ancestry` (host-captured kernel ancestor-pid chain, present only
+    /// for the raw CLI socket transport) is tried FIRST and, when it resolves
+    /// to a live pane, wins outright — this is the same trust upgrade
+    /// `Notify`/`DismissNotification` already get from stint 0636's
+    /// `resolve_socket_peer_pane`. `claimed_pane_id` (the client-forwarded
+    /// `PLEXI_PANE_ID`) is only a fallback for when ancestry resolution fails
+    /// (platform unsupported, or the peer already exited) — never trusted
+    /// over a successful ancestry resolution, since any local process can set
+    /// that environment variable to name an arbitrary pane.
+    pub(crate) fn resolve_event_bus_caller(
+        &self,
+        claimed_pane_id: Option<u64>,
+        peer_ancestry: Option<&[u32]>,
+    ) -> (Option<u64>, Option<u64>, Option<std::path::PathBuf>) {
+        let verified_pane_id = peer_ancestry
+            .and_then(|ancestry| self.resolve_socket_peer_pane(ancestry))
+            .map(|(pane_id, _context_id, _window_id)| pane_id);
+        let effective_pane_id = verified_pane_id.or(claimed_pane_id);
+        let Some(effective_pane_id) = effective_pane_id else {
+            return (None, None, None);
+        };
+        match self.origin_for_pane(effective_pane_id) {
+            Some(origin) => (
+                Some(effective_pane_id),
+                Some(origin.context_id),
+                Some(origin.context_root),
+            ),
+            None => (Some(effective_pane_id), None, None),
+        }
+    }
+
     /// Single choke point for every scope-affecting lifecycle event: a
     /// context's root moving, a context or pane being removed, a package
     /// being installed/replaced, or a watched source reporting a new
@@ -2319,6 +2379,14 @@ impl PlexiApp {
             log::warn!("app events: subscriber pane {pane_id} is closed");
             return;
         };
+        // Host-established context this subscriber pane lives in (stint 0724
+        // Phase D) — the viewer side of `evaluate_reach` for every stream
+        // this subscription will ever match against. Resolved fresh here,
+        // never cached: `origin_for_pane` reads the pane's owning window's
+        // live `context_id`, not whichever context was last active.
+        let context_id = self
+            .origin_for_pane(pane_id)
+            .map(|origin| origin.context_id);
         let (reply, receiver) = std::sync::mpsc::sync_channel(1);
         let request = crate::host::event_subscriptions::HostSubscribeRequest {
             publisher_app_id,
@@ -2331,6 +2399,12 @@ impl PlexiApp {
             subscriber_type_override: Some(crate::broker::ActorType::App),
             broker_actor_override: Some(subscriber_app_id),
             workspace_root_override: Some(workspace_root),
+            context_id_override: context_id,
+            // This request never travels over the raw event-bus socket — the
+            // pane id is already host-known (the WASM/Python app dispatch
+            // path resolved it, not a client claim), so there is no peer
+            // ancestry to verify against.
+            peer_ancestry: None,
             reply,
         };
         self.host_subscriptions.reload(&crate::config::config_dir());
@@ -2477,7 +2551,6 @@ impl PlexiApp {
             );
         let host_subscriptions = crate::host::event_subscriptions::HostSubscriptionService::new(
             &crate::config::config_dir(),
-            std::env::current_dir().unwrap_or_default(),
             crate::host::app_timeline::global(),
         );
         (

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1144,6 +1144,16 @@ fn handle_events_publish(
     let _ = write_half.flush();
 }
 
+/// Test-only observability for `PlexiApp::emit_scope_invalidation`. Phase A
+/// (stint 0724) has no real consumer of `ScopeInvalidation` — later phases
+/// add handling inside that method as they migrate onto the scope model — so
+/// this counter is the smoke-test seam proving the emit call sites actually
+/// fire, without inventing a log-capture harness for a method that is
+/// otherwise side-effect-free logging.
+#[cfg(test)]
+pub(crate) static SCOPE_INVALIDATION_COUNT_FOR_TEST: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(0);
+
 impl PlexiApp {
     pub fn new(
         cc: &eframe::CreationContext<'_>,
@@ -2057,6 +2067,68 @@ impl PlexiApp {
             "pane_ipc: peer identity: ancestry {peer_ancestry:?} resolved to no live pane — treating as outside-pane caller"
         );
         None
+    }
+
+    /// Resolve the host-established `ScopeOrigin` for a live pane: the
+    /// window's `context_id`, the router's canonical `Context.root` for that
+    /// context, the window's `window_id`, `pane_id` itself, and — for an app
+    /// pane — its manifest id. Never reads `router.active()` or
+    /// `active_window`; every field comes from the pane's owning window,
+    /// found via `find_pane_in_any_window`, so a caller in one context can
+    /// never be resolved against another context's active state.
+    pub(crate) fn origin_for_pane(
+        &self,
+        pane_id: crate::spatial::tiling::PaneId,
+    ) -> Option<crate::host::scope::ScopeOrigin> {
+        let (window_index, _tile_id) = self.find_pane_in_any_window(pane_id)?;
+        let window = &self.windows[window_index];
+        let context_id = window.context_id;
+        let context_root = self
+            .router
+            .position(|c| c.context_id == context_id)
+            .map(|idx| self.router.get(idx).root.clone())?;
+        let app_id = window
+            .panes
+            .get(&pane_id)
+            .and_then(crate::host::pane::Pane::as_app)
+            .map(|app_pane| app_pane.manifest_id.clone());
+        Some(crate::host::scope::ScopeOrigin {
+            context_id,
+            context_root,
+            window_id: window.window_id,
+            pane_id,
+            app_id,
+        })
+    }
+
+    /// Resolve a `ScopeOrigin` from a notify-socket peer's captured ancestry.
+    /// Wraps `resolve_socket_peer_pane` (stint 0636's trustworthy sender
+    /// identity, host-captured from the kernel credential at accept time,
+    /// never from the wire) and hands the resolved pane straight to
+    /// `origin_for_pane` — never re-deriving context/window from the caller's
+    /// own claims.
+    pub(crate) fn origin_for_socket_peer(
+        &self,
+        peer_ancestry: &[u32],
+    ) -> Option<crate::host::scope::ScopeOrigin> {
+        let (pane_id, _context_id, _window_id) = self.resolve_socket_peer_pane(peer_ancestry)?;
+        self.origin_for_pane(pane_id)
+    }
+
+    /// Single choke point for every scope-affecting lifecycle event: a
+    /// context's root moving, a context or pane being removed, a package
+    /// being installed/replaced, or a watched source reporting a new
+    /// generation. Phase A (stint 0724) only logs — no consumers subscribe
+    /// yet. Later phases add real invalidation handling here as state
+    /// routing, connector tools, the event bus, and notifications migrate
+    /// onto the scope model, so every future consumer reacts to one shared
+    /// vocabulary of "what changed" instead of re-deriving it from ad hoc
+    /// call sites. Never logs secrets, notification bodies, or event
+    /// payloads — `ScopeInvalidation` carries only ids and paths.
+    pub(crate) fn emit_scope_invalidation(&mut self, ev: crate::host::scope::ScopeInvalidation) {
+        log::info!(target: "plexi::scope", "invalidation: {ev:?}");
+        #[cfg(test)]
+        SCOPE_INVALIDATION_COUNT_FOR_TEST.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     }
 
     fn complete_wasm_host_effect(
@@ -3807,6 +3879,11 @@ impl eframe::App for PlexiApp {
         });
         if registry_changed {
             let root = self.router.active().root.clone();
+            self.emit_scope_invalidation(
+                crate::host::scope::ScopeInvalidation::SourceGenerationChanged {
+                    source_path: root.clone(),
+                },
+            );
             self.reload_app_registry_for_root(&root);
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2788,7 +2788,9 @@ impl PlexiApp {
             .cloned()
             .or_else(|| working_directory.clone())
             .unwrap_or_default();
-        if let Some((port, token)) = host_mcp::discovery_for_pane(pane_id, workspace_root) {
+        if let Some((port, token)) =
+            host_mcp::discovery_for_pane(pane_id, context_id, workspace_root)
+        {
             env.insert("PLEXI_HOST_MCP_PORT".into(), port.to_string());
             env.insert("PLEXI_HOST_MCP_TOKEN".into(), token);
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2206,7 +2206,42 @@ impl PlexiApp {
     /// sites. Never logs secrets, notification bodies, or event payloads —
     /// `ScopeInvalidation` carries only ids and paths.
     pub(crate) fn emit_scope_invalidation(&mut self, ev: crate::host::scope::ScopeInvalidation) {
-        log::info!(target: "plexi::scope", "invalidation: {ev:?}");
+        match &ev {
+            crate::host::scope::ScopeInvalidation::ContextRootChanged {
+                context_id,
+                old_root,
+                new_root,
+            } => {
+                log::info!(
+                    target: "plexi::scope",
+                    "invalidation: context_root_changed context_id={context_id} old_root={} new_root={}",
+                    old_root.display(),
+                    new_root.display()
+                );
+            }
+            crate::host::scope::ScopeInvalidation::ContextRemoved { context_id } => {
+                log::info!(
+                    target: "plexi::scope",
+                    "invalidation: context_removed context_id={context_id}"
+                );
+            }
+            crate::host::scope::ScopeInvalidation::PaneClosed {
+                pane_id,
+                context_id,
+            } => {
+                log::info!(
+                    target: "plexi::scope",
+                    "invalidation: pane_closed pane_id={pane_id} context_id={context_id}"
+                );
+            }
+            crate::host::scope::ScopeInvalidation::SourceGenerationChanged { source_path } => {
+                log::info!(
+                    target: "plexi::scope",
+                    "invalidation: source_generation_changed source_path={}",
+                    source_path.display()
+                );
+            }
+        }
         #[cfg(test)]
         SCOPE_INVALIDATION_COUNT_FOR_TEST.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2156,20 +2156,6 @@ impl PlexiApp {
         })
     }
 
-    /// Resolve a `ScopeOrigin` from a notify-socket peer's captured ancestry.
-    /// Wraps `resolve_socket_peer_pane` (stint 0636's trustworthy sender
-    /// identity, host-captured from the kernel credential at accept time,
-    /// never from the wire) and hands the resolved pane straight to
-    /// `origin_for_pane` — never re-deriving context/window from the caller's
-    /// own claims.
-    pub(crate) fn origin_for_socket_peer(
-        &self,
-        peer_ancestry: &[u32],
-    ) -> Option<crate::host::scope::ScopeOrigin> {
-        let (pane_id, _context_id, _window_id) = self.resolve_socket_peer_pane(peer_ancestry)?;
-        self.origin_for_pane(pane_id)
-    }
-
     /// Resolve the host-established origin for a raw event-bus socket request
     /// (`events_subscribe`/`events_declare`/`events_emit`) — stint 0724 Phase
     /// D. Returns `(verified_pane_id, context_id, workspace_root)`, all

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1371,12 +1371,12 @@ impl PlexiApp {
         registries.view_for_root(&cwd);
         let registry_watchers = start_registry_watchers_for(&registries, &ui_wake);
 
-        // Initialize the event log. Global log goes to ~/.plexi-*/events.jsonl;
-        // workspace log goes to .plexi/events.jsonl if we're inside a workspace.
+        // Initialize the event log. Global log goes to ~/.plexi-*/events.jsonl.
+        // Per-context routing (stint 0724 Phase E) is decided per-record at
+        // each emit call site via `emit_scoped`, not once here from cwd.
         {
             let global_path = crate::config::config_dir().join("events.jsonl");
-            let workspace_path = crate::host::event_log::find_workspace_events_path(&cwd);
-            crate::host::event_log::init_global(global_path, workspace_path);
+            crate::host::event_log::init_global(global_path);
         }
 
         // Check for an unclean shutdown from the previous session.
@@ -4258,11 +4258,17 @@ impl PlexiApp {
             scopes.len(),
             scopes.iter().map(|s| &s.dir).collect::<Vec<_>>()
         );
-        crate::host::event_log::emit(crate::host::event_log::HostEvent::NotesPickerOpened {
-            inbox_count,
-            kept_count: entries.len() - inbox_count,
-            timestamp: crate::host::event_log::now_timestamp(),
-        });
+        // Aggregates notes across every context scope in `scopes` — no single
+        // context owns this event, so it stays global-only (no per-root
+        // attribution is correct here, not merely unresolved).
+        crate::host::event_log::emit_scoped(
+            crate::host::event_log::HostEvent::NotesPickerOpened {
+                inbox_count,
+                kept_count: entries.len() - inbox_count,
+                timestamp: crate::host::event_log::now_timestamp(),
+            },
+            None,
+        );
         self.notes_picker_entries = entries;
         self.notes_picker_selected = 0;
         self.notes_picker_query.clear();

--- a/src/app/notifications.rs
+++ b/src/app/notifications.rs
@@ -235,6 +235,47 @@ impl NotifySource {
     }
 }
 
+/// Core scope-match: whether a notification owned at `scope` — carrying its
+/// `source_window_id`/`source_context_id` — is visible to a viewer sitting at
+/// `active_window_id`/`active_context_id`. Plain scalar ids, not borrowed
+/// `PendingNotification`/`PlexiApp`, so this can be called from a site that
+/// already holds a conflicting borrow (see the `render.rs` call site).
+///
+/// Pure scope comparison only — does NOT consider snooze (`deliver_after`),
+/// tombstone, or queue state. Callers that need the full visibility answer
+/// combine this with their own checks (see `PlexiApp::notification_is_visible`).
+pub(crate) fn notification_visible(
+    scope: crate::app_protocol::NotifyScope,
+    source_window_id: u64,
+    source_context_id: u64,
+    active_window_id: u64,
+    active_context_id: u64,
+) -> bool {
+    match scope {
+        crate::app_protocol::NotifyScope::Global => true,
+        crate::app_protocol::NotifyScope::Window => source_window_id == active_window_id,
+        crate::app_protocol::NotifyScope::Context => source_context_id == active_context_id,
+    }
+}
+
+/// Whether a notification at `scope`/`source_context_id` counts toward the
+/// badge for context `ctx_id`. `Global` never counts — it already renders
+/// everywhere via [`notification_visible`], so counting it again on every
+/// context's badge would double-report it. `Window`/`Context` count toward
+/// their originating context's badge regardless of that context's snooze
+/// state (badge counts have never consulted `deliver_after` — preserved as
+/// existing behavior, not introduced here).
+pub(crate) fn notification_counts_toward_context(
+    scope: crate::app_protocol::NotifyScope,
+    source_context_id: u64,
+    ctx_id: u64,
+) -> bool {
+    matches!(
+        scope,
+        crate::app_protocol::NotifyScope::Window | crate::app_protocol::NotifyScope::Context
+    ) && source_context_id == ctx_id
+}
+
 impl PlexiApp {
     /// Resolve app-notification provenance without consulting focus. A live
     /// sender pane supplies its window; a parked or gone sender has only the
@@ -342,11 +383,19 @@ impl PlexiApp {
         let notify_id = notification.notify_id.clone();
         let title = notification.title.clone();
 
-        crate::host::event_log::emit(crate::host::event_log::HostEvent::NotificationPosted {
-            id: notify_id.clone(),
-            title: title.clone(),
-            timestamp: crate::host::event_log::now_timestamp(),
-        });
+        // `source_context_id` is stamped on every notification regardless of
+        // whether the sender pane is still live (CLI notifications may have
+        // sender_pane_id == 0), so resolve routing from it via the router
+        // rather than `origin_for_pane`, which needs a live pane.
+        let context_root = self.context_root_for(notification.source_context_id);
+        crate::host::event_log::emit_scoped(
+            crate::host::event_log::HostEvent::NotificationPosted {
+                id: notify_id.clone(),
+                title: title.clone(),
+                timestamp: crate::host::event_log::now_timestamp(),
+            },
+            context_root.as_deref(),
+        );
 
         let is_visible = self.notification_is_visible(&notification);
         let may_interrupt = self.notification_may_interrupt(&notification);
@@ -473,15 +522,13 @@ impl PlexiApp {
         {
             return false;
         }
-        match n.scope {
-            crate::app_protocol::NotifyScope::Global => true,
-            crate::app_protocol::NotifyScope::Window => {
-                n.source_window_id == self.windows[self.active_window].window_id
-            }
-            crate::app_protocol::NotifyScope::Context => {
-                n.source_context_id == self.router.active().context_id
-            }
-        }
+        notification_visible(
+            n.scope,
+            n.source_window_id,
+            n.source_context_id,
+            self.windows[self.active_window].window_id,
+            self.router.active().context_id,
+        )
     }
 
     /// Return ids of all *visible* notifications (for the current context),
@@ -656,13 +703,7 @@ impl PlexiApp {
         let ctx_id = ctx.context_id;
         self.pending_notifications
             .iter()
-            .filter(|n| {
-                matches!(
-                    n.scope,
-                    crate::app_protocol::NotifyScope::Window
-                        | crate::app_protocol::NotifyScope::Context
-                ) && n.source_context_id == ctx_id
-            })
+            .filter(|n| notification_counts_toward_context(n.scope, n.source_context_id, ctx_id))
             .count()
     }
 
@@ -681,13 +722,7 @@ impl PlexiApp {
         let direct = self
             .pending_notifications
             .iter()
-            .filter(|n| {
-                matches!(
-                    n.scope,
-                    crate::app_protocol::NotifyScope::Window
-                        | crate::app_protocol::NotifyScope::Context
-                ) && n.source_context_id == ctx_id
-            })
+            .filter(|n| notification_counts_toward_context(n.scope, n.source_context_id, ctx_id))
             .count();
         direct
             + self

--- a/src/app/registry_views.rs
+++ b/src/app/registry_views.rs
@@ -1,0 +1,457 @@
+//! Per-root `AppRegistry` views (stint 0724, Phase B).
+//!
+//! Before this module, `PlexiApp` held exactly one `AppRegistry`, rescanned
+//! only when the *active* context transitioned (`apply_context_transition_effects`
+//! in `pane_ops::workspace`). Any call site that resolved an app id against a
+//! context other than whichever one happened to be active last — a launch
+//! targeting an explicit `context_id`, the registry watcher for a background
+//! context, app-state routing for a parked pane — got whatever the active
+//! context's registry happened to contain, which is either stale or simply
+//! the wrong workspace's apps.
+//!
+//! `RegistryViews` fixes this by keying the cache on the canonical root
+//! itself (the host's source-address for "which app definitions apply here"),
+//! not on which context is active. Two contexts whose `Context.root` is the
+//! same path share one scan and one cache entry; two contexts with different
+//! roots always get independently correct views, no matter which one is
+//! active. This is the "shared root ⇒ shared root-backed definitions,
+//! distinct runtime ownership" rule from the stint.
+//!
+//! Every view is produced by [`crate::app::registry::AppRegistry::load`] (or
+//! `load_with_global` for the global-dir override tests need) — this module
+//! never reimplements discovery, shadowing, or conflict handling; it only
+//! decides which root to scan and when to rescan it.
+
+use crate::app::registry::AppRegistry;
+use crate::host::scope::ScopeInvalidation;
+use crate::workspace::router::WorkspaceRouter;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Canonical root → (loaded registry, generation). `generation` increments on
+/// every forced rescan so callers that only need "did this change" can diff
+/// it cheaply; Phase B has no such caller yet, but it costs nothing to track
+/// and later phases (or a future palette optimization) can read it.
+pub(crate) struct RegistryViews {
+    views: HashMap<PathBuf, (AppRegistry, u64)>,
+    /// Global apps dir override. Defaults to the real `~/.plexi-<channel>/apps/`;
+    /// tests substitute a tempdir so they never touch the user's real profile
+    /// (mirrors `AppRegistry::load_with_global`'s existing test seam).
+    global_dir: PathBuf,
+}
+
+impl RegistryViews {
+    pub(crate) fn new() -> Self {
+        Self {
+            views: HashMap::new(),
+            global_dir: crate::app::registry::apps_dir(),
+        }
+    }
+
+    /// Test-only constructor mirroring `AppRegistry::load_with_global` — lets
+    /// tests stage a fake global apps dir instead of the real profile.
+    #[cfg(test)]
+    pub(crate) fn new_with_global(global_dir: &Path) -> Self {
+        Self {
+            views: HashMap::new(),
+            global_dir: global_dir.to_path_buf(),
+        }
+    }
+
+    /// Canonicalize for use as a cache key. Falls back to the given path
+    /// unchanged when canonicalization fails (root not yet created, or a
+    /// synthetic test path like `/tmp/perf-gate-...` that is never scanned) —
+    /// a missing root simply produces an empty `AppRegistry`, same as
+    /// `AppRegistry::load` on a nonexistent cwd today.
+    fn canonical_root(root: &Path) -> PathBuf {
+        root.canonicalize().unwrap_or_else(|_| root.to_path_buf())
+    }
+
+    fn load_for(&self, root: &Path) -> AppRegistry {
+        AppRegistry::load_with_global(root, &self.global_dir)
+    }
+
+    /// The view for `root`, loading it on first access. Cheap on every
+    /// subsequent call for the same canonical root (`HashMap` lookup only —
+    /// no rescan) until an explicit [`Self::rescan_root`] or an invalidation
+    /// event forces a fresh scan.
+    pub(crate) fn view_for_root(&mut self, root: &Path) -> &AppRegistry {
+        let key = Self::canonical_root(root);
+        if !self.views.contains_key(&key) {
+            log::info!("registry_views: loading view for root={}", key.display());
+            let registry = self.load_for(&key);
+            self.views.insert(key.clone(), (registry, 0));
+        }
+        &self.views.get(&key).expect("just inserted").0
+    }
+
+    /// The view for whichever root `context_id` is anchored to. Falls back to
+    /// the process cwd (logged at `warn`) when `context_id` names no context
+    /// in `router` — this should only happen for a context that raced its own
+    /// removal; it must never panic the host.
+    pub(crate) fn view_for_context(
+        &mut self,
+        context_id: u64,
+        router: &WorkspaceRouter,
+    ) -> &AppRegistry {
+        let root = router
+            .iter()
+            .find(|c| c.context_id == context_id)
+            .map(|c| c.root.clone())
+            .unwrap_or_else(|| {
+                log::warn!(
+                    "registry_views: context_id={context_id} not found in router — \
+                     falling back to process cwd"
+                );
+                std::env::current_dir()
+                    .unwrap_or_else(|_| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")))
+            });
+        self.view_for_root(&root)
+    }
+
+    /// Force a fresh scan of `root` regardless of cache state — used for an
+    /// explicit "rescan now" (a watched source changed, a root was just
+    /// (re)assigned to a context, or a caller couldn't find an app id and
+    /// wants to check disk for a just-installed one).
+    pub(crate) fn rescan_root(&mut self, root: &Path) -> &AppRegistry {
+        let key = Self::canonical_root(root);
+        log::info!("registry_views: rescanning root={}", key.display());
+        let generation = self.views.get(&key).map_or(0, |(_, gen)| gen + 1);
+        let registry = self.load_for(&key);
+        self.views.insert(key.clone(), (registry, generation));
+        &self.views.get(&key).expect("just inserted").0
+    }
+
+    /// Drop the cached view for `root` if no live context in `router` still
+    /// anchors there. No-op if the root isn't cached or is still referenced.
+    fn drop_if_orphaned(&mut self, root: &Path, router: &WorkspaceRouter) {
+        let key = Self::canonical_root(root);
+        if !self.views.contains_key(&key) {
+            return;
+        }
+        let still_referenced = router.iter().any(|c| Self::canonical_root(&c.root) == key);
+        if !still_referenced {
+            log::info!(
+                "registry_views: dropping orphaned root={} (no live context references it)",
+                key.display()
+            );
+            self.views.remove(&key);
+        }
+    }
+
+    /// React to a scope-lifecycle event. Called from
+    /// `PlexiApp::emit_scope_invalidation` — the single choke point every
+    /// scope-affecting change already flows through.
+    ///
+    /// `ContextRemoved` relies on `router` already having the removed
+    /// context(s) dropped (see `pane_ops::workspace::delete_context`, which
+    /// emits this event after `WorkspaceRouter::remove_at`, not before) —
+    /// otherwise a doomed context would still "reference" its own root and
+    /// the orphan check would never fire.
+    pub(crate) fn invalidate(&mut self, ev: &ScopeInvalidation, router: &WorkspaceRouter) {
+        match ev {
+            ScopeInvalidation::ContextRootChanged {
+                old_root, new_root, ..
+            } => {
+                self.rescan_root(new_root);
+                self.drop_if_orphaned(old_root, router);
+            }
+            ScopeInvalidation::ContextRemoved { .. } => {
+                // A context is gone; sweep every cached root and drop any
+                // that no surviving context still anchors to. Cheap: this is
+                // a HashMap of roots (one per open workspace), never one per
+                // context.
+                let orphaned: Vec<PathBuf> = self
+                    .views
+                    .keys()
+                    .filter(|root| {
+                        !router
+                            .iter()
+                            .any(|c| &Self::canonical_root(&c.root) == *root)
+                    })
+                    .cloned()
+                    .collect();
+                for root in orphaned {
+                    log::info!(
+                        "registry_views: dropping orphaned root={} (context removed)",
+                        root.display()
+                    );
+                    self.views.remove(&root);
+                }
+            }
+            ScopeInvalidation::SourceGenerationChanged { source_path } => {
+                self.rescan_root(source_path);
+            }
+            ScopeInvalidation::PaneClosed { .. } | ScopeInvalidation::PackageReplaced { .. } => {
+                // Not a registry-shaped event: a pane closing doesn't change
+                // which apps are installed, and a package replace names an
+                // app id, not necessarily a root already in view. Left for a
+                // later phase's deletion sweep / install-path wiring.
+            }
+        }
+    }
+
+    /// Every canonical root currently cached — what the watcher (or any other
+    /// caller enumerating "what's live") should be watching / aware of.
+    pub(crate) fn roots(&self) -> Vec<PathBuf> {
+        self.views.keys().cloned().collect()
+    }
+
+    /// Test-only direct injection: install `registry` as the view for `root`,
+    /// bypassing a disk scan entirely. Lets tests stage a hand-built
+    /// `AppRegistry` (e.g. one app with a specific `[launch] on_launch`
+    /// policy) for a specific context's root without writing manifest.toml
+    /// fixtures to disk for every case.
+    #[cfg(test)]
+    pub(crate) fn set_view_for_test(&mut self, root: &Path, registry: AppRegistry) {
+        let key = Self::canonical_root(root);
+        self.views.insert(key, (registry, 0));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::context::Context;
+
+    fn ctx(id: u64, root: &Path) -> Context {
+        Context {
+            name: format!("ctx{id}"),
+            root: root.to_path_buf(),
+            description: None,
+            context_id: id,
+            parent_id: None,
+            depth: 0,
+            parked: false,
+        }
+    }
+
+    fn write_app(dir: &Path, id: &str) {
+        let app_dir = dir.join(id);
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(
+            app_dir.join("manifest.toml"),
+            format!(
+                "schema_version = 1\n\n[app]\nid = \"{id}\"\ntype = \"app\"\nname = \"{id}\"\n\
+                 version = \"0.0.1\"\nentry = \"run.sh\"\n"
+            ),
+        )
+        .unwrap();
+        std::fs::write(app_dir.join("run.sh"), "#!/bin/sh\nexit 0\n").unwrap();
+    }
+
+    #[test]
+    fn view_for_root_loads_once_and_caches() {
+        let global = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let mut views = RegistryViews::new_with_global(global.path());
+        assert!(views.view_for_root(root.path()).get("nope").is_none());
+        // Install after the first load; without a rescan the cached view must
+        // not pick it up (proves it's actually caching, not reloading).
+        let channel_dir = crate::config::workspace_channel_dir();
+        let apps = root.path().join(&channel_dir).join("apps");
+        write_app(&apps, "late-app");
+        assert!(
+            views.view_for_root(root.path()).get("late-app").is_none(),
+            "cached view must not silently re-scan on every access"
+        );
+        views.rescan_root(root.path());
+        assert!(
+            views.view_for_root(root.path()).get("late-app").is_some(),
+            "explicit rescan must pick up the new app"
+        );
+    }
+
+    #[test]
+    fn two_contexts_sharing_a_root_share_one_view() {
+        let global = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let channel_dir = crate::config::workspace_channel_dir();
+        write_app(&root.path().join(&channel_dir).join("apps"), "shared-app");
+
+        let router = WorkspaceRouter::new(vec![ctx(1, root.path()), ctx(2, root.path())], 0);
+        let mut views = RegistryViews::new_with_global(global.path());
+        assert!(views
+            .view_for_context(1, &router)
+            .get("shared-app")
+            .is_some());
+        assert!(views
+            .view_for_context(2, &router)
+            .get("shared-app")
+            .is_some());
+        assert_eq!(views.roots().len(), 1, "one shared root ⇒ one cached view");
+    }
+
+    #[test]
+    fn different_roots_never_cross_contaminate() {
+        let global = tempfile::tempdir().unwrap();
+        let root_a = tempfile::tempdir().unwrap();
+        let root_b = tempfile::tempdir().unwrap();
+        let channel_dir = crate::config::workspace_channel_dir();
+        write_app(&root_a.path().join(&channel_dir).join("apps"), "app-a");
+        write_app(&root_b.path().join(&channel_dir).join("apps"), "app-b");
+
+        let router = WorkspaceRouter::new(vec![ctx(1, root_a.path()), ctx(2, root_b.path())], 0);
+        let mut views = RegistryViews::new_with_global(global.path());
+        assert!(views.view_for_context(1, &router).get("app-a").is_some());
+        assert!(views.view_for_context(1, &router).get("app-b").is_none());
+        assert!(views.view_for_context(2, &router).get("app-b").is_some());
+        assert!(views.view_for_context(2, &router).get("app-a").is_none());
+    }
+
+    /// Same app id installed in two different roots: each view must resolve
+    /// its own root's copy, never the other's.
+    #[test]
+    fn duplicate_app_id_in_two_roots_resolves_per_view() {
+        let global = tempfile::tempdir().unwrap();
+        let root_a = tempfile::tempdir().unwrap();
+        let root_b = tempfile::tempdir().unwrap();
+        let channel_dir = crate::config::workspace_channel_dir();
+        let dir_a = root_a.path().join(&channel_dir).join("apps").join("dup");
+        std::fs::create_dir_all(&dir_a).unwrap();
+        std::fs::write(
+            dir_a.join("manifest.toml"),
+            "schema_version = 1\n\n[app]\nid = \"dup\"\ntype = \"app\"\nname = \"A copy\"\n\
+             version = \"0.0.1\"\nentry = \"run.sh\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir_a.join("run.sh"), "#!/bin/sh\nexit 0\n").unwrap();
+
+        let dir_b = root_b.path().join(&channel_dir).join("apps").join("dup");
+        std::fs::create_dir_all(&dir_b).unwrap();
+        std::fs::write(
+            dir_b.join("manifest.toml"),
+            "schema_version = 1\n\n[app]\nid = \"dup\"\ntype = \"app\"\nname = \"B copy\"\n\
+             version = \"0.0.1\"\nentry = \"run.sh\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir_b.join("run.sh"), "#!/bin/sh\nexit 0\n").unwrap();
+
+        let router = WorkspaceRouter::new(vec![ctx(1, root_a.path()), ctx(2, root_b.path())], 0);
+        let mut views = RegistryViews::new_with_global(global.path());
+        assert_eq!(
+            views
+                .view_for_context(1, &router)
+                .get("dup")
+                .unwrap()
+                .manifest
+                .name,
+            "A copy"
+        );
+        assert_eq!(
+            views
+                .view_for_context(2, &router)
+                .get("dup")
+                .unwrap()
+                .manifest
+                .name,
+            "B copy"
+        );
+    }
+
+    #[test]
+    fn context_root_changed_rescans_new_root_and_drops_orphaned_old_root() {
+        let global = tempfile::tempdir().unwrap();
+        let old_root = tempfile::tempdir().unwrap();
+        let new_root = tempfile::tempdir().unwrap();
+        let channel_dir = crate::config::workspace_channel_dir();
+        write_app(&new_root.path().join(&channel_dir).join("apps"), "new-app");
+
+        let mut views = RegistryViews::new_with_global(global.path());
+        // Prime the old root's view before the "move".
+        views.view_for_root(old_root.path());
+        assert_eq!(views.roots().len(), 1);
+
+        // Router already reflects the root change (matches how
+        // `set_context_root` emits the event after mutating the router).
+        let router = WorkspaceRouter::new(vec![ctx(1, new_root.path())], 0);
+        views.invalidate(
+            &ScopeInvalidation::ContextRootChanged {
+                context_id: 1,
+                old_root: old_root.path().to_path_buf(),
+                new_root: new_root.path().to_path_buf(),
+            },
+            &router,
+        );
+
+        assert!(
+            views
+                .view_for_root(new_root.path())
+                .get("new-app")
+                .is_some(),
+            "new root must be rescanned"
+        );
+        assert_eq!(
+            views.roots().len(),
+            1,
+            "orphaned old root must be dropped, leaving only the new root cached"
+        );
+    }
+
+    #[test]
+    fn context_removed_drops_root_only_when_no_context_still_references_it() {
+        let global = tempfile::tempdir().unwrap();
+        let root_a = tempfile::tempdir().unwrap();
+        let root_b = tempfile::tempdir().unwrap();
+
+        // Two contexts share root_a, one context owns root_b.
+        let router_before = WorkspaceRouter::new(
+            vec![
+                ctx(1, root_a.path()),
+                ctx(2, root_a.path()),
+                ctx(3, root_b.path()),
+            ],
+            0,
+        );
+        let mut views = RegistryViews::new_with_global(global.path());
+        views.view_for_context(1, &router_before);
+        views.view_for_context(3, &router_before);
+        assert_eq!(views.roots().len(), 2);
+
+        // Context 2 (sharing root_a with context 1) is removed — root_a must
+        // survive because context 1 still anchors there.
+        let router_after_remove_2 =
+            WorkspaceRouter::new(vec![ctx(1, root_a.path()), ctx(3, root_b.path())], 0);
+        views.invalidate(
+            &ScopeInvalidation::ContextRemoved { context_id: 2 },
+            &router_after_remove_2,
+        );
+        assert_eq!(
+            views.roots().len(),
+            2,
+            "root_a is still referenced by context 1 — must not be dropped"
+        );
+
+        // Now context 1 (the last reference to root_a) is also removed.
+        let router_after_remove_1 = WorkspaceRouter::new(vec![ctx(3, root_b.path())], 0);
+        views.invalidate(
+            &ScopeInvalidation::ContextRemoved { context_id: 1 },
+            &router_after_remove_1,
+        );
+        assert_eq!(
+            views.roots().len(),
+            1,
+            "root_a must be dropped once no context references it"
+        );
+    }
+
+    #[test]
+    fn source_generation_changed_forces_a_rescan() {
+        let global = tempfile::tempdir().unwrap();
+        let root = tempfile::tempdir().unwrap();
+        let channel_dir = crate::config::workspace_channel_dir();
+        let mut views = RegistryViews::new_with_global(global.path());
+        views.view_for_root(root.path());
+        assert!(views.view_for_root(root.path()).get("fresh").is_none());
+
+        write_app(&root.path().join(&channel_dir).join("apps"), "fresh");
+        let router = WorkspaceRouter::new(vec![ctx(1, root.path())], 0);
+        views.invalidate(
+            &ScopeInvalidation::SourceGenerationChanged {
+                source_path: root.path().to_path_buf(),
+            },
+            &router,
+        );
+        assert!(views.view_for_root(root.path()).get("fresh").is_some());
+    }
+}

--- a/src/app/registry_views.rs
+++ b/src/app/registry_views.rs
@@ -216,7 +216,7 @@ mod tests {
 
     fn ctx(id: u64, root: &Path) -> Context {
         Context {
-            name: format!("ctx{id}"),
+            name: format!("ctx{id}").into(),
             root: root.to_path_buf(),
             description: None,
             context_id: id,

--- a/src/app/registry_views.rs
+++ b/src/app/registry_views.rs
@@ -182,11 +182,9 @@ impl RegistryViews {
             ScopeInvalidation::SourceGenerationChanged { source_path } => {
                 self.rescan_root(source_path);
             }
-            ScopeInvalidation::PaneClosed { .. } | ScopeInvalidation::PackageReplaced { .. } => {
+            ScopeInvalidation::PaneClosed { .. } => {
                 // Not a registry-shaped event: a pane closing doesn't change
-                // which apps are installed, and a package replace names an
-                // app id, not necessarily a root already in view. Left for a
-                // later phase's deletion sweep / install-path wiring.
+                // which apps are installed.
             }
         }
     }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -345,22 +345,22 @@ impl PlexiApp {
                 }
 
                 // Build per-pane notification counts before `ctx` mutably borrows
-                // `self.windows`. Inline the notification_is_visible logic to
-                // avoid a borrow conflict with the mutable ctx reference below.
+                // `self.windows`. Calls the extracted `notification_visible` free
+                // function (plain scalar ids) rather than
+                // `PlexiApp::notification_is_visible` to avoid a borrow conflict
+                // with the mutable `ctx` reference below.
                 let notify_counts: std::collections::HashMap<u64, usize> = {
                     let active_context_id = self.router.active().context_id;
                     let active_window_id = self.windows[self.active_window].window_id;
                     let mut counts = std::collections::HashMap::new();
                     for n in &self.pending_notifications {
-                        let visible = match n.scope {
-                            crate::app_protocol::NotifyScope::Global => true,
-                            crate::app_protocol::NotifyScope::Window => {
-                                n.source_window_id == active_window_id
-                            }
-                            crate::app_protocol::NotifyScope::Context => {
-                                n.source_context_id == active_context_id
-                            }
-                        };
+                        let visible = crate::app::notifications::notification_visible(
+                            n.scope,
+                            n.source_window_id,
+                            n.source_context_id,
+                            active_window_id,
+                            active_context_id,
+                        );
                         if visible {
                             *counts.entry(n.sender_pane_id).or_insert(0) += 1;
                         }

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -736,10 +736,12 @@ fn delete_context_cascades_cleans_depth_stack_and_revokes_credentials() {
     let b_pane_id = 65_300_112u64;
     let a_token = crate::app::host_mcp::register_pane_credential_for_test(
         a_pane_id,
+        a_id,
         std::path::PathBuf::from("/tmp/a"),
     );
     let b_token = crate::app::host_mcp::register_pane_credential_for_test(
         b_pane_id,
+        b_id,
         std::path::PathBuf::from("/tmp/b"),
     );
 
@@ -868,6 +870,7 @@ fn delete_window_revokes_removed_pane_credentials() {
     let removed_pane_id = 65_300_101u64;
     let removed_token = crate::app::host_mcp::register_pane_credential_for_test(
         removed_pane_id,
+        context_id,
         std::path::PathBuf::from("/tmp/removed"),
     );
 
@@ -1688,6 +1691,7 @@ fn dissolve_portal_grafts_single_child_window_tree_in_place() {
         .push_depth(child_ctx_id, child_win_id, Some(child_right_tile));
     let moved_token = crate::app::host_mcp::register_pane_credential_for_test(
         child_left,
+        child_ctx_id,
         std::path::PathBuf::from("/tmp/dissolve_single_child"),
     );
 
@@ -2531,7 +2535,11 @@ fn set_context_root_ipc_targets_caller_context() {
         context_id: other_id,
     });
     let old_root = std::path::PathBuf::from("/tmp/background");
-    let token = crate::app::host_mcp::register_pane_credential_for_test(pane_id, old_root.clone());
+    let token = crate::app::host_mcp::register_pane_credential_for_test(
+        pane_id,
+        other_id,
+        old_root.clone(),
+    );
     assert_eq!(
         crate::app::host_mcp::authenticated_workspace_for_test(&token),
         Some(old_root)

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -3455,6 +3455,12 @@ fn registry_watcher_covers_an_inactive_contexts_root_and_rescans_it_alone() {
 
     let ctx_a_id = app.router.active().context_id;
     let root_a = app.router.active().root.clone();
+    // `PlexiApp::new_for_test`'s isolated workspace has no channel dir of
+    // its own either — same reasoning as root_b below applies symmetrically,
+    // so create it here too rather than let this assertion depend on the
+    // ambient global apps dir.
+    std::fs::create_dir_all(root_a.join(crate::config::workspace_channel_dir()))
+        .expect("create root_a channel dir");
 
     // A second, inactive context with its own root. Create its channel dir
     // up front so `registry_watch_dirs` recognizes root_b as a real

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -3351,9 +3351,15 @@ fn launch_into_an_inactive_context_resolves_that_contexts_own_registry() {
     // the app genuinely isn't installed there.
     assert_eq!(app.active_window, 0, "context A must still be active");
     let result_from_a = app.launch_app_by_id_with_layout(app_id, None, &[], None);
+    let err_from_a =
+        result_from_a.expect_err("the app is not installed in context A's root — launch must fail");
     assert!(
-        result_from_a.is_err(),
-        "the app is not installed in context A's root — launch must fail, got {result_from_a:?}"
+        !err_from_a.contains("WASM"),
+        "a not-found app must not be misreported as a runtime problem, got {err_from_a:?}"
+    );
+    assert!(
+        err_from_a.contains("not found") || err_from_a.contains("this context"),
+        "a not-found app's error must say so, got {err_from_a:?}"
     );
 
     // Redirect `active_window` to context B's window — the sanctioned

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -3456,8 +3456,18 @@ fn registry_watcher_covers_an_inactive_contexts_root_and_rescans_it_alone() {
     let ctx_a_id = app.router.active().context_id;
     let root_a = app.router.active().root.clone();
 
-    // A second, inactive context with its own root.
+    // A second, inactive context with its own root. Create its channel dir
+    // up front so `registry_watch_dirs` recognizes root_b as a real
+    // workspace root via `resolve_workspace_root_with_channel` (which walks
+    // up looking for `<root>/<channel>/`) — otherwise this assertion would
+    // pass or fail purely based on whether the *ambient global* apps dir
+    // happens to exist on the machine running the test (it does on a dev
+    // box with real Plexi usage history, it does not on a clean CI runner),
+    // rather than testing what it claims to: that root_b's OWN root gets
+    // watched.
     let root_b = tempfile::tempdir().expect("root b");
+    std::fs::create_dir_all(root_b.path().join(crate::config::workspace_channel_dir()))
+        .expect("create root_b channel dir");
     let ctx_b_id = 2;
     app.router.push(crate::host::context::Context {
         name: "Context B".into(),

--- a/src/app/tests/context_tests.rs
+++ b/src/app/tests/context_tests.rs
@@ -69,8 +69,12 @@ fn switching_contexts_refreshes_workspace_app_registry() {
     app.router.get_mut(0).root = root_a.path().to_path_buf();
     app.windows[0].path = root_a.path().to_path_buf();
     app.reload_config();
+    let ctx_a_id = app.router.active().context_id;
     assert!(
-        app.registry.get("local-tool").is_none(),
+        app.registries
+            .view_for_context(ctx_a_id, &app.router)
+            .get("local-tool")
+            .is_none(),
         "root B app must not leak into root A registry"
     );
 
@@ -99,14 +103,16 @@ fn switching_contexts_refreshes_workspace_app_registry() {
     });
 
     app.switch_workspace(1);
-    // Registry rescan is async (stint 0548) — spin-wait for the background
-    // load to land instead of asserting synchronously.
-    while !app.drain_registry_load() {
-        std::thread::sleep(std::time::Duration::from_millis(5));
-    }
+    // Registry resolution is a synchronous per-root cache (stint 0724 Phase
+    // B) — `apply_context_transition_effects` (called by `switch_workspace`)
+    // resolves the new root's view inline, so no background-load drain is
+    // needed here anymore.
 
     assert!(
-        app.registry.get("local-tool").is_some(),
+        app.registries
+            .view_for_context(ctx_b_id, &app.router)
+            .get("local-tool")
+            .is_some(),
         "switching into a workspace should refresh palette-visible local apps immediately"
     );
 }
@@ -1074,14 +1080,14 @@ fn context_transition_rescans_registry() {
     let idx0 = app.router.active_idx();
     app.router.get_mut(idx0).root = dir_a.clone();
     app.apply_context_transition_effects();
-    // Registry rescan is async (stint 0548) — spin-wait for the background
-    // load to land instead of asserting synchronously.
-    while !app.drain_registry_load() {
-        std::thread::sleep(std::time::Duration::from_millis(5));
-    }
+    // Registry resolution is a synchronous per-root cache (stint 0724 Phase
+    // B) — `apply_context_transition_effects` resolves it inline, so no
+    // background-load drain is needed here anymore.
+    let ctx_a_id = app.router.active().context_id;
 
     let ids: Vec<String> = app
-        .registry
+        .registries
+        .view_for_context(ctx_a_id, &app.router)
         .list()
         .into_iter()
         .map(|a| a.manifest.id.clone())
@@ -1123,12 +1129,10 @@ fn context_transition_rescans_registry() {
     });
     let ctx_b_idx = app.router.len() - 1;
     app.switch_workspace(ctx_b_idx);
-    while !app.drain_registry_load() {
-        std::thread::sleep(std::time::Duration::from_millis(5));
-    }
 
     let ids: Vec<String> = app
-        .registry
+        .registries
+        .view_for_context(ctx_b_id, &app.router)
         .list()
         .into_iter()
         .map(|a| a.manifest.id.clone())
@@ -3239,33 +3243,280 @@ fn perf_gate_delete_context_does_not_block_ui_thread() {
     );
 }
 
+// `perf_gate_context_transition_does_not_block_ui_thread` (the background-
+// thread registry rescan gate from stint 0548) was removed in stint 0724
+// Phase B: `RegistryViews` resolves per-root synchronously by design — a
+// never-before-seen root must resolve correctly at the point of use (e.g.
+// launching into a context nobody has visited yet), which a background
+// load racing the caller cannot guarantee. The perf property this gate
+// checked (context transitions don't stall the UI thread on a large
+// registry scan) no longer holds as an architectural claim; the tradeoff is
+// deliberate — see `crate::app::registry_views` module docs.
+
+// ── Stint 0724 Phase B: per-context registry resolution ─────────────────────
+
+fn counter_wasm_fixture() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/wasm-fixtures/counter.wasm")
+}
+
+/// Install a WASM-manifest app (a copy of the `counter.wasm` POC fixture,
+/// which needs no external process and is already exercised elsewhere in the
+/// suite) under `root`'s workspace-local apps dir.
+fn write_registry_wasm_app(root: &std::path::Path, id: &str) {
+    let app_dir = root
+        .join(crate::config::workspace_channel_dir())
+        .join("apps")
+        .join(id);
+    std::fs::create_dir_all(&app_dir).expect("create app dir");
+    std::fs::write(
+        app_dir.join("manifest.toml"),
+        format!(
+            "schema_version = 1\n\n[app]\nid = \"{id}\"\ntype = \"wasm\"\nname = \"{id}\"\n\
+             version = \"0.0.1\"\nentry = \"counter.wasm\"\n\n[app.capabilities]\n\
+             capabilities = []\n"
+        ),
+    )
+    .expect("write manifest");
+    std::fs::copy(counter_wasm_fixture(), app_dir.join("counter.wasm")).expect("copy fixture");
+}
+
+/// The falsifying regression test for the stint 0724 bug: before Phase B,
+/// `PlexiApp` held exactly one `AppRegistry`, refreshed only when the
+/// *active* context transitioned (`apply_context_transition_effects`). A
+/// launch redirected at a DIFFERENT context — via the sanctioned
+/// `active_window`-redirect convention `pane_ops::dispatch` already uses for
+/// an explicit target (never by mutating `router.active()`) — never
+/// triggered that refresh, so it resolved against whichever registry the
+/// last real transition happened to load. An app installed only in another
+/// context's root was invisible there no matter how the launch was routed.
+///
+/// `RegistryViews::view_for_context` fixes this structurally: every launch
+/// resolves its OWN target context's root at the point of use, independent
+/// of transition history.
 #[test]
-#[ignore = "perf-gate: run explicitly on a quiet machine"]
-fn perf_gate_context_transition_does_not_block_ui_thread() {
+fn launch_into_an_inactive_context_resolves_that_contexts_own_registry() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+    let app_id = "com.plexi.counter-cross-context-test";
+
+    // Context A (the harness default, active) has no such app installed.
+    let ctx_a_id = app.router.active().context_id;
+    assert!(
+        app.registries
+            .view_for_context(ctx_a_id, &app.router)
+            .get(app_id)
+            .is_none(),
+        "setup: context A must not have the app installed"
+    );
+
+    // Context B, NOT active, with the app installed only in its own root.
+    let root_b = tempfile::tempdir().expect("root b");
+    write_registry_wasm_app(root_b.path(), app_id);
+    let ctx_b_id = 2;
+    let win_b_id = 2;
+    app.router.push(crate::host::context::Context {
+        name: "Context B".into(),
+        root: root_b.path().to_path_buf(),
+        description: None,
+        context_id: ctx_b_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    let win_b_idx = app.windows.len();
+    app.windows.push(Window {
+        name: "Context B".into(),
+        path: root_b.path().to_path_buf(),
+        tree: egui_tiles::Tree::empty("cross_context_launch_test"),
+        panes: HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 1,
+        grid_y: 0,
+        window_id: win_b_id,
+        context_id: ctx_b_id,
+    });
+
+    // Context A is still active — no `switch_workspace`/context transition
+    // has happened. Launching by id while active_window targets A must fail:
+    // the app genuinely isn't installed there.
+    assert_eq!(app.active_window, 0, "context A must still be active");
+    let result_from_a = app.launch_app_by_id_with_layout(app_id, None, &[], None);
+    assert!(
+        result_from_a.is_err(),
+        "the app is not installed in context A's root — launch must fail, got {result_from_a:?}"
+    );
+
+    // Redirect `active_window` to context B's window — the sanctioned
+    // explicit-target convention (mirrors `pane_ops::dispatch`'s spawn_pane
+    // handling of `from_pane_id`), never a real context switch. Context A
+    // remains the router's active context throughout.
+    app.active_window = win_b_idx;
+    let result_from_b = app.launch_app_by_id_with_layout(app_id, None, &[], None);
+    assert!(
+        result_from_b.is_ok(),
+        "launching into context B's window must resolve context B's OWN \
+         registry view, not whatever context last transitioned — got {result_from_b:?}"
+    );
+    assert_eq!(
+        app.windows[win_b_idx].panes.len(),
+        1,
+        "the app must have spawned a pane in context B's window"
+    );
+    let spawned = app.windows[win_b_idx]
+        .panes
+        .values()
+        .next()
+        .and_then(|p| p.as_app())
+        .expect("spawned pane must be an app pane");
+    assert_eq!(spawned.manifest_id, app_id);
+}
+
+/// `PlexiApp::set_context_root` on a context that is NOT the active one used
+/// to silently do nothing to the registry: the old `apply_context_transition_effects`
+/// (registry rescan + watcher restart) only ran when `idx == router.active_idx()`.
+/// `emit_scope_invalidation`'s `ContextRootChanged` handling now rescans
+/// `RegistryViews` unconditionally, regardless of which context is active.
+#[test]
+fn set_context_root_on_an_inactive_context_rescans_its_registry() {
+    let ctx = egui::Context::default();
+    let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
+    let app_id = "com.plexi.inactive-set-root-test";
+
+    // A second, inactive context.
+    let ctx_b_id = 2;
+    app.router.push(crate::host::context::Context {
+        name: "Context B".into(),
+        root: tempfile::tempdir().expect("root b placeholder").keep(),
+        description: None,
+        context_id: ctx_b_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    app.windows.push(Window {
+        name: "Context B".into(),
+        path: std::env::temp_dir(),
+        tree: egui_tiles::Tree::empty("inactive_set_root_test"),
+        panes: HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 1,
+        grid_y: 0,
+        window_id: 2,
+        context_id: ctx_b_id,
+    });
+    assert_ne!(
+        app.router.active().context_id,
+        ctx_b_id,
+        "setup: context B must not be active"
+    );
+
+    let new_root = tempfile::tempdir().expect("new root");
+    write_registry_wasm_app(new_root.path(), app_id);
+
+    app.set_context_root(new_root.path().to_path_buf(), Some(ctx_b_id));
+
+    assert_ne!(
+        app.router.active().context_id,
+        ctx_b_id,
+        "set_context_root(Some(ctx_b_id)) must not itself change the active context"
+    );
+    assert!(
+        app.registries
+            .view_for_context(ctx_b_id, &app.router)
+            .get(app_id)
+            .is_some(),
+        "setting an INACTIVE context's root must rescan its registry view immediately, \
+         not leave it stale until the user happens to navigate there"
+    );
+}
+
+/// The registry watcher must cover every root `RegistryViews` holds a view
+/// for, not just the active context's — `reconcile_registry_watchers` starts
+/// a watcher the first time any context's root is resolved, and firing that
+/// specific root's `SourceGenerationChanged` (exactly what the per-root
+/// watcher drain loop in `PlexiApp::logic` does) must rescan only that root.
+#[test]
+fn registry_watcher_covers_an_inactive_contexts_root_and_rescans_it_alone() {
     let ctx = egui::Context::default();
     let frame_tick = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
     let (mut app, _tx) = PlexiApp::new_for_test(ctx, frame_tick);
 
-    let root = tempfile::tempdir().expect("root");
-    app.router.get_mut(0).root = root.path().to_path_buf();
+    let ctx_a_id = app.router.active().context_id;
+    let root_a = app.router.active().root.clone();
 
-    // The registry rescan itself now runs on a background thread (stint
-    // 0548), so this gate covers only the synchronous remainder: agent-host
-    // reload, watcher restart, and config reload.
-    let start = std::time::Instant::now();
-    app.apply_context_transition_effects();
-    let elapsed = start.elapsed();
-    eprintln!("perf_gate_context_transition_does_not_block_ui_thread: elapsed={elapsed:?}");
+    // A second, inactive context with its own root.
+    let root_b = tempfile::tempdir().expect("root b");
+    let ctx_b_id = 2;
+    app.router.push(crate::host::context::Context {
+        name: "Context B".into(),
+        root: root_b.path().to_path_buf(),
+        description: None,
+        context_id: ctx_b_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    app.windows.push(Window {
+        name: "Context B".into(),
+        path: root_b.path().to_path_buf(),
+        tree: egui_tiles::Tree::empty("watcher_inactive_root_test"),
+        panes: HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 1,
+        grid_y: 0,
+        window_id: 2,
+        context_id: ctx_b_id,
+    });
 
+    // Resolve BOTH contexts' views (context A's happens automatically at
+    // harness construction; context B's here simulates a cross-context
+    // launch, palette open, or any other resolution).
+    let _ = app.registries.view_for_context(ctx_a_id, &app.router);
+    let _ = app.registries.view_for_context(ctx_b_id, &app.router);
+
+    app.reconcile_registry_watchers();
+    let root_a_canon = root_a.canonicalize().unwrap_or(root_a.clone());
+    let root_b_canon = root_b
+        .path()
+        .canonicalize()
+        .unwrap_or(root_b.path().to_path_buf());
     assert!(
-        elapsed < std::time::Duration::from_millis(25),
-        "apply_context_transition_effects' synchronous remainder must not block \
-         the UI thread waiting on the registry rescan; took {elapsed:?}"
+        app.registry_watchers.contains_key(&root_b_canon),
+        "the inactive context's root must be watched too, not just the active one"
+    );
+    assert!(
+        app.registry_watchers.contains_key(&root_a_canon),
+        "the active context's root must still be watched (no regression)"
     );
 
-    // Drain the background load so the test doesn't leak a dangling thread
-    // assertion for the next test in the binary.
-    while !app.drain_registry_load() {
-        std::thread::sleep(std::time::Duration::from_millis(5));
-    }
+    // Simulate the inactive root's watcher firing (exactly what the per-root
+    // drain loop in `PlexiApp::logic` does when THAT root's receiver has a
+    // signal) and confirm only root B gets rescanned.
+    let app_id = "com.plexi.watcher-inactive-test";
+    write_registry_wasm_app(root_b.path(), app_id);
+    app.emit_scope_invalidation(
+        crate::host::scope::ScopeInvalidation::SourceGenerationChanged {
+            source_path: root_b.path().to_path_buf(),
+        },
+    );
+
+    assert!(
+        app.registries
+            .view_for_context(ctx_b_id, &app.router)
+            .get(app_id)
+            .is_some(),
+        "firing the inactive root's own invalidation must rescan it and pick up the new app"
+    );
+    assert!(
+        app.registries
+            .view_for_context(ctx_a_id, &app.router)
+            .get(app_id)
+            .is_none(),
+        "root A must be untouched by root B's invalidation"
+    );
 }

--- a/src/app/tests/navigation_tests.rs
+++ b/src/app/tests/navigation_tests.rs
@@ -548,7 +548,8 @@ fn on_launch_focus_existing_focuses_cross_context_instead_of_spawning() {
     h.app.router.push(context_b(2));
 
     let (_tmp, registry) = registry_with_on_launch("singleton", "focus_existing");
-    h.app.registry = registry;
+    let ctx1_root = h.app.router.active().root.clone();
+    h.app.registries.set_view_for_test(&ctx1_root, registry);
 
     assert_eq!(h.app.active_window, 0);
     let caller_ctx = h.app.windows[0].context_id;
@@ -593,7 +594,8 @@ fn on_launch_focus_existing_in_context_is_per_context() {
     h.app.router.push(context_b(2));
 
     let (_tmp, registry) = registry_with_on_launch("percontext", "focus_existing_in_context");
-    h.app.registry = registry;
+    let ctx1_root = h.app.router.active().root.clone();
+    h.app.registries.set_view_for_test(&ctx1_root, registry);
 
     let ctx1 = h.app.windows[0].context_id;
     assert!(
@@ -639,7 +641,8 @@ fn on_launch_matches_by_manifest_id_not_runtime_type_id() {
             .add_app_pane_in_window_with_runtime_id(0, "wasm_singleton", "wasm");
 
     let (_tmp, registry) = registry_with_on_launch("wasm_singleton", "focus_existing");
-    h.app.registry = registry;
+    let ctx1_root = h.app.router.active().root.clone();
+    h.app.registries.set_view_for_test(&ctx1_root, registry);
 
     assert_eq!(
         h.app
@@ -670,7 +673,8 @@ fn on_launch_always_new_never_dedups() {
     let _existing = h.app.add_app_pane_in_window(0, "stacker");
 
     let (_tmp, registry) = registry_with_on_launch("stacker", "always_new");
-    h.app.registry = registry;
+    let ctx1_root = h.app.router.active().root.clone();
+    h.app.registries.set_view_for_test(&ctx1_root, registry);
 
     let ctx1 = h.app.windows[0].context_id;
     assert!(
@@ -709,9 +713,14 @@ fn split_mirror_bypasses_on_launch_dedup() {
     // Make the app a singleton. The registry entry names the same id as the
     // builtin, so the dedup policy is now live for "text-editor".
     let (_tmp, registry) = registry_with_on_launch("text-editor", "focus_existing");
-    h.app.registry = registry;
+    let ctx1_root = h.app.router.active().root.clone();
+    h.app.registries.set_view_for_test(&ctx1_root, registry);
+    let ctx1_id = h.app.router.active().context_id;
     assert_eq!(
-        h.app.registry.on_launch_for("text-editor"),
+        h.app
+            .registries
+            .view_for_context(ctx1_id, &h.app.router)
+            .on_launch_for("text-editor"),
         crate::app::registry::OnLaunchPolicy::FocusExisting,
         "policy must be active for the mirror to have something to bypass"
     );

--- a/src/app/tests/notification_tests.rs
+++ b/src/app/tests/notification_tests.rs
@@ -1813,3 +1813,191 @@ fn focus_mode_suppresses_resurface() {
         "the in-view state is still tracked even when suppressed"
     );
 }
+
+// ── stint 0724 Phase E: dedup parity — notification_visible /
+// notification_counts_toward_context ────────────────────────────────────────
+//
+// Phase E extracted the scope-match logic duplicated across
+// `notification_is_visible`, the `render.rs` per-pane count inline copy, and
+// the two context-badge count functions into two free functions taking plain
+// scalar ids. These tests enumerate scope × (same/other window) ×
+// (same/other context) and assert the extracted functions answer exactly
+// like the pre-extraction inline logic — pure dedup, no behavior change.
+
+/// `notification_visible`'s full compatibility matrix: Global is always
+/// visible; Window depends only on window id match; Context depends only on
+/// context id match — independent of the other id in both cases.
+#[test]
+fn notification_visible_matches_scope_semantics_matrix() {
+    use crate::app::notifications::notification_visible;
+    use crate::app_protocol::NotifyScope;
+
+    let active_window_id = 10;
+    let active_context_id = 20;
+    let other_window_id = 11;
+    let other_context_id = 21;
+
+    // Global: always visible, in every window/context combination.
+    for (window_id, context_id) in [
+        (active_window_id, active_context_id),
+        (active_window_id, other_context_id),
+        (other_window_id, active_context_id),
+        (other_window_id, other_context_id),
+    ] {
+        assert!(
+            notification_visible(
+                NotifyScope::Global,
+                window_id,
+                context_id,
+                active_window_id,
+                active_context_id
+            ),
+            "Global must always be visible (window={window_id}, context={context_id})"
+        );
+    }
+
+    // Window: visible iff source_window_id == active_window_id, regardless of context.
+    assert!(notification_visible(
+        NotifyScope::Window,
+        active_window_id,
+        active_context_id,
+        active_window_id,
+        active_context_id
+    ));
+    assert!(notification_visible(
+        NotifyScope::Window,
+        active_window_id,
+        other_context_id,
+        active_window_id,
+        active_context_id
+    ));
+    assert!(!notification_visible(
+        NotifyScope::Window,
+        other_window_id,
+        active_context_id,
+        active_window_id,
+        active_context_id
+    ));
+    assert!(!notification_visible(
+        NotifyScope::Window,
+        other_window_id,
+        other_context_id,
+        active_window_id,
+        active_context_id
+    ));
+
+    // Context: visible iff source_context_id == active_context_id, regardless of window.
+    assert!(notification_visible(
+        NotifyScope::Context,
+        active_window_id,
+        active_context_id,
+        active_window_id,
+        active_context_id
+    ));
+    assert!(notification_visible(
+        NotifyScope::Context,
+        other_window_id,
+        active_context_id,
+        active_window_id,
+        active_context_id
+    ));
+    assert!(!notification_visible(
+        NotifyScope::Context,
+        active_window_id,
+        other_context_id,
+        active_window_id,
+        active_context_id
+    ));
+    assert!(!notification_visible(
+        NotifyScope::Context,
+        other_window_id,
+        other_context_id,
+        active_window_id,
+        active_context_id
+    ));
+}
+
+/// `PlexiApp::notification_is_visible` (the real call site, including the
+/// snooze/`deliver_after` gate) must agree with the extracted
+/// `notification_visible` for every non-snoozed notification across the same
+/// scope × window × context matrix — proving the extraction changed where
+/// the scope-match logic lives, not what it answers.
+#[test]
+fn notification_is_visible_agrees_with_extracted_scope_match_when_not_snoozed() {
+    let h = HostHarness::new();
+    let active_window_id = h.app.windows[h.app.active_window].window_id;
+    let active_context_id = h.app.router.active().context_id;
+
+    for scope in [
+        crate::app_protocol::NotifyScope::Global,
+        crate::app_protocol::NotifyScope::Window,
+        crate::app_protocol::NotifyScope::Context,
+    ] {
+        for (source_window_id, source_context_id) in [
+            (active_window_id, active_context_id),
+            (active_window_id, active_context_id + 1),
+            (active_window_id + 1, active_context_id),
+            (active_window_id + 1, active_context_id + 1),
+        ] {
+            let mut n = cue_test_notification("parity");
+            n.scope = scope;
+            n.source_window_id = source_window_id;
+            n.source_context_id = source_context_id;
+            let expected = crate::app::notifications::notification_visible(
+                scope,
+                source_window_id,
+                source_context_id,
+                active_window_id,
+                active_context_id,
+            );
+            assert_eq!(
+                h.app.notification_is_visible(&n),
+                expected,
+                "scope={scope:?} source_window={source_window_id} source_context={source_context_id}"
+            );
+        }
+    }
+}
+
+/// `notification_counts_toward_context`: Global never counts toward any
+/// context's badge (it already renders everywhere via `notification_visible`
+/// — counting it again would double-report it); Window/Context count toward
+/// their originating context's badge based purely on context id match.
+#[test]
+fn notification_counts_toward_context_matrix() {
+    use crate::app::notifications::notification_counts_toward_context;
+    use crate::app_protocol::NotifyScope;
+
+    assert!(!notification_counts_toward_context(
+        NotifyScope::Global,
+        5,
+        5
+    ));
+    assert!(!notification_counts_toward_context(
+        NotifyScope::Global,
+        5,
+        6
+    ));
+
+    assert!(notification_counts_toward_context(
+        NotifyScope::Window,
+        5,
+        5
+    ));
+    assert!(!notification_counts_toward_context(
+        NotifyScope::Window,
+        5,
+        6
+    ));
+
+    assert!(notification_counts_toward_context(
+        NotifyScope::Context,
+        5,
+        5
+    ));
+    assert!(!notification_counts_toward_context(
+        NotifyScope::Context,
+        5,
+        6
+    ));
+}

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -476,8 +476,7 @@ fn tool_output_preview(output_json: &str) -> String {
 /// body — string values keep their real newlines, non-strings print as
 /// compact JSON. Falls back to the raw input when it isn't a JSON object.
 fn tool_input_detail(input_json: &str) -> String {
-    let detail =
-        render_json_object_lines(input_json).unwrap_or_else(|| input_json.to_string());
+    let detail = render_json_object_lines(input_json).unwrap_or_else(|| input_json.to_string());
     bounded_head_tail_multiline(&detail, TOOL_OUTPUT_PREVIEW_BUDGET)
 }
 
@@ -566,6 +565,14 @@ pub struct AssistantApp {
     store: AssistantStore,
     broker: Arc<dyn AiBroker>,
     workspace_root: PathBuf,
+    /// The host context this pane lives in, captured once at construction —
+    /// stint 0724 Phase C. `gated_dispatcher`/`apps_for_context` resolve
+    /// connector-tool reachability from this, never from `workspace_root`
+    /// path-equality or ambient focus state. Set from the host-observed
+    /// window `context_id` the caller passed to `new`/`new_with_timeline`
+    /// (see `restore_assistant_pane`/`open_assistant_pane_with_hint`), not
+    /// re-derived later.
+    context_id: u64,
     profile_dir: PathBuf,
     agent_registry: AgentRegistry,
     skill_registry: SkillRegistry,
@@ -721,6 +728,7 @@ impl AssistantApp {
             store,
             broker,
             workspace_root,
+            context_id,
             profile_dir: profile_dir.to_path_buf(),
             agent_registry,
             skill_registry,
@@ -1027,6 +1035,21 @@ impl AssistantApp {
         )
     }
 
+    /// Test-only seam onto the real connector-tool visibility path
+    /// (`gated_dispatcher`, unfiltered by broker grants) — lets a
+    /// `HostHarness` test assert what this pane's own context can see
+    /// without reaching into private fields. Stint 0724 Phase C regression
+    /// coverage (context-scoped connector reachability) uses this from
+    /// `testing::harness_tests`.
+    #[cfg(test)]
+    pub(crate) fn visible_connector_tool_names_for_test(&self) -> Vec<String> {
+        self.gated_dispatcher()
+            .all_tools()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect()
+    }
+
     /// Build the broker-gated dispatcher for one turn: denied tools are
     /// stripped (invisible and uninvocable), ask tools stay visible behind
     /// the permission-sheet hook, allowed tools pass through.
@@ -1034,7 +1057,7 @@ impl AssistantApp {
         let mut dispatcher = ToolDispatcher::from_registry(
             0,
             format!("agent:{}", self.connector_actor().0),
-            self.workspace_root.clone(),
+            self.context_id,
         );
         let mut allowed = HashSet::new();
         let mut ask_tools = HashSet::new();
@@ -3048,7 +3071,7 @@ impl AssistantApp {
         let dispatcher = ToolDispatcher::from_registry(
             0,
             format!("agent:{ASSISTANT_ACTOR_ID}"),
-            self.workspace_root.clone(),
+            self.context_id,
         );
         let mut tools = dispatcher.all_tools();
         tools.sort_by(|a, b| a.name.cmp(&b.name));
@@ -3249,7 +3272,7 @@ impl AssistantApp {
 
     /// `/apps`: running apps and the connectors they expose, with broker decisions.
     fn cmd_list_apps(&mut self) {
-        let apps = ToolDispatcher::apps_for_workspace(self.workspace_root.clone());
+        let apps = ToolDispatcher::apps_for_context(self.context_id);
         log::info!(
             "assistant: /apps — {} app(s) with connector tools in workspace",
             apps.len()
@@ -3626,6 +3649,22 @@ mod tests {
     use super::*;
     use crate::plexi_ai::broker::AiBrokerResponse;
 
+    /// A `ScopeOrigin` for a tool provider pane in `context_id` — stint 0724
+    /// Phase C. Every field but `context_id`/`pane_id` is a deterministic
+    /// placeholder never inspected by `evaluate_reach`. `test_app` always
+    /// constructs its `AssistantApp` with `context_id = 1` (see `test_app`
+    /// below), so registering a provider with `context_id = 1` is what makes
+    /// it reachable from the assistant under test.
+    fn test_scope_origin(context_id: u64, pane_id: u64) -> crate::host::scope::ScopeOrigin {
+        crate::host::scope::ScopeOrigin {
+            context_id,
+            context_root: PathBuf::from(format!("/test-ctx-root-{context_id}")),
+            window_id: context_id,
+            pane_id,
+            app_id: None,
+        }
+    }
+
     /// Scripted test broker.
     struct MockBroker {
         /// Canned reply text. If None, simulates an error turn.
@@ -3686,6 +3725,22 @@ mod tests {
     /// Assistant whose grants + audit live in the (temp) workspace dir.
     fn test_app(ws: &Path) -> AssistantApp {
         AssistantApp::new(ws.to_path_buf(), MockBroker::ok("echo: ok"), ws, 1)
+    }
+
+    /// Like `test_app` but with an explicit `context_id`. The global tool
+    /// registry (`plexi_ai::tool_dispatch`) is a process-wide singleton, so
+    /// any test that registers a connector-tool provider must give its
+    /// assistant a `context_id` distinct from every other such test —
+    /// `cargo test`'s parallel runner means two tests both anchored at
+    /// `test_app`'s fixed `context_id = 1` would make each other's
+    /// same-named tools ("gated.tool", "csv.read_range", ...) mutually
+    /// visible, tripping the same-name-conflict withholding
+    /// (`snapshot_for_caller`) and hanging the test waiting for a permission
+    /// sheet that never appears because the tool got withheld. Pass a value
+    /// unique to the test (its own pane id is a convenient, already-unique
+    /// choice).
+    fn test_app_with_context(ws: &Path, context_id: u64) -> AssistantApp {
+        AssistantApp::new(ws.to_path_buf(), MockBroker::ok("echo: ok"), ws, context_id)
     }
 
     fn wait_for_turn(app: &mut AssistantApp) {
@@ -3877,12 +3932,8 @@ enabled = ["allowed.tool"]
         )
         .unwrap();
         let broker = Arc::new(CapturingBroker::default());
-        let mut app = AssistantApp::new(ws.path().to_path_buf(), broker.clone(), ws.path(), 1);
-        register_echo_provider(
-            9199,
-            &["allowed.tool", "denied.tool"],
-            ws.path().to_path_buf(),
-        );
+        let mut app = AssistantApp::new(ws.path().to_path_buf(), broker.clone(), ws.path(), 9199);
+        register_echo_provider(9199, &["allowed.tool", "denied.tool"], 9199);
 
         app.model.composer = "/agent writer".to_string();
         let effects = app.model.submit();
@@ -4040,7 +4091,7 @@ enabled = ["allowed.tool"]
     #[test]
     fn read_only_connector_auto_allowed_without_broker_grant() {
         let ws = tempfile::tempdir().unwrap();
-        let app = test_app(ws.path());
+        let app = test_app_with_context(ws.path(), 9200);
         let (tx, _rx) = std::sync::mpsc::channel();
         let ro_tool = crate::app_protocol::AiTool {
             name: "csv.read_range".to_string(),
@@ -4063,7 +4114,7 @@ enabled = ["allowed.tool"]
             "csv".to_string(),
             vec![ro_tool, rw_tool],
             AppEventSender::Channel(tx),
-            ws.path().to_path_buf(),
+            test_scope_origin(9200, 9200),
         );
         // No grants seeded — read-only tool must be auto-allowed; mutating
         // tool must remain ask-gated and visible.
@@ -4084,7 +4135,7 @@ enabled = ["allowed.tool"]
     #[test]
     fn deny_grant_withholds_read_only_tool() {
         let ws = tempfile::tempdir().unwrap();
-        let mut app = test_app(ws.path());
+        let mut app = test_app_with_context(ws.path(), 9205);
         let (tx, _rx) = std::sync::mpsc::channel();
         tool_dispatch::register(
             9205,
@@ -4098,7 +4149,7 @@ enabled = ["allowed.tool"]
                 read_only: true,
             }],
             AppEventSender::Channel(tx),
-            ws.path().to_path_buf(),
+            test_scope_origin(9205, 9205),
         );
         // Explicit deny must still win even though the tool is read-only.
         seed_grant(&mut app, "app.csv.read_range", Decision::Deny);
@@ -4122,7 +4173,7 @@ enabled = ["allowed.tool"]
             "[permissions]\ndeny = [\"app.csv.read_range\"]\n",
         )
         .unwrap();
-        let app = test_app(ws.path());
+        let app = test_app_with_context(ws.path(), 9206);
         let (tx, _rx) = std::sync::mpsc::channel();
         tool_dispatch::register(
             9206,
@@ -4136,7 +4187,7 @@ enabled = ["allowed.tool"]
                 read_only: true,
             }],
             AppEventSender::Channel(tx),
-            ws.path().to_path_buf(),
+            test_scope_origin(9206, 9206),
         );
 
         let visible: Vec<String> = app
@@ -4156,7 +4207,7 @@ enabled = ["allowed.tool"]
         let settings_path = ws.path().join("agents/settings.toml");
         std::fs::create_dir_all(settings_path.parent().unwrap()).unwrap();
         std::fs::write(settings_path, "[permissions]\ndefault_posture = \"plan\"\n").unwrap();
-        let mut app = test_app(ws.path());
+        let mut app = test_app_with_context(ws.path(), 9207);
         let (tx, _rx) = std::sync::mpsc::channel();
         tool_dispatch::register(
             9207,
@@ -4180,7 +4231,7 @@ enabled = ["allowed.tool"]
                 },
             ],
             AppEventSender::Channel(tx),
-            ws.path().to_path_buf(),
+            test_scope_origin(9207, 9207),
         );
         seed_grant(&mut app, "app.csv.write_cell", Decision::Allow);
 
@@ -4222,7 +4273,7 @@ enabled = ["allowed.tool"]
     #[test]
     fn apps_command_lists_running_app_connectors() {
         let ws = tempfile::tempdir().unwrap();
-        let mut app = test_app(ws.path());
+        let mut app = test_app_with_context(ws.path(), 9201);
         let (tx, _rx) = std::sync::mpsc::channel();
         tool_dispatch::register(
             9201,
@@ -4246,7 +4297,7 @@ enabled = ["allowed.tool"]
                 },
             ],
             AppEventSender::Channel(tx),
-            ws.path().to_path_buf(),
+            test_scope_origin(9201, 9201),
         );
         app.model.composer = "/apps".to_string();
         let effects = app.model.submit();
@@ -4434,8 +4485,10 @@ enabled = ["allowed.tool"]
     use crate::plexi_ai::tool_dispatch::{self, AppEventSender, ToolCallResult};
 
     /// Register tools in the global registry with a responder thread that
-    /// answers every `ToolCall` event with `{"ok": true}`.
-    fn register_echo_provider(pane_id: u64, tool_names: &[&str], ws: PathBuf) {
+    /// answers every `ToolCall` event with `{"ok": true}`. `context_id` must
+    /// match the assistant under test's own context (`test_app` always uses
+    /// `1`) for the provider to be reachable.
+    fn register_echo_provider(pane_id: u64, tool_names: &[&str], context_id: u64) {
         let (tx, rx) = std::sync::mpsc::channel();
         let tools = tool_names
             .iter()
@@ -4453,7 +4506,7 @@ enabled = ["allowed.tool"]
             "test-app".to_string(),
             tools,
             AppEventSender::Channel(tx),
-            ws,
+            test_scope_origin(context_id, pane_id),
         );
         std::thread::spawn(move || {
             while let Ok(item) = rx.recv() {
@@ -4538,12 +4591,8 @@ enabled = ["allowed.tool"]
     #[test]
     fn connector_filtering_denied_invisible_ask_and_allow_visible() {
         let ws = tempfile::tempdir().unwrap();
-        let mut app = test_app(ws.path());
-        register_echo_provider(
-            9100,
-            &["t_allow", "t_ask", "t_deny"],
-            ws.path().to_path_buf(),
-        );
+        let mut app = test_app_with_context(ws.path(), 9100);
+        register_echo_provider(9100, &["t_allow", "t_ask", "t_deny"], 9100);
         seed_grant(&mut app, "app.t_allow", Decision::Allow);
         seed_grant(&mut app, "app.t_deny", Decision::Deny);
         // t_ask has no grant → default Ask.
@@ -4582,8 +4631,8 @@ enabled = ["allowed.tool"]
     #[test]
     fn ask_allow_once_runs_tool_without_persisting_a_grant() {
         let ws = tempfile::tempdir().unwrap();
-        let mut app = test_app(ws.path());
-        register_echo_provider(9101, &["gated.tool"], ws.path().to_path_buf());
+        let mut app = test_app_with_context(ws.path(), 9101);
+        register_echo_provider(9101, &["gated.tool"], 9101);
 
         let dispatcher = Arc::new(app.gated_dispatcher());
         let result_rx = dispatch_on_worker(dispatcher, "gated.tool");
@@ -4636,8 +4685,8 @@ enabled = ["allowed.tool"]
     #[test]
     fn ask_allow_always_persists_grant_and_next_call_skips_sheet() {
         let ws = tempfile::tempdir().unwrap();
-        let mut app = test_app(ws.path());
-        register_echo_provider(9102, &["gated.tool"], ws.path().to_path_buf());
+        let mut app = test_app_with_context(ws.path(), 9102);
+        register_echo_provider(9102, &["gated.tool"], 9102);
 
         let dispatcher = Arc::new(app.gated_dispatcher());
         let result_rx = dispatch_on_worker(dispatcher, "gated.tool");
@@ -4683,8 +4732,8 @@ enabled = ["allowed.tool"]
     #[test]
     fn ask_denied_by_user_returns_tool_error_not_a_crash() {
         let ws = tempfile::tempdir().unwrap();
-        let mut app = test_app(ws.path());
-        register_echo_provider(9103, &["gated.tool"], ws.path().to_path_buf());
+        let mut app = test_app_with_context(ws.path(), 9103);
+        register_echo_provider(9103, &["gated.tool"], 9103);
 
         let dispatcher = Arc::new(app.gated_dispatcher());
         let result_rx = dispatch_on_worker(dispatcher, "gated.tool");
@@ -4723,8 +4772,8 @@ enabled = ["allowed.tool"]
     #[test]
     fn slash_views_answer_with_info_rows() {
         let ws = tempfile::tempdir().unwrap();
-        let mut app = test_app(ws.path());
-        register_echo_provider(9104, &["view.tool"], ws.path().to_path_buf());
+        let mut app = test_app_with_context(ws.path(), 9104);
+        register_echo_provider(9104, &["view.tool"], 9104);
         seed_grant(&mut app, "app.view.tool", Decision::Allow);
 
         app.model.composer = "/tools".to_string();
@@ -4879,7 +4928,13 @@ enabled = ["allowed.tool"]
     }
 
     fn test_app_with_timeline(ws: &Path, timeline: Arc<Mutex<AppTimeline>>) -> AssistantApp {
-        AssistantApp::new_with_timeline(ws.to_path_buf(), MockBroker::ok("echo: ok"), ws, timeline, 1)
+        AssistantApp::new_with_timeline(
+            ws.to_path_buf(),
+            MockBroker::ok("echo: ok"),
+            ws,
+            timeline,
+            1,
+        )
     }
 
     fn emit_move(
@@ -5458,13 +5513,15 @@ enabled = ["allowed.tool"]
     #[test]
     fn rename_persists_session_name() {
         let ws = tempfile::tempdir().unwrap();
-        let mut app = AssistantApp::new(ws.path().to_path_buf(), MockBroker::ok("ok"), ws.path(), 1);
+        let mut app =
+            AssistantApp::new(ws.path().to_path_buf(), MockBroker::ok("ok"), ws.path(), 1);
         assert_eq!(app.model.session_name, None);
         app.on_pane_renamed("My Session");
         assert_eq!(app.model.session_name.as_deref(), Some("My Session"));
         // Reopen: name persists.
         drop(app);
-        let reopened = AssistantApp::new(ws.path().to_path_buf(), MockBroker::ok("ok"), ws.path(), 1);
+        let reopened =
+            AssistantApp::new(ws.path().to_path_buf(), MockBroker::ok("ok"), ws.path(), 1);
         assert_eq!(reopened.model.session_name.as_deref(), Some("My Session"));
     }
 

--- a/src/assistant/mod.rs
+++ b/src/assistant/mod.rs
@@ -833,6 +833,7 @@ impl AssistantApp {
             app,
             ActorType::Agent,
             ASSISTANT_ACTOR_ID,
+            self.context_id,
             event_names,
             PayloadMode::Full,
             TriggerMode::Conversation,
@@ -1027,7 +1028,7 @@ impl AssistantApp {
         crate::host::event_subscriptions::evaluate_subscription(
             &self.grant_store,
             Some(&posture),
-            &self.workspace_root,
+            Some(&self.workspace_root),
             app,
             ActorType::Agent,
             ASSISTANT_ACTOR_ID,
@@ -3075,7 +3076,20 @@ impl AssistantApp {
         );
         let mut tools = dispatcher.all_tools();
         tools.sort_by(|a, b| a.name.cmp(&b.name));
-        let streams = self.timeline.lock().unwrap().all_declared_streams();
+        // Filtered to this assistant's own context (stint 0724 Phase D): a
+        // stream declared only in another context can never be subscribed to
+        // from here anyway (no cross-context grant exists), so listing it
+        // would be misleading busywork for the user.
+        let streams: Vec<(String, String)> = self
+            .timeline
+            .lock()
+            .unwrap()
+            .all_declared_streams()
+            .into_iter()
+            .filter_map(|(context_id, app, event)| {
+                (context_id == self.context_id).then_some((app, event))
+            })
+            .collect();
         log::info!(
             "assistant: /tools — {} connector tool(s), {} declared event stream(s) discovered",
             tools.len(),
@@ -4910,12 +4924,19 @@ enabled = ["allowed.tool"]
     use crate::app_protocol::{AppEventActor, EventStreamDecl};
     use crate::host::app_timeline::EmittedEvent;
 
+    /// Matches the `context_id` `test_app_with_timeline` constructs its
+    /// `AssistantApp` with, so the assistant's subscriptions (viewer
+    /// context) line up with these fixtures' declared/emitted streams
+    /// (owner context) by default.
+    const TEST_CTX: u64 = 1;
+
     fn chess_timeline() -> Arc<Mutex<AppTimeline>> {
         let timeline = Arc::new(Mutex::new(AppTimeline::default()));
         timeline
             .lock()
             .unwrap()
             .declare_streams(
+                TEST_CTX,
                 "chess",
                 vec![EventStreamDecl {
                     name: "move.played".to_string(),
@@ -4947,6 +4968,7 @@ enabled = ["allowed.tool"]
             .lock()
             .unwrap()
             .record_event(
+                TEST_CTX,
                 "chess",
                 1,
                 EmittedEvent {
@@ -5094,6 +5116,10 @@ enabled = ["allowed.tool"]
         assert_eq!(record.subscriber_id, ASSISTANT_ACTOR_ID);
         assert_eq!(record.app_id, "chess");
         assert_eq!(record.event_names, vec!["move.played".to_string()]);
+        assert_eq!(
+            record.subscriber_context_id, TEST_CTX,
+            "the assistant's subscription must carry its own host-established context"
+        );
 
         // `*` subscribes to all declared streams → empty event_names.
         drop(guard);

--- a/src/host/app_timeline.rs
+++ b/src/host/app_timeline.rs
@@ -35,6 +35,11 @@ pub struct AppEventRecord {
     pub event_id: u64,
     /// App that emitted the event (host-stamped, not app-supplied).
     pub app_id: String,
+    /// Host-established context the emitting app instance lives in (stint
+    /// 0724 Phase D) — the owning `Scope::AppInstance` for reachability.
+    /// Never app-supplied; resolved by the caller from
+    /// `PlexiApp::origin_for_pane` at the point the event was recorded.
+    pub owner_context_id: u64,
     /// Pane the emitting app instance lives in (host-stamped).
     pub pane_id: u64,
     /// Declared stream name, e.g. `move.played`.
@@ -201,13 +206,35 @@ pub struct SubscriptionRecord {
     /// `None` = any resource the app emits on; `Some` = only that resource.
     pub resource_id: Option<String>,
     pub duration: GrantDuration,
+    /// Host-established context the subscriber lives/acts in (stint 0724
+    /// Phase D) — the viewer side of `evaluate_reach`. Never client-supplied;
+    /// resolved by the caller from `PlexiApp::origin_for_pane` (or the
+    /// equivalent host-trusted identity for non-pane subscribers) at the
+    /// point the subscription was recorded.
+    pub subscriber_context_id: u64,
     /// RFC 3339.
     pub created_at: String,
 }
 
 impl SubscriptionRecord {
+    /// A subscription matches an event when: the publisher app-id matches,
+    /// the event's owning scope is reachable from this subscriber's context
+    /// (stint 0724 Phase D — same context only, since no cross-context grant
+    /// is ever issued yet), the event name is one of the subscribed names
+    /// (or the subscription covers all of the app's streams), and the
+    /// resource filter (if any) matches.
     fn matches(&self, app_id: &str, record: &AppEventRecord) -> bool {
         if self.app_id != app_id {
+            return false;
+        }
+        let owner = crate::host::scope::Scope::AppInstance {
+            pane_id: record.pane_id,
+            app_id: app_id.to_string(),
+            context_id: record.owner_context_id,
+        };
+        if crate::host::scope::evaluate_reach(&owner, self.subscriber_context_id, None)
+            != crate::host::scope::Reach::Allowed
+        {
             return false;
         }
         if !self.event_names.is_empty() && !self.event_names.contains(&record.event) {
@@ -256,8 +283,11 @@ pub struct EventDelivery {
 /// all point at [`global()`], harness tests construct isolated instances.
 #[derive(Debug, Default)]
 pub struct AppTimeline {
-    /// `app_id -> stream name -> declaration`.
-    streams: HashMap<String, HashMap<String, EventStreamDecl>>,
+    /// `(context_id, app_id) -> stream name -> declaration`. Context-keyed
+    /// (stint 0724 Phase D) so two contexts running the same `app_id` never
+    /// share a stream namespace or clobber each other's schema — the
+    /// cross-context bleed this phase fixes.
+    streams: HashMap<(u64, String), HashMap<String, EventStreamDecl>>,
     events: Vec<AppEventRecord>,
     checkpoints: Vec<UndoCheckpoint>,
     subscriptions: Vec<SubscriptionRecord>,
@@ -270,11 +300,16 @@ pub struct AppTimeline {
 impl AppTimeline {
     // ── Stream declaration ──────────────────────────────────────────────────
 
-    /// Register an app's declared event streams. Replaces any previous
-    /// declaration for the same stream name (hot-reload friendly). Returns
-    /// the names accepted; invalid declarations are rejected with a reason.
+    /// Register an app's declared event streams, namespaced under the
+    /// declaring instance's host-established `context_id` (stint 0724 Phase
+    /// D) so the same `app_id` running in two different contexts never
+    /// shares a stream namespace. Replaces any previous declaration for the
+    /// same `(context_id, app_id, stream name)` (hot-reload friendly).
+    /// Returns the names accepted; invalid declarations are rejected with a
+    /// reason.
     pub fn declare_streams(
         &mut self,
+        context_id: u64,
         app_id: &str,
         decls: Vec<EventStreamDecl>,
     ) -> Result<Vec<String>, String> {
@@ -293,42 +328,53 @@ impl AppTimeline {
                 ));
             }
         }
-        let entry = self.streams.entry(app_id.to_string()).or_default();
+        let entry = self
+            .streams
+            .entry((context_id, app_id.to_string()))
+            .or_default();
         for decl in decls {
             accepted.push(decl.name.clone());
             entry.insert(decl.name.clone(), decl);
         }
-        log::info!("app_timeline: '{app_id}' declared event streams {accepted:?}");
+        log::info!(
+            "app_timeline: '{app_id}' (context={context_id}) declared event streams {accepted:?}"
+        );
         Ok(accepted)
     }
 
-    /// Every declared `(app_id, stream_name)` pair, sorted — the discovery
-    /// surface for actors that subscribe at runtime (Phase D Assistant).
-    pub fn all_declared_streams(&self) -> Vec<(String, String)> {
-        let mut out: Vec<(String, String)> = self
+    /// Every declared `(context_id, app_id, stream_name)` triple, sorted —
+    /// the discovery surface for actors that subscribe at runtime (Phase D
+    /// Assistant). Context-qualified since the same `app_id` may declare
+    /// different streams/schemas in different contexts.
+    pub fn all_declared_streams(&self) -> Vec<(u64, String, String)> {
+        let mut out: Vec<(u64, String, String)> = self
             .streams
             .iter()
-            .flat_map(|(app, m)| m.keys().map(move |name| (app.clone(), name.clone())))
+            .flat_map(|((context_id, app), m)| {
+                m.keys()
+                    .map(move |name| (*context_id, app.clone(), name.clone()))
+            })
             .collect();
         out.sort();
         out
     }
 
-    /// Declared streams for an app (empty when none declared).
+    /// Declared streams for an app in one context (empty when none declared).
     #[cfg(test)]
-    pub fn declared_streams(&self, app_id: &str) -> Vec<&EventStreamDecl> {
+    pub fn declared_streams(&self, context_id: u64, app_id: &str) -> Vec<&EventStreamDecl> {
         self.streams
-            .get(app_id)
+            .get(&(context_id, app_id.to_string()))
             .map(|m| m.values().collect())
             .unwrap_or_default()
     }
 
-    /// Whether `app_id` has declared a stream named `name` — an O(1) lookup
-    /// (mirrors `record_event`'s declared-stream check), for callers that only
-    /// need existence and not the full `EventStreamDecl` list.
-    pub fn has_stream(&self, app_id: &str, name: &str) -> bool {
+    /// Whether `app_id` in `context_id` has declared a stream named `name` —
+    /// an O(1) lookup (mirrors `record_event`'s declared-stream check), for
+    /// callers that only need existence and not the full `EventStreamDecl`
+    /// list.
+    pub fn has_stream(&self, context_id: u64, app_id: &str, name: &str) -> bool {
         self.streams
-            .get(app_id)
+            .get(&(context_id, app_id.to_string()))
             .is_some_and(|m| m.contains_key(name))
     }
 
@@ -340,6 +386,7 @@ impl AppTimeline {
     /// and the reason names the missing/invalid field.
     pub fn record_event(
         &mut self,
+        context_id: u64,
         app_id: &str,
         pane_id: u64,
         emitted: EmittedEvent,
@@ -358,15 +405,16 @@ impl AppTimeline {
         if emitted.revision_after.trim().is_empty() {
             return Err("emit_event: 'revision_after' must be non-empty".to_string());
         }
-        // Streams must be declared with a schema before use.
+        // Streams must be declared (in this context, under this app_id) with
+        // a schema before use.
         let declared = self
             .streams
-            .get(app_id)
+            .get(&(context_id, app_id.to_string()))
             .is_some_and(|m| m.contains_key(&emitted.event));
         if !declared {
             return Err(format!(
                 "emit_event: '{}' is not a declared event stream for app '{app_id}' \
-                 — declare it via declare_event_streams first",
+                 in this context — declare it via declare_event_streams first",
                 emitted.event
             ));
         }
@@ -380,6 +428,7 @@ impl AppTimeline {
         let record = AppEventRecord {
             event_id: self.next_event_id,
             app_id: app_id.to_string(),
+            owner_context_id: context_id,
             pane_id,
             event: emitted.event,
             actor: emitted.actor,
@@ -783,9 +832,16 @@ mod tests {
         }
     }
 
+    /// Default owning context for tests that don't care about cross-context
+    /// behavior — one fixed value keeps every existing same-context
+    /// assertion unchanged.
+    const CTX: u64 = 1;
+    /// A second, distinct context — used only by the cross-context tests.
+    const OTHER_CTX: u64 = 2;
+
     fn timeline_with_stream() -> AppTimeline {
         let mut t = AppTimeline::default();
-        t.declare_streams("chess", vec![decl("move.played")])
+        t.declare_streams(CTX, "chess", vec![decl("move.played")])
             .unwrap();
         t
     }
@@ -801,6 +857,7 @@ mod tests {
             trigger_mode,
             resource_id: None,
             duration: GrantDuration::Session,
+            subscriber_context_id: CTX,
             created_at: "2026-06-11T00:00:00Z".to_string(),
         }
     }
@@ -808,16 +865,16 @@ mod tests {
     #[test]
     fn declare_rejects_empty_name_and_non_object_schema() {
         let mut t = AppTimeline::default();
-        assert!(t.declare_streams("a", vec![]).is_err());
-        assert!(t.declare_streams("a", vec![decl(" ")]).is_err());
+        assert!(t.declare_streams(CTX, "a", vec![]).is_err());
+        assert!(t.declare_streams(CTX, "a", vec![decl(" ")]).is_err());
         let bad = EventStreamDecl {
             name: "x".to_string(),
             schema: serde_json::json!("not an object"),
             description: None,
         };
-        assert!(t.declare_streams("a", vec![bad]).is_err());
+        assert!(t.declare_streams(CTX, "a", vec![bad]).is_err());
         assert!(
-            t.declared_streams("a").is_empty(),
+            t.declared_streams(CTX, "a").is_empty(),
             "nothing partial recorded"
         );
     }
@@ -826,10 +883,24 @@ mod tests {
     fn undeclared_stream_is_rejected() {
         let mut t = AppTimeline::default();
         let err = t
-            .record_event("chess", 1, emitted("move.played"))
+            .record_event(CTX, "chess", 1, emitted("move.played"))
             .unwrap_err();
         assert!(err.contains("not a declared event stream"), "{err}");
         assert!(t.events().is_empty());
+    }
+
+    #[test]
+    fn same_app_id_in_different_context_needs_its_own_declaration() {
+        // Declaring "move.played" for "chess" in CTX must not make it usable
+        // for the same app_id running in OTHER_CTX — stream namespace is
+        // (context_id, app_id), not app_id alone.
+        let mut t = timeline_with_stream();
+        let err = t
+            .record_event(OTHER_CTX, "chess", 99, emitted("move.played"))
+            .unwrap_err();
+        assert!(err.contains("not a declared event stream"), "{err}");
+        assert!(t.declared_streams(OTHER_CTX, "chess").is_empty());
+        assert!(!t.declared_streams(CTX, "chess").is_empty());
     }
 
     #[test]
@@ -856,7 +927,7 @@ mod tests {
         ] {
             let mut e = emitted("move.played");
             mutate(&mut e);
-            let err = t.record_event("chess", 1, e).unwrap_err();
+            let err = t.record_event(CTX, "chess", 1, e).unwrap_err();
             assert!(
                 err.contains(field),
                 "expected '{field}' in error, got: {err}"
@@ -871,7 +942,9 @@ mod tests {
     #[test]
     fn accepted_event_enters_timeline_without_checkpoint() {
         let mut t = timeline_with_stream();
-        let out = t.record_event("chess", 7, emitted("move.played")).unwrap();
+        let out = t
+            .record_event(CTX, "chess", 7, emitted("move.played"))
+            .unwrap();
         assert_eq!(
             out.checkpoint_id, None,
             "no rollback metadata = no checkpoint"
@@ -891,7 +964,7 @@ mod tests {
         let mut e = emitted("move.played");
         e.rollback_token = Some("undo-abc".to_string());
         e.changed_resources = vec!["game-abc".to_string()];
-        let out = t.record_event("chess", 7, e).unwrap();
+        let out = t.record_event(CTX, "chess", 7, e).unwrap();
         let ckpt_id = out
             .checkpoint_id
             .expect("rollback metadata must checkpoint");
@@ -912,7 +985,7 @@ mod tests {
         let mut e = emitted("move.played");
         e.rollback_token = Some("undo-abc".to_string());
         let ckpt_id = t
-            .record_event("chess", 7, e)
+            .record_event(CTX, "chess", 7, e)
             .unwrap()
             .checkpoint_id
             .unwrap();
@@ -941,7 +1014,7 @@ mod tests {
         let mut e = emitted("move.played");
         e.rollback_token = Some("undo-abc".to_string());
         let ckpt_id = t
-            .record_event("chess", 7, e)
+            .record_event(CTX, "chess", 7, e)
             .unwrap()
             .checkpoint_id
             .unwrap();
@@ -966,7 +1039,7 @@ mod tests {
         let mut e = emitted("move.played");
         e.rollback_token = Some("undo-abc".to_string());
         let ckpt_id = t
-            .record_event("chess", 7, e)
+            .record_event(CTX, "chess", 7, e)
             .unwrap()
             .checkpoint_id
             .unwrap();
@@ -983,18 +1056,22 @@ mod tests {
     #[test]
     fn subscription_routing_filters_event_name_and_resource() {
         let mut t = timeline_with_stream();
-        t.declare_streams("chess", vec![decl("game.ended")])
+        t.declare_streams(CTX, "chess", vec![decl("game.ended")])
             .unwrap();
         let mut sub = subscription(PayloadMode::Summary, TriggerMode::Conversation);
         sub.event_names = vec!["game.ended".to_string()];
         t.add_subscription(sub);
 
         // Non-matching event name → no delivery.
-        let out = t.record_event("chess", 1, emitted("move.played")).unwrap();
+        let out = t
+            .record_event(CTX, "chess", 1, emitted("move.played"))
+            .unwrap();
         assert_eq!(out.deliveries_queued, 0);
 
         // Matching event name → delivery.
-        let out = t.record_event("chess", 1, emitted("game.ended")).unwrap();
+        let out = t
+            .record_event(CTX, "chess", 1, emitted("game.ended"))
+            .unwrap();
         assert_eq!(out.deliveries_queued, 1);
 
         // Resource-scoped subscription only matches its resource.
@@ -1002,7 +1079,9 @@ mod tests {
         sub2.subscription_id = "sub-2".to_string();
         sub2.resource_id = Some("game-other".to_string());
         t.add_subscription(sub2);
-        let out = t.record_event("chess", 1, emitted("move.played")).unwrap();
+        let out = t
+            .record_event(CTX, "chess", 1, emitted("move.played"))
+            .unwrap();
         assert_eq!(
             out.deliveries_queued, 0,
             "resource mismatch must not deliver"
@@ -1025,7 +1104,9 @@ mod tests {
     fn never_trigger_records_timeline_only() {
         let mut t = timeline_with_stream();
         t.add_subscription(subscription(PayloadMode::Full, TriggerMode::Never));
-        let out = t.record_event("chess", 1, emitted("move.played")).unwrap();
+        let out = t
+            .record_event(CTX, "chess", 1, emitted("move.played"))
+            .unwrap();
         assert_eq!(
             out.deliveries_queued, 0,
             "never = timeline only, no delivery"
@@ -1050,7 +1131,9 @@ mod tests {
             sub.subscription_id = format!("sub-{i}");
             t.add_subscription(sub);
         }
-        let out = t.record_event("chess", 1, emitted("move.played")).unwrap();
+        let out = t
+            .record_event(CTX, "chess", 1, emitted("move.played"))
+            .unwrap();
         assert_eq!(out.deliveries_queued, 4);
         let d = t.take_deliveries_for(ActorType::Agent, "chess-opponent");
         // Off: nothing.
@@ -1069,7 +1152,9 @@ mod tests {
         t.add_subscription(subscription(PayloadMode::Summary, TriggerMode::Ambient));
         assert!(t.remove_subscription("sub-1"));
         assert!(!t.remove_subscription("sub-1"));
-        let out = t.record_event("chess", 1, emitted("move.played")).unwrap();
+        let out = t
+            .record_event(CTX, "chess", 1, emitted("move.played"))
+            .unwrap();
         assert_eq!(out.deliveries_queued, 0);
     }
 
@@ -1096,10 +1181,10 @@ mod tests {
     fn app_subscriptions_deliver_across_python_and_wasm_publishers() {
         let mut timeline = AppTimeline::default();
         timeline
-            .declare_streams("python-notes", vec![decl("note.saved")])
+            .declare_streams(CTX, "python-notes", vec![decl("note.saved")])
             .unwrap();
         timeline
-            .declare_streams("wasm-counter", vec![decl("count.changed")])
+            .declare_streams(CTX, "wasm-counter", vec![decl("count.changed")])
             .unwrap();
 
         let mut wasm_subscriber = subscription(PayloadMode::Full, TriggerMode::Conversation);
@@ -1122,7 +1207,7 @@ mod tests {
         python_event.resource_id = "note-1".to_string();
         assert_eq!(
             timeline
-                .record_event("python-notes", 11, python_event)
+                .record_event(CTX, "python-notes", 11, python_event)
                 .unwrap()
                 .deliveries_queued,
             1
@@ -1135,7 +1220,7 @@ mod tests {
         wasm_event.resource_id = "counter-1".to_string();
         assert_eq!(
             timeline
-                .record_event("wasm-counter", 12, wasm_event)
+                .record_event(CTX, "wasm-counter", 12, wasm_event)
                 .unwrap()
                 .deliveries_queued,
             1
@@ -1149,10 +1234,122 @@ mod tests {
             .unwrap());
         assert_eq!(
             timeline
-                .record_event("python-notes", 11, emitted("note.saved"))
+                .record_event(CTX, "python-notes", 11, emitted("note.saved"))
                 .unwrap()
                 .deliveries_queued,
             0
         );
+    }
+
+    // ── Phase D: context-scoped stream ownership / reachability ─────────────
+
+    /// The falsifying regression this phase fixes: the SAME `app_id`
+    /// ("chess") runs once in `CTX` and once in `OTHER_CTX`. A subscriber
+    /// whose own context is `CTX` must receive ONLY `CTX`'s emitted events —
+    /// never `OTHER_CTX`'s — even though both declare identical stream names
+    /// under the identical app_id. Before this phase, `SubscriptionRecord`
+    /// carried no context dimension at all, so this delivery would have
+    /// bled across contexts.
+    #[test]
+    fn cross_context_same_app_id_does_not_bleed_into_subscriber() {
+        let mut t = AppTimeline::default();
+        t.declare_streams(CTX, "chess", vec![decl("move.played")])
+            .unwrap();
+        t.declare_streams(OTHER_CTX, "chess", vec![decl("move.played")])
+            .unwrap();
+
+        // Subscriber lives in CTX.
+        let mut sub = subscription(PayloadMode::Full, TriggerMode::Conversation);
+        sub.subscriber_context_id = CTX;
+        t.add_subscription(sub);
+
+        // CTX's own "chess" instance emits — must deliver.
+        let out = t
+            .record_event(CTX, "chess", 1, emitted("move.played"))
+            .unwrap();
+        assert_eq!(out.deliveries_queued, 1, "same-context event must deliver");
+
+        // OTHER_CTX's "chess" instance (identical app_id, identical stream
+        // name) emits — must NOT deliver to the CTX subscriber.
+        let out = t
+            .record_event(OTHER_CTX, "chess", 99, emitted("move.played"))
+            .unwrap();
+        assert_eq!(
+            out.deliveries_queued, 0,
+            "a different context's same-app_id event must never reach a subscriber \
+             scoped to another context"
+        );
+
+        // Exactly the one CTX delivery is queued — never the OTHER_CTX one.
+        let deliveries = t.take_deliveries_for(ActorType::Agent, "chess-opponent");
+        assert_eq!(deliveries.len(), 1);
+        assert_eq!(deliveries[0].event_id, out.event_id - 1);
+    }
+
+    /// A subscriber scoped to `OTHER_CTX` is the symmetric case: it receives
+    /// only `OTHER_CTX`'s events, never `CTX`'s.
+    #[test]
+    fn subscriber_in_other_context_only_sees_its_own_context_events() {
+        let mut t = AppTimeline::default();
+        t.declare_streams(CTX, "chess", vec![decl("move.played")])
+            .unwrap();
+        t.declare_streams(OTHER_CTX, "chess", vec![decl("move.played")])
+            .unwrap();
+
+        let mut sub = subscription(PayloadMode::Full, TriggerMode::Conversation);
+        sub.subscriber_context_id = OTHER_CTX;
+        t.add_subscription(sub);
+
+        let out = t
+            .record_event(CTX, "chess", 1, emitted("move.played"))
+            .unwrap();
+        assert_eq!(
+            out.deliveries_queued, 0,
+            "CTX event must not reach OTHER_CTX subscriber"
+        );
+
+        let out = t
+            .record_event(OTHER_CTX, "chess", 99, emitted("move.played"))
+            .unwrap();
+        assert_eq!(
+            out.deliveries_queued, 1,
+            "OTHER_CTX event must reach its own subscriber"
+        );
+    }
+
+    /// Direct unit coverage of `SubscriptionRecord::matches`'s new
+    /// `evaluate_reach` gate, independent of the higher-level `record_event`
+    /// flow above — mirrors Phase C's `tool_dispatch.rs` test style.
+    #[test]
+    fn matches_rejects_cross_context_even_with_identical_app_and_event_name() {
+        let mut same_context = subscription(PayloadMode::Full, TriggerMode::Conversation);
+        same_context.subscriber_context_id = CTX;
+        let mut cross_context = subscription(PayloadMode::Full, TriggerMode::Conversation);
+        cross_context.subscriber_context_id = OTHER_CTX;
+
+        let record = AppEventRecord {
+            event_id: 1,
+            app_id: "chess".to_string(),
+            owner_context_id: CTX,
+            pane_id: 7,
+            event: "move.played".to_string(),
+            actor: AppEventActor::User,
+            actor_id: "chess".to_string(),
+            caused_by: None,
+            summary: "White played e4".to_string(),
+            resource_id: "game-abc".to_string(),
+            resource_scope: "game".to_string(),
+            revision_after: "rev-13".to_string(),
+            payload: None,
+            state_ref: None,
+            revision_before: None,
+            rollback_token: None,
+            changed_resources: vec![],
+            suggested_trigger: None,
+            created_at: "2026-06-11T00:00:00Z".to_string(),
+        };
+
+        assert!(same_context.matches("chess", &record));
+        assert!(!cross_context.matches("chess", &record));
     }
 }

--- a/src/host/event_log.rs
+++ b/src/host/event_log.rs
@@ -2,11 +2,19 @@
 //!
 //! The `EventLog` struct owns a background writer thread that receives
 //! `HostEvent` values via a bounded mpsc channel and appends them as
-//! newline-delimited JSON to one or two log files:
+//! newline-delimited JSON to:
 //!
-//! - Global:    `~/.plexi/events.jsonl`
-//! - Workspace: `.plexi/events.jsonl` relative to the workspace root,
-//!   when Plexi is running inside a `.plexi/` workspace.
+//! - Global:    `~/.plexi/events.jsonl` — always, for every event.
+//! - Per-root:  `<context_root>/<channel>/events.jsonl` — additionally,
+//!   whenever the emitting call site can resolve a `context_root` for the
+//!   event (stint 0724 Phase E). This replaces the old single
+//!   startup-cwd-resolved workspace file: every event used to attribute to
+//!   whichever workspace was current cwd when the process started, for the
+//!   life of the session, regardless of which context actually raised it.
+//!   Per-record routing means a session with panes open across several
+//!   contexts writes each event to its own context's file, not to one
+//!   startup-chosen file. File handles are cached per root in the writer
+//!   thread so repeated events from the same root never reopen the file.
 //!
 //! The host stamps every event with a `source` field before enqueueing;
 //! apps cannot forge provenance.
@@ -15,6 +23,7 @@
 //! event is silently discarded and `dropped_count` is incremented. No retry,
 //! no blocking, no rotation.
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -194,8 +203,15 @@ struct EventEnvelope {
 
 // ── EventLog ──────────────────────────────────────────────────────────────────
 
+/// One message on the writer-thread channel: the envelope to serialize, plus
+/// the per-record routing destination (`None` = global-only).
+struct EmitMessage {
+    envelope: EventEnvelope,
+    context_root: Option<PathBuf>,
+}
+
 pub struct EventLog {
-    tx: mpsc::SyncSender<EventEnvelope>,
+    tx: mpsc::SyncSender<EmitMessage>,
     /// Monotonic count of events dropped due to a full channel.
     pub dropped_count: Arc<AtomicU64>,
 }
@@ -203,27 +219,42 @@ pub struct EventLog {
 impl EventLog {
     /// Create a new `EventLog` and start the background writer thread.
     ///
-    /// `global_path` — path to the global events.jsonl file (created if absent).
-    /// `workspace_path` — optional workspace-scoped events.jsonl path.
-    pub fn new(global_path: PathBuf, workspace_path: Option<PathBuf>) -> Self {
-        let (tx, rx) = mpsc::sync_channel::<EventEnvelope>(4096);
+    /// `global_path` — path to the global events.jsonl file (created if
+    /// absent). Per-root workspace files are resolved and opened lazily, one
+    /// per distinct `context_root` an emitted event names — see
+    /// [`Self::emit_scoped`].
+    pub fn new(global_path: PathBuf) -> Self {
+        let (tx, rx) = mpsc::sync_channel::<EmitMessage>(4096);
         let dropped_count = Arc::new(AtomicU64::new(0));
 
         std::thread::Builder::new()
             .name("plexi-event-log".into())
             .spawn(move || {
-                // Open (or create) the log files for appending.
+                // Open (or create) the always-on global log file.
                 let mut global_file = open_log_file(&global_path);
-                let mut workspace_file = workspace_path.as_ref().and_then(|p| open_log_file(p));
+                // Per-root files, opened lazily on first use and cached by
+                // root so a long session with many contexts never reopens a
+                // file it already holds a handle for. `None` is cached too
+                // (a root whose file failed to open once is not retried
+                // every subsequent event).
+                let mut root_files: HashMap<PathBuf, Option<std::fs::File>> = HashMap::new();
 
-                while let Ok(envelope) = rx.recv() {
-                    match serde_json::to_string(&envelope) {
+                while let Ok(msg) = rx.recv() {
+                    match serde_json::to_string(&msg.envelope) {
                         Ok(line) => {
                             if let Some(ref mut f) = global_file {
                                 append_line(f, &line);
                             }
-                            if let Some(ref mut f) = workspace_file {
-                                append_line(f, &line);
+                            if let Some(root) = msg.context_root {
+                                let file = root_files.entry(root.clone()).or_insert_with(|| {
+                                    let path = root
+                                        .join(crate::config::workspace_channel_dir())
+                                        .join("events.jsonl");
+                                    open_log_file(&path)
+                                });
+                                if let Some(ref mut f) = file {
+                                    append_line(f, &line);
+                                }
                             }
                         }
                         Err(e) => {
@@ -237,12 +268,20 @@ impl EventLog {
         Self { tx, dropped_count }
     }
 
-    /// Emit a host event. Non-blocking — drops the event (incrementing
-    /// `dropped_count`) if the channel is at capacity.
-    pub fn emit(&self, event: HostEvent) {
+    /// Emit a host event. Always appends to the global log; additionally
+    /// appends to `context_root`'s per-context `<channel>/events.jsonl` when
+    /// `context_root` is `Some` — the caller supplies whatever
+    /// `ScopeOrigin`/context-root it already resolved nearby (this function
+    /// performs no resolution of its own). Non-blocking — drops the event
+    /// (incrementing `dropped_count`) if the channel is at capacity.
+    pub fn emit_scoped(&self, event: HostEvent, context_root: Option<&std::path::Path>) {
         let source = format!("plexi/{}", env!("CARGO_CRATE_NAME"));
         let envelope = EventEnvelope { source, event };
-        match self.tx.try_send(envelope) {
+        let msg = EmitMessage {
+            envelope,
+            context_root: context_root.map(PathBuf::from),
+        };
+        match self.tx.try_send(msg) {
             Ok(()) => {}
             Err(mpsc::TrySendError::Full(_)) => {
                 self.dropped_count.fetch_add(1, Ordering::Relaxed);
@@ -286,19 +325,6 @@ fn append_line(file: &mut std::fs::File, line: &str) {
     }
 }
 
-// ── Workspace detection ───────────────────────────────────────────────────────
-
-/// Returns the path to `.plexi/events.jsonl` for the workspace containing
-/// `start`, or `None` if `start` is not inside a workspace. Uses
-/// [`crate::app::registry::resolve_workspace_root`] so workspace detection
-/// is consistent across registry, secrets, and event logging.
-pub fn find_workspace_events_path(start: &std::path::Path) -> Option<PathBuf> {
-    crate::app::registry::resolve_workspace_root(start).map(|root| {
-        root.join(crate::config::workspace_channel_dir())
-            .join("events.jsonl")
-    })
-}
-
 /// Returns the current UTC timestamp as an RFC 3339 string.
 pub fn now_timestamp() -> String {
     chrono::Utc::now().to_rfc3339()
@@ -310,14 +336,23 @@ static GLOBAL_EVENT_LOG: OnceLock<EventLog> = OnceLock::new();
 
 /// Initialize the global event log. Call once at app startup.
 /// Subsequent calls are no-ops (OnceLock guarantees at-most-once init).
-pub fn init_global(global_path: PathBuf, workspace_path: Option<PathBuf>) {
-    let _ = GLOBAL_EVENT_LOG.get_or_init(|| EventLog::new(global_path, workspace_path));
+///
+/// Takes only the global log path — there is no startup-resolved workspace
+/// path any more. Per-root routing (stint 0724 Phase E) is decided at each
+/// emit call site via [`emit_scoped`], not once at process start from
+/// whatever the cwd happened to be.
+pub fn init_global(global_path: PathBuf) {
+    let _ = GLOBAL_EVENT_LOG.get_or_init(|| EventLog::new(global_path));
 }
 
-/// Emit an event to the global log. No-op if the log was not initialized.
-pub fn emit(event: HostEvent) {
+/// Emit an event to the global log, additionally routing it to
+/// `context_root`'s per-context log when `context_root` is `Some`. No-op if
+/// the log was not initialized. This is the one entry point every call site
+/// uses — pass `None` when no `ScopeOrigin`/context-root is resolvable
+/// nearby (global-only, same behavior as before Phase E).
+pub fn emit_scoped(event: HostEvent, context_root: Option<&std::path::Path>) {
     if let Some(log) = GLOBAL_EVENT_LOG.get() {
-        log.emit(event);
+        log.emit_scoped(event, context_root);
     }
 }
 
@@ -347,4 +382,121 @@ pub fn read_recent(path: &std::path::Path, limit: usize) -> Vec<serde_json::Valu
         }
     }
     lines.into_iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Poll `read_recent` until it returns at least one line or the deadline
+    /// passes. The writer thread appends asynchronously off the emit call, so
+    /// tests must wait for delivery rather than assume synchronous flush.
+    fn wait_for_line(path: &std::path::Path) -> Vec<serde_json::Value> {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let lines = read_recent(path, 10);
+            if !lines.is_empty() || std::time::Instant::now() >= deadline {
+                return lines;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+    }
+
+    /// Stint 0724 Phase E: per-record attribution replaces the old
+    /// startup-chosen single workspace file. Two events emitted with
+    /// DIFFERENT `context_root`s must land in their OWN root's
+    /// `<channel>/events.jsonl` — never both in whichever root happened to be
+    /// active first, and never cross-contaminating the other root's file.
+    #[test]
+    fn emit_scoped_routes_each_root_to_its_own_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let global_path = dir.path().join("global-events.jsonl");
+        let root_a = dir.path().join("root-a");
+        let root_b = dir.path().join("root-b");
+        std::fs::create_dir_all(&root_a).expect("mkdir root_a");
+        std::fs::create_dir_all(&root_b).expect("mkdir root_b");
+
+        let log = EventLog::new(global_path.clone());
+
+        log.emit_scoped(
+            HostEvent::NoteOpened {
+                path: "a-note.md".to_string(),
+                timestamp: now_timestamp(),
+            },
+            Some(&root_a),
+        );
+        log.emit_scoped(
+            HostEvent::NoteOpened {
+                path: "b-note.md".to_string(),
+                timestamp: now_timestamp(),
+            },
+            Some(&root_b),
+        );
+
+        let channel_dir = crate::config::workspace_channel_dir();
+        let path_a = root_a.join(&channel_dir).join("events.jsonl");
+        let path_b = root_b.join(&channel_dir).join("events.jsonl");
+
+        let lines_a = wait_for_line(&path_a);
+        let lines_b = wait_for_line(&path_b);
+
+        assert_eq!(
+            lines_a.len(),
+            1,
+            "root_a's file must contain exactly its own event"
+        );
+        assert_eq!(
+            lines_a[0]["path"], "a-note.md",
+            "root_a's file must contain root_a's event, not root_b's"
+        );
+        assert_eq!(
+            lines_b.len(),
+            1,
+            "root_b's file must contain exactly its own event"
+        );
+        assert_eq!(
+            lines_b[0]["path"], "b-note.md",
+            "root_b's file must contain root_b's event, not root_a's"
+        );
+
+        // The always-on global file gets both, regardless of per-root routing.
+        let global_lines = wait_for_line(&global_path);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut global_lines = global_lines;
+        while global_lines.len() < 2 && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            global_lines = read_recent(&global_path, 10);
+        }
+        assert_eq!(
+            global_lines.len(),
+            2,
+            "the global log must receive every event regardless of context_root"
+        );
+    }
+
+    /// A `context_root: None` emit (no resolvable origin at the call site)
+    /// must still reach the global file and must not create any per-root
+    /// file at all.
+    #[test]
+    fn emit_scoped_with_no_context_root_is_global_only() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let global_path = dir.path().join("global-events.jsonl");
+        let log = EventLog::new(global_path.clone());
+
+        log.emit_scoped(
+            HostEvent::NoteOpened {
+                path: "global-note.md".to_string(),
+                timestamp: now_timestamp(),
+            },
+            None,
+        );
+
+        let global_lines = wait_for_line(&global_path);
+        assert_eq!(
+            global_lines.len(),
+            1,
+            "global-only emit must reach the global file"
+        );
+        assert_eq!(global_lines[0]["path"], "global-note.md");
+    }
 }

--- a/src/host/event_subscriptions.rs
+++ b/src/host/event_subscriptions.rs
@@ -49,11 +49,12 @@ pub fn app_subscriber_id(pane_id: u64) -> String {
 pub fn evaluate_and_record_subscription(
     grant_store: &GrantStore,
     posture: Option<&PermissionPosture>,
-    workspace_root: &Path,
+    workspace_root: Option<&Path>,
     timeline: &Arc<Mutex<AppTimeline>>,
     publisher_app_id: &str,
     subscriber_type: ActorType,
     subscriber_id: &str,
+    subscriber_context_id: u64,
     event_names: Vec<String>,
     payload_mode: PayloadMode,
     trigger_mode: TriggerMode,
@@ -82,6 +83,7 @@ pub fn evaluate_and_record_subscription(
         publisher_app_id,
         subscriber_type,
         subscriber_id,
+        subscriber_context_id,
         event_names,
         payload_mode,
         trigger_mode,
@@ -126,7 +128,7 @@ fn publish_targets(app_id: &str, event_names: &[String]) -> Vec<String> {
 pub fn evaluate_subscription(
     grant_store: &GrantStore,
     posture: Option<&PermissionPosture>,
-    workspace_root: &Path,
+    workspace_root: Option<&Path>,
     publisher_app_id: &str,
     subscriber_type: ActorType,
     subscriber_id: &str,
@@ -147,7 +149,7 @@ pub fn evaluate_subscription(
 fn evaluate_publish(
     grant_store: &GrantStore,
     posture: Option<&PermissionPosture>,
-    workspace_root: &Path,
+    workspace_root: Option<&Path>,
     app_id: &str,
     actor_type: ActorType,
     actor_id: &str,
@@ -170,7 +172,7 @@ fn evaluate_publish(
 fn evaluate_targets(
     grant_store: &GrantStore,
     posture: Option<&PermissionPosture>,
-    workspace_root: &Path,
+    workspace_root: Option<&Path>,
     actor_type: ActorType,
     actor_id: &str,
     targets: &[String],
@@ -182,7 +184,7 @@ fn evaluate_targets(
             actor_id,
             TargetType::AppEventStream,
             target,
-            Some(workspace_root),
+            workspace_root,
         );
         match grant_store.evaluate(&req, posture) {
             Decision::Allow => {}
@@ -206,6 +208,7 @@ pub fn record_subscription(
     publisher_app_id: &str,
     subscriber_type: ActorType,
     subscriber_id: &str,
+    subscriber_context_id: u64,
     event_names: Vec<String>,
     payload_mode: PayloadMode,
     trigger_mode: TriggerMode,
@@ -223,11 +226,13 @@ pub fn record_subscription(
         trigger_mode,
         resource_id,
         duration,
+        subscriber_context_id,
         created_at: event_log::now_timestamp(),
     };
     log::info!(
         "event_subscriptions: recorded subscription {subscription_id} for {subscriber_type:?} \
-         '{subscriber_id}' -> '{publisher_app_id}' (payload={payload_mode:?}, trigger={trigger_mode:?})"
+         '{subscriber_id}' (context={subscriber_context_id}) -> '{publisher_app_id}' \
+         (payload={payload_mode:?}, trigger={trigger_mode:?})"
     );
     timeline.lock().unwrap().add_subscription(record);
     subscription_id
@@ -264,9 +269,30 @@ pub struct HostSubscribeRequest {
     /// host MCP server sets this to the stable `mcp:host` so one "Always" grant
     /// covers every concurrent connection.
     pub broker_actor_override: Option<String>,
-    /// Workspace used for broker posture evaluation. App runtimes supply their
-    /// own workspace; transports use the service's active workspace.
+    /// Workspace used for broker posture evaluation, resolved by the caller
+    /// from the subscriber's host-established `ScopeOrigin` (stint 0724
+    /// Phase D — there is no ambient service-level fallback). `None` only
+    /// when the caller has no resolvable pane (e.g. an outside-pane CLI
+    /// connection), in which case the broker check runs with no workspace
+    /// context.
     pub workspace_root_override: Option<PathBuf>,
+    /// The subscriber's host-established context id, resolved the same way
+    /// as `workspace_root_override` — the viewer side of `evaluate_reach`
+    /// for every stream this subscription will ever match against. `None`
+    /// only when the caller has no resolvable pane; resolved to `0` (matches
+    /// no real context, mirroring `AgentHost`'s pre-attach sentinel) at the
+    /// point the request is classified.
+    pub context_id_override: Option<u64>,
+    /// Host-captured kernel ancestor-pid chain of the socket peer (stint
+    /// 0636's `capture_peer_ancestry`, threaded the same way as
+    /// `Notify`/`DismissNotification`'s `peer_pid`). `Some` only for the raw
+    /// CLI-socket transport; when present it independently re-derives
+    /// `from_pane_id` instead of trusting the client-forwarded
+    /// `PLEXI_PANE_ID` value, closing the gap where any local process could
+    /// otherwise claim to be calling from an arbitrary pane. `None` for
+    /// transports that already establish identity another way (host MCP's
+    /// bearer credential, a WASM/Python app's own host-known pane id).
+    pub peer_ancestry: Option<Vec<u32>>,
     pub reply: SyncSender<HostSubscribeReply>,
 }
 
@@ -292,6 +318,12 @@ pub struct PendingEventConsent {
     /// Stream names touched (empty = all of the app's declared streams). Drives
     /// both the consent label and the `AllowAlways` grant targets.
     pub event_names: Vec<String>,
+    /// The subscriber/publisher's host-established context id, resolved once
+    /// at classify time and carried in the parked struct — never re-resolved
+    /// when the user later answers the modal (command-handler data must be
+    /// self-contained; by the time `resolve_consent` runs, the pane that
+    /// requested this may have closed).
+    pub subscriber_context_id: u64,
     /// The effect to apply once allowed — owns the transport's reply channel.
     action: ConsentAction,
 }
@@ -349,6 +381,18 @@ pub struct HostPublishRequest {
     /// Trusted host-transport override for the actor id (e.g. the host MCP
     /// server). Never sourced from an untrusted client argument.
     pub subscriber_override: Option<String>,
+    /// Workspace for broker posture evaluation — see
+    /// [`HostSubscribeRequest::workspace_root_override`]; same contract,
+    /// publish twin.
+    pub workspace_root_override: Option<PathBuf>,
+    /// Context id under which the declared/emitted stream is owned — see
+    /// [`HostSubscribeRequest::context_id_override`]; same contract, publish
+    /// twin. Stamped onto every `AppEventRecord`/stream declaration this
+    /// request produces.
+    pub context_id_override: Option<u64>,
+    /// See [`HostSubscribeRequest::peer_ancestry`]; same contract, publish
+    /// twin.
+    pub peer_ancestry: Option<Vec<u32>>,
     pub reply: SyncSender<HostPublishReply>,
 }
 
@@ -407,18 +451,23 @@ pub enum HostSubscribeReply {
 pub struct HostSubscriptionService {
     grant_store: GrantStore,
     posture: Option<PermissionPosture>,
-    workspace_root: PathBuf,
     timeline: Arc<Mutex<AppTimeline>>,
 }
 
 impl HostSubscriptionService {
     /// Load the host grant store + posture from `config_dir` and bind the
     /// service to `timeline` (the global timeline in production).
-    pub fn new(
-        config_dir: &Path,
-        workspace_root: PathBuf,
-        timeline: Arc<Mutex<AppTimeline>>,
-    ) -> Self {
+    ///
+    /// Deliberately takes no workspace/context — stint 0724 Phase D removed
+    /// the service-wide `workspace_root` field that used to be captured once
+    /// at host startup (`active_workspace_root()`/cwd) and silently applied
+    /// to every request regardless of which context the caller actually
+    /// lives in. Every request now carries its own resolved
+    /// `workspace_root_override`/`context_id_override` (or, for the raw CLI
+    /// socket path, is resolved per-request by the caller from
+    /// `PlexiApp::origin_for_pane` before it reaches this service) — there is
+    /// no ambient fallback.
+    pub fn new(config_dir: &Path, timeline: Arc<Mutex<AppTimeline>>) -> Self {
         let grant_store = GrantStore::load_or_default(config_dir);
         let posture = PermissionPosture::load_from_config(config_dir);
         log::info!(
@@ -429,7 +478,6 @@ impl HostSubscriptionService {
         Self {
             grant_store,
             posture,
-            workspace_root,
             timeline,
         }
     }
@@ -441,7 +489,6 @@ impl HostSubscriptionService {
         Self {
             grant_store,
             posture: None,
-            workspace_root: PathBuf::from("/tmp/ws"),
             timeline,
         }
     }
@@ -498,12 +545,20 @@ impl HostSubscriptionService {
             .broker_actor_override
             .clone()
             .unwrap_or_else(|| subscriber_id.clone());
+        // Viewer context for reachability and stream-declaration scoping —
+        // stint 0724 Phase D. `0` matches no real context (mirrors
+        // `AgentHost`'s pre-attach sentinel) and is only reached when the
+        // caller has no resolvable pane at all.
+        let subscriber_context_id = req.context_id_override.unwrap_or(0);
         // Reject undeclared streams before involving the broker so the client
-        // gets a precise error instead of a generic permission denial.
+        // gets a precise error instead of a generic permission denial. Scoped
+        // to the subscriber's own context: a stream declared only in a
+        // different context is, correctly, "not declared" from here — no
+        // cross-context grant exists yet to make it visible.
         let undeclared: Vec<String> = req
             .event_names
             .iter()
-            .filter(|n| !self.stream_is_declared(&req.publisher_app_id, n))
+            .filter(|n| !self.stream_is_declared(subscriber_context_id, &req.publisher_app_id, n))
             .cloned()
             .collect();
         if !undeclared.is_empty() {
@@ -519,9 +574,7 @@ impl HostSubscriptionService {
         let decision = evaluate_subscription(
             &self.grant_store,
             self.posture.as_ref(),
-            req.workspace_root_override
-                .as_deref()
-                .unwrap_or(&self.workspace_root),
+            req.workspace_root_override.as_deref(),
             &req.publisher_app_id,
             subscriber_type,
             &broker_actor_id,
@@ -534,6 +587,7 @@ impl HostSubscriptionService {
                     &req.publisher_app_id,
                     subscriber_type,
                     &subscriber_id,
+                    subscriber_context_id,
                     req.event_names,
                     req.payload_mode,
                     req.trigger_mode,
@@ -565,6 +619,7 @@ impl HostSubscriptionService {
                     broker_actor_id,
                     app_id: req.publisher_app_id,
                     event_names: req.event_names,
+                    subscriber_context_id,
                     action: ConsentAction::Subscribe {
                         payload_mode: req.payload_mode,
                         trigger_mode: req.trigger_mode,
@@ -594,6 +649,7 @@ impl HostSubscriptionService {
             broker_actor_id,
             app_id,
             event_names,
+            subscriber_context_id,
             action,
         } = consent;
 
@@ -643,6 +699,7 @@ impl HostSubscriptionService {
                     &app_id,
                     subscriber_type,
                     &subscriber_id,
+                    subscriber_context_id,
                     event_names,
                     payload_mode,
                     trigger_mode,
@@ -689,7 +746,13 @@ impl HostSubscriptionService {
                     });
                     return;
                 }
-                let outcome = Self::perform_publish(&self.timeline, &app_id, pane_id, publish);
+                let outcome = Self::perform_publish(
+                    &self.timeline,
+                    subscriber_context_id,
+                    &app_id,
+                    pane_id,
+                    publish,
+                );
                 let summary = match &outcome {
                     HostPublishReply::Ok { detail, .. } => detail.clone(),
                     HostPublishReply::Err { message } => format!("failed: {message}"),
@@ -779,6 +842,10 @@ impl HostSubscriptionService {
         if let PublishAction::Emit(ev) = &mut req.action {
             ev.actor_id = Some(actor_id.clone());
         }
+        // Owning context for the declared/emitted stream — stint 0724 Phase
+        // D. `0` matches no real context, reached only when the caller has
+        // no resolvable pane.
+        let context_id = req.context_id_override.unwrap_or(0);
         // Stream names this request touches — the broker targets and the label.
         let event_names: Vec<String> = match &req.action {
             PublishAction::Declare(decls) => decls.iter().map(|d| d.name.clone()).collect(),
@@ -786,12 +853,13 @@ impl HostSubscriptionService {
         };
         // Reject an emit on an undeclared stream before the broker so the client
         // gets a precise error and the user is never prompted for a doomed emit
-        // (mirrors the subscribe undeclared-stream check).
+        // (mirrors the subscribe undeclared-stream check). Scoped to this
+        // request's own context, matching what `record_event` will enforce.
         if let PublishAction::Emit(ev) = &req.action {
-            if !self.stream_is_declared(&req.app_id, &ev.event) {
+            if !self.stream_is_declared(context_id, &req.app_id, &ev.event) {
                 let _ = req.reply.send(HostPublishReply::Err {
                     message: format!(
-                        "app '{}' has not declared stream '{}' — declare it first",
+                        "app '{}' has not declared stream '{}' in this context — declare it first",
                         req.app_id, ev.event
                     ),
                 });
@@ -801,7 +869,7 @@ impl HostSubscriptionService {
         let decision = evaluate_publish(
             &self.grant_store,
             self.posture.as_ref(),
-            &self.workspace_root,
+            req.workspace_root_override.as_deref(),
             &req.app_id,
             actor_type,
             &actor_id,
@@ -810,8 +878,13 @@ impl HostSubscriptionService {
         let pane_id = req.from_pane_id.unwrap_or(0);
         match decision {
             Decision::Allow => {
-                let outcome =
-                    Self::perform_publish(&self.timeline, &req.app_id, pane_id, req.action);
+                let outcome = Self::perform_publish(
+                    &self.timeline,
+                    context_id,
+                    &req.app_id,
+                    pane_id,
+                    req.action,
+                );
                 let _ = req.reply.send(outcome);
                 None
             }
@@ -835,6 +908,7 @@ impl HostSubscriptionService {
                     subscriber_id: actor_id,
                     app_id: req.app_id,
                     event_names,
+                    subscriber_context_id: context_id,
                     action: ConsentAction::Publish {
                         publish: req.action,
                         pane_id,
@@ -850,39 +924,44 @@ impl HostSubscriptionService {
     /// caller has already established consent.
     fn perform_publish(
         timeline: &Arc<Mutex<AppTimeline>>,
+        context_id: u64,
         app_id: &str,
         pane_id: u64,
         action: PublishAction,
     ) -> HostPublishReply {
         let mut timeline = timeline.lock().unwrap();
         match action {
-            PublishAction::Declare(decls) => match timeline.declare_streams(app_id, decls) {
-                Ok(names) => HostPublishReply::Ok {
-                    detail: format!("declared stream(s): {}", names.join(", ")),
-                    event_id: None,
-                },
-                Err(message) => HostPublishReply::Err { message },
-            },
-            PublishAction::Emit(ev) => match timeline.record_event(app_id, pane_id, *ev) {
-                Ok(outcome) => HostPublishReply::Ok {
-                    detail: format!(
-                        "recorded event {} ({} delivery(ies) queued)",
-                        outcome.event_id, outcome.deliveries_queued
-                    ),
-                    event_id: Some(outcome.event_id),
-                },
-                Err(message) => HostPublishReply::Err { message },
-            },
+            PublishAction::Declare(decls) => {
+                match timeline.declare_streams(context_id, app_id, decls) {
+                    Ok(names) => HostPublishReply::Ok {
+                        detail: format!("declared stream(s): {}", names.join(", ")),
+                        event_id: None,
+                    },
+                    Err(message) => HostPublishReply::Err { message },
+                }
+            }
+            PublishAction::Emit(ev) => {
+                match timeline.record_event(context_id, app_id, pane_id, *ev) {
+                    Ok(outcome) => HostPublishReply::Ok {
+                        detail: format!(
+                            "recorded event {} ({} delivery(ies) queued)",
+                            outcome.event_id, outcome.deliveries_queued
+                        ),
+                        event_id: Some(outcome.event_id),
+                    },
+                    Err(message) => HostPublishReply::Err { message },
+                }
+            }
         }
     }
 
     /// Whether `app_id` has declared `stream_name`. Used to reject subscribe
     /// requests for undeclared streams before they reach the broker.
-    pub fn stream_is_declared(&self, app_id: &str, stream_name: &str) -> bool {
+    pub fn stream_is_declared(&self, context_id: u64, app_id: &str, stream_name: &str) -> bool {
         self.timeline
             .lock()
             .unwrap()
-            .has_stream(app_id, stream_name)
+            .has_stream(context_id, app_id, stream_name)
     }
 }
 
@@ -892,6 +971,11 @@ mod tests {
     use crate::app_protocol::{AppEventActor, EventStreamDecl};
     use crate::broker::{ActorScope, Decision, GrantRecord, GrantSource, ResourceScope};
     use crate::host::app_timeline::EmittedEvent;
+
+    /// Fixed owning/viewer context for tests that don't exercise
+    /// cross-context behavior (that's `app_timeline.rs`'s job) — keeps every
+    /// existing same-context assertion unchanged.
+    const CTX: u64 = 1;
 
     fn allow_grant(actor_id: &str, target_id: &str) -> GrantRecord {
         GrantRecord {
@@ -914,6 +998,7 @@ mod tests {
     fn timeline_with_stream() -> Arc<Mutex<AppTimeline>> {
         let mut t = AppTimeline::default();
         t.declare_streams(
+            CTX,
             "event-probe",
             vec![EventStreamDecl {
                 name: "probe.tick".to_string(),
@@ -934,11 +1019,12 @@ mod tests {
         let res = evaluate_and_record_subscription(
             &store,
             None,
-            Path::new("/tmp/ws"),
+            Some(Path::new("/tmp/ws")),
             &timeline,
             "event-probe",
             ActorType::Agent,
             "pane:7",
+            CTX,
             vec!["probe.tick".to_string()],
             PayloadMode::Full,
             TriggerMode::Conversation,
@@ -958,11 +1044,12 @@ mod tests {
         let res = evaluate_and_record_subscription(
             &store,
             None,
-            Path::new("/tmp/ws"),
+            Some(Path::new("/tmp/ws")),
             &timeline,
             "event-probe",
             ActorType::Agent,
             "pane:7",
+            CTX,
             vec!["probe.tick".to_string()],
             PayloadMode::Full,
             TriggerMode::Conversation,
@@ -1006,6 +1093,8 @@ mod tests {
             subscriber_type_override: Some(ActorType::App),
             broker_actor_override: Some("notes-app".to_string()),
             workspace_root_override: Some(PathBuf::from("/workspace/notes")),
+            context_id_override: Some(CTX),
+            peer_ancestry: None,
             reply,
         };
 
@@ -1045,7 +1134,9 @@ mod tests {
             subscriber_override: override_id.map(String::from),
             subscriber_type_override: None,
             broker_actor_override: None,
-            workspace_root_override: None,
+            workspace_root_override: Some(PathBuf::from("/tmp/ws")),
+            context_id_override: Some(CTX),
+            peer_ancestry: None,
             reply: tx,
         };
         (req, rx)
@@ -1072,7 +1163,9 @@ mod tests {
             subscriber_override: Some(delivery_id.to_string()),
             subscriber_type_override: None,
             broker_actor_override: Some(broker_actor.to_string()),
-            workspace_root_override: None,
+            workspace_root_override: Some(PathBuf::from("/tmp/ws")),
+            context_id_override: Some(CTX),
+            peer_ancestry: None,
             reply: tx,
         };
         (req, rx)
@@ -1115,7 +1208,7 @@ mod tests {
         timeline
             .lock()
             .unwrap()
-            .record_event("event-probe", 7, probe_event(1))
+            .record_event(CTX, "event-probe", 7, probe_event(1))
             .expect("emit should record");
 
         // Tear down A. B's subscription and its queued delivery must survive.
@@ -1243,11 +1336,7 @@ mod tests {
     fn consent_allow_always_persists_grant() {
         let dir = tempfile::tempdir().unwrap();
         let timeline = timeline_with_stream();
-        let mut svc = HostSubscriptionService::new(
-            dir.path(),
-            PathBuf::from("/tmp/ws"),
-            Arc::clone(&timeline),
-        );
+        let mut svc = HostSubscriptionService::new(dir.path(), Arc::clone(&timeline));
         let (req, rx) = subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
         let consent = svc
             .classify_subscribe_request(req)
@@ -1257,11 +1346,7 @@ mod tests {
 
         // Fresh service over the same profile dir: the persisted grant makes the
         // next subscribe pass inline (no parked consent).
-        let svc2 = HostSubscriptionService::new(
-            dir.path(),
-            PathBuf::from("/tmp/ws"),
-            Arc::clone(&timeline),
-        );
+        let svc2 = HostSubscriptionService::new(dir.path(), Arc::clone(&timeline));
         let (req2, rx2) =
             subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
         assert!(
@@ -1292,7 +1377,7 @@ mod tests {
         timeline
             .lock()
             .unwrap()
-            .record_event("event-probe", 7, probe_event(3))
+            .record_event(CTX, "event-probe", 7, probe_event(3))
             .expect("emit should record");
 
         let deliveries = timeline.lock().unwrap().take_deliveries_for(stype, &sid);
@@ -1306,7 +1391,7 @@ mod tests {
         timeline
             .lock()
             .unwrap()
-            .record_event("event-probe", 7, probe_event(4))
+            .record_event(CTX, "event-probe", 7, probe_event(4))
             .expect("emit should record");
         assert_eq!(timeline.lock().unwrap().pending_delivery_count(), 1);
         let (subs, drops) = timeline.lock().unwrap().clear_subscriber(stype, &sid);
@@ -1334,7 +1419,7 @@ mod tests {
         timeline
             .lock()
             .unwrap()
-            .record_event("event-probe", 7, probe_event(1))
+            .record_event(CTX, "event-probe", 7, probe_event(1))
             .expect("emit should record");
         let deliveries = timeline.lock().unwrap().take_deliveries_for(stype, &sid);
         assert_eq!(deliveries.len(), 1);
@@ -1358,6 +1443,9 @@ mod tests {
             action,
             from_pane_id: Some(7),
             subscriber_override: override_id.map(String::from),
+            workspace_root_override: Some(PathBuf::from("/tmp/ws")),
+            context_id_override: Some(CTX),
+            peer_ancestry: None,
             reply: tx,
         };
         (req, rx)
@@ -1437,7 +1525,7 @@ mod tests {
         assert!(timeline
             .lock()
             .unwrap()
-            .declared_streams("declare-probe")
+            .declared_streams(CTX, "declare-probe")
             .is_empty());
 
         svc.resolve_consent(consent, ConsentChoice::AllowOnce, Path::new("/tmp/ws"));
@@ -1449,7 +1537,7 @@ mod tests {
             timeline
                 .lock()
                 .unwrap()
-                .declared_streams("declare-probe")
+                .declared_streams(CTX, "declare-probe")
                 .len(),
             1
         );
@@ -1483,11 +1571,7 @@ mod tests {
     fn publish_allow_always_persists_grant() {
         let dir = tempfile::tempdir().unwrap();
         let timeline = timeline_with_stream();
-        let mut svc = HostSubscriptionService::new(
-            dir.path(),
-            PathBuf::from("/tmp/ws"),
-            Arc::clone(&timeline),
-        );
+        let mut svc = HostSubscriptionService::new(dir.path(), Arc::clone(&timeline));
         let (req, rx) = publish_request(
             "event-probe",
             PublishAction::Emit(Box::new(probe_event(1))),
@@ -1499,11 +1583,7 @@ mod tests {
         svc.resolve_consent(consent, ConsentChoice::AllowAlways, dir.path());
         assert!(matches!(rx.recv().unwrap(), HostPublishReply::Ok { .. }));
 
-        let svc2 = HostSubscriptionService::new(
-            dir.path(),
-            PathBuf::from("/tmp/ws"),
-            Arc::clone(&timeline),
-        );
+        let svc2 = HostSubscriptionService::new(dir.path(), Arc::clone(&timeline));
         let (req2, rx2) = publish_request(
             "event-probe",
             PublishAction::Emit(Box::new(probe_event(2))),
@@ -1524,11 +1604,7 @@ mod tests {
     fn subscribe_grant_does_not_authorize_publish() {
         let dir = tempfile::tempdir().unwrap();
         let timeline = timeline_with_stream();
-        let mut svc = HostSubscriptionService::new(
-            dir.path(),
-            PathBuf::from("/tmp/ws"),
-            Arc::clone(&timeline),
-        );
+        let mut svc = HostSubscriptionService::new(dir.path(), Arc::clone(&timeline));
 
         // Grant a persistent subscribe (read) Allow-Always.
         let (sub_req, sub_rx) =
@@ -1544,11 +1620,7 @@ mod tests {
 
         // A publish from the same identity must still be gated (Ask → parked),
         // not silently authorized by the read grant.
-        let svc2 = HostSubscriptionService::new(
-            dir.path(),
-            PathBuf::from("/tmp/ws"),
-            Arc::clone(&timeline),
-        );
+        let svc2 = HostSubscriptionService::new(dir.path(), Arc::clone(&timeline));
         let (pub_req, _pub_rx) = publish_request(
             "event-probe",
             PublishAction::Emit(Box::new(probe_event(1))),
@@ -1566,11 +1638,7 @@ mod tests {
     fn publish_grant_does_not_authorize_subscribe() {
         let dir = tempfile::tempdir().unwrap();
         let timeline = timeline_with_stream();
-        let mut svc = HostSubscriptionService::new(
-            dir.path(),
-            PathBuf::from("/tmp/ws"),
-            Arc::clone(&timeline),
-        );
+        let mut svc = HostSubscriptionService::new(dir.path(), Arc::clone(&timeline));
 
         // Grant a persistent publish (write) Allow-Always.
         let (pub_req, pub_rx) = publish_request(
@@ -1588,11 +1656,7 @@ mod tests {
         ));
 
         // A subscribe from the same identity must still be gated (Ask → parked).
-        let svc2 = HostSubscriptionService::new(
-            dir.path(),
-            PathBuf::from("/tmp/ws"),
-            Arc::clone(&timeline),
-        );
+        let svc2 = HostSubscriptionService::new(dir.path(), Arc::clone(&timeline));
         let (sub_req, _sub_rx) =
             subscribe_request(vec!["probe.tick".to_string()], PayloadMode::Full, None);
         assert!(

--- a/src/host/mod.rs
+++ b/src/host/mod.rs
@@ -24,6 +24,7 @@ pub mod launch_failed;
 pub mod model;
 pub mod pane;
 pub mod scheduler;
+pub mod scope;
 pub mod services;
 pub mod shell;
 pub mod state_scope;

--- a/src/host/scope.rs
+++ b/src/host/scope.rs
@@ -13,12 +13,14 @@
 //! ambient state (`active_window`, `router.active()`, a client-supplied id) at
 //! the moment of use, rather than from an identity the host established once,
 //! at the trust boundary. `ScopeOrigin` is that identity. It is constructed
-//! only by the host model (`PlexiApp::origin_for_pane`,
-//! `PlexiApp::origin_for_socket_peer`) from host-observed facts — the pane
-//! table, the window's `context_id`, the router's `Context.root` — never from
-//! a request payload, cwd, or env var. Socket-peer resolution reuses stint
-//! 0636's `resolve_socket_peer_pane`, which already establishes trustworthy
-//! sender identity from kernel-captured ancestry, not the wire.
+//! only by the host model (`PlexiApp::origin_for_pane`) from host-observed
+//! facts — the pane table, the window's `context_id`, the router's
+//! `Context.root` — never from a request payload, cwd, or env var.
+//! Socket-peer callers (e.g. `PlexiApp::resolve_event_bus_caller`) resolve
+//! ancestry to a pane id first via stint 0636's `resolve_socket_peer_pane`
+//! (kernel-captured ancestry, not the wire), then hand that pane id to
+//! `origin_for_pane` — never re-deriving context/window from the caller's
+//! own claims.
 
 use std::collections::BTreeMap;
 use std::path::PathBuf;

--- a/src/host/scope.rs
+++ b/src/host/scope.rs
@@ -1,10 +1,9 @@
-//! Host-owned scope/ownership model (stint 0724, Phase A).
+//! Host-owned scope/ownership model (stint 0724).
 //!
-//! Pure new infrastructure: types, a reachability predicate, a layered-source
-//! resolver, and lifecycle invalidation plumbing. Nothing outside this module
-//! and the emit-site wiring in `PlexiApp`/`pane_ops` changes behavior in this
-//! phase — later phases (state routing, connector tools, event bus,
-//! notifications, deletion sweep) migrate real consumers onto these types.
+//! `ScopeOrigin`/`Scope`/`evaluate_reach` are the one reachability predicate
+//! connector tools, the event bus, directed/typed pipes, and app discovery
+//! route through instead of each reimplementing its own workspace-path or
+//! active-context comparison.
 //!
 //! # Why a host-owned origin
 //!
@@ -22,7 +21,6 @@
 //! `origin_for_pane` — never re-deriving context/window from the caller's
 //! own claims.
 
-use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 /// Host-established identity of the acting pane at the dispatch boundary.
@@ -39,19 +37,20 @@ pub struct ScopeOrigin {
     pub app_id: Option<String>,
 }
 
-/// The scope a resource (app instance, event stream, notification, layered
-/// config entry, ...) is owned at. Distinct from `crate::host::state_scope::StateScope`,
+/// The scope a resource (app instance, connector tool, event stream, pipe,
+/// ...) is owned at. Distinct from `crate::host::state_scope::StateScope`,
 /// which is app-declared addressing for on-disk state files; `Scope` is the
 /// host's ownership/visibility model for in-memory and wire resources.
+///
+/// Every resource this model currently owns is either pane-scoped or
+/// app-instance-scoped — nothing in this codebase today has a genuinely
+/// global (visible-everywhere) or bare-context/window-scoped resource with
+/// no owning pane, so those broader variants aren't declared here. Add one
+/// back only when a real consumer needs it (matches `RegistryViews`'s own
+/// decision not to adopt `resolve_layers` speculatively — see stint 0724
+/// Phase F's follow-up notes).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Scope {
-    /// Visible everywhere, in every context.
-    Global,
-    /// Visible only within the owning context.
-    Context { context_id: u64 },
-    /// Visible only within the owning context — never cross-context even if
-    /// another context happens to have a window with the same `window_id`.
-    Window { window_id: u64, context_id: u64 },
     /// Visible only within the owning context — never cross-context even if
     /// another context happens to have a pane with the same `pane_id`.
     Pane { pane_id: u64, context_id: u64 },
@@ -88,34 +87,29 @@ pub enum Reach {
     Rejected,
 }
 
-/// The one central reachability predicate every later phase's connector
-/// tools, event bus, notifications, and deletion sweep call to decide whether
-/// a viewer in `viewer_context_id` may see a resource owned at `owner`.
+/// The one central reachability predicate connector tools, the event bus,
+/// and directed/typed pipes call to decide whether a viewer in
+/// `viewer_context_id` may see a resource owned at `owner`.
 ///
-/// Rule: context-owned is visible only in the owning context; global is
-/// visible everywhere; anything else (`Window`/`Pane`/`AppInstance`) needs an
-/// explicit grant to cross a context boundary — and even with a grant,
-/// reachability is decided purely by `context_id`. A `Window`/`Pane` scope is
-/// never reachable from another context merely because the numeric
-/// `window_id`/`pane_id` happens to match one there; ids are only unique
-/// within their owning context.
+/// Rule: every scope is context-owned and visible only in the owning
+/// context, unless an explicit `CrossContextGrant` names exactly this
+/// (owner_context, viewer_context) pair — and even with a grant, reachability
+/// is decided purely by `context_id`. A `Pane`/`AppInstance` scope is never
+/// reachable from another context merely because the numeric `pane_id`
+/// happens to match one there; ids are only unique within their owning
+/// context.
 ///
-/// Every `Rejected` outcome is logged at `info!` so a denied cross-context
-/// access is observable without ever logging the resource's payload — only
-/// ids and the scope's shape (`{:?}` on `Scope`/`Reach` never includes
-/// secrets, notification bodies, or event payloads by construction, since
-/// `Scope` carries no such fields).
+/// `AllowedByGrant` and `Rejected` are both logged at `info!` — an allowed
+/// cross-context grant use names the grant's `reason`, a denied crossing
+/// names the scope's shape — without ever logging the resource's payload:
+/// `Scope` carries no secret, notification-body, or event-payload fields.
 pub fn evaluate_reach(
     owner: &Scope,
     viewer_context_id: u64,
     grant: Option<&CrossContextGrant>,
 ) -> Reach {
     let owner_context_id = match owner {
-        Scope::Global => return Reach::Allowed,
-        Scope::Context { context_id }
-        | Scope::Window { context_id, .. }
-        | Scope::Pane { context_id, .. }
-        | Scope::AppInstance { context_id, .. } => *context_id,
+        Scope::Pane { context_id, .. } | Scope::AppInstance { context_id, .. } => *context_id,
     };
 
     if owner_context_id == viewer_context_id {
@@ -126,6 +120,11 @@ pub fn evaluate_reach(
         if grant.granting_context_id == owner_context_id
             && grant.grantee_context_id == viewer_context_id
         {
+            log::info!(
+                target: "plexi::scope",
+                "reach allowed by grant: owner_context={owner_context_id} viewer_context={viewer_context_id} reason={}",
+                grant.reason
+            );
             return Reach::AllowedByGrant;
         }
     }
@@ -137,90 +136,11 @@ pub fn evaluate_reach(
     Reach::Rejected
 }
 
-/// A resolved layered value plus the provenance a caller needs to explain
-/// where it came from: which scope it's owned at, which file it was read
-/// from (when the layer has one), a stable identity fingerprint for the
-/// (path, key) pair, and the generation (layer index) it resolved from.
-#[derive(Debug, Clone)]
-pub struct ResolvedSource<T> {
-    pub value: T,
-    pub scope: Scope,
-    pub source_path: Option<PathBuf>,
-    pub fingerprint: u64,
-    pub generation: u64,
-}
-
-/// One layer of a layered-source resolution — e.g. a global config file and a
-/// context-local override, both declaring entries keyed by the same
-/// namespace. `resolve_layers` shadows earlier layers with later ones,
-/// whole-entry.
-pub struct SourceLayer<T> {
-    pub scope: Scope,
-    pub path: PathBuf,
-    pub entries: BTreeMap<String, T>,
-}
-
-/// Deterministic identity fingerprint for a (source path, key) pair. Not a
-/// content hash — Phase A has no consumer that needs change detection on
-/// value contents, only a stable identifier tying a resolved entry back to
-/// the layer + key it came from. `DefaultHasher` is documented to start from
-/// a fixed, non-randomized state, so this is deterministic across calls and
-/// across process runs.
-fn fingerprint_for(path: &std::path::Path, key: &str) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    path.hash(&mut hasher);
-    key.hash(&mut hasher);
-    hasher.finish()
-}
-
-/// Resolve a stack of layers into one map keyed by entry name. Later layers
-/// (higher index in `layers`) shadow earlier ones WHOLE-ENTRY: when two
-/// layers declare the same key, the later layer's entire value replaces the
-/// earlier one — individual fields of `T` are never merged across layers.
-/// Deterministic for a given `layers` slice regardless of the entries' own
-/// (BTreeMap) iteration — key order inside a layer never affects the result,
-/// only the layer order the caller passes in does.
-///
-/// Every shadowing event (a later layer overwriting an earlier layer's entry
-/// for the same key) is logged at `info!` with both source paths and the key
-/// — never the value, which may be app-controlled and is not the host's to
-/// name in a shared log line.
-pub fn resolve_layers<T: Clone>(layers: &[SourceLayer<T>]) -> BTreeMap<String, ResolvedSource<T>> {
-    let mut resolved: BTreeMap<String, ResolvedSource<T>> = BTreeMap::new();
-    for (generation, layer) in layers.iter().enumerate() {
-        let generation = generation as u64;
-        for (key, value) in &layer.entries {
-            if let Some(previous) = resolved.get(key) {
-                log::info!(
-                    target: "plexi::scope",
-                    "layer shadow: key={key} previous_source={:?} new_source={:?}",
-                    previous.source_path,
-                    layer.path
-                );
-            }
-            resolved.insert(
-                key.clone(),
-                ResolvedSource {
-                    value: value.clone(),
-                    scope: layer.scope.clone(),
-                    source_path: Some(layer.path.clone()),
-                    fingerprint: fingerprint_for(&layer.path, key),
-                    generation,
-                },
-            );
-        }
-    }
-    resolved
-}
-
 /// A lifecycle event that makes some previously-resolved scope/origin/source
-/// stale. Phase A has no consumers — `PlexiApp::emit_scope_invalidation` only
-/// logs it. Later phases (state routing, connector tools, event bus,
-/// notifications, deletion sweep) add real invalidation handling behind this
-/// same enum as they migrate onto the scope model, so every future consumer
-/// reacts to one shared vocabulary of "what changed" instead of re-deriving
-/// it from ad hoc call sites.
+/// stale. `PlexiApp::emit_scope_invalidation` fans this out to every live
+/// consumer (`RegistryViews::invalidate`, per-pane app-state root refresh)
+/// so each reacts to one shared vocabulary of "what changed" instead of
+/// re-deriving it from ad hoc call sites.
 #[derive(Debug, Clone)]
 pub enum ScopeInvalidation {
     /// `pane_ops::workspace::set_context_root` moved a context's anchor.
@@ -234,12 +154,6 @@ pub enum ScopeInvalidation {
     ContextRemoved { context_id: u64 },
     /// `pane_ops::layout::close_pane_by_id` closed a pane.
     PaneClosed { pane_id: u64, context_id: u64 },
-    /// An app package was installed or replaced on disk. `root` is the
-    /// installed app's directory when known.
-    PackageReplaced {
-        app_id: String,
-        root: Option<PathBuf>,
-    },
     /// A filesystem-watched source (e.g. the app registry) reported a change
     /// generation the host has not yet resolved against.
     SourceGenerationChanged { source_path: PathBuf },
@@ -257,74 +171,6 @@ mod tests {
             grantee_context_id: grantee,
             reason: "test grant".to_string(),
         }
-    }
-
-    #[test]
-    fn global_is_always_allowed() {
-        assert_eq!(evaluate_reach(&Scope::Global, 1, None), Reach::Allowed);
-        assert_eq!(evaluate_reach(&Scope::Global, 2, None), Reach::Allowed);
-        // Even a grant for an unrelated pair doesn't change global's answer.
-        let g = grant(9, 9);
-        assert_eq!(evaluate_reach(&Scope::Global, 42, Some(&g)), Reach::Allowed);
-    }
-
-    #[test]
-    fn context_scope_same_context_is_allowed() {
-        let owner = Scope::Context { context_id: 5 };
-        assert_eq!(evaluate_reach(&owner, 5, None), Reach::Allowed);
-    }
-
-    #[test]
-    fn context_scope_different_context_without_grant_is_rejected() {
-        let owner = Scope::Context { context_id: 5 };
-        assert_eq!(evaluate_reach(&owner, 6, None), Reach::Rejected);
-    }
-
-    #[test]
-    fn context_scope_different_context_with_matching_grant_is_allowed_by_grant() {
-        let owner = Scope::Context { context_id: 5 };
-        let g = grant(5, 6);
-        assert_eq!(evaluate_reach(&owner, 6, Some(&g)), Reach::AllowedByGrant);
-    }
-
-    #[test]
-    fn context_scope_different_context_with_mismatched_grant_is_rejected() {
-        let owner = Scope::Context { context_id: 5 };
-        // Grant exists but names a different grantor/grantee pair.
-        let g = grant(5, 999);
-        assert_eq!(evaluate_reach(&owner, 6, Some(&g)), Reach::Rejected);
-        let g2 = grant(4, 6);
-        assert_eq!(evaluate_reach(&owner, 6, Some(&g2)), Reach::Rejected);
-    }
-
-    #[test]
-    fn window_scope_same_context_is_allowed() {
-        let owner = Scope::Window {
-            window_id: 100,
-            context_id: 5,
-        };
-        assert_eq!(evaluate_reach(&owner, 5, None), Reach::Allowed);
-    }
-
-    #[test]
-    fn window_scope_matching_window_id_in_another_context_is_still_rejected() {
-        // window_id collision across contexts must never grant reach — ids
-        // are only unique within their owning context.
-        let owner = Scope::Window {
-            window_id: 100,
-            context_id: 5,
-        };
-        assert_eq!(evaluate_reach(&owner, 6, None), Reach::Rejected);
-    }
-
-    #[test]
-    fn window_scope_different_context_with_grant_is_allowed_by_grant() {
-        let owner = Scope::Window {
-            window_id: 100,
-            context_id: 5,
-        };
-        let g = grant(5, 6);
-        assert_eq!(evaluate_reach(&owner, 6, Some(&g)), Reach::AllowedByGrant);
     }
 
     #[test]
@@ -353,6 +199,25 @@ mod tests {
         };
         let g = grant(5, 6);
         assert_eq!(evaluate_reach(&owner, 6, Some(&g)), Reach::AllowedByGrant);
+    }
+
+    #[test]
+    fn pane_scope_grant_naming_a_different_pair_is_still_rejected() {
+        let owner = Scope::Pane {
+            pane_id: 200,
+            context_id: 5,
+        };
+        // Grant exists but names a different grantor/grantee pair.
+        let wrong_grantee = grant(5, 999);
+        assert_eq!(
+            evaluate_reach(&owner, 6, Some(&wrong_grantee)),
+            Reach::Rejected
+        );
+        let wrong_grantor = grant(4, 6);
+        assert_eq!(
+            evaluate_reach(&owner, 6, Some(&wrong_grantor)),
+            Reach::Rejected
+        );
     }
 
     #[test]
@@ -386,152 +251,13 @@ mod tests {
         assert_eq!(evaluate_reach(&owner, 6, Some(&g)), Reach::AllowedByGrant);
     }
 
-    // ── resolve_layers ───────────────────────────────────────────────────────
-
-    fn layer(scope: Scope, path: &str, entries: &[(&str, &str)]) -> SourceLayer<String> {
-        SourceLayer {
-            scope,
-            path: PathBuf::from(path),
-            entries: entries
-                .iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect(),
-        }
-    }
-
-    #[test]
-    fn later_layer_shadows_earlier_layer_whole_entry() {
-        let layers = vec![
-            layer(
-                Scope::Global,
-                "/global/config.toml",
-                &[("greeting", "hello-global"), ("only_global", "g")],
-            ),
-            layer(
-                Scope::Context { context_id: 1 },
-                "/ctx/config.toml",
-                &[("greeting", "hello-context")],
-            ),
-        ];
-        let resolved = resolve_layers(&layers);
-
-        // The later (context) layer's whole entry wins for the shared key.
-        let greeting = &resolved["greeting"];
-        assert_eq!(greeting.value, "hello-context");
-        assert_eq!(greeting.scope, Scope::Context { context_id: 1 });
-        assert_eq!(
-            greeting.source_path,
-            Some(PathBuf::from("/ctx/config.toml"))
-        );
-        assert_eq!(greeting.generation, 1);
-
-        // The key only the earlier layer declared survives untouched.
-        let only_global = &resolved["only_global"];
-        assert_eq!(only_global.value, "g");
-        assert_eq!(only_global.scope, Scope::Global);
-        assert_eq!(only_global.generation, 0);
-    }
-
-    #[test]
-    fn resolve_layers_is_deterministic_for_the_same_slice_order() {
-        let make_layers = || {
-            vec![
-                layer(
-                    Scope::Global,
-                    "/global/config.toml",
-                    &[("a", "1"), ("b", "2")],
-                ),
-                layer(
-                    Scope::Context { context_id: 7 },
-                    "/ctx/config.toml",
-                    &[("b", "override"), ("c", "3")],
-                ),
-            ]
-        };
-
-        let first = resolve_layers(&make_layers());
-        let second = resolve_layers(&make_layers());
-
-        assert_eq!(
-            first.keys().collect::<Vec<_>>(),
-            second.keys().collect::<Vec<_>>()
-        );
-        for key in first.keys() {
-            assert_eq!(first[key].value, second[key].value);
-            assert_eq!(first[key].scope, second[key].scope);
-            assert_eq!(first[key].source_path, second[key].source_path);
-            assert_eq!(first[key].fingerprint, second[key].fingerprint);
-            assert_eq!(first[key].generation, second[key].generation);
-        }
-    }
-
-    #[test]
-    fn resolve_layers_attributes_each_entry_to_its_originating_layer() {
-        let layers = vec![
-            layer(Scope::Global, "/global/config.toml", &[("x", "global-x")]),
-            layer(
-                Scope::Context { context_id: 3 },
-                "/ctx-a/config.toml",
-                &[("y", "ctx-a-y")],
-            ),
-            layer(
-                Scope::Context { context_id: 4 },
-                "/ctx-b/config.toml",
-                &[("z", "ctx-b-z")],
-            ),
-        ];
-        let resolved = resolve_layers(&layers);
-
-        assert_eq!(resolved["x"].scope, Scope::Global);
-        assert_eq!(
-            resolved["x"].source_path,
-            Some(PathBuf::from("/global/config.toml"))
-        );
-        assert_eq!(resolved["x"].generation, 0);
-
-        assert_eq!(resolved["y"].scope, Scope::Context { context_id: 3 });
-        assert_eq!(
-            resolved["y"].source_path,
-            Some(PathBuf::from("/ctx-a/config.toml"))
-        );
-        assert_eq!(resolved["y"].generation, 1);
-
-        assert_eq!(resolved["z"].scope, Scope::Context { context_id: 4 });
-        assert_eq!(
-            resolved["z"].source_path,
-            Some(PathBuf::from("/ctx-b/config.toml"))
-        );
-        assert_eq!(resolved["z"].generation, 2);
-    }
-
-    #[test]
-    fn resolve_layers_never_merges_fields_of_a_shadowed_struct_entry() {
-        // T here is a struct-like tuple encoded as a String "field_a|field_b"
-        // to prove shadowing replaces the whole value, not just one field.
-        let layers = vec![
-            layer(Scope::Global, "/global.toml", &[("entry", "a1|b1")]),
-            layer(
-                Scope::Context { context_id: 1 },
-                "/ctx.toml",
-                &[("entry", "a2|MISSING")], // later layer only "declares" a2 conceptually
-            ),
-        ];
-        let resolved = resolve_layers(&layers);
-        // The later layer's value replaces the earlier one entirely — this
-        // would fail if resolve_layers merged per-field instead of shadowing
-        // the whole entry.
-        assert_eq!(resolved["entry"].value, "a2|MISSING");
-        assert_ne!(resolved["entry"].value, "a1|b1");
-    }
-
     // ── ScopeInvalidation / emit_scope_invalidation smoke test ──────────────
 
     /// `PlexiApp::set_context_root` must fire `emit_scope_invalidation` with a
-    /// `ContextRootChanged` event. Phase A has no real consumer, so the
-    /// observable proof is the test-only counter `emit_scope_invalidation`
-    /// increments under `#[cfg(test)]` — a HostHarness-based smoke test per
-    /// TESTING.md (host logic → HostHarness, not a TOML scene, since nothing
-    /// here is pixel-observable).
+    /// `ContextRootChanged` event. The observable proof is the test-only
+    /// counter `emit_scope_invalidation` increments under `#[cfg(test)]` — a
+    /// HostHarness-based smoke test per TESTING.md (host logic → HostHarness,
+    /// not a TOML scene, since nothing here is pixel-observable).
     #[test]
     fn set_context_root_fires_scope_invalidation() {
         let mut harness = crate::testing::HostHarness::new();

--- a/src/host/scope.rs
+++ b/src/host/scope.rs
@@ -1,0 +1,551 @@
+//! Host-owned scope/ownership model (stint 0724, Phase A).
+//!
+//! Pure new infrastructure: types, a reachability predicate, a layered-source
+//! resolver, and lifecycle invalidation plumbing. Nothing outside this module
+//! and the emit-site wiring in `PlexiApp`/`pane_ops` changes behavior in this
+//! phase — later phases (state routing, connector tools, event bus,
+//! notifications, deletion sweep) migrate real consumers onto these types.
+//!
+//! # Why a host-owned origin
+//!
+//! Every prior resource-scoping bug in this codebase traced back to the same
+//! root cause: some caller derived "which context/pane is this for" from
+//! ambient state (`active_window`, `router.active()`, a client-supplied id) at
+//! the moment of use, rather than from an identity the host established once,
+//! at the trust boundary. `ScopeOrigin` is that identity. It is constructed
+//! only by the host model (`PlexiApp::origin_for_pane`,
+//! `PlexiApp::origin_for_socket_peer`) from host-observed facts — the pane
+//! table, the window's `context_id`, the router's `Context.root` — never from
+//! a request payload, cwd, or env var. Socket-peer resolution reuses stint
+//! 0636's `resolve_socket_peer_pane`, which already establishes trustworthy
+//! sender identity from kernel-captured ancestry, not the wire.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+/// Host-established identity of the acting pane at the dispatch boundary.
+///
+/// Constructed ONLY by the host model or from socket-peer resolution (stint
+/// 0636's `resolve_socket_peer_pane`) — never from client payloads, active
+/// focus, `active_window`, `router.active()`, pane cwd, or ambient env vars.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ScopeOrigin {
+    pub context_id: u64,
+    pub context_root: PathBuf,
+    pub window_id: u64,
+    pub pane_id: u64,
+    pub app_id: Option<String>,
+}
+
+/// The scope a resource (app instance, event stream, notification, layered
+/// config entry, ...) is owned at. Distinct from `crate::host::state_scope::StateScope`,
+/// which is app-declared addressing for on-disk state files; `Scope` is the
+/// host's ownership/visibility model for in-memory and wire resources.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Scope {
+    /// Visible everywhere, in every context.
+    Global,
+    /// Visible only within the owning context.
+    Context { context_id: u64 },
+    /// Visible only within the owning context — never cross-context even if
+    /// another context happens to have a window with the same `window_id`.
+    Window { window_id: u64, context_id: u64 },
+    /// Visible only within the owning context — never cross-context even if
+    /// another context happens to have a pane with the same `pane_id`.
+    Pane { pane_id: u64, context_id: u64 },
+    /// Visible only within the owning context — never cross-context even if
+    /// another context happens to have a pane/app_id pair that collides.
+    AppInstance {
+        pane_id: u64,
+        app_id: String,
+        context_id: u64,
+    },
+}
+
+/// Minimal in-memory attributable grant carrier. NOT persisted — persistence
+/// for cross-context grants is a different, out-of-scope stint. This exists
+/// only so `evaluate_reach` has a grant path to evaluate against in Phase A
+/// and the phases that migrate consumers onto it.
+#[derive(Debug, Clone)]
+pub struct CrossContextGrant {
+    pub granting_context_id: u64,
+    pub grantee_context_id: u64,
+    pub reason: String,
+}
+
+/// Outcome of `evaluate_reach`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reach {
+    /// Owner scope is inherently visible to this viewer (global, or the
+    /// viewer's own context).
+    Allowed,
+    /// Owner scope is a different context, but a matching `CrossContextGrant`
+    /// makes it visible anyway.
+    AllowedByGrant,
+    /// Owner scope is a different context and no matching grant exists.
+    Rejected,
+}
+
+/// The one central reachability predicate every later phase's connector
+/// tools, event bus, notifications, and deletion sweep call to decide whether
+/// a viewer in `viewer_context_id` may see a resource owned at `owner`.
+///
+/// Rule: context-owned is visible only in the owning context; global is
+/// visible everywhere; anything else (`Window`/`Pane`/`AppInstance`) needs an
+/// explicit grant to cross a context boundary — and even with a grant,
+/// reachability is decided purely by `context_id`. A `Window`/`Pane` scope is
+/// never reachable from another context merely because the numeric
+/// `window_id`/`pane_id` happens to match one there; ids are only unique
+/// within their owning context.
+///
+/// Every `Rejected` outcome is logged at `info!` so a denied cross-context
+/// access is observable without ever logging the resource's payload — only
+/// ids and the scope's shape (`{:?}` on `Scope`/`Reach` never includes
+/// secrets, notification bodies, or event payloads by construction, since
+/// `Scope` carries no such fields).
+pub fn evaluate_reach(
+    owner: &Scope,
+    viewer_context_id: u64,
+    grant: Option<&CrossContextGrant>,
+) -> Reach {
+    let owner_context_id = match owner {
+        Scope::Global => return Reach::Allowed,
+        Scope::Context { context_id }
+        | Scope::Window { context_id, .. }
+        | Scope::Pane { context_id, .. }
+        | Scope::AppInstance { context_id, .. } => *context_id,
+    };
+
+    if owner_context_id == viewer_context_id {
+        return Reach::Allowed;
+    }
+
+    if let Some(grant) = grant {
+        if grant.granting_context_id == owner_context_id
+            && grant.grantee_context_id == viewer_context_id
+        {
+            return Reach::AllowedByGrant;
+        }
+    }
+
+    log::info!(
+        target: "plexi::scope",
+        "reach rejected: owner_context={owner_context_id} viewer_context={viewer_context_id} scope={owner:?}"
+    );
+    Reach::Rejected
+}
+
+/// A resolved layered value plus the provenance a caller needs to explain
+/// where it came from: which scope it's owned at, which file it was read
+/// from (when the layer has one), a stable identity fingerprint for the
+/// (path, key) pair, and the generation (layer index) it resolved from.
+#[derive(Debug, Clone)]
+pub struct ResolvedSource<T> {
+    pub value: T,
+    pub scope: Scope,
+    pub source_path: Option<PathBuf>,
+    pub fingerprint: u64,
+    pub generation: u64,
+}
+
+/// One layer of a layered-source resolution — e.g. a global config file and a
+/// context-local override, both declaring entries keyed by the same
+/// namespace. `resolve_layers` shadows earlier layers with later ones,
+/// whole-entry.
+pub struct SourceLayer<T> {
+    pub scope: Scope,
+    pub path: PathBuf,
+    pub entries: BTreeMap<String, T>,
+}
+
+/// Deterministic identity fingerprint for a (source path, key) pair. Not a
+/// content hash — Phase A has no consumer that needs change detection on
+/// value contents, only a stable identifier tying a resolved entry back to
+/// the layer + key it came from. `DefaultHasher` is documented to start from
+/// a fixed, non-randomized state, so this is deterministic across calls and
+/// across process runs.
+fn fingerprint_for(path: &std::path::Path, key: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    path.hash(&mut hasher);
+    key.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Resolve a stack of layers into one map keyed by entry name. Later layers
+/// (higher index in `layers`) shadow earlier ones WHOLE-ENTRY: when two
+/// layers declare the same key, the later layer's entire value replaces the
+/// earlier one — individual fields of `T` are never merged across layers.
+/// Deterministic for a given `layers` slice regardless of the entries' own
+/// (BTreeMap) iteration — key order inside a layer never affects the result,
+/// only the layer order the caller passes in does.
+///
+/// Every shadowing event (a later layer overwriting an earlier layer's entry
+/// for the same key) is logged at `info!` with both source paths and the key
+/// — never the value, which may be app-controlled and is not the host's to
+/// name in a shared log line.
+pub fn resolve_layers<T: Clone>(layers: &[SourceLayer<T>]) -> BTreeMap<String, ResolvedSource<T>> {
+    let mut resolved: BTreeMap<String, ResolvedSource<T>> = BTreeMap::new();
+    for (generation, layer) in layers.iter().enumerate() {
+        let generation = generation as u64;
+        for (key, value) in &layer.entries {
+            if let Some(previous) = resolved.get(key) {
+                log::info!(
+                    target: "plexi::scope",
+                    "layer shadow: key={key} previous_source={:?} new_source={:?}",
+                    previous.source_path,
+                    layer.path
+                );
+            }
+            resolved.insert(
+                key.clone(),
+                ResolvedSource {
+                    value: value.clone(),
+                    scope: layer.scope.clone(),
+                    source_path: Some(layer.path.clone()),
+                    fingerprint: fingerprint_for(&layer.path, key),
+                    generation,
+                },
+            );
+        }
+    }
+    resolved
+}
+
+/// A lifecycle event that makes some previously-resolved scope/origin/source
+/// stale. Phase A has no consumers — `PlexiApp::emit_scope_invalidation` only
+/// logs it. Later phases (state routing, connector tools, event bus,
+/// notifications, deletion sweep) add real invalidation handling behind this
+/// same enum as they migrate onto the scope model, so every future consumer
+/// reacts to one shared vocabulary of "what changed" instead of re-deriving
+/// it from ad hoc call sites.
+#[derive(Debug, Clone)]
+pub enum ScopeInvalidation {
+    /// `pane_ops::workspace::set_context_root` moved a context's anchor.
+    ContextRootChanged {
+        context_id: u64,
+        old_root: PathBuf,
+        new_root: PathBuf,
+    },
+    /// `pane_ops::workspace::delete_context` removed a context (emitted once
+    /// per deleted context in a cascading delete, including descendants).
+    ContextRemoved { context_id: u64 },
+    /// `pane_ops::layout::close_pane_by_id` closed a pane.
+    PaneClosed { pane_id: u64, context_id: u64 },
+    /// An app package was installed or replaced on disk. `root` is the
+    /// installed app's directory when known.
+    PackageReplaced {
+        app_id: String,
+        root: Option<PathBuf>,
+    },
+    /// A filesystem-watched source (e.g. the app registry) reported a change
+    /// generation the host has not yet resolved against.
+    SourceGenerationChanged { source_path: PathBuf },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── evaluate_reach: the scope compatibility matrix ──────────────────────
+
+    fn grant(granting: u64, grantee: u64) -> CrossContextGrant {
+        CrossContextGrant {
+            granting_context_id: granting,
+            grantee_context_id: grantee,
+            reason: "test grant".to_string(),
+        }
+    }
+
+    #[test]
+    fn global_is_always_allowed() {
+        assert_eq!(evaluate_reach(&Scope::Global, 1, None), Reach::Allowed);
+        assert_eq!(evaluate_reach(&Scope::Global, 2, None), Reach::Allowed);
+        // Even a grant for an unrelated pair doesn't change global's answer.
+        let g = grant(9, 9);
+        assert_eq!(evaluate_reach(&Scope::Global, 42, Some(&g)), Reach::Allowed);
+    }
+
+    #[test]
+    fn context_scope_same_context_is_allowed() {
+        let owner = Scope::Context { context_id: 5 };
+        assert_eq!(evaluate_reach(&owner, 5, None), Reach::Allowed);
+    }
+
+    #[test]
+    fn context_scope_different_context_without_grant_is_rejected() {
+        let owner = Scope::Context { context_id: 5 };
+        assert_eq!(evaluate_reach(&owner, 6, None), Reach::Rejected);
+    }
+
+    #[test]
+    fn context_scope_different_context_with_matching_grant_is_allowed_by_grant() {
+        let owner = Scope::Context { context_id: 5 };
+        let g = grant(5, 6);
+        assert_eq!(evaluate_reach(&owner, 6, Some(&g)), Reach::AllowedByGrant);
+    }
+
+    #[test]
+    fn context_scope_different_context_with_mismatched_grant_is_rejected() {
+        let owner = Scope::Context { context_id: 5 };
+        // Grant exists but names a different grantor/grantee pair.
+        let g = grant(5, 999);
+        assert_eq!(evaluate_reach(&owner, 6, Some(&g)), Reach::Rejected);
+        let g2 = grant(4, 6);
+        assert_eq!(evaluate_reach(&owner, 6, Some(&g2)), Reach::Rejected);
+    }
+
+    #[test]
+    fn window_scope_same_context_is_allowed() {
+        let owner = Scope::Window {
+            window_id: 100,
+            context_id: 5,
+        };
+        assert_eq!(evaluate_reach(&owner, 5, None), Reach::Allowed);
+    }
+
+    #[test]
+    fn window_scope_matching_window_id_in_another_context_is_still_rejected() {
+        // window_id collision across contexts must never grant reach — ids
+        // are only unique within their owning context.
+        let owner = Scope::Window {
+            window_id: 100,
+            context_id: 5,
+        };
+        assert_eq!(evaluate_reach(&owner, 6, None), Reach::Rejected);
+    }
+
+    #[test]
+    fn window_scope_different_context_with_grant_is_allowed_by_grant() {
+        let owner = Scope::Window {
+            window_id: 100,
+            context_id: 5,
+        };
+        let g = grant(5, 6);
+        assert_eq!(evaluate_reach(&owner, 6, Some(&g)), Reach::AllowedByGrant);
+    }
+
+    #[test]
+    fn pane_scope_same_context_is_allowed() {
+        let owner = Scope::Pane {
+            pane_id: 200,
+            context_id: 5,
+        };
+        assert_eq!(evaluate_reach(&owner, 5, None), Reach::Allowed);
+    }
+
+    #[test]
+    fn pane_scope_matching_pane_id_in_another_context_is_still_rejected() {
+        let owner = Scope::Pane {
+            pane_id: 200,
+            context_id: 5,
+        };
+        assert_eq!(evaluate_reach(&owner, 6, None), Reach::Rejected);
+    }
+
+    #[test]
+    fn pane_scope_different_context_with_grant_is_allowed_by_grant() {
+        let owner = Scope::Pane {
+            pane_id: 200,
+            context_id: 5,
+        };
+        let g = grant(5, 6);
+        assert_eq!(evaluate_reach(&owner, 6, Some(&g)), Reach::AllowedByGrant);
+    }
+
+    #[test]
+    fn app_instance_scope_same_context_is_allowed() {
+        let owner = Scope::AppInstance {
+            pane_id: 200,
+            app_id: "acme.todo".to_string(),
+            context_id: 5,
+        };
+        assert_eq!(evaluate_reach(&owner, 5, None), Reach::Allowed);
+    }
+
+    #[test]
+    fn app_instance_scope_matching_ids_in_another_context_is_still_rejected() {
+        let owner = Scope::AppInstance {
+            pane_id: 200,
+            app_id: "acme.todo".to_string(),
+            context_id: 5,
+        };
+        assert_eq!(evaluate_reach(&owner, 6, None), Reach::Rejected);
+    }
+
+    #[test]
+    fn app_instance_scope_different_context_with_grant_is_allowed_by_grant() {
+        let owner = Scope::AppInstance {
+            pane_id: 200,
+            app_id: "acme.todo".to_string(),
+            context_id: 5,
+        };
+        let g = grant(5, 6);
+        assert_eq!(evaluate_reach(&owner, 6, Some(&g)), Reach::AllowedByGrant);
+    }
+
+    // ── resolve_layers ───────────────────────────────────────────────────────
+
+    fn layer(scope: Scope, path: &str, entries: &[(&str, &str)]) -> SourceLayer<String> {
+        SourceLayer {
+            scope,
+            path: PathBuf::from(path),
+            entries: entries
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn later_layer_shadows_earlier_layer_whole_entry() {
+        let layers = vec![
+            layer(
+                Scope::Global,
+                "/global/config.toml",
+                &[("greeting", "hello-global"), ("only_global", "g")],
+            ),
+            layer(
+                Scope::Context { context_id: 1 },
+                "/ctx/config.toml",
+                &[("greeting", "hello-context")],
+            ),
+        ];
+        let resolved = resolve_layers(&layers);
+
+        // The later (context) layer's whole entry wins for the shared key.
+        let greeting = &resolved["greeting"];
+        assert_eq!(greeting.value, "hello-context");
+        assert_eq!(greeting.scope, Scope::Context { context_id: 1 });
+        assert_eq!(
+            greeting.source_path,
+            Some(PathBuf::from("/ctx/config.toml"))
+        );
+        assert_eq!(greeting.generation, 1);
+
+        // The key only the earlier layer declared survives untouched.
+        let only_global = &resolved["only_global"];
+        assert_eq!(only_global.value, "g");
+        assert_eq!(only_global.scope, Scope::Global);
+        assert_eq!(only_global.generation, 0);
+    }
+
+    #[test]
+    fn resolve_layers_is_deterministic_for_the_same_slice_order() {
+        let make_layers = || {
+            vec![
+                layer(
+                    Scope::Global,
+                    "/global/config.toml",
+                    &[("a", "1"), ("b", "2")],
+                ),
+                layer(
+                    Scope::Context { context_id: 7 },
+                    "/ctx/config.toml",
+                    &[("b", "override"), ("c", "3")],
+                ),
+            ]
+        };
+
+        let first = resolve_layers(&make_layers());
+        let second = resolve_layers(&make_layers());
+
+        assert_eq!(
+            first.keys().collect::<Vec<_>>(),
+            second.keys().collect::<Vec<_>>()
+        );
+        for key in first.keys() {
+            assert_eq!(first[key].value, second[key].value);
+            assert_eq!(first[key].scope, second[key].scope);
+            assert_eq!(first[key].source_path, second[key].source_path);
+            assert_eq!(first[key].fingerprint, second[key].fingerprint);
+            assert_eq!(first[key].generation, second[key].generation);
+        }
+    }
+
+    #[test]
+    fn resolve_layers_attributes_each_entry_to_its_originating_layer() {
+        let layers = vec![
+            layer(Scope::Global, "/global/config.toml", &[("x", "global-x")]),
+            layer(
+                Scope::Context { context_id: 3 },
+                "/ctx-a/config.toml",
+                &[("y", "ctx-a-y")],
+            ),
+            layer(
+                Scope::Context { context_id: 4 },
+                "/ctx-b/config.toml",
+                &[("z", "ctx-b-z")],
+            ),
+        ];
+        let resolved = resolve_layers(&layers);
+
+        assert_eq!(resolved["x"].scope, Scope::Global);
+        assert_eq!(
+            resolved["x"].source_path,
+            Some(PathBuf::from("/global/config.toml"))
+        );
+        assert_eq!(resolved["x"].generation, 0);
+
+        assert_eq!(resolved["y"].scope, Scope::Context { context_id: 3 });
+        assert_eq!(
+            resolved["y"].source_path,
+            Some(PathBuf::from("/ctx-a/config.toml"))
+        );
+        assert_eq!(resolved["y"].generation, 1);
+
+        assert_eq!(resolved["z"].scope, Scope::Context { context_id: 4 });
+        assert_eq!(
+            resolved["z"].source_path,
+            Some(PathBuf::from("/ctx-b/config.toml"))
+        );
+        assert_eq!(resolved["z"].generation, 2);
+    }
+
+    #[test]
+    fn resolve_layers_never_merges_fields_of_a_shadowed_struct_entry() {
+        // T here is a struct-like tuple encoded as a String "field_a|field_b"
+        // to prove shadowing replaces the whole value, not just one field.
+        let layers = vec![
+            layer(Scope::Global, "/global.toml", &[("entry", "a1|b1")]),
+            layer(
+                Scope::Context { context_id: 1 },
+                "/ctx.toml",
+                &[("entry", "a2|MISSING")], // later layer only "declares" a2 conceptually
+            ),
+        ];
+        let resolved = resolve_layers(&layers);
+        // The later layer's value replaces the earlier one entirely — this
+        // would fail if resolve_layers merged per-field instead of shadowing
+        // the whole entry.
+        assert_eq!(resolved["entry"].value, "a2|MISSING");
+        assert_ne!(resolved["entry"].value, "a1|b1");
+    }
+
+    // ── ScopeInvalidation / emit_scope_invalidation smoke test ──────────────
+
+    /// `PlexiApp::set_context_root` must fire `emit_scope_invalidation` with a
+    /// `ContextRootChanged` event. Phase A has no real consumer, so the
+    /// observable proof is the test-only counter `emit_scope_invalidation`
+    /// increments under `#[cfg(test)]` — a HostHarness-based smoke test per
+    /// TESTING.md (host logic → HostHarness, not a TOML scene, since nothing
+    /// here is pixel-observable).
+    #[test]
+    fn set_context_root_fires_scope_invalidation() {
+        let mut harness = crate::testing::HostHarness::new();
+        let before =
+            crate::app::SCOPE_INVALIDATION_COUNT_FOR_TEST.load(std::sync::atomic::Ordering::SeqCst);
+
+        let new_root = tempfile::tempdir().expect("new root tempdir");
+        harness
+            .app
+            .set_context_root(new_root.path().to_path_buf(), None);
+
+        let after =
+            crate::app::SCOPE_INVALIDATION_COUNT_FOR_TEST.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            after > before,
+            "set_context_root must fire emit_scope_invalidation (before={before}, after={after})"
+        );
+    }
+}

--- a/src/host/typed_pipes.rs
+++ b/src/host/typed_pipes.rs
@@ -122,7 +122,9 @@ impl TypedPipeRegistry {
 
     /// Phase F's audit surface: the scope this registry's pipes are owned
     /// at. `None` only before the owning pane's placement setter has run
-    /// (should not observably happen past pane placement).
+    /// (should not observably happen past pane placement). Test-only — its
+    /// sole caller, `WasmApp::pipe_owner`, is itself `#[cfg(test)]`.
+    #[cfg(test)]
     pub fn owner(&self) -> Option<&crate::host::scope::Scope> {
         self.owner.as_ref()
     }

--- a/src/host/typed_pipes.rs
+++ b/src/host/typed_pipes.rs
@@ -91,6 +91,16 @@ pub struct TypedPipeRegistry {
     pipes: HashMap<String, PipeEntry>,
     /// Private directory where binary pipe sockets are created (mode 0700).
     pipes_dir: PathBuf,
+    /// Host-established owner of this registry (stint 0724 Phase D 2/2) —
+    /// the pane it belongs to. `None` until `set_owner` is called: the
+    /// registry is constructed deep inside runtime instantiation (wasmtime
+    /// `HostCtx::new`, before pane placement assigns a `pane_id`/`context_id`
+    /// at all), so ownership is a two-phase init, mirroring the existing
+    /// `WasmPane::pane_id`/`context_id` fields (`0` until `set_pane_id`/
+    /// `set_context_id` run from the placement closure). One registry is
+    /// created per pane, so every entry it ever holds shares this one owner —
+    /// there is no per-entry variance to track, only per-registry.
+    owner: Option<crate::host::scope::Scope>,
 }
 
 impl TypedPipeRegistry {
@@ -98,7 +108,23 @@ impl TypedPipeRegistry {
         Self {
             pipes: HashMap::new(),
             pipes_dir,
+            owner: None,
         }
+    }
+
+    /// Stamp the host-established scope this registry's pipes are owned at.
+    /// Called once, from the owning pane's own placement setter (e.g.
+    /// `WasmPane::set_context_id`), itself fed only by
+    /// `PlexiApp::origin_for_pane` — never a caller-supplied value.
+    pub fn set_owner(&mut self, owner: crate::host::scope::Scope) {
+        self.owner = Some(owner);
+    }
+
+    /// Phase F's audit surface: the scope this registry's pipes are owned
+    /// at. `None` only before the owning pane's placement setter has run
+    /// (should not observably happen past pane placement).
+    pub fn owner(&self) -> Option<&crate::host::scope::Scope> {
+        self.owner.as_ref()
     }
 
     /// Allocate a binary pipe backed by a unix domain socket.
@@ -434,6 +460,24 @@ mod tests {
             !reg.drain_failed("nonexistent"),
             "drain_failed should be false for unknown pipe"
         );
+    }
+
+    #[test]
+    fn owner_is_none_until_stamped_then_reflects_the_stamped_scope() {
+        // Stint 0724 Phase D 2/2: the registry itself carries no pane/context
+        // identity at construction (it's built deep inside runtime
+        // instantiation, before pane placement assigns one) — `set_owner` is
+        // the caller's one chance to attribute every pipe this registry ever
+        // holds to its owning pane.
+        let (mut reg, _dir) = test_registry();
+        assert!(reg.owner().is_none());
+
+        let owner = crate::host::scope::Scope::Pane {
+            pane_id: 7,
+            context_id: 3,
+        };
+        reg.set_owner(owner.clone());
+        assert_eq!(reg.owner(), Some(&owner));
     }
 
     #[test]

--- a/src/host/wasm_app.rs
+++ b/src/host/wasm_app.rs
@@ -699,6 +699,22 @@ impl WasmApp {
         self.store.data().pipes.binary_socket_path(pipe_id)
     }
 
+    /// Stamp the owning pane's host-established scope onto this instance's
+    /// typed-pipe registry (stint 0724 Phase D 2/2). Called once from
+    /// `WasmPane::set_context_id`, which runs at pane placement — after
+    /// `pane_id` is already known — so every pipe this instance ever opens is
+    /// attributable to its owning pane for Phase F's audit.
+    pub fn set_pipe_owner(&mut self, owner: crate::host::scope::Scope) {
+        self.store.data_mut().pipes.set_owner(owner);
+    }
+
+    /// Phase F's audit surface: the scope this instance's typed-pipe registry
+    /// is owned at. `None` before pane placement stamps it.
+    #[cfg(test)]
+    pub fn pipe_owner(&self) -> Option<&crate::host::scope::Scope> {
+        self.store.data().pipes.owner()
+    }
+
     /// True when the gpu capability was granted (the app declares a surface).
     pub fn has_gpu(&self) -> bool {
         self.store.data().gpu.is_some()

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -501,8 +501,17 @@ impl WasmPane {
 
     /// Stamp the host-established context this instance lives in — called
     /// alongside `set_pane_id` at pane placement (stint 0724 Phase D).
+    /// Always called AFTER `set_pane_id` (see the placement closure in
+    /// `pane_ops/create.rs`), so `self.pane_id` is already the real id here —
+    /// that ordering is what lets this same call also stamp the owning scope
+    /// onto the instance's typed-pipe registry (Phase D 2/2), since both
+    /// halves of `Scope::Pane` are only known once both setters have run.
     pub fn set_context_id(&mut self, context_id: u64) {
         self.context_id = context_id;
+        self.app.set_pipe_owner(crate::host::scope::Scope::Pane {
+            pane_id: self.pane_id,
+            context_id,
+        });
     }
 
     pub fn with_remembered_capabilities(
@@ -2534,6 +2543,39 @@ mod tests {
         )
         .expect("load counter");
         WasmPane::new(app, Box::new(FakeStats { cpu: 0.0 }))
+    }
+
+    /// Stint 0724 Phase D 2/2: `WasmPane::set_context_id` — always called
+    /// right after `set_pane_id` from the pane-placement closure in
+    /// `pane_ops/create.rs` — must stamp the owning `Scope::Pane` onto this
+    /// instance's typed-pipe registry (`WasmApp`'s `HostCtx.pipes`), matching
+    /// the SAME pane_id/context_id the placement closure assigned. This is
+    /// the one owner-scope test the sub-phase requires: it proves the field
+    /// is populated and correct at creation, without inventing a cross-pane
+    /// consumption check that doesn't exist today (typed pipes are one
+    /// registry per pane by construction — see `typed_pipes.rs`'s own
+    /// `directed_pipe_routes_to_target_pane_only` test).
+    #[test]
+    fn typed_pipe_owner_stamped_at_placement_matches_pane_context() {
+        let mut pane = counter_pane();
+        assert_eq!(
+            pane.app.pipe_owner(),
+            None,
+            "owner must be unstamped before pane placement runs its setters"
+        );
+
+        pane.set_pane_id(42);
+        pane.set_context_id(7);
+
+        assert_eq!(
+            pane.app.pipe_owner(),
+            Some(&crate::host::scope::Scope::Pane {
+                pane_id: 42,
+                context_id: 7,
+            }),
+            "set_context_id must stamp the owning Scope::Pane using the SAME \
+             pane_id set_pane_id just assigned"
+        );
     }
 
     #[test]

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -273,9 +273,7 @@ impl WasmAccessPolicy {
     /// created as a directory. A save-*file* grant is never a directory grant,
     /// so its path can never be turned into a writable directory tree.
     fn is_within_write_dir(&self, path: &Path) -> bool {
-        self.fs_write_dirs
-            .iter()
-            .any(|dir| path.starts_with(dir))
+        self.fs_write_dirs.iter().any(|dir| path.starts_with(dir))
     }
 
     fn allows_host(&self, url: &str) -> Result<(), String> {
@@ -314,8 +312,7 @@ fn canonicalize_scope(path: PathBuf, require_existing: bool) -> Result<PathBuf, 
 /// components, so every tail segment is a plain name.
 fn canonicalize_for_create(path: &Path) -> Result<PathBuf, String> {
     if path.exists() {
-        return std::fs::canonicalize(path)
-            .map_err(|e| format!("resolve {}: {e}", path.display()));
+        return std::fs::canonicalize(path).map_err(|e| format!("resolve {}: {e}", path.display()));
     }
     let mut node = path;
     let mut tail: Vec<std::ffi::OsString> = Vec::new();
@@ -384,6 +381,11 @@ pub struct WasmPane {
     ai_broker: Arc<dyn AiBroker>,
     app_timeline: Arc<Mutex<AppTimeline>>,
     pane_id: u64,
+    /// Host-established context this app instance lives in (stint 0724 Phase
+    /// D) — stamped onto every stream this pane declares/emits on. `0`
+    /// (matches no real context) until `set_context_id` is called from the
+    /// pane-placement closure that also calls `set_pane_id`.
+    context_id: u64,
     http_tx: Sender<InputEvent>,
     http_rx: Receiver<InputEvent>,
     /// File-picker backend (stint 0508); scripted in tests / under
@@ -424,6 +426,7 @@ impl WasmPane {
             ai_broker: Arc::new(default_live_broker()),
             app_timeline: crate::host::app_timeline::global(),
             pane_id: 0,
+            context_id: 0,
             http_tx,
             http_rx,
             picker: default_picker_service(),
@@ -494,6 +497,12 @@ impl WasmPane {
 
     pub fn set_pane_id(&mut self, pane_id: u64) {
         self.pane_id = pane_id;
+    }
+
+    /// Stamp the host-established context this instance lives in — called
+    /// alongside `set_pane_id` at pane placement (stint 0724 Phase D).
+    pub fn set_context_id(&mut self, context_id: u64) {
+        self.context_id = context_id;
     }
 
     pub fn with_remembered_capabilities(
@@ -1129,10 +1138,11 @@ impl WasmPane {
                         self.queue
                             .push_back(InputEvent::FilePickCancelled(request_id));
                     } else {
-                        self.queue.push_back(InputEvent::FilePicked(FilePickedEvent {
-                            request_id,
-                            paths: granted,
-                        }));
+                        self.queue
+                            .push_back(InputEvent::FilePicked(FilePickedEvent {
+                                request_id,
+                                paths: granted,
+                            }));
                     }
                 }
                 FilePickOutcome::Cancelled => {
@@ -1366,10 +1376,11 @@ impl WasmPane {
                 description: stream.description,
             });
         }
-        self.app_timeline
-            .lock()
-            .unwrap()
-            .declare_streams(self.app.app_id(), streams)
+        self.app_timeline.lock().unwrap().declare_streams(
+            self.context_id,
+            self.app.app_id(),
+            streams,
+        )
     }
 
     fn emit_event(&mut self, req: EmitEventEffect) -> Result<u64, String> {
@@ -1403,6 +1414,7 @@ impl WasmPane {
             suggested_trigger,
         };
         let outcome = self.app_timeline.lock().unwrap().record_event(
+            self.context_id,
             self.app.app_id(),
             self.pane_id,
             emitted,
@@ -1893,6 +1905,10 @@ impl LiveWasmPane {
 
     pub fn set_pane_id(&mut self, pane_id: u64) {
         self.inner.set_pane_id(pane_id);
+    }
+
+    pub fn set_context_id(&mut self, context_id: u64) {
+        self.inner.set_context_id(context_id);
     }
 
     pub fn take_host_effects(&mut self) -> Vec<WasmHostEffect> {
@@ -3882,8 +3898,8 @@ mod tests {
     // and a display-scale change frees + reallocates the surface with a
     // fresh surface-ready so the guest re-targets the new texture.
     #[test]
-    fn surface_allocates_physical_resolution_and_reallocates_on_ppp_change(
-    ) -> wasmtime::Result<()> {
+    fn surface_allocates_physical_resolution_and_reallocates_on_ppp_change() -> wasmtime::Result<()>
+    {
         let mut p = pong_pane();
         p.set_pixels_per_point(2.0);
         p.init(&StateSnapshot { entries: vec![] }, (480.0, 360.0), 0, &[])?;
@@ -3973,8 +3989,8 @@ mod tests {
         let mut p = pong_pane();
         p.init(&StateSnapshot { entries: vec![] }, (480.0, 360.0), 0, &[])?;
         let (w, h) = p.surface_size().expect("surface allocated after init");
-        let deadline = Instant::now()
-            + crate::testing::load_aware_timeout(std::time::Duration::from_secs(5));
+        let deadline =
+            Instant::now() + crate::testing::load_aware_timeout(std::time::Duration::from_secs(5));
 
         p.request_surface_readback()
             .expect("queue async surface readback");
@@ -4229,10 +4245,7 @@ mod tests {
     }
 
     /// The ToolResult host effect for `call_id`, as (output_json, error).
-    fn tool_result(
-        effects: &[WasmHostEffect],
-        call_id: &str,
-    ) -> (Option<String>, Option<String>) {
+    fn tool_result(effects: &[WasmHostEffect], call_id: &str) -> (Option<String>, Option<String>) {
         effects
             .iter()
             .find_map(|e| match e {
@@ -4257,8 +4270,7 @@ mod tests {
     // read-only flags: exactly the four read tools may auto-grant; every
     // mutation (and both POC tools) must prompt.
     #[test]
-    fn daw_app_declares_namespaced_tools_with_correct_read_only_flags(
-    ) -> wasmtime::Result<()> {
+    fn daw_app_declares_namespaced_tools_with_correct_read_only_flags() -> wasmtime::Result<()> {
         let mut p = daw_pane();
         p.init(&StateSnapshot { entries: vec![] }, (480.0, 360.0), 0, &[])?;
         let effects = p.take_host_effects();
@@ -4325,12 +4337,19 @@ mod tests {
         p.take_host_effects();
 
         // Create a MIDI track — the headline "create a MIDI track" ask.
-        p.push_input(tool_call("c1", "daw.add_track", r#"{"kind":"midi","name":"Bass"}"#));
+        p.push_input(tool_call(
+            "c1",
+            "daw.add_track",
+            r#"{"kind":"midi","name":"Bass"}"#,
+        ));
         p.tick(16)?;
         let out = tool_output(&p.take_host_effects(), "c1");
         assert_eq!(out["outcome"], "applied");
         let track_id = out["track_id"].as_u64().expect("new track id");
-        assert!(tree_text(&p.view()?).contains("Bass"), "tree shows the new track");
+        assert!(
+            tree_text(&p.view()?).contains("Bass"),
+            "tree shows the new track"
+        );
 
         // "Reduce the volume of the bass track" — by name, then read it back
         // by id (list → set → get chaining on ids).
@@ -4343,7 +4362,10 @@ mod tests {
         let out = tool_output(&p.take_host_effects(), "c2");
         assert_eq!(out["outcome"], "applied");
         assert_eq!(out["track_id"], track_id);
-        assert!(tree_text(&p.view()?).contains("vol 0.25"), "tree shows the new volume");
+        assert!(
+            tree_text(&p.view()?).contains("vol 0.25"),
+            "tree shows the new volume"
+        );
 
         p.push_input(tool_call(
             "c3",
@@ -4376,8 +4398,9 @@ mod tests {
     }
 
     fn jukebox_pane() -> WasmPane {
-        let app = WasmApp::load_ephemeral_run("jukebox", &jukebox_fixture(), StateStore::ephemeral())
-            .expect("load jukebox");
+        let app =
+            WasmApp::load_ephemeral_run("jukebox", &jukebox_fixture(), StateStore::ephemeral())
+                .expect("load jukebox");
         WasmPane::new(app, Box::new(FakeStats { cpu: 0.0 }))
     }
 
@@ -4419,8 +4442,7 @@ mod tests {
     // read-only flags: exactly the two read tools may auto-grant; every
     // transport mutation must prompt (a mislabel would bypass the prompt).
     #[test]
-    fn jukebox_declares_namespaced_tools_with_correct_read_only_flags(
-    ) -> wasmtime::Result<()> {
+    fn jukebox_declares_namespaced_tools_with_correct_read_only_flags() -> wasmtime::Result<()> {
         let mut p = jukebox_pane();
         p.init(&StateSnapshot { entries: vec![] }, (480.0, 360.0), 0, &[])?;
         let effects = p.take_host_effects();
@@ -4569,7 +4591,10 @@ mod tests {
             .find(|t| t["name"] == "my-song")
             .expect("picked track named by file stem");
         assert_eq!(picked["state"], "loaded");
-        assert!(picked["duration_ms"].as_u64().unwrap() > 0, "decoded a real duration");
+        assert!(
+            picked["duration_ms"].as_u64().unwrap() > 0,
+            "decoded a real duration"
+        );
         Ok(())
     }
 

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -660,12 +660,21 @@ impl WasmPane {
             capability_id,
             granted
         );
-        crate::host::event_log::emit(crate::host::event_log::HostEvent::PermissionDecision {
-            app_id: self.app.app_id().to_string(),
-            capability: capability_id,
-            granted,
-            timestamp: crate::host::event_log::now_timestamp(),
-        });
+        // `permission_workspace_root` is the app's own workspace root — set at
+        // launch via `Self::with_remembered_capabilities` — so it doubles as
+        // this event's context root with no new lookup. Empty (the
+        // pre-launch default) means "not yet known": route global-only.
+        let context_root = (!self.permission_workspace_root.as_os_str().is_empty())
+            .then_some(self.permission_workspace_root.as_path());
+        crate::host::event_log::emit_scoped(
+            crate::host::event_log::HostEvent::PermissionDecision {
+                app_id: self.app.app_id().to_string(),
+                capability: capability_id,
+                granted,
+                timestamp: crate::host::event_log::now_timestamp(),
+            },
+            context_root,
+        );
     }
 
     /// Fire any due timers and drain the input queue. `now_ms` is monotonic

--- a/src/overlays/command_palette.rs
+++ b/src/overlays/command_palette.rs
@@ -829,26 +829,24 @@ impl PlexiApp {
         // ── Workspace-aware app entries ────────────────────────────────────
         // Use the workspace root cached at palette-open time (not re-resolved
         // per frame) to avoid filesystem traversal in the egui draw loop.
+        //
+        // The palette is a viewer surface for the focused window, not a
+        // resource owner (stint 0724 Phase B) — it resolves its view by the
+        // focused pane's own resolved workspace root via
+        // `RegistryViews::view_for_root`, a synchronous per-root cache. No
+        // staleness comparison is needed the way the old single shared
+        // `AppRegistry` required: a root already seen is a cache hit, and a
+        // never-seen root loads on this first access.
         let focused_workspace_root = self.palette_workspace_root.clone();
-
-        // If the cached workspace differs from what the registry was last loaded
-        // for, rescan once now so local apps for this workspace appear.
-        if focused_workspace_root.as_ref() != self.registry.loaded_workspace.as_ref() {
-            let home = dirs::home_dir();
-            let rescan_cwd = focused_workspace_root
-                .as_deref()
-                .or(home.as_deref())
-                .unwrap_or(std::path::Path::new("/"));
-            log::info!(
-                "palette: registry workspace ({:?}) differs from palette workspace ({:?}), rescanning",
-                self.registry.loaded_workspace,
-                focused_workspace_root,
-            );
-            self.reload_app_registry_for_root(rescan_cwd);
-        }
+        let home = dirs::home_dir();
+        let rescan_cwd = focused_workspace_root
+            .as_deref()
+            .or(home.as_deref())
+            .unwrap_or(std::path::Path::new("/"));
 
         let app_entries: Vec<(String, String, String, bool, String)> = self
-            .registry
+            .registries
+            .view_for_root(rescan_cwd)
             .list()
             .into_iter()
             .filter_map(|app| {

--- a/src/overlays/misc.rs
+++ b/src/overlays/misc.rs
@@ -595,11 +595,17 @@ impl PlexiApp {
                     log::info!("rename_pane: app pane {pane_id} named {:?}", a.name);
                 }
             }
-            crate::host::event_log::emit(crate::host::event_log::HostEvent::PaneRenamed {
-                pane_id,
-                name: new_name,
-                timestamp: crate::host::event_log::now_timestamp(),
-            });
+            let context_root = self
+                .origin_for_pane(pane_id)
+                .map(|origin| origin.context_root);
+            crate::host::event_log::emit_scoped(
+                crate::host::event_log::HostEvent::PaneRenamed {
+                    pane_id,
+                    name: new_name,
+                    timestamp: crate::host::event_log::now_timestamp(),
+                },
+                context_root.as_deref(),
+            );
             self.renaming_pane = None;
         }
     }

--- a/src/overlays/notes_picker.rs
+++ b/src/overlays/notes_picker.rs
@@ -205,7 +205,7 @@ impl PlexiApp {
         {
             log::info!("notes_picker: already open in pane {existing_pane_id}, focusing");
             self.set_window_focused_pane(active, existing_tile_id);
-            emit_note_opened(&path);
+            emit_note_opened(&path, Some(&self.router.active().root));
             self.pop_focus_layer(&FocusKind::NotesPicker);
             return;
         }
@@ -228,7 +228,7 @@ impl PlexiApp {
                     if let crate::host::pane::AppRuntime::Builtin(app) = &mut app_pane.runtime {
                         log::info!("notes_picker: opening {:?} in focused pane", path);
                         app.restore_state(&state);
-                        emit_note_opened(&path);
+                        emit_note_opened(&path, Some(&self.router.active().root));
                     }
                 }
                 self.pop_focus_layer(&FocusKind::NotesPicker);
@@ -250,11 +250,12 @@ impl PlexiApp {
         let path = self.notes_picker_entries[entry_idx].path.clone();
         let path_str = path.display().to_string();
         log::info!("notes_picker: opening {:?} in new text-editor pane", path);
+        let context_root = self.router.active().root.clone();
         if self
             .launch_app_by_id_with_layout("text-editor", None, &[path_str], None)
             .is_ok()
         {
-            emit_note_opened(&path);
+            emit_note_opened(&path, Some(&context_root));
         }
         self.pop_focus_layer(&FocusKind::NotesPicker);
     }
@@ -401,11 +402,14 @@ impl PlexiApp {
     }
 }
 
-fn emit_note_opened(path: &std::path::Path) {
-    crate::host::event_log::emit(crate::host::event_log::HostEvent::NoteOpened {
-        path: path.display().to_string(),
-        timestamp: crate::host::event_log::now_timestamp(),
-    });
+fn emit_note_opened(path: &std::path::Path, context_root: Option<&std::path::Path>) {
+    crate::host::event_log::emit_scoped(
+        crate::host::event_log::HostEvent::NoteOpened {
+            path: path.display().to_string(),
+            timestamp: crate::host::event_log::now_timestamp(),
+        },
+        context_root,
+    );
 }
 
 #[cfg(test)]

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1288,7 +1288,11 @@ impl PlexiApp {
         cwd_override: Option<&Path>,
     ) -> Option<PaneId> {
         use crate::app::registry::OnLaunchPolicy;
-        let (scope, target) = match self.registry.on_launch_for(id) {
+        let on_launch = self
+            .registries
+            .view_for_context(caller_context_id, &self.router)
+            .on_launch_for(id);
+        let (scope, target) = match on_launch {
             OnLaunchPolicy::AlwaysNew => return None,
             OnLaunchPolicy::FocusExisting => ("focus_existing", self.locate_app_instance(id, None)),
             OnLaunchPolicy::FocusExistingInContext => (
@@ -1432,11 +1436,29 @@ impl PlexiApp {
             }
         }
 
+        // The context this launch resolves against. Read from
+        // `self.active_window` rather than an explicit parameter because
+        // every caller that targets a different context (e.g. dispatch.rs's
+        // pane-IPC spawn path) redirects `self.active_window` to the target
+        // window BEFORE calling in — never by mutating `router.active()` —
+        // so by the time this function runs, "active window" already means
+        // "target window" (see the `create_page_at`/explicit-context_id
+        // convention documented in the repo root AGENTS.md). Resolving the
+        // registry view against THIS context_id (rather than a single global
+        // registry that only ever followed the last real context switch) is
+        // the stint 0724 Phase B fix: launching into an inactive context now
+        // sees that context's own apps, not whatever was scanned last.
+        let context_id = self.windows[self.active_window].context_id;
+
         // When the caller does not specify a placement, fall back to the app's
         // manifest-declared `[launch] placement` before the host default
         // (`overlay`). One resolution point so every downstream hint inherits
         // it (#2283). Builtins are not in the registry → None → `overlay`.
-        let layout = layout.or_else(|| self.registry.placement_for(id));
+        let layout = layout.or_else(|| {
+            self.registries
+                .view_for_context(context_id, &self.router)
+                .placement_for(id)
+        });
 
         // #0336: honor the app's `[launch] on_launch` dedup policy before any
         // spawn path (unless the caller forces a fresh instance, e.g. the
@@ -1447,9 +1469,8 @@ impl PlexiApp {
         // app whose pane was closed (its process parked in `background_apps`)
         // finds no pane here, falls through, and re-attaches — the two compose.
         if !bypass_on_launch {
-            let caller_context_id = self.windows[self.active_window].context_id;
             if let Some(existing_id) =
-                self.resolve_on_launch_policy(id, caller_context_id, args, cwd_override.as_deref())
+                self.resolve_on_launch_policy(id, context_id, args, cwd_override.as_deref())
             {
                 return Ok(Some(existing_id));
             }
@@ -1471,7 +1492,8 @@ impl PlexiApp {
         if let Some(app) = builtin_factory(id, &cwd, args) {
             log::info!("launch_app_by_id_with_layout: '{id}' resolved as builtin");
             let group = self
-                .registry
+                .registries
+                .view_for_context(context_id, &self.router)
                 .group_for(id)
                 .or_else(|| builtin_default_group(app.type_id()));
             let hint = layout.unwrap_or_else(|| "overlay".to_string());
@@ -1482,13 +1504,29 @@ impl PlexiApp {
 
         // Ensure the registry is up-to-date: rescan if the app was added mid-session
         // via `plexi app init` and wasn't present at startup.
-        if self.registry.get(id).is_none() {
+        if self
+            .registries
+            .view_for_context(context_id, &self.router)
+            .get(id)
+            .is_none()
+        {
             log::info!("launch_app_by_id: '{id}' not in startup registry — rescanning from disk");
-            self.registry = crate::app::registry::AppRegistry::load(&cwd);
+            // Rescan the CONTEXT's own root, not `cwd` — `view_for_context`
+            // below looks the app up by that same key, so rescanning any
+            // other path (even one that happens to resolve to the same
+            // workspace via `cwd`'s internal walk-up) would leave the cache
+            // entry `view_for_context` actually reads unchanged.
+            let context_root = self
+                .context_root_for(context_id)
+                .unwrap_or_else(|| cwd.clone());
+            self.registries.rescan_root(&context_root);
         }
 
         // Pre-flight: check config-level capability requirements before spawning.
-        let missing = self.registry.check_config_capabilities(id, &self.config);
+        let missing = self
+            .registries
+            .view_for_context(context_id, &self.router)
+            .check_config_capabilities(id, &self.config);
         if !missing.is_empty() {
             log::warn!("pre-flight: '{id}' cannot launch — missing: {missing:?}");
             let fail_hint = layout.or_else(|| Some("overlay".to_string()));
@@ -1499,7 +1537,12 @@ impl PlexiApp {
         // Query group/hint after any registry reload so metadata reflects the
         // actual registry that found the app.
         let hint = layout.or_else(|| Some("overlay".to_string()));
-        if let Some(installed) = self.registry.get(id).cloned() {
+        if let Some(installed) = self
+            .registries
+            .view_for_context(context_id, &self.router)
+            .get(id)
+            .cloned()
+        {
             if installed.manifest.manifest_type == crate::app::registry::ManifestType::Wasm {
                 let workspace_root = installed
                     .workspace_root
@@ -1610,12 +1653,16 @@ impl PlexiApp {
     ) -> Result<Option<PaneId>, String> {
         let app_dir = PathBuf::from(app_path);
         log::info!("launch_app_by_path_with_layout: path={app_path}");
+        // Path-open launches resolve against the active window's context —
+        // there is no explicit target context for this entry point.
+        let context_id = self.windows[self.active_window].context_id;
 
         // A `.wasm` file is a sandboxed component app (the run primitive, G6),
         // not a manifest-backed process app. Route it to the wasmtime path.
         if app_dir.extension().and_then(|e| e.to_str()) == Some("wasm") {
             let app_id = self
-                .registry
+                .registries
+                .view_for_context(context_id, &self.router)
                 .manifest_id_for_wasm_path(&app_dir)
                 .map(str::to_owned)
                 .unwrap_or_else(|| {
@@ -1646,7 +1693,11 @@ impl PlexiApp {
                 .map(Some);
         }
 
-        let installed = match self.registry.load_app(&app_dir) {
+        let installed = match self
+            .registries
+            .view_for_context(context_id, &self.router)
+            .load_app(&app_dir)
+        {
             Ok(a) => a,
             Err(e) => {
                 log::warn!(
@@ -2304,7 +2355,8 @@ mod tests {
         assert!(registry.get("com.plexi.daw-engine-poc").is_some());
 
         let mut h = HostHarness::new();
-        h.app.registry = registry;
+        let ctx1_root = h.app.router.active().root.clone();
+        h.app.registries.set_view_for_test(&ctx1_root, registry);
         let error = h
             .app
             .launch_app_by_path_with_layout_no_review_modal(

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -670,6 +670,12 @@ impl PlexiApp {
 
         let manifest_id = app_id.to_string();
         let name = app_id.to_string();
+        // `place_app_pane` always targets `self.active_window`, so its
+        // context_id — captured now, before the closure runs — is exactly
+        // the context this instance is placed into (stint 0724 Phase D;
+        // mirrors the same `self.active_window` reasoning `SpawnPane`'s
+        // cross-context redirect already relies on).
+        let context_id = self.windows[self.active_window].context_id;
         let new_id = self
             .place_app_pane(
                 app_id,
@@ -678,6 +684,7 @@ impl PlexiApp {
                 None,
                 move |new_id, linked_pane_id, overlay_replaced| {
                     live.set_pane_id(new_id);
+                    live.set_context_id(context_id);
                     Pane::App(Box::new(crate::host::pane::AppPane {
                         pip_status: None,
                         id: new_id,
@@ -1478,9 +1485,7 @@ impl PlexiApp {
 
         let cwd_explicit = cwd_override.is_some();
         let cwd = cwd_override
-            .or_else(|| {
-                self.resolve_new_pane_cwd(None)
-            })
+            .or_else(|| self.resolve_new_pane_cwd(None))
             .unwrap_or_else(|| dirs::home_dir().unwrap_or_else(|| PathBuf::from("/")));
         log::info!(
             "launch_app_by_id_with_layout: id={id} cwd={cwd:?} cwd_source={} context_root={:?}",
@@ -1870,7 +1875,12 @@ impl PlexiApp {
 
         let path_str = path.display().to_string();
         log::info!("scratchpad: opening text-editor pane for {:?}", path);
-        match self.launch_app_by_id_with_layout("text-editor", None, std::slice::from_ref(&path_str), None) {
+        match self.launch_app_by_id_with_layout(
+            "text-editor",
+            None,
+            std::slice::from_ref(&path_str),
+            None,
+        ) {
             Ok(_) => {
                 let pane_id = target_pane_id.or_else(|| {
                     self.windows[active].focused_pane.and_then(|tile_id| {
@@ -1930,14 +1940,8 @@ impl PlexiApp {
             "QuickNote: committing to notes/inbox/ attachments={}",
             self.quick_note_attachments.len()
         );
-        Self::write_inbox_note(
-            text,
-            "quick-note",
-            &dir,
-            &ctx,
-            &self.quick_note_attachments,
-        )
-        .is_some()
+        Self::write_inbox_note(text, "quick-note", &dir, &ctx, &self.quick_note_attachments)
+            .is_some()
     }
 
     /// Validate and stage one local image for the open QuickNote modal. The
@@ -1948,11 +1952,12 @@ impl PlexiApp {
             .map_err(|e| format!("failed to read dropped image {}: {e}", source.display()))?;
         image::load_from_memory(&bytes)
             .map_err(|e| format!("not a decodable image ({}): {e}", source.display()))?;
-        if self.quick_note_attachments.iter().any(|path| path == &source) {
-            log::info!(
-                "QuickNote: drop already staged source={}",
-                source.display()
-            );
+        if self
+            .quick_note_attachments
+            .iter()
+            .any(|path| path == &source)
+        {
+            log::info!("QuickNote: drop already staged source={}", source.display());
             return Ok(());
         }
         log::info!(

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -566,12 +566,18 @@ impl PlexiApp {
         // State files (stint 0644): watch for external writes so CLI/agent
         // edits reach the running app without a relaunch.
         self.state_watch.watch(new_id, &state_paths);
-        crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
-            app_id: app_id.clone(),
-            type_id: "python-wasm".to_string(),
-            pane_id: new_id,
-            timestamp: crate::host::event_log::now_timestamp(),
-        });
+        let context_root = self
+            .origin_for_pane(new_id)
+            .map(|origin| origin.context_root);
+        crate::host::event_log::emit_scoped(
+            crate::host::event_log::HostEvent::AppSpawned {
+                app_id: app_id.clone(),
+                type_id: "python-wasm".to_string(),
+                pane_id: new_id,
+                timestamp: crate::host::event_log::now_timestamp(),
+            },
+            context_root.as_deref(),
+        );
         log::info!("app::{app_id}: launched CPython WASM pane {new_id}");
         Ok(new_id)
     }
@@ -704,12 +710,18 @@ impl PlexiApp {
                 },
             )
             .ok_or_else(|| format!("overlay launch target unavailable for {app_id}"))?;
-        crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
-            app_id: app_id.to_string(),
-            type_id: "wasm".to_string(),
-            pane_id: new_id,
-            timestamp: crate::host::event_log::now_timestamp(),
-        });
+        let context_root = self
+            .origin_for_pane(new_id)
+            .map(|origin| origin.context_root);
+        crate::host::event_log::emit_scoped(
+            crate::host::event_log::HostEvent::AppSpawned {
+                app_id: app_id.to_string(),
+                type_id: "wasm".to_string(),
+                pane_id: new_id,
+                timestamp: crate::host::event_log::now_timestamp(),
+            },
+            context_root.as_deref(),
+        );
         log::info!("wasm::{app_id}: spawned pane {new_id}");
         Ok(new_id)
     }
@@ -947,12 +959,18 @@ impl PlexiApp {
             },
         );
         if let Some(pane_id) = placed {
-            crate::host::event_log::emit(crate::host::event_log::HostEvent::AppSpawned {
-                app_id: app_type_id.clone(),
-                type_id: app_type_id.clone(),
-                pane_id,
-                timestamp: crate::host::event_log::now_timestamp(),
-            });
+            let context_root = self
+                .origin_for_pane(pane_id)
+                .map(|origin| origin.context_root);
+            crate::host::event_log::emit_scoped(
+                crate::host::event_log::HostEvent::AppSpawned {
+                    app_id: app_type_id.clone(),
+                    type_id: app_type_id.clone(),
+                    pane_id,
+                    timestamp: crate::host::event_log::now_timestamp(),
+                },
+                context_root.as_deref(),
+            );
         }
     }
 
@@ -1891,12 +1909,16 @@ impl PlexiApp {
                     })
                 });
                 if let Some(pane_id) = pane_id {
-                    crate::host::event_log::emit(
+                    let context_root = self
+                        .origin_for_pane(pane_id)
+                        .map(|origin| origin.context_root);
+                    crate::host::event_log::emit_scoped(
                         crate::host::event_log::HostEvent::ScratchpadOpened {
                             pane_id,
                             path: path_str,
                             timestamp: crate::host::event_log::now_timestamp(),
                         },
+                        context_root.as_deref(),
                     );
                 } else {
                     log::warn!("scratchpad: opened note but could not resolve pane id");

--- a/src/pane_ops/create.rs
+++ b/src/pane_ops/create.rs
@@ -1560,19 +1560,19 @@ impl PlexiApp {
         // Query group/hint after any registry reload so metadata reflects the
         // actual registry that found the app.
         let hint = layout.or_else(|| Some("overlay".to_string()));
-        if let Some(installed) = self
+        let installed = self
             .registries
             .view_for_context(context_id, &self.router)
             .get(id)
-            .cloned()
-        {
+            .cloned();
+        if let Some(installed) = &installed {
             if installed.manifest.manifest_type == crate::app::registry::ManifestType::Wasm {
                 let workspace_root = installed
                     .workspace_root
                     .clone()
                     .unwrap_or_else(|| cwd.clone());
                 self.open_installed_wasm_app_pane(
-                    installed,
+                    installed.clone(),
                     workspace_root,
                     hint.as_deref(),
                     args.to_vec(),
@@ -1625,8 +1625,24 @@ impl PlexiApp {
             ));
         }
 
-        log::warn!("launch_app_by_id: app '{id}' has no WASM runtime");
-        Err(format!("app '{id}' has no WASM runtime"))
+        match installed {
+            None => {
+                log::warn!(
+                    "launch_app_by_id: app '{id}' not found in context_id={context_id}'s registry"
+                );
+                Err(format!("app '{id}' not found in this context's registry"))
+            }
+            Some(installed) => {
+                log::warn!(
+                    "launch_app_by_id: app '{id}' has manifest type {:?} with no launch runtime for it",
+                    installed.manifest.manifest_type
+                );
+                Err(format!(
+                    "app '{id}' has manifest type {:?} with no launch runtime for it",
+                    installed.manifest.manifest_type
+                ))
+            }
+        }
     }
 
     /// Launch an app directly from a filesystem path without looking it up in the registry.

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -40,13 +40,18 @@ pub(super) fn restore_overlay_replacement(
         Pane::App(mut app) => {
             if let Some(replaced) = app.overlay_replaced.take() {
                 let type_id = app.runtime.type_id().to_string();
-                crate::host::event_log::emit(crate::host::event_log::HostEvent::AppClosed {
-                    app_id: type_id.clone(),
-                    type_id,
-                    pane_id,
-                    reason: Some("overlay_restored".to_string()),
-                    timestamp: crate::host::event_log::now_timestamp(),
-                });
+                // Free function — no `PlexiApp`/router access, so no origin is
+                // resolvable here without a new ambient lookup. Global-only.
+                crate::host::event_log::emit_scoped(
+                    crate::host::event_log::HostEvent::AppClosed {
+                        app_id: type_id.clone(),
+                        type_id,
+                        pane_id,
+                        reason: Some("overlay_restored".to_string()),
+                        timestamp: crate::host::event_log::now_timestamp(),
+                    },
+                    None,
+                );
                 panes.insert(pane_id, *replaced);
                 true
             } else {
@@ -332,11 +337,17 @@ impl PlexiApp {
 
         let direction = if vertical { "vertical" } else { "horizontal" }.to_string();
         log::info!("split_focused: emitting PaneSplit pane_id={new_id} direction={direction}");
-        crate::host::event_log::emit(crate::host::event_log::HostEvent::PaneSplit {
-            pane_id: new_id,
-            direction,
-            timestamp: crate::host::event_log::now_timestamp(),
-        });
+        // The new pane is split into the currently active context/window, so
+        // its root is exactly `router.active().root` — already resolved just
+        // below for logging; reused here too rather than looked up twice.
+        crate::host::event_log::emit_scoped(
+            crate::host::event_log::HostEvent::PaneSplit {
+                pane_id: new_id,
+                direction,
+                timestamp: crate::host::event_log::now_timestamp(),
+            },
+            Some(&self.router.active().root),
+        );
 
         let cwd = self.resolve_new_pane_cwd(cwd_override);
         log::info!(
@@ -762,6 +773,11 @@ impl PlexiApp {
     /// Close a tile in a specific context by its TileId. Handles sibling focus
     /// transfer, container cleanup, and pane removal.
     pub(crate) fn close_tile(&mut self, ctx_idx: usize, tile_id: TileId) {
+        // Resolved up front, before Phase 3 takes a mutable borrow of
+        // `self.windows[ctx_idx]` that would otherwise conflict with a
+        // `&self` router lookup at the `PaneClosed` emit site below.
+        let context_root = self.context_root_for(self.windows[ctx_idx].context_id);
+
         // Snapshot focus/zoom state before any mutation so Phase 2 guards are accurate.
         let is_focused = self.windows[ctx_idx].focused_pane == Some(tile_id);
         let is_zoomed = self.windows[ctx_idx].zoomed_pane == Some(tile_id);
@@ -855,10 +871,13 @@ impl PlexiApp {
 
             let removed = if let Some(Tile::Pane(pane_id)) = ctx.tree.tiles.remove(tile_id) {
                 log::info!("close_tile: emitting PaneClosed pane_id={pane_id}");
-                crate::host::event_log::emit(crate::host::event_log::HostEvent::PaneClosed {
-                    pane_id,
-                    timestamp: crate::host::event_log::now_timestamp(),
-                });
+                crate::host::event_log::emit_scoped(
+                    crate::host::event_log::HostEvent::PaneClosed {
+                        pane_id,
+                        timestamp: crate::host::event_log::now_timestamp(),
+                    },
+                    context_root.as_deref(),
+                );
                 closed_pane_id = Some(pane_id);
                 ctx.panes.remove(&pane_id)
             } else {

--- a/src/pane_ops/layout.rs
+++ b/src/pane_ops/layout.rs
@@ -730,6 +730,10 @@ impl PlexiApp {
         for ctx_idx in 0..self.windows.len() {
             if let Some(tile_id) = self.windows[ctx_idx].tree.tiles.find_pane(&pane_id) {
                 let ctx_id = self.windows[ctx_idx].context_id;
+                self.emit_scope_invalidation(crate::host::scope::ScopeInvalidation::PaneClosed {
+                    pane_id,
+                    context_id: ctx_id,
+                });
                 self.close_tile(ctx_idx, tile_id);
                 // Mirror the guard in execute_close_pane: if the window is now empty
                 // and there are other pages in the same context, delete the zombie window.

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -53,7 +53,6 @@ fn auto_init_workspace(root: &std::path::Path) {
 
     ensure_context_state_ignore(root);
 
-
     let channel_dir = crate::config::workspace_channel_dir();
     let channel_path = root.join(&channel_dir);
     if channel_path.exists() {
@@ -991,9 +990,7 @@ impl PlexiApp {
         let old_focus = self.windows[self.active_window].focused_pane;
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
         let cwd = cwd_override
-            .or_else(|| {
-                self.resolve_new_pane_cwd(None)
-            })
+            .or_else(|| self.resolve_new_pane_cwd(None))
             .filter(|p| p != &PathBuf::from("/"))
             .unwrap_or(home);
         log::info!(
@@ -1088,9 +1085,7 @@ impl PlexiApp {
     ) -> Option<crate::spatial::tiling::PaneId> {
         let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
         let cwd = cwd_override
-            .or_else(|| {
-                self.resolve_new_pane_cwd(None)
-            })
+            .or_else(|| self.resolve_new_pane_cwd(None))
             .filter(|p| p != &PathBuf::from("/"))
             .unwrap_or(home);
         let active = self.active_window;
@@ -1758,8 +1753,10 @@ impl PlexiApp {
         // Same workspace resolution `AppRegistry::load` performs internally
         // (cwd-walk to the channel dir) — agents live in that workspace's
         // `agents/` dir.
-        self.agent_host
-            .reload_workspace(crate::app::registry::resolve_workspace_root(&root));
+        self.agent_host.reload_workspace(
+            crate::app::registry::resolve_workspace_root(&root),
+            context_id,
+        );
         // Reload config so workspace-scoped config.toml applies immediately —
         // both on initial launch and on context switches.
         self.reload_config_for_active_context();

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -783,11 +783,15 @@ impl PlexiApp {
         let displayed = name.displayed().to_owned();
         self.router.get_mut(ctx_idx).name = name;
         log::info!("context_rename: context_id={context_id} name={displayed}");
-        crate::host::event_log::emit(crate::host::event_log::HostEvent::ContextRenamed {
-            context_id,
-            name: displayed.clone(),
-            timestamp: crate::host::event_log::now_timestamp(),
-        });
+        let context_root = self.router.get(ctx_idx).root.clone();
+        crate::host::event_log::emit_scoped(
+            crate::host::event_log::HostEvent::ContextRenamed {
+                context_id,
+                name: displayed.clone(),
+                timestamp: crate::host::event_log::now_timestamp(),
+            },
+            Some(&context_root),
+        );
         self.mark_workspace_dirty();
         displayed
     }
@@ -855,11 +859,15 @@ impl PlexiApp {
         log::info!(
             "new_context_empty: emitting ContextCreated context_id={ctx_id} name={ctx_name}"
         );
-        crate::host::event_log::emit(crate::host::event_log::HostEvent::ContextCreated {
-            context_id: ctx_id,
-            name: ctx_name,
-            timestamp: crate::host::event_log::now_timestamp(),
-        });
+        let context_root = self.router.active().root.clone();
+        crate::host::event_log::emit_scoped(
+            crate::host::event_log::HostEvent::ContextCreated {
+                context_id: ctx_id,
+                name: ctx_name,
+                timestamp: crate::host::event_log::now_timestamp(),
+            },
+            Some(&context_root),
+        );
     }
 
     /// Create a new context at a specific directory path. The terminal pane

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -1166,6 +1166,11 @@ impl PlexiApp {
             deleted.len() - 1,
             &deleted[1..]
         );
+        for &ctx_id in &deleted {
+            self.emit_scope_invalidation(crate::host::scope::ScopeInvalidation::ContextRemoved {
+                context_id: ctx_id,
+            });
+        }
 
         // 3. Remove all windows belonging to any deleted context. Release
         // their host MCP credentials before dropping the panes: a context
@@ -1675,6 +1680,7 @@ impl PlexiApp {
         let idx = self.resolve_context_idx(context_id, "set_context_root");
         auto_init_workspace(&root);
         let context_id = self.router.get(idx).context_id;
+        let old_root = self.router.get(idx).root.clone();
         for pane_id in self
             .windows
             .iter()
@@ -1700,6 +1706,12 @@ impl PlexiApp {
             if is_auto { "auto" } else { "custom" }
         );
         self.mark_workspace_dirty();
+        self.emit_scope_invalidation(crate::host::scope::ScopeInvalidation::ContextRootChanged {
+            context_id,
+            old_root,
+            new_root: root,
+        });
+
 
         // Transition effects (registry rescan, watcher restart, agent reload)
         // only apply when the *active* context's root changed.

--- a/src/pane_ops/workspace.rs
+++ b/src/pane_ops/workspace.rs
@@ -1166,11 +1166,6 @@ impl PlexiApp {
             deleted.len() - 1,
             &deleted[1..]
         );
-        for &ctx_id in &deleted {
-            self.emit_scope_invalidation(crate::host::scope::ScopeInvalidation::ContextRemoved {
-                context_id: ctx_id,
-            });
-        }
 
         // 3. Remove all windows belonging to any deleted context. Release
         // their host MCP credentials before dropping the panes: a context
@@ -1276,6 +1271,19 @@ impl PlexiApp {
                 }
                 None => break,
             }
+        }
+
+        // 5b. Emit ContextRemoved AFTER the router mutation above, not
+        // before: `RegistryViews::invalidate` (stint 0724 Phase B) decides
+        // whether a deleted context's root is now orphaned by sweeping the
+        // router for any surviving context that still anchors there. Emitting
+        // earlier — while the doomed contexts are still present — would make
+        // every root in a same-root cascade look "still referenced" by its
+        // own soon-to-be-removed sibling and never get dropped.
+        for &ctx_id in &deleted {
+            self.emit_scope_invalidation(crate::host::scope::ScopeInvalidation::ContextRemoved {
+                context_id: ctx_id,
+            });
         }
 
         // 6. Clean depth_stack: drop entries pointing to any deleted context.
@@ -1724,9 +1732,13 @@ impl PlexiApp {
     ///
     /// Must be called after every operation that changes the active context (either
     /// which context is active or what root it points at). Owns, in order:
-    ///   1. Rescan the AppRegistry for the new context root.
-    ///   2. Restart the app_registry_watcher on the new root's watch dirs.
-    ///   3. Palette scope follows implicitly — the palette reads `self.registry` directly.
+    ///   1. Resolve (loading on first access) the `RegistryViews` entry for
+    ///      the new context root — a synchronous per-root cache (stint 0724
+    ///      Phase B), so a context visited before is a cache hit and any
+    ///      other context's view is unaffected.
+    ///   2. Reconcile registry watchers so the new root is watched too.
+    ///   3. Palette scope follows implicitly — the palette resolves its own
+    ///      view via `RegistryViews::view_for_root` at open-time.
     ///   4. Reload workspace agents into the AgentHost — agents are
     ///      workspace-scoped, so a workspace that becomes active after boot
     ///      must still get its agents attached.
@@ -1734,82 +1746,23 @@ impl PlexiApp {
         let root = self.router.active().root.clone();
         let context_id = self.router.active().context_id;
         log::info!(
-            "transition_context: ctx_id={context_id} root={} — rescanning registry off-thread + reloading config + restarting watcher",
+            "transition_context: ctx_id={context_id} root={} — resolving registry view + reloading config",
             root.display()
         );
-        // The full registry rescan (apps/agents dir walk + every manifest.toml
-        // parse) is a filesystem-bound operation that can stall the UI thread
-        // on a workspace with many apps. Spawn it off-thread and apply the
-        // result later via `registry_load_rx`, guarded by `context_id` so a
-        // stale result (user already navigated elsewhere) is dropped instead
-        // of applied (stint 0548).
-        let (tx, rx) = crate::app::ui_mailbox::UiMailbox::channel(
-            std::sync::Arc::clone(&self.ui_wake),
-            "registry_load",
-        );
-        self.registry_load_rx = Some(rx);
-        let load_root = root.clone();
-        std::thread::spawn(move || {
-            let start = std::time::Instant::now();
-            let registry = crate::app::registry::AppRegistry::load(&load_root);
-            log::debug!(
-                "transition_context: registry load thread finished in {:?} (ctx_id={context_id})",
-                start.elapsed()
-            );
-            let _ = tx.send((context_id, registry));
-        });
+        // `RegistryViews` is a per-root cache keyed on the canonical root, not
+        // on "whichever context is active" (stint 0724 Phase B) — resolving
+        // it here is idempotent and does not race a later navigation the way
+        // the old background-thread load (guarded by `context_id`) could.
+        let _ = self.registries.view_for_context(context_id, &self.router);
+        self.reconcile_registry_watchers();
         // Same workspace resolution `AppRegistry::load` performs internally
-        // (cwd-walk to the channel dir) — cheap enough to run synchronously,
-        // and agents live in that workspace's `agents/` dir, so the agent host
-        // reload doesn't need to wait on the background registry scan.
+        // (cwd-walk to the channel dir) — agents live in that workspace's
+        // `agents/` dir.
         self.agent_host
             .reload_workspace(crate::app::registry::resolve_workspace_root(&root));
-        let watch_dirs = crate::app::registry::registry_watch_dirs(&root);
-        match crate::app::registry_watcher::start(watch_dirs, std::sync::Arc::clone(&self.ui_wake))
-        {
-            Some((watcher, rx)) => {
-                self._registry_watcher = Some(watcher);
-                self.registry_reload_rx = Some(rx);
-            }
-            None => {
-                self._registry_watcher = None;
-                self.registry_reload_rx = None;
-            }
-        }
         // Reload config so workspace-scoped config.toml applies immediately —
         // both on initial launch and on context switches.
         self.reload_config_for_active_context();
-    }
-
-    /// Drain the background `AppRegistry::load` result queued by
-    /// [`Self::apply_context_transition_effects`]. Only the newest queued
-    /// result is applied — anything older is superseded. Returns `true` when
-    /// a result was applied or discarded (i.e. a message was drained at
-    /// all), so tests can spin-wait on this instead of guessing a sleep.
-    pub(crate) fn drain_registry_load(&mut self) -> bool {
-        let Some(rx) = &self.registry_load_rx else {
-            return false;
-        };
-        let mut latest = None;
-        while let Ok((loaded_ctx_id, registry)) = rx.try_recv() {
-            latest = Some((loaded_ctx_id, registry));
-        }
-        let Some((loaded_ctx_id, registry)) = latest else {
-            return false;
-        };
-        if self.router.active().context_id == loaded_ctx_id {
-            let app_count = registry.list().len();
-            self.registry = registry;
-            log::info!(
-                "transition_context: registry reload applied for ctx_id={loaded_ctx_id} ({app_count} apps)"
-            );
-        } else {
-            log::debug!(
-                "transition_context: discarding stale registry load for ctx_id={loaded_ctx_id} — active context is now {}",
-                self.router.active().context_id
-            );
-        }
-        true
     }
 
     /// True when the active window holds a Portal tile targeting `child_ctx_id`,

--- a/src/plexi_ai/broker.rs
+++ b/src/plexi_ai/broker.rs
@@ -965,13 +965,19 @@ fn run_turn_and_respond(
                         cost_usd,
                     );
                     ledger::append(&row);
-                    event_log::emit(HostEvent::AgentTurn {
-                        pane_id: None,
-                        tokens_in,
-                        tokens_out,
-                        cost_cents,
-                        timestamp: finish_ts,
-                    });
+                    // Runs on a spawned background thread with no `PlexiApp`
+                    // access and `pane_id: None` already — no origin is
+                    // resolvable here without a new ambient lookup.
+                    event_log::emit_scoped(
+                        HostEvent::AgentTurn {
+                            pane_id: None,
+                            tokens_in,
+                            tokens_out,
+                            cost_cents,
+                            timestamp: finish_ts,
+                        },
+                        None,
+                    );
                 });
             match spawn_result {
                 Ok(_) => {
@@ -1007,13 +1013,18 @@ fn run_turn_and_respond(
         None,
     );
     ledger::append(&row);
-    event_log::emit(HostEvent::AgentTurn {
-        pane_id: None,
-        tokens_in: total_tokens_in,
-        tokens_out: total_tokens_out,
-        cost_cents: 0,
-        timestamp: event_log::now_timestamp(),
-    });
+    // Free function with no `PlexiApp`/router access and `pane_id: None`
+    // already — no origin is resolvable here without a new ambient lookup.
+    event_log::emit_scoped(
+        HostEvent::AgentTurn {
+            pane_id: None,
+            tokens_in: total_tokens_in,
+            tokens_out: total_tokens_out,
+            cost_cents: 0,
+            timestamp: event_log::now_timestamp(),
+        },
+        None,
+    );
     AiBrokerResponse::ok(final_text, total_tokens_in, total_tokens_out)
 }
 

--- a/src/plexi_ai/tool_dispatch.rs
+++ b/src/plexi_ai/tool_dispatch.rs
@@ -13,25 +13,34 @@
 //! Pending-call state lives in `PENDING_CALLS`. `WASM app runtime::routing` feeds
 //! `DrawCommand::ToolResult` back here to unblock the waiting broker thread.
 //!
-//! # Authorization model (#1182)
+//! # Authorization model (#1182, re-scoped stint 0724 Phase C)
 //!
-//! Every registry entry records the `workspace_root` of the pane that exposed
-//! the tools. When building a `ToolDispatcher`, the caller supplies its own
-//! `workspace_root`. Only tools from panes in the **same workspace** are
-//! included in the snapshot. Cross-workspace tools are invisible to the caller
-//! and cannot be invoked — the model never sees them, so confused-deputy calls
-//! fail before they can be attempted.
+//! Every registry entry records the host-established [`ScopeOrigin`](crate::host::scope::ScopeOrigin)
+//! of the pane that exposed the tools, captured once at registration time via
+//! `PlexiApp::origin_for_pane` — never the pane's (mutable) `workspace_root`.
+//! When building a `ToolDispatcher`, the caller supplies its own
+//! `viewer_context_id`, also host-resolved, never read from `router.active()`
+//! or any client-supplied path. Reachability is decided by
+//! `crate::host::scope::evaluate_reach` against `Scope::AppInstance`: only
+//! tools owned in the caller's own context are included in the snapshot — two
+//! contexts sharing the same canonical root are NOT mutually reachable,
+//! because reachability's runtime dimension is `context_id`, not root. Every
+//! `RegistryEntry` is context-owned with no cross-context grant issuance wired
+//! yet (`grant: None` everywhere here), so today the rule is simply "same
+//! context only." Cross-context tools are invisible to the caller and cannot
+//! be invoked — the model never sees them, so confused-deputy calls fail
+//! before they can be attempted.
 //!
 //! Every dispatched call is logged at `info` level with both the caller
 //! (app_id, pane_id) and provider (pane_id, tool name) so every invocation is
 //! attributable in the audit trail.
 
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use crate::app_protocol::{AiTool, PlexiEvent};
+use crate::host::scope::{evaluate_reach, Reach, ScopeOrigin};
 
 // ── AppEventSender ──────────────────────────────────────────────────────────
 
@@ -98,15 +107,34 @@ impl AppEventSender {
 // ── ToolRegistry ────────────────────────────────────────────────────────────
 
 /// One registered app — its tool definitions, how to reach it, and the
-/// workspace it belongs to (used for authorization checks).
+/// host-established scope origin it was registered from (used for
+/// authorization checks).
 struct RegistryEntry {
     tools: Vec<AiTool>,
     sender: AppEventSender,
     /// App type id (manifest `app.id`) — used to group tools by app for `/apps`.
     app_id: String,
-    /// Workspace root of the pane that exposed these tools. Used to restrict
-    /// cross-workspace tool invocation.
-    workspace_root: std::path::PathBuf,
+    /// Host-established origin of the pane that exposed these tools, captured
+    /// once at registration time via `PlexiApp::origin_for_pane` — stint 0724
+    /// Phase C. Reachability is decided from `origin.context_id`, never from
+    /// the pane's (mutable, `sync_app_cwd`-updated) `workspace_root`.
+    origin: ScopeOrigin,
+}
+
+impl RegistryEntry {
+    /// The owner scope for `evaluate_reach`: context-owned, per the stint's
+    /// rule that context-owned resources are visible only inside their
+    /// owning context. Two entries with colliding `pane_id`/`app_id` in
+    /// different contexts are still distinct scopes — `Scope::AppInstance`
+    /// carries `context_id` precisely so a numeric collision across contexts
+    /// never grants reach.
+    fn owner_scope(&self, pane_id: u64) -> crate::host::scope::Scope {
+        crate::host::scope::Scope::AppInstance {
+            pane_id,
+            app_id: self.app_id.clone(),
+            context_id: self.origin.context_id,
+        }
+    }
 }
 
 /// Global map from `pane_id` → `RegistryEntry`.
@@ -127,7 +155,7 @@ impl ToolRegistry {
         app_id: String,
         tools: Vec<AiTool>,
         sender: AppEventSender,
-        workspace_root: std::path::PathBuf,
+        origin: ScopeOrigin,
     ) {
         self.entries.insert(
             pane_id,
@@ -135,7 +163,7 @@ impl ToolRegistry {
                 tools,
                 sender,
                 app_id,
-                workspace_root,
+                origin,
             },
         );
     }
@@ -144,8 +172,12 @@ impl ToolRegistry {
         self.entries.remove(&pane_id);
     }
 
-    /// Snapshot of tools visible to a caller in `caller_workspace`, keyed by
-    /// tool name. Only panes in the same workspace are included.
+    /// Snapshot of tools visible to a caller in `viewer_context_id`, keyed by
+    /// tool name. Only panes owned in that same context are included —
+    /// decided by `evaluate_reach`, never by comparing paths. Two contexts
+    /// anchored at the same canonical root are NOT mutually visible; only
+    /// `context_id` equality (or, in a later stint, a `CrossContextGrant`)
+    /// grants reach.
     ///
     /// If two panes expose the same tool name, both are **excluded** from the
     /// snapshot and an `error!` is logged listing the conflicting pane IDs.
@@ -154,18 +186,17 @@ impl ToolRegistry {
     /// until the apps are fixed or namespaced.
     fn snapshot_for_caller(
         &self,
-        caller_workspace: &Path,
+        viewer_context_id: u64,
     ) -> HashMap<String, (u64, String, AiTool)> {
         let mut map: HashMap<String, (u64, String, AiTool)> = HashMap::new();
-        // Use component-by-component comparison to avoid false mismatches from
-        // trailing separators or platform path normalization differences.
         let mut pane_ids: Vec<u64> = self
             .entries
             .iter()
-            .filter(|(_, e)| {
-                e.workspace_root
-                    .components()
-                    .eq(caller_workspace.components())
+            .filter(|(&pane_id, entry)| {
+                matches!(
+                    evaluate_reach(&entry.owner_scope(pane_id), viewer_context_id, None),
+                    Reach::Allowed
+                )
             })
             .map(|(&id, _)| id)
             .collect();
@@ -210,16 +241,16 @@ impl ToolRegistry {
     /// Those collisions are withheld instead of selecting an arbitrary pane.
     fn namespaced_snapshot_for_caller(
         &self,
-        caller_workspace: &Path,
+        viewer_context_id: u64,
     ) -> HashMap<String, (u64, String, AiTool)> {
         let mut pane_ids: Vec<u64> = self
             .entries
             .iter()
-            .filter(|(_, entry)| {
-                entry
-                    .workspace_root
-                    .components()
-                    .eq(caller_workspace.components())
+            .filter(|(&pane_id, entry)| {
+                matches!(
+                    evaluate_reach(&entry.owner_scope(pane_id), viewer_context_id, None),
+                    Reach::Allowed
+                )
             })
             .map(|(&pane_id, _)| pane_id)
             .collect();
@@ -261,17 +292,17 @@ impl ToolRegistry {
         snapshot
     }
 
-    /// Map from app_id to tool list for all panes in `caller_workspace`.
-    /// Used by `/apps` to present tools grouped by the app that exposed them.
-    fn apps_for_workspace(&self, caller_workspace: &Path) -> Vec<(String, Vec<AiTool>)> {
+    /// Map from app_id to tool list for all panes reachable from
+    /// `viewer_context_id`. Used by `/apps` to present tools grouped by the
+    /// app that exposed them.
+    fn apps_for_context(&self, viewer_context_id: u64) -> Vec<(String, Vec<AiTool>)> {
         let mut by_app: std::collections::BTreeMap<String, Vec<AiTool>> =
             std::collections::BTreeMap::new();
-        for entry in self.entries.values() {
-            if !entry
-                .workspace_root
-                .components()
-                .eq(caller_workspace.components())
-            {
+        for (&pane_id, entry) in &self.entries {
+            if !matches!(
+                evaluate_reach(&entry.owner_scope(pane_id), viewer_context_id, None),
+                Reach::Allowed
+            ) {
                 continue;
             }
             by_app
@@ -295,19 +326,22 @@ fn global_registry() -> &'static Arc<Mutex<ToolRegistry>> {
 }
 
 /// Register (or replace) the tools for `pane_id`. Called by routing when
-/// `DrawCommand::ExposeTools` arrives.
+/// `DrawCommand::ExposeTools` arrives. `origin` is the host-established
+/// `ScopeOrigin` for `pane_id`, resolved by the caller via
+/// `PlexiApp::origin_for_pane` — never derived from the pane's own
+/// `workspace_root` field, which `sync_app_cwd` can mutate live.
 pub(crate) fn register(
     pane_id: u64,
     app_id: String,
     tools: Vec<AiTool>,
     sender: AppEventSender,
-    workspace_root: std::path::PathBuf,
+    origin: ScopeOrigin,
 ) {
     let count = tools.len();
     global_registry()
         .lock()
         .unwrap()
-        .register(pane_id, app_id, tools, sender, workspace_root);
+        .register(pane_id, app_id, tools, sender, origin);
     log::info!("tool_dispatch: registered {count} tool(s) for pane {pane_id}");
 }
 
@@ -375,12 +409,12 @@ pub trait ToolCallHooks: Send + Sync {
 /// routing layer before spawning the broker thread. Passed into the broker
 /// via `AiBrokerRequest::tool_dispatcher`.
 ///
-/// Only contains tools from panes in the same workspace as the caller — cross-
-/// workspace tools are excluded at construction time and never visible to the
-/// dispatching app or the model it drives.
+/// Only contains tools reachable from the caller's context — cross-context
+/// tools are excluded at construction time (via `evaluate_reach`) and never
+/// visible to the dispatching app or the model it drives.
 pub struct ToolDispatcher {
     /// Snapshot: exposed_name → (provider_pane_id, provider_tool_name, AiTool).
-    /// Already filtered to the caller's workspace.
+    /// Already filtered to the caller's context.
     tools: HashMap<String, (u64, String, AiTool)>,
     /// Caller-local host tools (Phase D3: the Assistant's
     /// `host.events.subscribe`/`unsubscribe`). Dispatched through
@@ -413,19 +447,19 @@ impl std::fmt::Debug for ToolDispatcher {
 }
 
 impl ToolDispatcher {
-    /// Build a dispatcher scoped to `caller_workspace`. Only tools from panes
-    /// in that workspace are included in the snapshot.
+    /// Build a dispatcher scoped to `viewer_context_id` — the caller's own
+    /// host-established context, never `router.active()` or a client-supplied
+    /// path. Only tools reachable from that context are included.
     pub fn from_registry(
         caller_pane_id: u64,
         caller_app_id: String,
-        caller_workspace: std::path::PathBuf,
+        viewer_context_id: u64,
     ) -> Self {
         let registry = global_registry().lock().unwrap();
-        let tools = registry.snapshot_for_caller(&caller_workspace);
+        let tools = registry.snapshot_for_caller(viewer_context_id);
         let visible: Vec<&str> = tools.keys().map(|s| s.as_str()).collect();
         log::info!(
-            "tool_dispatch: dispatcher for caller={caller_app_id} pane={caller_pane_id} workspace={} — {} tool(s) visible: {visible:?}",
-            caller_workspace.display(),
+            "tool_dispatch: dispatcher for caller={caller_app_id} pane={caller_pane_id} viewer_context={viewer_context_id} — {} tool(s) visible: {visible:?}",
             tools.len(),
         );
         Self {
@@ -438,19 +472,15 @@ impl ToolDispatcher {
         }
     }
 
-    /// Build the workspace-scoped snapshot exposed by the singleton host MCP
+    /// Build the context-scoped snapshot exposed by the singleton host MCP
     /// server. Definitions are namespaced `<app_id>__<tool>` while dispatch
     /// retains the provider's original tool name.
-    pub(crate) fn from_namespaced_registry(
-        caller_pane_id: u64,
-        caller_workspace: std::path::PathBuf,
-    ) -> Self {
+    pub(crate) fn from_namespaced_registry(caller_pane_id: u64, viewer_context_id: u64) -> Self {
         let caller_app_id = format!("mcp:pane:{caller_pane_id}");
         let registry = global_registry().lock().unwrap();
-        let tools = registry.namespaced_snapshot_for_caller(&caller_workspace);
+        let tools = registry.namespaced_snapshot_for_caller(viewer_context_id);
         log::info!(
-            "tool_dispatch: external MCP dispatcher caller={caller_app_id} workspace={} — {} tool(s) visible",
-            caller_workspace.display(),
+            "tool_dispatch: external MCP dispatcher caller={caller_app_id} viewer_context={viewer_context_id} — {} tool(s) visible",
             tools.len(),
         );
         Self {
@@ -493,13 +523,13 @@ impl ToolDispatcher {
             .collect()
     }
 
-    /// Apps and their tools visible to the caller's workspace — for `/apps`.
+    /// Apps and their tools visible to the caller's context — for `/apps`.
     /// Returns `(app_id, tools)` pairs sorted by app_id.
-    pub fn apps_for_workspace(workspace_root: std::path::PathBuf) -> Vec<(String, Vec<AiTool>)> {
+    pub fn apps_for_context(viewer_context_id: u64) -> Vec<(String, Vec<AiTool>)> {
         global_registry()
             .lock()
             .unwrap()
-            .apps_for_workspace(&workspace_root)
+            .apps_for_context(viewer_context_id)
     }
 
     /// Restrict the snapshot to `allowed` tool names (Phase C: the agent
@@ -691,31 +721,43 @@ mod tests {
         }
     }
 
+    /// A minimal `ScopeOrigin` for tests that only care about `context_id` —
+    /// every other field is a deterministic placeholder never inspected by
+    /// `evaluate_reach` or `Scope::AppInstance`.
+    fn origin(context_id: u64, pane_id: u64) -> ScopeOrigin {
+        ScopeOrigin {
+            context_id,
+            context_root: PathBuf::from(format!("/ctx-root-{context_id}")),
+            window_id: context_id,
+            pane_id,
+            app_id: None,
+        }
+    }
+
     // ── ToolRegistry unit tests (private access via same-module #[cfg(test)]) ──
 
     #[test]
-    fn same_workspace_tools_are_visible() {
+    fn same_context_tools_are_visible() {
         let mut reg = ToolRegistry::new();
-        let ws = PathBuf::from("/workspace/a");
         let (tx, _rx) = std::sync::mpsc::channel();
         reg.register(
             1,
             "search-app".to_string(),
             vec![make_tool("search")],
             AppEventSender::Channel(tx),
-            ws.clone(),
+            origin(10, 1),
         );
 
-        let snap = reg.snapshot_for_caller(&ws);
+        let snap = reg.snapshot_for_caller(10);
         assert!(
             snap.contains_key("search"),
-            "same-workspace tool must be visible"
+            "same-context tool must be visible"
         );
         assert_eq!(snap["search"].0, 1, "provider pane id must be 1");
     }
 
     #[test]
-    fn cross_workspace_tools_are_hidden() {
+    fn cross_context_tools_are_hidden() {
         let mut reg = ToolRegistry::new();
         let (tx, _rx) = std::sync::mpsc::channel();
         reg.register(
@@ -723,88 +765,129 @@ mod tests {
             "attacker-app".to_string(),
             vec![make_tool("dangerous_tool")],
             AppEventSender::Channel(tx.clone()),
-            PathBuf::from("/workspace/attacker"),
+            origin(100, 10),
         );
         reg.register(
             20,
             "victim-app".to_string(),
             vec![make_tool("safe_tool")],
             AppEventSender::Channel(tx),
-            PathBuf::from("/workspace/victim"),
+            origin(200, 20),
         );
 
-        // Snapshot from attacker workspace must NOT see victim's tools.
-        let snap_attacker = reg.snapshot_for_caller(Path::new("/workspace/attacker"));
+        // Snapshot from the attacker's context must NOT see the victim's tools.
+        let snap_attacker = reg.snapshot_for_caller(100);
         assert!(snap_attacker.contains_key("dangerous_tool"));
         assert!(
             !snap_attacker.contains_key("safe_tool"),
-            "cross-workspace tool must be hidden from attacker"
+            "cross-context tool must be hidden from attacker"
         );
 
-        // Snapshot from victim workspace must NOT see attacker's tools.
-        let snap_victim = reg.snapshot_for_caller(Path::new("/workspace/victim"));
+        // Snapshot from the victim's context must NOT see the attacker's tools.
+        let snap_victim = reg.snapshot_for_caller(200);
         assert!(snap_victim.contains_key("safe_tool"));
         assert!(
             !snap_victim.contains_key("dangerous_tool"),
-            "cross-workspace tool must be hidden from victim"
+            "cross-context tool must be hidden from victim"
         );
     }
 
     #[test]
     fn unregistered_pane_tools_disappear() {
         let mut reg = ToolRegistry::new();
-        let ws = PathBuf::from("/workspace/x");
         let (tx, _rx) = std::sync::mpsc::channel();
         reg.register(
             5,
             "app-x".to_string(),
             vec![make_tool("tool_a")],
             AppEventSender::Channel(tx),
-            ws.clone(),
+            origin(1, 5),
         );
 
-        assert!(reg.snapshot_for_caller(&ws).contains_key("tool_a"));
+        assert!(reg.snapshot_for_caller(1).contains_key("tool_a"));
         reg.unregister(5);
         assert!(
-            reg.snapshot_for_caller(&ws).is_empty(),
+            reg.snapshot_for_caller(1).is_empty(),
             "tools must disappear after pane unregisters"
         );
     }
 
     #[test]
-    fn empty_workspace_snapshot_for_unknown_workspace() {
+    fn empty_snapshot_for_unknown_context() {
         let reg = ToolRegistry::new();
-        let snap = reg.snapshot_for_caller(Path::new("/workspace/unknown"));
+        let snap = reg.snapshot_for_caller(999_999);
         assert!(snap.is_empty());
+    }
+
+    /// Deliberate tightening vs. pre-Phase-C behavior (stint 0724 Phase C):
+    /// two sibling contexts anchored at the SAME canonical root are no longer
+    /// mutually visible. Before this phase, reachability was decided by
+    /// path-equality on `AppPane::workspace_root`, so two panes whose contexts
+    /// happened to share a root were mutually reachable regardless of
+    /// `context_id`. Reachability's runtime dimension is now `context_id`
+    /// only — a tool registered from a pane in context A must stay invisible
+    /// to a caller in a sibling context B that merely shares A's root, unless
+    /// a `CrossContextGrant` (not wired until a later stint) says otherwise.
+    #[test]
+    fn connector_from_same_root_sibling_context_is_unreachable_without_grant() {
+        let mut reg = ToolRegistry::new();
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let shared_root = PathBuf::from("/workspace/shared-root");
+        let context_a = 501u64;
+        let context_b = 502u64; // sibling context, SAME canonical root as A
+        let origin_a = ScopeOrigin {
+            context_id: context_a,
+            context_root: shared_root.clone(),
+            window_id: 1,
+            pane_id: 30,
+            app_id: Some("root-app".to_string()),
+        };
+        reg.register(
+            30,
+            "root-app".to_string(),
+            vec![make_tool("shared_root_tool")],
+            AppEventSender::Channel(tx),
+            origin_a,
+        );
+
+        // Sanity: the owning context still sees its own tool.
+        let snap_a = reg.snapshot_for_caller(context_a);
+        assert!(snap_a.contains_key("shared_root_tool"));
+
+        // The sibling context sharing the same root must NOT see it.
+        let snap_b = reg.snapshot_for_caller(context_b);
+        assert!(
+            !snap_b.contains_key("shared_root_tool"),
+            "same-root sibling context must not see another context's tool without a grant"
+        );
     }
 
     // ── ToolDispatcher: unauthorized call returns tool_not_found ──────────────
     //
-    // The authorization boundary is: cross-workspace tools are excluded from the
+    // The authorization boundary is: cross-context tools are excluded from the
     // snapshot, so `dispatch_call` returns `tool_not_found` for them — the model
     // never learns they exist.
 
     #[test]
-    fn dispatcher_excludes_cross_workspace_tools() {
-        // Register a tool in workspace B.
+    fn dispatcher_excludes_cross_context_tools() {
+        // Register a tool in context B.
         let (tx_b, _rx_b) = std::sync::mpsc::channel();
         register(
             999,
             "app-b".to_string(),
             vec![make_tool("secret_tool")],
             AppEventSender::Channel(tx_b),
-            PathBuf::from("/workspace/b"),
+            origin(200, 999),
         );
 
-        // Build a dispatcher for a caller in workspace A.
-        let dispatcher =
-            ToolDispatcher::from_registry(1, "app_a".to_string(), PathBuf::from("/workspace/a"));
+        // Build a dispatcher for a caller in context A.
+        let dispatcher = ToolDispatcher::from_registry(1, "app_a".to_string(), 100);
 
         // The tool must not appear in the visible set.
         let visible: Vec<String> = dispatcher.all_tools().into_iter().map(|t| t.name).collect();
         assert!(
             !visible.contains(&"secret_tool".to_string()),
-            "cross-workspace tool must not appear in dispatcher: {visible:?}"
+            "cross-context tool must not appear in dispatcher: {visible:?}"
         );
 
         // A direct dispatch attempt must return tool_not_found.
@@ -825,12 +908,11 @@ mod tests {
         unregister(999);
     }
 
-    /// Two panes in the same workspace exposing the same tool name must both be
+    /// Two panes in the same context exposing the same tool name must both be
     /// excluded from the snapshot — no silent winner selection.
     #[test]
     fn conflicting_tool_names_excluded_from_snapshot() {
         let mut reg = ToolRegistry::new();
-        let ws = PathBuf::from("/workspace/conflict-test");
         let (tx1, _rx1) = std::sync::mpsc::channel();
         let (tx2, _rx2) = std::sync::mpsc::channel();
         reg.register(
@@ -838,17 +920,17 @@ mod tests {
             "app-conflict-1".to_string(),
             vec![make_tool("shared_tool"), make_tool("unique_a")],
             AppEventSender::Channel(tx1),
-            ws.clone(),
+            origin(50, 10),
         );
         reg.register(
             20,
             "app-conflict-2".to_string(),
             vec![make_tool("shared_tool"), make_tool("unique_b")],
             AppEventSender::Channel(tx2),
-            ws.clone(),
+            origin(50, 20),
         );
 
-        let snap = reg.snapshot_for_caller(&ws);
+        let snap = reg.snapshot_for_caller(50);
         assert!(
             !snap.contains_key("shared_tool"),
             "conflicting tool must be excluded from snapshot, not silently picked"
@@ -866,7 +948,6 @@ mod tests {
     #[test]
     fn namespaced_snapshot_withholds_duplicate_app_instances() {
         let mut reg = ToolRegistry::new();
-        let workspace = PathBuf::from("/workspace/mcp-duplicates");
         let (tx1, _rx1) = std::sync::mpsc::channel();
         let (tx2, _rx2) = std::sync::mpsc::channel();
         reg.register(
@@ -874,17 +955,17 @@ mod tests {
             "same-app".to_string(),
             vec![make_tool("echo")],
             AppEventSender::Channel(tx1),
-            workspace.clone(),
+            origin(60, 30),
         );
         reg.register(
             20,
             "same-app".to_string(),
             vec![make_tool("echo"), make_tool("unique")],
             AppEventSender::Channel(tx2),
-            workspace.clone(),
+            origin(60, 20),
         );
 
-        let snapshot = reg.namespaced_snapshot_for_caller(&workspace);
+        let snapshot = reg.namespaced_snapshot_for_caller(60);
         assert!(
             !snapshot.contains_key("same-app__echo"),
             "two live instances must not select an arbitrary provider"
@@ -915,13 +996,9 @@ mod tests {
             "hooks-app".to_string(),
             vec![make_tool("gated_tool")],
             AppEventSender::Channel(tx),
-            PathBuf::from("/workspace/hooks-test"),
+            origin(70, 998),
         );
-        let mut dispatcher = ToolDispatcher::from_registry(
-            2,
-            "agent:assistant".to_string(),
-            PathBuf::from("/workspace/hooks-test"),
-        );
+        let mut dispatcher = ToolDispatcher::from_registry(2, "agent:assistant".to_string(), 70);
         dispatcher.set_hooks(Arc::new(DenyHook));
 
         let blocked = dispatcher.dispatch_call("c1".to_string(), "gated_tool", "{}".to_string());
@@ -951,16 +1028,15 @@ mod tests {
 
     #[test]
     fn wasm_provider_receives_tool_call_and_returns_result() {
-        let workspace = PathBuf::from("/workspace/wasm-tools");
         let (sender, queue) = crate::host::wasm_pane::WasmInputSender::new_for_test();
         register(
             997,
             "wasm-tools".to_string(),
             vec![make_tool("wasm.echo")],
             AppEventSender::Wasm(sender),
-            workspace.clone(),
+            origin(80, 997),
         );
-        let dispatcher = ToolDispatcher::from_registry(2, "agent:assistant".to_string(), workspace);
+        let dispatcher = ToolDispatcher::from_registry(2, "agent:assistant".to_string(), 80);
         let worker = std::thread::spawn(move || {
             dispatcher.dispatch_call(
                 "wasm-call-1".to_string(),
@@ -1009,17 +1085,15 @@ mod tests {
             fn after_call(&self, _name: &str, _error: Option<&str>, _output: Option<&str>) {}
         }
 
-        let workspace = PathBuf::from("/workspace/wasm-denied");
         let (sender, queue) = crate::host::wasm_pane::WasmInputSender::new_for_test();
         register(
             996,
             "wasm-denied".to_string(),
             vec![make_tool("wasm.write")],
             AppEventSender::Wasm(sender),
-            workspace.clone(),
+            origin(90, 996),
         );
-        let mut dispatcher =
-            ToolDispatcher::from_registry(2, "agent:assistant".to_string(), workspace);
+        let mut dispatcher = ToolDispatcher::from_registry(2, "agent:assistant".to_string(), 90);
         dispatcher.set_hooks(Arc::new(DenyHook));
 
         let result = dispatcher.dispatch_call(

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -10,6 +10,101 @@ fn add_app_pane_to_window(h: &mut HostHarness, window_id: u64, manifest_id: &str
     h.app.add_app_pane_in_window(win_idx, manifest_id);
 }
 
+/// Push a second context + window (no PTY dependency) and return its window
+/// index. Mirrors the pattern in `app::tests::context_tests`, duplicated here
+/// since that helper is module-private.
+fn push_secondary_context(h: &mut HostHarness, context_id: u64, root: &std::path::Path) -> usize {
+    let win_id = h.app.next_window_id;
+    h.app.next_window_id += 1;
+    h.app.windows.push(crate::host::context::Window {
+        name: String::new(),
+        path: root.to_path_buf(),
+        tree: egui_tiles::Tree::empty("tool_dispatch_context_b"),
+        panes: std::collections::HashMap::new(),
+        focused_pane: None,
+        zoomed_pane: None,
+        grid_x: 1,
+        grid_y: 0,
+        window_id: win_id,
+        context_id,
+    });
+    h.app.router.push(crate::host::context::Context {
+        name: "context-b".to_string(),
+        root: root.to_path_buf(),
+        description: None,
+        context_id,
+        parent_id: None,
+        depth: 0,
+        parked: false,
+    });
+    h.app.windows.len() - 1
+}
+
+/// Stint 0724 Phase C regression: an app pane in context A exposes a
+/// connector tool; an Assistant pane in a sibling context B must NOT see it,
+/// and an Assistant pane in context A must. Proves the migration off
+/// path-equality onto `evaluate_reach`/`context_id` end-to-end through the
+/// real `AssistantApp::gated_dispatcher` path (not a synthetic registry
+/// check), covering `App::dispatch`'s `ExposeTools` registration and
+/// `ToolDispatcher::from_registry`'s context-scoped snapshot together.
+#[test]
+fn connector_tool_visible_only_to_assistant_in_the_owning_context() {
+    let mut h = HostHarness::new();
+    let context_a = h.app.windows[0].context_id;
+    let context_b = context_a + 1_000;
+    let root_b = tempfile::tempdir().expect("root b");
+    let win_b_idx = push_secondary_context(&mut h, context_b, root_b.path());
+
+    // An app pane in context A exposes a connector tool. Registering directly
+    // through `tool_dispatch::register` (rather than the `ExposeTools` wire
+    // path) isolates this test to the reachability question; `App::dispatch`
+    // resolving the same `origin_for_pane` at its two `ExposeTools` call
+    // sites is covered by reading those call sites, not re-simulated here.
+    let (_, provider_pane_id) = h.app.add_app_pane_in_window(0, "connector-app");
+    let origin = h
+        .app
+        .origin_for_pane(provider_pane_id)
+        .expect("origin_for_pane must resolve for a live app pane");
+    assert_eq!(origin.context_id, context_a);
+    let (tx, _rx) = std::sync::mpsc::channel();
+    crate::plexi_ai::tool_dispatch::register(
+        provider_pane_id,
+        "connector-app".to_string(),
+        vec![crate::app_protocol::AiTool {
+            name: "connector_tool".to_string(),
+            description: "test connector tool".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+            output_schema: serde_json::json!({"type": "object"}),
+            timeout_ms: Some(1_000),
+            read_only: true,
+        }],
+        crate::plexi_ai::tool_dispatch::AppEventSender::Channel(tx),
+        origin,
+    );
+
+    // Assistant pane in context A (windows[0]) sees the tool.
+    let assistant_a = h.add_assistant_pane();
+    let visible_a = h
+        .assistant_mut(assistant_a)
+        .visible_connector_tool_names_for_test();
+    assert!(
+        visible_a.contains(&"connector_tool".to_string()),
+        "assistant in the owning context must see the connector tool: {visible_a:?}"
+    );
+
+    // Assistant pane in sibling context B does NOT see it.
+    let assistant_b = h.add_assistant_pane_in_window(win_b_idx);
+    let visible_b = h
+        .assistant_mut(assistant_b)
+        .visible_connector_tool_names_for_test();
+    assert!(
+        !visible_b.contains(&"connector_tool".to_string()),
+        "assistant in a sibling context must NOT see the connector tool: {visible_b:?}"
+    );
+
+    crate::plexi_ai::tool_dispatch::unregister(provider_pane_id);
+}
+
 // -- DrawCommand routing --------------------------------------------------
 
 /// Regression guard for PR #536: `AiQuery` was silently dropped into
@@ -184,8 +279,7 @@ fn pane_heartbeat_fires_when_idle() {
             next_fire: std::time::Instant::now(),
         },
     );
-    h.app
-        .windows[0]
+    h.app.windows[0]
         .panes
         .get_mut(&pane)
         .expect("pane")
@@ -374,11 +468,9 @@ fn notes_drop_uses_production_dispatch_and_exposes_semantic_rejection() {
     let response = read_json_response(&response);
     assert!(response.get("ok").is_none());
     // 0478: drops are validated by decodable content — fake PNG bytes reject.
-    assert!(
-        response["error"]
-            .as_str()
-            .is_some_and(|error| error.contains("not a decodable image"))
-    );
+    assert!(response["error"]
+        .as_str()
+        .is_some_and(|error| error.contains("not a decodable image")));
     let app = h.app.windows[0]
         .panes
         .get(&pane_id)
@@ -454,12 +546,10 @@ fn drop_rejects_apps_without_a_production_handler_observably() {
         response_file: response.clone(),
     });
     h.run_frames(1);
-    assert!(
-        read_json_response(&response)["error"]
-            .as_str()
-            .unwrap()
-            .contains("does not accept")
-    );
+    assert!(read_json_response(&response)["error"]
+        .as_str()
+        .unwrap()
+        .contains("does not accept"));
 }
 
 #[derive(Default)]
@@ -1261,12 +1351,10 @@ fn pane_slot_read_errors_use_sidecar_file() {
     let error_file = format!("{read_file}.err");
     let response = read_json_response(&error_file);
     assert_eq!(response["ok"].as_bool(), Some(false));
-    assert!(
-        response["error"]
-            .as_str()
-            .expect("error")
-            .contains("slot 'missing' not found")
-    );
+    assert!(response["error"]
+        .as_str()
+        .expect("error")
+        .contains("slot 'missing' not found"));
 }
 
 #[test]
@@ -1697,8 +1785,8 @@ fn palette_close_surrenders_focus_before_pane_close() {
 
 #[test]
 fn notification_modal_handle_key_returns_consumed() {
-    use crate::app::FocusKind;
     use crate::app::app_trait::KeyDisposition;
+    use crate::app::FocusKind;
     let mut h = HostHarness::new();
     h.app.push_focus_layer(FocusKind::NotificationModal);
     let ctx = h.app.ctx.clone();
@@ -2309,7 +2397,8 @@ fn click_pane_delivers_canvas_space_coordinate_through_fit_contain_transform() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "canvas-click-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2388,7 +2477,8 @@ fn click_pane_delivers_canvas_space_coordinate_through_fit_contain_transform() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "app did not report the click's canvas-space coordinate in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2443,7 +2533,8 @@ fn drag_pane_delivers_press_moves_release_through_canvas_transform() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "canvas-click-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2516,7 +2607,8 @@ fn drag_pane_delivers_press_moves_release_through_canvas_transform() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "app did not report a completed drag in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2572,7 +2664,8 @@ fn drag_pane_node_endpoints_fail_loudly_without_bounds() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "canvas-click-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2644,7 +2737,8 @@ fn emitted_app_event_is_recorded_and_awaitable() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "event-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2719,7 +2813,8 @@ fn click_pane_node_activates_button_and_mutates_guest_view() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "node-click-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -2960,7 +3055,8 @@ fn key_pane_delivers_key_event_and_mutates_guest_view() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "key-event-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -3011,7 +3107,8 @@ fn key_pane_delivers_key_event_and_mutates_guest_view() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "app did not reflect the key event's mutation in time (last seen: {observed_count:?})"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -3056,7 +3153,8 @@ fn bare_escape_closes_focused_python_wasm_pane() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "key-event-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -3140,7 +3238,8 @@ fn queued_node_click_survives_a_hot_reload_relaunch_race() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "node-click-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -3205,7 +3304,8 @@ fn queued_node_click_survives_a_hot_reload_relaunch_race() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "click queued before a hot-reload relaunch must still land once the \
              relaunched pane is ready again (last seen count: {observed_count:?})"
         );
@@ -3623,7 +3723,8 @@ fn wait_for_text_label(h: &mut HostHarness, pane_id: PaneId, prefix: &str, expec
             return;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "timed out waiting for label '{expected}' (last seen: {seen:?})"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -3668,7 +3769,8 @@ fn focused_text_input_receives_typing_and_enter_submits() {
             break;
         }
         assert!(
-            start.elapsed() < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
             "text-input-probe did not render its first frame in time"
         );
         std::thread::sleep(std::time::Duration::from_millis(25));
@@ -4256,11 +4358,9 @@ fn editor_gate_host_surfaces() {
         response_file: response.clone(),
     });
     h.run_frames(2);
-    assert!(
-        read_json_response(&response)["error"]
-            .as_str()
-            .is_some_and(|error| error.contains("not a decodable image"))
-    );
+    assert!(read_json_response(&response)["error"]
+        .as_str()
+        .is_some_and(|error| error.contains("not a decodable image")));
     let state = gate_note_semantics(&h, pane_id);
     assert_eq!(
         state["last_drop_result"]["result"].as_str(),
@@ -4784,9 +4884,8 @@ fn app_commands_execute_while_window_hidden() {
         "no notification should be queued before the app emits one"
     );
 
-    h.assistant_mut(pane)
-        .pending_commands
-        .push(crate::app::app_trait::AppCommand::ShowNotification {
+    h.assistant_mut(pane).pending_commands.push(
+        crate::app::app_trait::AppCommand::ShowNotification {
             notify_id: "hidden-pass-notify".to_string(),
             sender_pane_id: pane,
             source_context_id: 0,
@@ -4801,7 +4900,8 @@ fn app_commands_execute_while_window_hidden() {
             image_pipe_id: None,
             timeout_secs: None,
             on_dismiss: None,
-        });
+        },
+    );
 
     h.run_hidden_frames(1);
 

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -2813,6 +2813,317 @@ fn resolve_event_bus_caller_falls_back_to_claimed_pane_id_without_ancestry() {
     assert_eq!(workspace_root, None);
 }
 
+// ── Directed pipes: context-scoped keys + reachability (stint 0724 Phase D 2/2) ──
+
+/// Minimal `App` stub for directed-pipe tests: `queue_pipe_command` pushes an
+/// `AppCommand` a real app would have emitted onto `outgoing`, drained by the
+/// next `service_app_commands` pass exactly like a live app's own queue;
+/// `queue_outbound_event` records every `PlexiEvent` the host delivers back
+/// into `received` so a test can assert on what actually arrived. Mirrors
+/// `focus_tests::ThemeEventRecorder`. Commands are constructed directly here
+/// rather than through an SDK bridge because no SDK exposes
+/// `pipe_open_directed`/`pipe_send` to real apps yet (`wasm_python.rs`'s JSON
+/// bridge table is the only current producer, and nothing in `sdk/python`
+/// calls it) — the host-side contract under test is the same regardless of
+/// which SDK eventually reaches it.
+struct PipeTestApp {
+    outgoing: Vec<crate::app::app_trait::AppCommand>,
+    received: std::sync::Arc<std::sync::Mutex<Vec<crate::app_protocol::PlexiEvent>>>,
+}
+
+impl crate::app::app_trait::App for PipeTestApp {
+    fn type_id(&self) -> &'static str {
+        "pipe-test-app"
+    }
+
+    fn display_name(&self) -> String {
+        "Pipe test app".to_string()
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn ui(
+        &mut self,
+        _ui: &mut egui::Ui,
+        _ctx: &crate::app::app_trait::AppRenderContext<'_>,
+        _pending_click: Option<crate::host::pane::PendingPaneClick>,
+    ) {
+    }
+
+    fn take_pending_commands(&mut self) -> Vec<crate::app::app_trait::AppCommand> {
+        std::mem::take(&mut self.outgoing)
+    }
+
+    fn queue_outbound_event(&mut self, event: crate::app_protocol::PlexiEvent) {
+        self.received
+            .lock()
+            .expect("pipe test app event log")
+            .push(event);
+    }
+}
+
+/// Place a `PipeTestApp` pane in `windows[win_idx]`, returning its pane id and
+/// the shared inbox for asserting on delivered `PipeMessage` events.
+fn add_pipe_test_pane(
+    h: &mut HostHarness,
+    win_idx: usize,
+) -> (
+    u64,
+    std::sync::Arc<std::sync::Mutex<Vec<crate::app_protocol::PlexiEvent>>>,
+) {
+    let received = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let pane_id = h.app.host.alloc_pane_id();
+    let pane = crate::host::pane::Pane::App(Box::new(crate::host::pane::AppPane {
+        pip_status: None,
+        id: pane_id,
+        runtime: crate::host::pane::AppRuntime::Builtin(Box::new(PipeTestApp {
+            outgoing: Vec::new(),
+            received: received.clone(),
+        })),
+        workspace_root: "/tmp".into(),
+        permissions: crate::app::permissions::AppPermissions::builtin(),
+        manifest_id: "pipe-test-app".to_string(),
+        name: "pipe-test-app".to_string(),
+        pane_group: None,
+        linked_pane_id: None,
+        overlay_replaced: None,
+        hidden: false,
+        agent: None,
+        slots: std::collections::HashMap::new(),
+        semantic_state: Default::default(),
+    }));
+    h.app.windows[win_idx].panes.insert(pane_id, pane);
+    let tile = h.app.windows[win_idx].tree.tiles.insert_pane(pane_id);
+    if h.app.windows[win_idx].tree.root().is_none() {
+        h.app.windows[win_idx].tree.root = Some(tile);
+    }
+    (pane_id, received)
+}
+
+/// Queue `cmd` onto `pane_id`'s own outgoing queue, exactly as if the app
+/// itself had emitted it — the next `service_app_commands` pass (driven by
+/// `run_hidden_frames`) drains and dispatches it through the real production
+/// path, including the `sender_pane_id` rewrite `drain_all_app_commands`
+/// performs.
+fn queue_pipe_command(h: &mut HostHarness, pane_id: u64, cmd: crate::app::app_trait::AppCommand) {
+    let app = h
+        .app
+        .windows
+        .iter_mut()
+        .find_map(|w| w.panes.get_mut(&pane_id))
+        .and_then(crate::host::pane::Pane::as_app_mut)
+        .expect("pipe test pane must exist");
+    let crate::host::pane::AppRuntime::Builtin(runtime) = &mut app.runtime else {
+        panic!("pipe test pane must be a Builtin runtime");
+    };
+    runtime
+        .as_any_mut()
+        .downcast_mut::<PipeTestApp>()
+        .expect("pipe test pane must be a PipeTestApp")
+        .outgoing
+        .push(cmd);
+}
+
+/// Falsifying regression #1: before stint 0724 Phase D 2/2, `OpenDirectedPipe`
+/// resolved its target purely by `active_window`, with no check that the
+/// target lives in the caller's own context — a pane in context A could open
+/// a directed pipe to a pane in context B. Proves the fix: a caller in
+/// context A opening a directed pipe to a target in sibling context B is
+/// rejected (no `directed_pipes` entry, no delivery ever reaches the
+/// target), while the identical call between two panes in the SAME context
+/// succeeds — isolating the rejection to the context boundary specifically,
+/// not e.g. a general regression in `OpenDirectedPipe` itself.
+#[test]
+fn open_directed_pipe_rejects_cross_context_target() {
+    let mut h = HostHarness::new();
+    let context_a = h.app.windows[0].context_id;
+    let context_b = context_a + 1_000;
+    let root_b = tempfile::tempdir().expect("root b");
+    let win_b_idx = push_secondary_context(&mut h, context_b, root_b.path());
+
+    let (sender_a, _sender_a_events) = add_pipe_test_pane(&mut h, 0);
+    let (target_b, target_b_events) = add_pipe_test_pane(&mut h, win_b_idx);
+
+    queue_pipe_command(
+        &mut h,
+        sender_a,
+        crate::app::app_trait::AppCommand::OpenDirectedPipe {
+            sender_pane_id: sender_a,
+            pipe_id: "cross-ctx".to_string(),
+            target_pane_id: target_b,
+        },
+    );
+    h.run_hidden_frames(1);
+
+    assert!(
+        !h.app
+            .directed_pipes
+            .contains_key(&(context_a, "cross-ctx".to_string())),
+        "a directed pipe from context A to a pane in sibling context B must be rejected \
+         — no entry recorded under either context's key"
+    );
+    assert!(!h
+        .app
+        .directed_pipes
+        .contains_key(&(context_b, "cross-ctx".to_string())),);
+    assert!(
+        target_b_events.lock().expect("event log").is_empty(),
+        "a rejected OpenDirectedPipe must never let anything reach the target"
+    );
+
+    // Contrast: the identical shape between two panes in the SAME context
+    // succeeds — proving the rejection above is specifically about the
+    // context boundary, not a general breakage of OpenDirectedPipe.
+    let (sender_a2, _) = add_pipe_test_pane(&mut h, 0);
+    let (target_a2, _) = add_pipe_test_pane(&mut h, 0);
+    queue_pipe_command(
+        &mut h,
+        sender_a2,
+        crate::app::app_trait::AppCommand::OpenDirectedPipe {
+            sender_pane_id: sender_a2,
+            pipe_id: "same-ctx".to_string(),
+            target_pane_id: target_a2,
+        },
+    );
+    h.run_hidden_frames(1);
+    assert_eq!(
+        h.app
+            .directed_pipes
+            .get(&(context_a, "same-ctx".to_string())),
+        Some(&(sender_a2, target_a2)),
+        "a directed pipe between two panes in the SAME context must succeed"
+    );
+}
+
+/// Falsifying regression #2: before stint 0724 Phase D 2/2, `directed_pipes`
+/// was keyed by `pipe_id` alone in one flat, host-global namespace. Two
+/// different contexts independently choosing the same caller-selected
+/// `pipe_id` string (a real scenario — callers pick pipe ids with no
+/// coordination across contexts) would collide in that map, so the SECOND
+/// `OpenDirectedPipe` would silently overwrite the first context's pipe pair,
+/// and a `DeliverPipeMessage` from either context's sender could cross-
+/// deliver into the other context's target. Proves the composite
+/// `(context_id, pipe_id)` key keeps them fully independent: both opens
+/// succeed as distinct entries, and a message sent on context A's "my-pipe"
+/// reaches ONLY context A's target — context B's identically-named pipe and
+/// target are entirely unaffected, and vice versa.
+#[test]
+fn directed_pipe_id_does_not_collide_across_contexts() {
+    let mut h = HostHarness::new();
+    let context_a = h.app.windows[0].context_id;
+    let context_b = context_a + 1_000;
+    let root_b = tempfile::tempdir().expect("root b");
+    let win_b_idx = push_secondary_context(&mut h, context_b, root_b.path());
+
+    let (sender_a, _) = add_pipe_test_pane(&mut h, 0);
+    let (target_a, target_a_events) = add_pipe_test_pane(&mut h, 0);
+    let (sender_b, _) = add_pipe_test_pane(&mut h, win_b_idx);
+    let (target_b, target_b_events) = add_pipe_test_pane(&mut h, win_b_idx);
+
+    queue_pipe_command(
+        &mut h,
+        sender_a,
+        crate::app::app_trait::AppCommand::OpenDirectedPipe {
+            sender_pane_id: sender_a,
+            pipe_id: "my-pipe".to_string(),
+            target_pane_id: target_a,
+        },
+    );
+    queue_pipe_command(
+        &mut h,
+        sender_b,
+        crate::app::app_trait::AppCommand::OpenDirectedPipe {
+            sender_pane_id: sender_b,
+            pipe_id: "my-pipe".to_string(),
+            target_pane_id: target_b,
+        },
+    );
+    h.run_hidden_frames(1);
+
+    assert_eq!(
+        h.app
+            .directed_pipes
+            .get(&(context_a, "my-pipe".to_string())),
+        Some(&(sender_a, target_a)),
+        "context A's \"my-pipe\" must record its own pair"
+    );
+    assert_eq!(
+        h.app
+            .directed_pipes
+            .get(&(context_b, "my-pipe".to_string())),
+        Some(&(sender_b, target_b)),
+        "context B's identically-named \"my-pipe\" must record its OWN pair, independent of A's"
+    );
+
+    // A sends on "my-pipe" — must reach ONLY target A.
+    queue_pipe_command(
+        &mut h,
+        sender_a,
+        crate::app::app_trait::AppCommand::DeliverPipeMessage {
+            sender_pane_id: sender_a,
+            pipe_id: "my-pipe".to_string(),
+            payload: serde_json::json!({"from": "a"}),
+        },
+    );
+    h.run_hidden_frames(1);
+
+    {
+        let events_a = target_a_events.lock().expect("event log");
+        assert_eq!(
+            events_a.len(),
+            1,
+            "target A must receive exactly one message"
+        );
+        match &events_a[0] {
+            crate::app_protocol::PlexiEvent::PipeMessage { pipe_id, payload } => {
+                assert_eq!(pipe_id, "my-pipe");
+                assert_eq!(payload["from"], "a");
+            }
+            other => panic!("expected PipeMessage, got {other:?}"),
+        }
+    }
+    assert!(
+        target_b_events.lock().expect("event log").is_empty(),
+        "context B's target must NEVER receive context A's message on the identically-named pipe_id"
+    );
+
+    // B sends on its own "my-pipe" — must reach ONLY target B, and must not
+    // add a second delivery to target A.
+    queue_pipe_command(
+        &mut h,
+        sender_b,
+        crate::app::app_trait::AppCommand::DeliverPipeMessage {
+            sender_pane_id: sender_b,
+            pipe_id: "my-pipe".to_string(),
+            payload: serde_json::json!({"from": "b"}),
+        },
+    );
+    h.run_hidden_frames(1);
+
+    assert_eq!(
+        target_a_events.lock().expect("event log").len(),
+        1,
+        "target A must still have received exactly one message — B's send must not cross over"
+    );
+    {
+        let events_b = target_b_events.lock().expect("event log");
+        assert_eq!(
+            events_b.len(),
+            1,
+            "target B must receive exactly one message"
+        );
+        match &events_b[0] {
+            crate::app_protocol::PlexiEvent::PipeMessage { pipe_id, payload } => {
+                assert_eq!(pipe_id, "my-pipe");
+                assert_eq!(payload["from"], "b");
+            }
+            other => panic!("expected PipeMessage, got {other:?}"),
+        }
+    }
+}
+
 /// Stint 0414: node-targeted counterpart of stint 0398's
 /// `click_pane_delivers_canvas_space_coordinate_through_fit_contain_transform`.
 /// Drives a REAL process-app pane (`apps/dev/node-click-probe`, a single

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -2771,6 +2771,48 @@ fn emitted_app_event_is_recorded_and_awaitable() {
     );
 }
 
+/// Stint 0724 Phase D: `PlexiApp::resolve_event_bus_caller` resolves the
+/// event-bus socket transport's caller identity — used to fill in
+/// `HostSubscribeRequest`/`HostPublishRequest`'s `context_id_override`/
+/// `workspace_root_override` when a CLI request arrives with neither
+/// pre-resolved. With no `peer_ancestry` (the common case for a platform
+/// where kernel ancestry capture is unavailable, or simply not exercised by
+/// this test), the claimed pane id is used as-is and its context/workspace
+/// come from the same `origin_for_pane` every other Phase C/D consumer uses
+/// — never a stale ambient default.
+#[test]
+fn resolve_event_bus_caller_falls_back_to_claimed_pane_id_without_ancestry() {
+    let mut h = HostHarness::new();
+
+    let app_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("apps/dev/event-probe");
+    h.app
+        .launch_app_by_path_with_layout(&app_dir.to_string_lossy(), None, None, &[])
+        .expect("launch event-probe");
+    let pane_id = *h
+        .state()
+        .open_panes
+        .last()
+        .expect("a pane appears after launching event-probe");
+
+    let expected_origin = h
+        .app
+        .origin_for_pane(pane_id)
+        .expect("the just-launched pane must resolve an origin");
+
+    let (resolved_pane_id, context_id, workspace_root) =
+        h.app.resolve_event_bus_caller(Some(pane_id), None);
+    assert_eq!(resolved_pane_id, Some(pane_id));
+    assert_eq!(context_id, Some(expected_origin.context_id));
+    assert_eq!(workspace_root, Some(expected_origin.context_root));
+
+    // A claim naming no pane at all (an outside-pane connection) resolves to
+    // nothing — no ambient default fills in silently.
+    let (resolved_pane_id, context_id, workspace_root) = h.app.resolve_event_bus_caller(None, None);
+    assert_eq!(resolved_pane_id, None);
+    assert_eq!(context_id, None);
+    assert_eq!(workspace_root, None);
+}
+
 /// Stint 0414: node-targeted counterpart of stint 0398's
 /// `click_pane_delivers_canvas_space_coordinate_through_fit_contain_transform`.
 /// Drives a REAL process-app pane (`apps/dev/node-click-probe`, a single

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -29,7 +29,7 @@ fn push_secondary_context(h: &mut HostHarness, context_id: u64, root: &std::path
         context_id,
     });
     h.app.router.push(crate::host::context::Context {
-        name: "context-b".to_string(),
+        name: "context-b".to_string().into(),
         root: root.to_path_buf(),
         description: None,
         context_id,

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -95,8 +95,14 @@ mod load_aware_timeout_tests {
     fn correctness_budget_scales_with_load_and_stops_at_the_cap() {
         let base = Duration::from_secs(10);
         assert_eq!(base.saturating_mul(load_multiplier(0.5, 4.0)), base);
-        assert_eq!(base.saturating_mul(load_multiplier(7.0, 4.0)), Duration::from_secs(20));
-        assert_eq!(base.saturating_mul(load_multiplier(100.0, 4.0)), Duration::from_secs(40));
+        assert_eq!(
+            base.saturating_mul(load_multiplier(7.0, 4.0)),
+            Duration::from_secs(20)
+        );
+        assert_eq!(
+            base.saturating_mul(load_multiplier(100.0, 4.0)),
+            Duration::from_secs(40)
+        );
     }
 }
 
@@ -241,7 +247,18 @@ impl HostHarness {
 
     /// Add a builtin Assistant app pane backed by an inert AI broker. Used by
     /// input-ownership tests that assert on the composer's observable state.
+    /// Always lands in `windows[0]` — for a pane in a specific (e.g.
+    /// secondary-context) window, use
+    /// [`Self::add_assistant_pane_in_window`].
     pub fn add_assistant_pane(&mut self) -> PaneId {
+        self.add_assistant_pane_in_window(0)
+    }
+
+    /// Like [`Self::add_assistant_pane`] but lands the pane in `windows[win_idx]`
+    /// — lets a multi-context test put an Assistant pane in a specific
+    /// (non-active) context's window (stint 0724 Phase C connector-tool
+    /// reachability regression coverage).
+    pub fn add_assistant_pane_in_window(&mut self, win_idx: usize) -> PaneId {
         struct InertBroker;
         impl crate::plexi_ai::broker::AiBroker for InertBroker {
             fn dispatch(
@@ -265,9 +282,10 @@ impl HostHarness {
         let pane_id = self.next_pane_id;
         self.next_pane_id += 1;
         let workspace_root = self._workspace_dir.path().to_path_buf();
-        // The pane is inserted into windows[0] below — scope the store to
-        // that window's context.
-        let context_id = self.app.windows[0].context_id;
+        // Scope the store to the target window's own context — never
+        // `windows[0]`'s, so a pane placed in a secondary context gets that
+        // context's identity.
+        let context_id = self.app.windows[win_idx].context_id;
         let assistant = crate::assistant::AssistantApp::new(
             workspace_root.clone(),
             Arc::new(InertBroker),
@@ -290,7 +308,7 @@ impl HostHarness {
             slots: HashMap::new(),
             semantic_state: Default::default(),
         };
-        let win = &mut self.app.windows[0];
+        let win = &mut self.app.windows[win_idx];
         win.panes.insert(pane_id, Pane::App(Box::new(app_pane)));
         let tile_id = win.tree.tiles.insert_pane(pane_id);
         // Join the layout so this pane actually renders each frame — a tile
@@ -309,10 +327,15 @@ impl HostHarness {
     }
 
     /// Mutable access to an assistant pane's concrete app for state assertions.
+    /// Searches every window, not just `windows[0]` — a pane placed via
+    /// [`Self::add_assistant_pane_in_window`] with a non-zero index must
+    /// still be found.
     pub fn assistant_mut(&mut self, pane_id: PaneId) -> &mut crate::assistant::AssistantApp {
-        let pane = self.app.windows[0]
-            .panes
-            .get_mut(&pane_id)
+        let pane = self
+            .app
+            .windows
+            .iter_mut()
+            .find_map(|window| window.panes.get_mut(&pane_id))
             .expect("assistant pane not found");
         let AppRuntime::Builtin(app) = &mut pane.as_app_mut().expect("not an app pane").runtime
         else {
@@ -359,11 +382,7 @@ impl HostHarness {
             )),
             ..Default::default()
         };
-        input
-            .viewports
-            .entry(viewport_id)
-            .or_default()
-            .occluded = Some(true);
+        input.viewports.entry(viewport_id).or_default().occluded = Some(true);
         app.raw_input_hook(&self.ctx, &mut input);
         let full_output = self.ctx.run_ui(input, |ui| {
             app.logic(ui.ctx(), &mut eframe::Frame::_new_kittest());

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -142,6 +142,31 @@ impl HostSnapshot {
 
 // ─── HostHarness ─────────────────────────────────────────────────────────────
 
+/// Process-wide pane-id block allocator for `HostHarness` instances.
+///
+/// `cargo test` runs every `#[test]` in one process across a thread pool, and
+/// production singletons that are correctly process-global in a real host
+/// (e.g. `plexi_ai::tool_dispatch::GLOBAL_REGISTRY`, keyed by `pane_id`) stay
+/// exactly that global in test builds too — there is no per-test process to
+/// isolate them. Before this, every `HostHarness::new()` started its own
+/// `next_pane_id` at the same fixed `100`, so two tests that both register
+/// into such a global registry could race on the identical key: one test's
+/// entry silently overwrites the other's, and the loser observes missing or
+/// foreign data with no error (`connector_tool_visible_only_to_assistant_in_the_owning_context`,
+/// stint 0724 Phase F — flaky only under full-suite parallel execution,
+/// always green in isolation). Each harness now reserves its own disjoint
+/// block from one atomic counter, so no two concurrently-running harnesses
+/// can ever assign the same `pane_id`, regardless of test execution order.
+static NEXT_TEST_PANE_ID_BLOCK: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(100);
+
+/// Reserve a fresh block of pane ids for one `HostHarness` instance. `10_000`
+/// is far more than any single test creates, so blocks never collide; `u64`
+/// has no realistic risk of exhausting across even a very large test run.
+fn reserve_pane_id_block() -> u64 {
+    NEXT_TEST_PANE_ID_BLOCK.fetch_add(10_000, std::sync::atomic::Ordering::SeqCst)
+}
+
 /// Headless egui test harness wrapping `PlexiApp`.
 ///
 /// ```rust,no_run
@@ -190,7 +215,7 @@ impl HostHarness {
         Self {
             app,
             ctx,
-            next_pane_id: 100,
+            next_pane_id: reserve_pane_id_block(),
             ipc_tx,
             last_platform_output: egui::PlatformOutput::default(),
             _profile_dir: profile_dir,


### PR DESCRIPTION
## Summary

Implements stint 0724: a single host-owned scope/ownership model (`src/host/scope.rs` — `ScopeOrigin`, `Scope`, `ResolvedSource<T>`, `evaluate_reach`, `ScopeInvalidation`) replacing the duplicated, active-context-only ownership/reachability predicates that previously existed independently for app discovery, connector tools, the event bus, pipes, and notifications.

Landed as 7 sequential commits, one per phase:

- **Phase A** (`cbd3274a`) — core types: `ScopeOrigin`, `Scope`, `ResolvedSource<T>`, `evaluate_reach` (the one reachability predicate), `resolve_layers` (layered-source resolver), `ScopeInvalidation` lifecycle signal + `PlexiApp::emit_scope_invalidation` fan-out wired at `set_context_root`/`delete_context`/`close_pane_by_id`/registry-watcher hits.
- **Phase B** (`0cd06616`) — `AppRegistry` → context-keyed `RegistryViews`. Fixes the bug where an inactive context's app registry was stale/wrong; every consumer now resolves against the actual target context, not whichever context was last active.
- **Phase C** (`086cc46b`) — connector tools carry `ScopeOrigin`. Deleted 3 duplicated path-equality reachability predicates in `tool_dispatch.rs`; reachability now flows through `evaluate_reach`. Deliberate tightening: same-root sibling contexts are no longer mutually visible (context_id is the runtime reachability dimension, root is only the source-address dimension).
- **Phase D 1/2** (`f6d0eae4`) — event bus + subscriptions gain context ownership; stream namespace is now `(context_id, app_id)`, closing cross-context bleed when the same app_id runs in two contexts. Extended stint 0636's socket-peer identity verification to subscribe/publish requests (previously trusted the client-claimed pane id alone).
- **Phase D 2/2** (`0def212f`) — directed pipes re-keyed `(context_id, pipe_id)` with cross-context rejection; typed pipes gain owner `Scope`. Found and documented (not fixed, see follow-ups) that directed-pipe registration has been a silent no-op for every runtime since a prior migration.
- **Phase E** (`ec2b27fa`) — deduped 4 copies of the notification visibility predicate into one free function (byte-identical semantics); event log moved from one startup-chosen workspace file to per-record attribution via each event's own resolved `context_root`.
- **Phase F** (`967b0e4d`) — deletion sweep (confirmed clean, plus 2 more dead-code deletions found by the audit), full HostHarness coverage-matrix audit against the stint's required list (all 11 areas covered), traces audit (source resolution / shadowing / invalidation / rejected crossings all logged, no secrets/bodies/payloads), and a real cross-test-isolation bug fix (`HostHarness` pane-id collision across parallel tests hitting a shared global registry).

## Size

`cbd3274a~1..HEAD`: 34 files changed, +4287/-1005 (net +3282). A large share is new test infrastructure — every phase shipped falsifying regressions for the specific cross-context bleed it closed.

## Follow-ups filed (deliberately out of scope here, each independently justified)

- **0740** (P3) — Phase B traded stint 0548's async registry-rescan for a synchronous per-root cache (needed for first-visit-to-a-context correctness). Reviewed: real regression on paper, but measured cost is negligible (~0.2ms warm scan) — the original multi-second stalls traced to `delete_context`'s guest-shutdown blocking, untouched here. Low-priority reintroduction of async loading for the steady-state active-context-transition path only.
- **0741** (P2) — `AgentHost.workspace_root`/`context_id` are still a wholesale active-context singleton, same bug class Phase B fixed for `AppRegistry` but never applied to agents.
- **0742** (P2) — directed-pipe registration discovered to be a silent no-op for every runtime since commit `c2a8c76d0` (#2386), predating and unrelated to this stint. This PR made the failure advisory instead of blocking so the new context-scoping could be tested, but did not restore the underlying feature.
- **0744** (P3) — `scope::resolve_layers`, required by this stint's own written scope, has zero production callers; Phase B reused `AppRegistry::load`'s existing precedence logic instead rather than risk-refactor the app-discovery hot path mid-stint. Open question in the task: whether unifying is worth it at all absent a second layered-source consumer.
- **0745** (P3) — `state_scope.rs` (app-state addressing) was named in this stint's scope as a migration target but never touched by any phase, since it was already correct and independently tested. Open question in the task: confirm whether there's a real problem to solve here before implementing anything.

## Test plan

- `cargo build` clean (10 pre-existing, documented, accepted dead-code warnings — unwired `ScopeInvalidation::PackageReplaced`, unconstructed `Scope`/`CrossContextGrant` fields future consumers will use).
- `cargo test --bin plexi`: 2384 passed, 0 failed, 6 ignored (confirmed twice, clean).
- Context-switch scenes (`subcontext-portal`, `event-probe`) pass.
- No `#[allow(dead_code)]`/`#[allow(unused)]` anywhere in the diff.