### PR TITLE
fix(host): route TextInput Escape to apps

### DIFF
--- a/apps/github-issues/main.py
+++ b/apps/github-issues/main.py
@@ -45,6 +45,7 @@ DEFAULT_STATE: dict[str, Any] = {
     "sort_mode": "created_desc",
     "view": "list",
     "detail": None,
+    "filter_autofocus": True,
 }
 
 
@@ -89,6 +90,9 @@ def update(event) -> list:
         return []
 
     key = event.key
+    if key == "escape" and data["view"] == "list":
+        data["filter_autofocus"] = False
+        return [SetState(data), SetStatus(_status(data))]
     if data["view"] == "detail":
         if key == "escape":
             data["view"] = "list"
@@ -262,7 +266,7 @@ def _list_view(data: dict):
                 value=data["filter"],
                 placeholder="filter labels or title",
                 on_change="issues-filter",
-                autofocus=True,
+                autofocus=bool(data["filter_autofocus"]),
             ),
             body,
             Spacer(grow=True),

--- a/apps/wikipedia/wikipedia.py
+++ b/apps/wikipedia/wikipedia.py
@@ -22,7 +22,7 @@ EXTRACT_API = "https://en.wikipedia.org/api/rest_v1/page/summary/"
 DEFAULT_STATE: dict[str, Any] = {
     "query": "", "results": [], "selected": 0, "article": "",
     "article_title": "", "loading": False, "pending": "", "error": "",
-    "searched_query": "",
+    "searched_query": "", "query_autofocus": True,
 }
 
 _SEARCH_TOOL_SCHEMA = {
@@ -101,6 +101,9 @@ def update(event) -> list:
         return []
 
     key = event.key
+    if key == "escape":
+        data["query_autofocus"] = False
+        return [SetState(data), SetStatus(_status(data))]
     if key in ("down", "ArrowDown"):
         data["selected"] = _clamp(data["selected"] + 1, len(data["results"]))
     elif key in ("up", "ArrowUp"):
@@ -131,7 +134,7 @@ def view():
             AppBar("Wikipedia", "The free encyclopedia"),
             TextInput(
                 "wiki-query", value=data["query"], on_change="wiki-query",
-                on_submit="wiki-submit", autofocus=True,
+                on_submit="wiki-submit", autofocus=bool(data["query_autofocus"]),
                 placeholder="Try “Detroit”, “Tetris”, or “Ada Lovelace”",
             ),
             Pending(active=data["loading"] and data["pending"] == "search",

--- a/src/app/dispatch.rs
+++ b/src/app/dispatch.rs
@@ -119,6 +119,38 @@ impl PlexiApp {
             }
             return;
         }
+        // Egui releases a TextInput's focus before this dispatch. On the
+        // physical Escape that did so, hand only that bare key to the app via
+        // its dedicated bridge path, then consume it before CloseApp sees it.
+        // Normal `handle_key` remains Escape-reserving for every other case.
+        let text_input_escape: Vec<egui::Event> = input
+            .events()
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    egui::Event::Key {
+                        key: egui::Key::Escape,
+                        pressed: true,
+                        modifiers,
+                        ..
+                    } if modifiers.is_none()
+                )
+            })
+            .cloned()
+            .collect();
+        if previously_focused && !text_input_escape.is_empty() {
+            let synthetic = crate::app::input_router::PlexiInput::synthetic(
+                text_input_escape,
+                input.modifiers(),
+            );
+            let disposition = app_pane.runtime.handle_text_input_escape(&synthetic);
+            input.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
+            log::info!(
+                "app_keys: pane {pane_id} Escape left focused TextInput — dedicated delivery disposition={disposition:?}, CloseApp suppressed"
+            );
+            return;
+        }
         // The app classifies keys from the frame's ownership-transfer buffer
         // (stint 0387) rather than a second read of `ctx`. If it consumed the
         // key, also claim Escape/ArrowUp out of the buffer so `poll_actions`
@@ -130,19 +162,6 @@ impl PlexiApp {
         if disposition == crate::app::app_trait::KeyDisposition::Consumed {
             input.consume_key(egui::Modifiers::NONE, egui::Key::Escape);
             input.consume_key(egui::Modifiers::NONE, egui::Key::ArrowUp);
-        }
-        // egui surrenders widget focus on Escape during `begin_pass`, before
-        // this dispatch runs — so on the keypress that leaves a focused
-        // TextInput the gate above is already off. The app has now seen that
-        // Escape through `handle_key` (stint 0460 — e.g. the assistant
-        // interrupts its in-flight turn on the same press that leaves the
-        // composer); claim whatever is left of it out of the buffer so the
-        // AppActive CloseApp binding can't close the pane on the same
-        // keypress.
-        if previously_focused && input.consume_key(egui::Modifiers::NONE, egui::Key::Escape) {
-            log::info!(
-                "app_keys: pane {pane_id} Escape left the focused TextInput — delivered to app, CloseApp suppressed"
-            );
         }
     }
 

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -887,7 +887,10 @@ impl AppRuntime {
         input: &crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         match self {
-            AppRuntime::Builtin(app) => app.handle_key(input),
+            // This is a Python/WASM bridge exception, not a general native-app
+            // key path. Builtins keep bare Escape reserved for the host; the
+            // caller still consumes it before CloseApp can run.
+            AppRuntime::Builtin(_) => crate::app::app_trait::KeyDisposition::Passthrough,
             AppRuntime::Python(app) => app.handle_text_input_escape(input),
             AppRuntime::Wasm(app) => app.handle_text_input_escape(input),
         }

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -878,6 +878,21 @@ impl AppRuntime {
         }
     }
 
+    /// Deliver the one bare Escape that just surrendered a declarative
+    /// `TextInput`'s egui focus. Ordinary key routing reserves Escape for the
+    /// host CloseApp binding; this narrowly-scoped path lets the field's app
+    /// react to its own focus-loss Escape before that binding is suppressed.
+    pub fn handle_text_input_escape(
+        &mut self,
+        input: &crate::app::input_router::PlexiInput,
+    ) -> crate::app::app_trait::KeyDisposition {
+        match self {
+            AppRuntime::Builtin(app) => app.handle_key(input),
+            AppRuntime::Python(app) => app.handle_text_input_escape(input),
+            AppRuntime::Wasm(app) => app.handle_text_input_escape(input),
+        }
+    }
+
     pub fn take_pending_commands(&mut self) -> Vec<AppCommand> {
         match self {
             AppRuntime::Builtin(app) => app.take_pending_commands(),

--- a/src/host/pane.rs
+++ b/src/host/pane.rs
@@ -887,10 +887,9 @@ impl AppRuntime {
         input: &crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
         match self {
-            // This is a Python/WASM bridge exception, not a general native-app
-            // key path. Builtins keep bare Escape reserved for the host; the
-            // caller still consumes it before CloseApp can run.
-            AppRuntime::Builtin(_) => crate::app::app_trait::KeyDisposition::Passthrough,
+            // Preserve the existing builtin TextInput Escape behavior. The
+            // caller consumes this one focus-loss Escape before CloseApp runs.
+            AppRuntime::Builtin(app) => app.handle_key(input),
             AppRuntime::Python(app) => app.handle_text_input_escape(input),
             AppRuntime::Wasm(app) => app.handle_text_input_escape(input),
         }

--- a/src/host/wasm_pane.rs
+++ b/src/host/wasm_pane.rs
@@ -2392,6 +2392,37 @@ impl LiveWasmPane {
             KeyDisposition::Passthrough
         }
     }
+
+    /// Forward the one bare Escape that released a declarative TextInput.
+    /// Ordinary `handle_key` continues to reserve Escape for host CloseApp.
+    pub fn handle_text_input_escape(
+        &mut self,
+        input: &crate::app::input_router::PlexiInput,
+    ) -> KeyDisposition {
+        let mut consumed = false;
+        for event in input.events() {
+            let is_bare_escape = matches!(
+                event,
+                egui::Event::Key {
+                    key: egui::Key::Escape,
+                    pressed: true,
+                    modifiers,
+                    ..
+                } if modifiers.is_none()
+            );
+            if is_bare_escape {
+                if let Some(key) = translate_key_event(event) {
+                    self.inner.push_input(InputEvent::Key(key));
+                    consumed = true;
+                }
+            }
+        }
+        if consumed {
+            KeyDisposition::Consumed
+        } else {
+            KeyDisposition::Passthrough
+        }
+    }
 }
 
 /// Join every text node in a view tree into a single string (newline-joined),
@@ -4237,6 +4268,16 @@ mod tests {
             ),
             KeyDisposition::Consumed,
             "normal keys are consumed and forwarded to the WASM guest"
+        );
+    }
+
+    #[test]
+    fn text_input_escape_bridge_encodes_bare_escape() {
+        let event = egui_key(egui::Key::Escape, true, false, egui::Modifiers::NONE);
+        let translated = translate_key_event(&event).expect("bare Escape has a guest encoding");
+        assert_eq!(
+            (translated.key.as_str(), translated.pressed),
+            ("escape", true)
         );
     }
 

--- a/src/host/wasm_python.rs
+++ b/src/host/wasm_python.rs
@@ -3688,7 +3688,23 @@ impl LivePythonPane {
         &mut self,
         input: &crate::app::input_router::PlexiInput,
     ) -> crate::app::app_trait::KeyDisposition {
-        let events = python_key_events(input.events());
+        self.send_key_events(python_key_events(input.events()))
+    }
+
+    /// The sole exception to the normal host-owned Escape rule: the Escape
+    /// that caused a declarative TextInput to release focus is delivered back
+    /// to its guest so it can leave its local form/search state too.
+    pub fn handle_text_input_escape(
+        &mut self,
+        input: &crate::app::input_router::PlexiInput,
+    ) -> crate::app::app_trait::KeyDisposition {
+        self.send_key_events(python_text_input_escape_events(input.events()))
+    }
+
+    fn send_key_events(
+        &mut self,
+        events: Vec<Value>,
+    ) -> crate::app::app_trait::KeyDisposition {
         if events.is_empty() {
             crate::app::app_trait::KeyDisposition::Passthrough
         } else {
@@ -4220,6 +4236,33 @@ fn python_key_events(events: &[egui::Event]) -> Vec<Value> {
                     "meta": modifiers.mac_cmd || modifiers.command,
                 }
             }))
+        })
+        .collect()
+}
+
+/// Encode only a physical, unmodified Escape press for the TextInput
+/// focus-loss handoff. Keeping this separate from [`python_key_events`] makes
+/// the host CloseApp reservation the normal bridge contract.
+fn python_text_input_escape_events(events: &[egui::Event]) -> Vec<Value> {
+    events
+        .iter()
+        .filter_map(|event| {
+            let egui::Event::Key {
+                key,
+                pressed,
+                modifiers,
+                ..
+            } = event
+            else {
+                return None;
+            };
+            (*key == egui::Key::Escape && *pressed && modifiers.is_none()).then(|| {
+                json!({
+                    "key": "escape",
+                    "pressed": true,
+                    "modifiers": {"ctrl": false, "shift": false, "alt": false, "meta": false}
+                })
+            })
         })
         .collect()
 }
@@ -7799,6 +7842,34 @@ mod tests {
             python_key_events(&cmd_d).is_empty(),
             "Cmd+D must never arrive at a Python app as bare delete input"
         );
+    }
+
+    #[test]
+    fn text_input_escape_bridge_encodes_only_bare_escape_press() {
+        let bare_escape = [egui::Event::Key {
+            key: egui::Key::Escape,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: egui::Modifiers::NONE,
+        }];
+        assert_eq!(
+            python_text_input_escape_events(&bare_escape),
+            vec![json!({
+                "key": "escape",
+                "pressed": true,
+                "modifiers": {"ctrl": false, "shift": false, "alt": false, "meta": false}
+            })]
+        );
+
+        let cmd_escape = [egui::Event::Key {
+            key: egui::Key::Escape,
+            physical_key: None,
+            pressed: true,
+            repeat: false,
+            modifiers: egui::Modifiers::COMMAND,
+        }];
+        assert!(python_text_input_escape_events(&cmd_escape).is_empty());
     }
 
     #[test]

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -4202,7 +4202,7 @@ fn focused_text_input_receives_typing_and_enter_submits() {
         "Escape in a focused TextInput must not close the app pane"
     );
     frame_with_events(&mut h, vec![pressed_key(egui::Key::Z)]);
-    wait_for_text_label(&mut h, pane_id, "keys:", "keys:2");
+    wait_for_text_label(&mut h, pane_id, "keys:", "keys:3");
 }
 
 /// Stint 0720: typing faster than the guest's render round trip must not lose

--- a/src/testing/harness_tests.rs
+++ b/src/testing/harness_tests.rs
@@ -4302,6 +4302,91 @@ fn text_input_keeps_the_draft_while_the_guest_echo_is_in_flight() {
     wait_for_text_label(&mut h, pane_id, "draft:", "draft:z");
 }
 
+// -- Declarative TextInput key routing -------------------------------------
+
+/// Escape that releases a real process app's focused `FormField` must also
+/// reach the guest exactly once, then stay consumed by the host so CloseApp
+/// cannot reclaim the pane. This drives the full physical-key route:
+/// focus -> egui TextInput focus-loss -> router -> Python bridge -> guest
+/// update -> host reconciliation.
+#[test]
+fn escape_leaving_todo_form_field_cancels_form_without_closing_or_reclaiming_pane() {
+    let mut h = HostHarness::new();
+    let app_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("apps/todo");
+    h.app
+        .launch_app_by_path_with_layout(&app_dir.to_string_lossy(), None, None, &[])
+        .expect("launch todo");
+    let pane_id = *h.state().open_panes.last().expect("todo pane appears");
+
+    let app_text = |h: &HostHarness| {
+        h.app.windows[h.app.active_window]
+            .panes
+            .get(&pane_id)
+            .and_then(Pane::as_app)
+            .map(|pane| {
+                pane.semantic_state()
+                    .nodes
+                    .iter()
+                    .flat_map(|node| {
+                        node.label
+                            .clone()
+                            .into_iter()
+                            .chain(node.value.clone())
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
+            .unwrap_or_default()
+    };
+    let wait_for = |h: &mut HostHarness, expected: &str| {
+        let start = std::time::Instant::now();
+        while !app_text(h).contains(expected) {
+            assert!(
+                start.elapsed()
+                    < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+                "todo never rendered {expected:?}:\n{}",
+                app_text(h)
+            );
+            h.run_frames(1);
+            std::thread::sleep(std::time::Duration::from_millis(25));
+        }
+    };
+
+    h.focus_pane(pane_id);
+    h.run_frames(2);
+    frame_with_events(&mut h, vec![pressed_key(egui::Key::A)]);
+    wait_for(&mut h, "What needs doing?");
+    h.run_frames(2); // autofocus commits through a real render/reconcile pass.
+
+    frame_with_events(&mut h, vec![egui::Event::Text("draft".to_string())]);
+    wait_for(&mut h, "draft");
+
+    // Physical bare Escape: egui has already dropped focus by dispatch time.
+    // The dedicated bridge must deliver it to todo, which exits the form;
+    // dispatch must consume it before AppActive can fire CloseApp.
+    frame_with_events(&mut h, vec![pressed_key(egui::Key::Escape)]);
+    let start = std::time::Instant::now();
+    while app_text(&h).contains("What needs doing?") {
+        assert!(
+            start.elapsed()
+                < crate::testing::load_aware_timeout(std::time::Duration::from_secs(30)),
+            "todo form remained open after Escape:\n{}",
+            app_text(&h)
+        );
+        h.run_frames(1);
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+    assert!(
+        h.app.windows[h.app.active_window].panes.contains_key(&pane_id),
+        "Escape leaving a focused TextInput must not close the pane"
+    );
+    h.run_frames(3);
+    assert!(
+        !app_text(&h).contains("What needs doing?"),
+        "the canceled form must not reclaim focus or reopen on later reconciliation passes"
+    );
+}
+
 // -- Stint 0729 follow-up: vertical-arrow list nav through a focused TextInput --
 
 /// End-to-end contract for `dispatch_app_key_events`'s arrow-forwarding gate,


### PR DESCRIPTION
Implements stint 0743.\n\n- Delivers bare Escape only when it just releases a declarative TextInput, while ordinary Escape remains host-reserved.\n- Prevents affected autofocus fields from reclaiming focus after the app handles Escape.\n- Adds a real Python Todo HostHarness regression over the raw input, focus, bridge, guest, and reconcile path.\n\nValidation:\n- focused HostHarness escape regression\n- cargo build --bin plexi\n- uv run pytest apps/wikipedia/tests/test_wikipedia_v3.py apps/github-issues/tests/test_filter_sort.py -q\n- python syntax checks\n- git diff --check